### PR TITLE
chore(RHTAPWATCH-1006): allow user1 access to ws2

### DIFF
--- a/test/resources/demo-users/user/ns2/rbac.yaml
+++ b/test/resources/demo-users/user/ns2/rbac.yaml
@@ -12,3 +12,17 @@ subjects:
 - kind: User
   name: user2@konflux.dev
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: user1-konflux-admin
+  namespace: user-ns2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-admin-user-actions
+subjects:
+- kind: User
+  name: user1@konflux.dev
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Adding RoleBinding to allow user1 access to user2's workspace in order to demonstrate user access to multiple workspaces.