### PR TITLE
Update workspace-manager

### DIFF
--- a/konflux-ci/ui/core/proxy/proxy.yaml
+++ b/konflux-ci/ui/core/proxy/proxy.yaml
@@ -137,7 +137,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1001
-      - image: quay.io/yftacherzog/workspace-manager:v1
+      - image: quay.io/yftacherzog/workspace-manager:v1.1
         name: workspace-manager
         ports:
           - containerPort: 5000

--- a/konflux-ci/ui/core/proxy/rbac.yaml
+++ b/konflux-ci/ui/core/proxy/rbac.yaml
@@ -22,6 +22,9 @@ rules:
 - apiGroups: [""]
   resources: ["users", "groups"]
   verbs: ["impersonate"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["localsubjectaccessreviews"]
+  verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/resources/demo-users/user/ns1/rbac.yaml
+++ b/test/resources/demo-users/user/ns1/rbac.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: user-ns1
+  labels:
+    konflux.ci/type: user
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/test/resources/demo-users/user/ns2/ns.yaml
+++ b/test/resources/demo-users/user/ns2/ns.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: user-ns2
+  labels:
+    konflux.ci/type: user


### PR DESCRIPTION
The new version uses local subject access review and namespace labels for determine if a namespace should be transformed into a workspace for a given user.