### PR TITLE
Adding Authentication

### DIFF
--- a/konflux-ci/ui/core/proxy/nginx.conf
+++ b/konflux-ci/ui/core/proxy/nginx.conf
@@ -12,6 +12,7 @@ events {
 http {
     log_format upstreamlog '[$time_local] $remote_addr - $remote_user - $server_name $host to: $proxy_host  $upstream_addr: $request $status upstream_response_time $upstream_response_time msec $msec request_time $request_time';
     access_log /dev/stderr upstreamlog;
+    error_log /dev/stderr;
 
     sendfile on;
     tcp_nopush on;
@@ -19,8 +20,13 @@ http {
     keepalive_timeout 65;
     types_hash_max_size 4096;
 
-    include /etc/nginx/mime.types;
     default_type application/octet-stream;
+
+    client_body_temp_path /var/run/openresty/nginx-client-body;
+    proxy_temp_path       /var/run/openresty/nginx-proxy;
+    fastcgi_temp_path     /var/run/openresty/nginx-fastcgi;
+    uwsgi_temp_path       /var/run/openresty/nginx-uwsgi;
+    scgi_temp_path        /var/run/openresty/nginx-scgi;
 
     map $http_upgrade $connection_upgrade {
         default upgrade;
@@ -49,52 +55,133 @@ http {
             autoindex on;
         }
 
+        location = /oauth2/auth {
+            internal; 
+            proxy_pass       http://127.0.0.1:6000;
+            proxy_set_header Host             $host;
+            proxy_set_header X-Real-IP        $remote_addr;
+            proxy_set_header X-Scheme         $scheme;
+            # nginx auth_request includes headers but not body
+            proxy_set_header Content-Length   "";
+            proxy_pass_request_body           off;
+        }
+
+        location /wss/oauth2/auth {
+            internal; 
+            proxy_pass       http://127.0.0.1:6000/oauth2/auth;
+            proxy_set_header Host             $host;
+            proxy_set_header X-Real-IP        $remote_addr;
+            proxy_set_header X-Scheme         $scheme;
+            # nginx auth_request includes headers but not body
+            proxy_set_header Content-Length   "";
+            proxy_pass_request_body           off;
+
+            # See https://github.com/kubernetes/kubernetes/pull/47740 for information
+            # about the Sec-Websocket-Protocol header and the k8s api server.
+            # We need to transform it back to a bearer token so oauth2-proxy can verifiy it.
+            set $auth_var "";
+            rewrite_by_lua_block {
+                local h = ngx.req.get_headers()["Sec-Websocket-Protocol"]
+                local patteren = [[base64url\.bearer\.authorization\.k8s\.io\.(.+?),]]
+                local m = ngx.re.match(h, patteren)
+                ngx.var.auth_var = ngx.decode_base64(m[1])
+            }
+            proxy_set_header Authorization "Bearer $auth_var";
+        }
+
         location /api/k8s/registration/ {
            # Registration Service registration endpoint
-           proxy_pass http://127.0.0.1:5000/;
+            auth_request_set $email  $upstream_http_x_auth_request_email;
+            proxy_set_header X-Email $email;
+            auth_request_set $user  $upstream_http_x_auth_request_user;
+            proxy_set_header X-User  $user;
+            auth_request_set $username  $upstream_http_x_auth_request_preferred_username; 
+            proxy_set_header X-Auth-Request-Preferred-Username $username;
+            auth_request_set $groups  $upstream_http_x_auth_request_groups;
+            proxy_set_header X-Auth-Request-Groups  $user;    
+
+            auth_request /oauth2/auth;
+            proxy_pass http://127.0.0.1:5000/;
         }
 
         location /api/k8s/apis/toolchain.dev.openshift.com/v1alpha1/workspaces {
            # Registration Service workspaces endpoint
-           proxy_pass http://127.0.0.1:5000/workspaces;
+            auth_request_set $email  $upstream_http_x_auth_request_email;
+            proxy_set_header X-Email $email;
+            auth_request_set $user  $upstream_http_x_auth_request_user;
+            proxy_set_header X-User  $user;
+            auth_request_set $username  $upstream_http_x_auth_request_preferred_username; 
+            proxy_set_header X-Auth-Request-Preferred-Username $username;
+            auth_request_set $groups  $upstream_http_x_auth_request_groups;
+            proxy_set_header X-Auth-Request-Groups  $user;
+
+            auth_request /oauth2/auth;
+            proxy_pass http://127.0.0.1:5000/workspaces;
         }
 
         location /api/k8s/workspaces/ {
             # Kube-API
+            auth_request_set $email  $upstream_http_x_auth_request_email;
+            auth_request /oauth2/auth;
+
             rewrite /api/k8s/workspaces/.+?/(.+) /$1 break;
             proxy_pass https://kubernetes.default.svc;
             proxy_read_timeout 30m;
-            proxy_set_header Impersonate-User user1;
+            proxy_set_header Impersonate-User $email;
             include /mnt/nginx-generated-config/bearer.conf;
         }
 
         location /wss/k8s/workspaces/ {
+            auth_request_set $email  $upstream_http_x_auth_request_email;
+            auth_request /wss/oauth2/auth;
+
             rewrite /wss/k8s/workspaces/.+?/(.+) /$1 break;
             proxy_pass https://kubernetes.default.svc/;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             proxy_read_timeout 30m;
-            proxy_set_header Impersonate-User user1;
+            proxy_set_header Impersonate-User $email;
             include /mnt/nginx-generated-config/websocket.conf;
         }
 
         location /api/k8s/ {
             # Kube-API
+            auth_request_set $email  $upstream_http_x_auth_request_email;
+            auth_request /oauth2/auth;
+
             proxy_pass https://kubernetes.default.svc/;
             proxy_read_timeout 30m;
-            proxy_set_header Impersonate-User user1;
+            proxy_set_header Impersonate-User $email;
             include /mnt/nginx-generated-config/bearer.conf;
         }
 
         location /wss/k8s/ {
-            proxy_pass https://kubernetes.default.svc/;
+            auth_request_set $email  $upstream_http_x_auth_request_email;
+            auth_request /wss/oauth2/auth;
+
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             proxy_read_timeout 30m;
-            proxy_set_header Impersonate-User user1;
+            proxy_set_header Impersonate-User $email;
             include /mnt/nginx-generated-config/websocket.conf;
+        }
+
+        location /test {
+            auth_request_set $email  $upstream_http_x_auth_request_email; 
+            proxy_set_header X-Email $email;
+            auth_request_set $user  $upstream_http_x_auth_request_user;
+            proxy_set_header X-User  $user;
+            auth_request_set $username  $upstream_http_x_auth_request_preferred_username; 
+            proxy_set_header X-Auth-Request-Preferred-Username $username;
+            auth_request_set $groups  $upstream_http_x_auth_request_groups;
+            proxy_set_header X-Auth-Request-Groups  $user;
+
+            auth_request /oauth2/auth;
+
+            proxy_http_version 1.1;
+            proxy_pass http://localhost:7000/oauth2/auth;
         }
 
         location /beta/apps/chrome {

--- a/konflux-ci/ui/core/proxy/proxy.yaml
+++ b/konflux-ci/ui/core/proxy/proxy.yaml
@@ -82,12 +82,14 @@ spec:
             cpu: 10m
             memory: 64Mi
       containers:
-      - image: registry.access.redhat.com/ubi9/nginx-120@sha256:88a4f2d184f52c4d3956be06b12d578d0bf681ec9d0a8b80e558a98c1860fa12
+      - image: openresty/openresty:1.25.3.1-0-jammy
         name: nginx-120
-        command:
-          - nginx
-          - -g 
+        command: 
+          - "/usr/local/openresty/bin/openresty"
+          - "-g"
           - "daemon off;"
+          - -c
+          - /etc/nginx/nginx.conf
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -129,6 +131,8 @@ spec:
             mountPath: /mnt
           - name: nginx-generated-config
             mountPath: /mnt/nginx-generated-config
+          - name: openresty
+            mountPath: /var/run/openresty
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -137,6 +141,46 @@ spec:
         name: workspace-manager
         ports:
           - containerPort: 5000
+            name: web
+            protocol: TCP
+        resources:
+          limits:
+            cpu: 300m
+            memory: 256Mi
+          requests:
+            cpu: 30m
+            memory: 128Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1001
+      - image: quay.io/oauth2-proxy/oauth2-proxy@sha256:3da33b9670c67bd782277f99acadf7026f75b9507bfba2088eb2d497266ef7fc
+        name: oauth2-proxy
+        args:
+          - --provider
+          - keycloak-oidc
+          - --http-address
+          - "127.0.0.1:6000"
+          - --oidc-issuer-url
+          - https://keycloak-rhtap-auth.apps.rosa.stone-stage-p01.apys.p3.openshiftapps.com/auth/realms/redhat-external
+          - --skip-jwt-bearer-tokens
+          - "true"
+          - --set-xauthrequest
+          - "true"
+          - --insecure-oidc-allow-unverified-email
+          - "true"
+          - --email-domain
+          - "*"
+          - --cookie-secret
+          - NOT_USED_BUT_REQUIRED_VALUE_32b_
+          - --client-secret
+          - this_value_is_required_but_not_used
+          - --client-id
+          - oauth2-proxy
+          - --oidc-extra-audience
+          - "account"
+        ports:
+          - containerPort: 6000
             name: web
             protocol: TCP
         resources:
@@ -174,6 +218,8 @@ spec:
         - name: api-token
           secret:
             secretName: proxy
+        - name: openresty
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/test/resources/demo-users/demo-users.yaml
+++ b/test/resources/demo-users/demo-users.yaml
@@ -33,7 +33,7 @@ roleRef:
   name: konflux-admin-user-actions
 subjects:
 - kind: User
-  name: user1
+  name: user1@konflux.dev
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -47,7 +47,7 @@ roleRef:
   name: konflux-admin-user-actions
 subjects:
 - kind: User
-  name: user1
+  name: user1@konflux.dev
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -60,5 +60,5 @@ roleRef:
   name: konflux-self-access-reviewer
 subjects:
 - kind: User
-  name: user1
+  name: user1@konflux.dev
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
1. Authenticate requests using oauth2-proxy (currently configured to use Keycloak since this is what our UI is using).

2. Since oauth2-proxy doesn't know how to parse the "Sec-Websocket-Protocol" header, transform the header to a standard bearer token using a lua function.

3. In order to use lua (which provides the base64 decode method), the ubi nginx image was changed to an openresty image. It provides nginx with the support of lua.

4. The change to the openresty image required some change to the deployment manifest of nginx.

5. Use the email address information of the logged user, as returned from oauth2-proxy for impersonation, registration and workspace listing.

6. Print nginx error log to STDERR for better debugging.

openresty:

- https://github.com/openresty/docker-openresty
- https://github.com/openresty/lua-nginx-module

oauth2-proxy:

- https://oauth2-proxy.github.io/oauth2-proxy/
- https://developer.okta.com/blog/2022/07/14/add-auth-to-any-app-with-oauth2-proxy