### PR TITLE
Use the "appstudio-pipeline" service account for running pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,10 +612,10 @@ kubectl create -n $NS secret generic regcred \
  --type=kubernetes.io/dockerconfigjson
 ```
 
-2. Add the secret to the namespace's default service account
+2. Add the secret to the namespace's appstudio-pipeline service account
 
 ```bash
-kubectl patch -n $NS serviceaccount default -p '{"secrets": [{"name": "regcred"}]}'
+kubectl patch -n $NS serviceaccount appstudio-pipeline -p '{"secrets": [{"name": "regcred"}]}'
 ```
 
 #### Example - Extract Quay Push Secret:
@@ -668,6 +668,7 @@ the relevant user namespace and repository URL.
 
 kubectl create namespace $NS
 kubectl label namespace "$NS konflux.ci/type=user
+kubectl create serviceaccount appstudio-pipeline -n $NS
 ```
 
 Example:
@@ -675,6 +676,7 @@ Example:
 ```bash
 kubectl create namespace user-ns3
 kubectl label namespace user-ns3 konflux.ci/type=user
+kubectl create serviceaccount appstudio-pipeline -n user-ns3
 ```
 
 #### Granting a User Access to a Namespace

--- a/dependencies/tekton-config/tekton-config.yml
+++ b/dependencies/tekton-config/tekton-config.yml
@@ -19,3 +19,5 @@ spec:
     artifacts.taskrun.format: in-toto
     artifacts.taskrun.storage: ""
     transparency.enabled: "false"
+  pipeline:
+    default-service-account: appstudio-pipeline

--- a/test/resources/demo-users/user/ns2/appstudio-pipeline-sa.yaml
+++ b/test/resources/demo-users/user/ns2/appstudio-pipeline-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: appstudio-pipeline
+  namespace: user-ns2

--- a/test/resources/demo-users/user/ns2/kustomization.yaml
+++ b/test/resources/demo-users/user/ns2/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ns.yaml
   - rbac.yaml
+  - appstudio-pipeline-sa.yaml


### PR DESCRIPTION
Add service account to user-ns2
Update README
Update tektonconfig to use appstudio-pipeline as a default service account

fix #105 