### PR TITLE
Integrate the new import flow

### DIFF
--- a/konflux-ci/build-service/build-pipeline-config.yaml
+++ b/konflux-ci/build-service/build-pipeline-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: build-pipeline-config
+  namespace: build-service
+data:
+  config.yaml: |
+    default-pipeline-name: docker-build
+    pipelines:
+    - name: fbc-builder
+      bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-fbc-builder:13ecd03ec9f7de811f837a5460c41105231c911a
+    - name: docker-build
+      bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-docker-build:13ecd03ec9f7de811f837a5460c41105231c911a

--- a/konflux-ci/build-service/core/apps_v1_deployment_build-service-controller-manager.yaml
+++ b/konflux-ci/build-service/core/apps_v1_deployment_build-service-controller-manager.yaml
@@ -27,7 +27,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: quay.io/redhat-appstudio/build-service:29b09e5d8350f75c92d5796fbbf62647fe28610b
+        image: quay.io/konflux-ci/build-service
         livenessProbe:
           httpGet:
             path: /healthz

--- a/konflux-ci/build-service/kustomization.yaml
+++ b/konflux-ci/build-service/kustomization.yaml
@@ -2,3 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - core
+  - build-pipeline-config.yaml
+images:
+- name: quay.io/konflux-ci/build-service
+  newName: quay.io/konflux-ci/build-service
+  newTag: edd586d9d07aba61d6d7f853a3db679db7d1a893

--- a/konflux-ci/ui/core/kustomization.yaml
+++ b/konflux-ci/ui/core/kustomization.yaml
@@ -21,7 +21,7 @@ images:
   # hac-dev
   - name: quay.io/cloudservices/hac-dev-frontend
     newName: quay.io/cloudservices/hac-dev-frontend
-    newTag: 91e1a9d
+    newTag: 7a3090e
 
 configMapGenerator:
   - name: fed-modules

--- a/test/resources/demo-users/user/ns1/application-and-component.yaml
+++ b/test/resources/demo-users/user/ns1/application-and-component.yaml
@@ -17,12 +17,13 @@ metadata:
   annotations:
     build.appstudio.openshift.io/request: configure-pac
     image.redhat.com/generate: '{"visibility": "public"}'
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build", "bundle": "latest"}'
 spec:
   application: sample-component
   componentName: sample-component
   source:
     git:
       revision: main
-      url: https://github.com/gbenhaim/sample-component.git
+      url: https://github.com/konflux-ci/testrepo.git
       dockerfileUrl: Dockerfile
       context: ./


### PR DESCRIPTION
    Update hac-dev image
    
    The new image has the new simple import form and several fixes
    for the link to the documentation.

    Update build-service image
    
    The new image supports importing a component without a devfile and
    selecting a pipeline by adding an annotation on the component.
    See test/resources/demo-users/user/ns1/application-and-component.yaml
    for an example.


![new-import](https://github.com/konflux-ci/konflux-ci/assets/17479229/f9a8bb41-1741-4e4b-8904-a6df4561283b)

