### PR TITLE
chore: create tekton-chains secret in another temp ns

### DIFF
--- a/konflux-ci/rbac/core/tekton-chains.yaml
+++ b/konflux-ci/rbac/core/tekton-chains.yaml
@@ -83,6 +83,69 @@ subjects:
   name: chains-secrets-admin
   namespace: tekton-pipelines
 ---
+# We temporarily create the cosign public key in another namespace
+# For this we need to create ns, role and bindings
+# More details: https://github.com/konflux-ci/konflux-ci/issues/114
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: tekton-chains-public-key-viewer
+  namespace: openshift-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-chains-public-key-viewer
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: chains-secret-admin
+  namespace: openshift-pipelines
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - create
+  - get
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: chains-secret-admin
+  namespace: openshift-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chains-secret-admin
+subjects:
+- kind: ServiceAccount
+  name: chains-secrets-admin
+  namespace: tekton-pipelines
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -130,6 +193,15 @@ spec:
           echo "Generating/updating the secret with the public key"
           kubectl create secret generic public-key \
             --namespace "$namespace" \
+            --from-literal=cosign.pub="$(
+              cosign public-key --key "k8s://$namespace/$secret"
+            )" \
+            --dry-run=client \
+            -o yaml | kubectl apply -f -
+
+          # Temporarily creating the secret also on openshift-pipelines namespace
+          kubectl create secret generic public-key \
+            --namespace openshift-pipelines \
             --from-literal=cosign.pub="$(
               cosign public-key --key "k8s://$namespace/$secret"
             )" \


### PR DESCRIPTION
Create the tekton-chains secret in openshift-pipelines namespace to work around a bug in which the UI looks for the secret on the wrong namespace.