### PR TITLE
fix: test pvc use old retry format

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,7 +830,10 @@ is restarted.
 The `deploy-deps` script includes a check to verify whether PVCs on the default storage
 class can be bind. If volume claims are unable to be fulfilled, the script will fail,
 displaying:
-`error: timed out waiting for the condition on persistentvolumeclaims/test-pvc`.
+```bash
+error: timed out waiting for the condition on persistentvolumeclaims/test-pvc
+... Test PVC unable to bind on default storage class
+```
 
 If you are using Kind, try to [restart the container](#running-out-of-resources).
 Otherwise, ensure that PVCs (Persistent Volume Claims) can be allocated for the

--- a/deploy-deps.sh
+++ b/deploy-deps.sh
@@ -50,7 +50,8 @@ test_pvc_binding(){
     local pvc_resources="${script_path}/dependencies/pre-deployment-pvc-binding"
     echo "Creating PVC from '$pvc_resources' using the cluster's default storage class"
     kubectl apply -k "$pvc_resources"
-    retry kubectl wait --for=jsonpath='{status.phase}'=Bound pvc/test-pvc -n test-pvc-ns --timeout=20s
+    retry "kubectl wait --for=jsonpath={status.phase}=Bound pvc/test-pvc -n test-pvc-ns --timeout=20s" \
+          "Test PVC unable to bind on default storage class"
     kubectl delete -k "$pvc_resources"
     echo "PVC binding successfull"
 }


### PR DESCRIPTION
The retry format was changed, but the procedure for deploying a test PVC is still using the old format. This change addresses that.