### PR TITLE
Deploy Keycloak

### DIFF
--- a/dependencies/keycloak/configure-keycloak.yaml
+++ b/dependencies/keycloak/configure-keycloak.yaml
@@ -1,0 +1,331 @@
+---
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  labels:
+    app: sso
+  name: keycloak
+spec:
+  instances: 1
+  hostname:
+   strict: false
+  ingress:
+    enabled: false
+  http:
+    httpEnabled: true
+  proxy:
+    headers: xforwarded
+  db:
+    vendor: postgres
+    host: postgres-db
+    usernameSecret:
+      name: keycloak-db-secret
+      key: POSTGRES_USER
+    passwordSecret:
+      name: keycloak-db-secret
+      key: POSTGRES_PASSWORD
+  additionalOptions:
+    - name: hostname-path
+      value: /idp
+    - name: http-relative-path
+      value: /idp
+---
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: KeycloakRealmImport
+metadata:
+  name: redhat-external
+  labels:
+    realm: redhat-external
+    app: sso
+spec:
+  keycloakCRName: keycloak
+  realm:
+    clientScopes:
+      - name: aud 
+        protocol: openid-connect
+        attributes:
+          display.on.consent.screen: 'true'
+        protocolMappers:
+          - name: cloud-services-audience
+            protocol: openid-connect
+            protocolMapper: oidc-audience-mapper
+            consentRequired: false
+            config:
+              included.client.audience: "account"
+              introspection.token.claim: "true"
+              userinfo.token.claim: "false"
+              id.token.claim: "false"
+              lightweight.claim: "false"
+              access.token.claim: "true"
+              included.custom.audience: ""
+      - attributes:
+          display.on.consent.screen: 'true'
+          include.in.token.scope: 'true'
+        id: 672455b2-1e92-44f6-9fb6-fe2017995aed
+        name: profile_level.name_and_dev_terms
+        protocol: openid-connect
+      - id: 65c7d0bd-243d-42d2-b7f2-64ce2fa7ca7e
+        name: profile
+        description: 'OpenID Connect built-in scope: profile'
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "true"
+          display.on.consent.screen: "true"
+          consent.screen.text: ${profileScopeConsentText}
+        protocolMappers:
+          - id: e3f5a475-0722-4293-bcd5-2bad6bc7dde6
+            name: locale
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            consentRequired: false
+            config:
+              userinfo.token.claim: "true"
+              user.attribute: locale
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: locale
+              jsonType.label: String
+          - id: 7b91d2ec-3c9f-4e7d-859e-67900de0c6b6
+            name: full name
+            protocol: openid-connect
+            protocolMapper: oidc-full-name-mapper
+            consentRequired: false
+            config:
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+          - id: d301c7b7-0d97-4d37-8527-a5c63d461a3c
+            name: family name
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            consentRequired: false
+            config:
+              userinfo.token.claim: "true"
+              user.attribute: lastName
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: family_name
+              jsonType.label: String
+          - id: 71c6caff-3f17-47db-8dc1-42f9af01832e
+            name: updated at
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            consentRequired: false
+            config:
+              userinfo.token.claim: "true"
+              user.attribute: updatedAt
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: updated_at
+              jsonType.label: long
+          - id: 6bcb9f8d-94be-48b3-bd47-2ba7746d65ac
+            name: picture
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            consentRequired: false
+            config:
+              userinfo.token.claim: "true"
+              user.attribute: picture
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: picture
+              jsonType.label: String
+          - id: d497ef2e-5d5b-4d8a-9392-04e09f5c51b6
+            name: nickname
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            consentRequired: false
+            config:
+              userinfo.token.claim: "true"
+              user.attribute: nickname
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: nickname
+              jsonType.label: String
+          - id: f8167604-073d-47ea-9fd1-6ec754ce5c49
+            name: website
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            consentRequired: false
+            config:
+              userinfo.token.claim: "true"
+              user.attribute: website
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: website
+              jsonType.label: String
+          - id: 48d8f2ff-d0e6-41f2-839e-3e51951ee078
+            name: profile
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            consentRequired: false
+            config:
+              userinfo.token.claim: "true"
+              user.attribute: profile
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: profile
+              jsonType.label: String
+          - id: 463f80df-1554-4f0b-889f-1e6f2308ba17
+            name: username
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            consentRequired: false
+            config:
+              userinfo.token.claim: "true"
+              user.attribute: username
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: preferred_username
+              jsonType.label: String
+          - id: c347cd4f-a2e1-4a5f-a676-e779beb7bccf
+            name: given name
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            consentRequired: false
+            config:
+              userinfo.token.claim: "true"
+              user.attribute: firstName
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: given_name
+              jsonType.label: String
+          - id: 665672fd-872e-4a58-b586-b6f6fddbc1ac
+            name: zoneinfo
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            consentRequired: false
+            config:
+              userinfo.token.claim: "true"
+              user.attribute: zoneinfo
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: zoneinfo
+              jsonType.label: String
+          - id: b76e46cc-98a9-4bf7-8918-0cc8eb2dfc8c
+            name: gender
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            consentRequired: false
+            config:
+              userinfo.token.claim: "true"
+              user.attribute: gender
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: gender
+              jsonType.label: String
+          - id: cb1a55e3-87f0-4efb-b5c0-d5de40344bfc
+            name: birthdate
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            consentRequired: false
+            config:
+              userinfo.token.claim: "true"
+              user.attribute: birthdate
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: birthdate
+              jsonType.label: String
+          - id: 9b5c1c92-c937-4216-9fdb-db23d6eee788
+            name: middle name
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            consentRequired: false
+            config:
+              userinfo.token.claim: "true"
+              user.attribute: middleName
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: middle_name
+              jsonType.label: String
+      - id: 45e1900d-2199-45fc-9028-a39497a6cdd5
+        name: email
+        description: 'OpenID Connect built-in scope: email'
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "true"
+          display.on.consent.screen: "true"
+          consent.screen.text: ${emailScopeConsentText}
+        protocolMappers:
+          - id: 149315f5-4595-4794-b11f-f4b68b1c9f7a
+            name: email
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            consentRequired: false
+            config:
+              userinfo.token.claim: "true"
+              user.attribute: email
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: email
+              jsonType.label: String
+          - id: 26f0791c-93cf-4241-9c92-5528e67b9817
+            name: email verified
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            consentRequired: false
+            config:
+              userinfo.token.claim: "true"
+              user.attribute: emailVerified
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: email_verified
+              jsonType.label: boolean
+    displayName: redhat-external
+    enabled: true
+    id: redhat-external
+    realm: redhat-external
+    sslRequired: all
+    users:
+      - clientRoles:
+          account:
+          - manage-account
+        credentials:
+          - type: password
+            value: password
+        email: user1@konflux.dev
+        emailVerified: false
+        enabled: true
+        firstName: user1
+        lastName: user1
+        username: user1
+      - clientRoles:
+          account:
+          - manage-account
+        credentials:
+          - type: password
+            value: password
+        email: user2@konflux.dev
+        emailVerified: false
+        enabled: true
+        firstName: user2
+        lastName: user2
+        username: user2
+    clients:
+      - enabled: true
+        clientAuthenticatorType: client-secret
+        redirectUris:
+          - '*'
+        clientId: cloud-services
+        optionalClientScopes:
+          - address
+          - phone
+          - profile_level.name_and_dev_terms
+          - offline_access
+          - microprofile-jwt
+        defaultClientScopes:
+          - web-origins
+          - acr
+          - nameandterms
+          - profile
+          - roles
+          - email
+          - aud
+        implicitFlowEnabled: false
+        secret: client-secret
+        publicClient: true
+        standardFlowEnabled: true
+        webOrigins:
+          - '*'
+        id: e3e1d703-62c1-46f4-b706-e3d7eebafd01
+        directAccessGrantsEnabled: false

--- a/dependencies/keycloak/db.yaml
+++ b/dependencies/keycloak/db.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgresql-db
+spec:
+  serviceName: postgresql-db-service
+  selector:
+    matchLabels:
+      app: postgresql-db
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: postgresql-db
+    spec:
+      containers:
+        - name: postgresql-db
+          image: postgres:15
+          volumeMounts:
+            - mountPath: /data
+              name: cache-volume
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-db-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-db-secret
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /data/pgdata
+            - name: POSTGRES_DB
+              value: keycloak
+      volumes:
+        - name: cache-volume
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-db
+spec:
+  selector:
+    app: postgresql-db
+  type: LoadBalancer
+  ports:
+  - port: 5432
+    targetPort: 5432

--- a/dependencies/keycloak/kustomization.yml
+++ b/dependencies/keycloak/kustomization.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ns.yaml
+
+  - https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/24.0.2/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
+  
+  - https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/24.0.2/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
+  
+  - https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/24.0.2/kubernetes/kubernetes.yml
+
+  - configure-keycloak.yaml
+
+namespace: keycloak

--- a/dependencies/keycloak/ns.yaml
+++ b/dependencies/keycloak/ns.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keycloak

--- a/deploy-deps.sh
+++ b/deploy-deps.sh
@@ -27,11 +27,21 @@ deploy() {
     kubectl create -k "${script_path}/dependencies/tekton-results"
 
     kubectl create -k "${script_path}/dependencies/ingress-nginx"
+    kubectl create -k "${script_path}/dependencies/keycloak"
 }
 
 deploy_cert_manager() {
     kubectl create -k "${script_path}/dependencies/cert-manager"
     kubectl wait --for=condition=Ready --timeout=120s -l app.kubernetes.io/instance=cert-manager -n cert-manager pod
+}
+
+deploy_keycloak() {
+    kubectl create secret generic keycloak-db-secret \
+        --namespace=keycloak \
+        --from-literal=POSTGRES_USER=postgres \
+        --from-literal=POSTGRES_PASSWORD="$(openssl rand -base64 20)"
+    kubectl wait --for=condition=Ready --timeout=120s -l app=postgresql-db -n keycloak pod
+    kubectl wait --for=condition=Ready --timeout=120s -l app=keycloak -n keycloak pod
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/konflux-ci/ui/core/fed-modules.json
+++ b/konflux-ci/ui/core/fed-modules.json
@@ -2,7 +2,7 @@
     "chrome": {
         "manifestLocation": "/apps/chrome/js/fed-mods.json",
         "config": {
-            "ssoUrl": "ADD-KEYCLOAK-ENDPOINT"
+            "ssoUrl": "https://localhost:9443/idp/"
         },
         "fullProfile": false
     },

--- a/konflux-ci/ui/core/proxy/nginx.conf
+++ b/konflux-ci/ui/core/proxy/nginx.conf
@@ -34,7 +34,7 @@ http {
     }
 
     server {
-        listen 6443 ssl;
+        listen 9443 ssl;
         ssl_certificate /mnt/tls.crt;
         ssl_certificate_key /mnt/tls.key;
         server_name _;
@@ -46,13 +46,25 @@ http {
         location = / {
             # We don't servce any other component using chrome
             # so redirect any request to the root to our UI.
-            return 301 https://$host:6443/application-pipeline;
+            return 301 https://$host:9443/application-pipeline;
         }
 
         location /api/chrome-service/v1/static {
             # Static files required for the chrome frontend.
             alias /opt/app-root/src/chrome/static;
             autoindex on;
+        }
+
+        location /idp/ {
+            # Identity Provider
+            proxy_set_header    Host               $host;
+            proxy_set_header    X-Real-IP          $remote_addr;
+            proxy_set_header    X-Forwarded-For    $proxy_add_x_forwarded_for;
+            proxy_set_header    X-Forwarded-Host   $host;
+            proxy_set_header    X-Forwarded-Server $host;
+            proxy_set_header    X-Forwarded-Port   9443;
+            proxy_set_header    X-Forwarded-Proto  $scheme;
+            proxy_pass http://keycloak-service.keycloak.svc.cluster.local:8080/idp/;
         }
 
         location = /oauth2/auth {

--- a/konflux-ci/ui/core/proxy/proxy.yaml
+++ b/konflux-ci/ui/core/proxy/proxy.yaml
@@ -94,7 +94,7 @@ spec:
           failureThreshold: 3
           httpGet:
             path: /health
-            port: 6443
+            port: 9443
             scheme: HTTPS
           initialDelaySeconds: 10
           periodSeconds: 60
@@ -104,7 +104,7 @@ spec:
         - containerPort: 8080
           name: web
           protocol: TCP
-        - containerPort: 6443
+        - containerPort: 9443
           name: web-tls
           protocol: TCP
         resources:
@@ -162,7 +162,9 @@ spec:
           - --http-address
           - "127.0.0.1:6000"
           - --oidc-issuer-url
-          - https://keycloak-rhtap-auth.apps.rosa.stone-stage-p01.apys.p3.openshiftapps.com/auth/realms/redhat-external
+          - https://localhost:9443/idp/realms/redhat-external
+          - --ssl-insecure-skip-verify
+          - "true"
           - --skip-jwt-bearer-tokens
           - "true"
           - --set-xauthrequest


### PR DESCRIPTION
It will be used as the IDP. It's configured with 2 test users by defualt, but it can also integrate with external IDPs such as Github, Google, etc. The port nginx uses for https was changed to match the port which is used to forward traffic from the host. It's required since oauth2-proxy expects them to be the same (when it queries the details of the realm from keycloak).

The endpoints are exposed through the nginx proxy.

The documentation used for creating this patch:

- https://www.keycloak.org/operator/basic-deployment
- https://www.keycloak.org/server/reverseproxy https://stackoverflow.com/questions/66822016/where-are-all-of-the-keycloak-protocol-mapper-config-options-documented