### PR TITLE
fix: use kubectl apply when deploying registry

### DIFF
--- a/deploy-deps.sh
+++ b/deploy-deps.sh
@@ -102,7 +102,7 @@ deploy_keycloak() {
 }
 
 deploy_registry() {
-    kubectl create -k "${script_path}/dependencies/registry"
+    kubectl apply -k "${script_path}/dependencies/registry"
     retry kubectl wait --for=condition=Ready --timeout=240s -n kind-registry -l run=registry pod
 }
 


### PR DESCRIPTION
We should use kubectl instead of create, so that the script could be executed multiple times.

closes #72 