### PR TITLE
feat: provide PaC links to the local console

### DIFF
--- a/dependencies/pipelines-as-code/custom-console-patch.yaml
+++ b/dependencies/pipelines-as-code/custom-console-patch.yaml
@@ -1,0 +1,16 @@
+---
+- op: add
+  path: /data/application-name
+  value: Local Konflux
+- op: add
+  path: /data/custom-console-name
+  value: Local Konflux
+- op: add
+  path: /data/custom-console-url
+  value: 'https://localhost:9443'
+- op: add
+  path: /data/custom-console-url-pr-details
+  value: 'https://localhost:9443/application-pipeline/ns/{{ namespace }}/pipelinerun/{{ pr }}'
+- op: add
+  path: /data/custom-console-url-pr-tasklog
+  value: 'https://localhost:9443/application-pipeline/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}'

--- a/dependencies/pipelines-as-code/kustomization.yml
+++ b/dependencies/pipelines-as-code/kustomization.yml
@@ -3,3 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/openshift-pipelines/pipelines-as-code/releases/download/v0.24.1/release.k8s.yaml
+patches:
+  - path: custom-console-patch.yaml
+    target:
+      kind: ConfigMap
+      version: v1
+      name: pipelines-as-code


### PR DESCRIPTION
This way, a user who clicks on their github check result will be directed to their their local instance's UI.

Fixes https://github.com/konflux-ci/konflux-ci/issues/97