### PR TITLE
Fix service account parsing

### DIFF
--- a/konflux-ci/ui/core/proxy/proxy.yaml
+++ b/konflux-ci/ui/core/proxy/proxy.yaml
@@ -59,7 +59,7 @@ spec:
             set -e
             
             token=$(cat /mnt/api-token/token)
-            token64=$(cat /mnt/api-token/token | base64 -w 0 | head -c-2)
+            token64=$(cat /mnt/api-token/token | base64 -w 0 | head -c-1)
 
             echo "proxy_set_header Authorization \"Bearer $token\";" > /mnt/nginx-generated-config/bearer.conf
 


### PR DESCRIPTION
The amount of bytes to remove from the service account is different when using long lived tokens.