### PR TITLE
doc(RHTAPWATCH-1049): onboard app through the UI

### DIFF
--- a/.github/workflows/check-toc.yaml
+++ b/.github/workflows/check-toc.yaml
@@ -11,11 +11,13 @@ jobs:
 
       - name: Verify ToC
         run: |
-          npx markdown-toc README.md -i
+          find . -name "*.md" | while read -r file; do
+              npx markdown-toc $file -i
+          done
           if [[ $(git status --porcelain) ]]; then
-              echo ERROR: "Did you forget to update the README table of contents?" >&2
-              echo ERROR: "Please run 'npx markdown-toc README.md -i' and update your PR" >&2
+              echo ERROR: "Did you forget to update markdowns table of contents?" >&2
+              echo ERROR: "Check CONTRIBUTING.md for instructions and update your PR" >&2
               git diff >&2
               exit 1
           fi
-          echo "the table of contents is up to date" >&2
+          echo "Markdowns table of contents are up to date" >&2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,21 @@
-# Contributing Guidelines
+Contributing Guidelines
+===
 
-## Editing the README
+<!-- toc -->
 
-If the structure of the README.md file changes, the README table of contents needs to be
-updated as well.
+- [Editing Markdown Files](#editing-markdown-files)
 
-To update it, run the command below and add the README changes to your PR.
+<!-- tocstop -->
+
+# Editing Markdown Files
+
+If the structure of markdown files containing table of contents changes, those
+need to be updated as well.
+
+To do that, run the command below and add the produced changes to your PR.
 
 ```bash
-npx markdown-toc README.md -i
+find . -name "*.md" | while read -r file; do
+    npx markdown-toc $file -i
+done
 ```

--- a/docs/github-secrets.md
+++ b/docs/github-secrets.md
@@ -1,0 +1,25 @@
+Configuring Github Application Secrets
+===
+
+The process of creating a GitHub application is explained in
+[Pipelines-as-Code documentation](https://pipelinesascode.com/docs/install/github_apps/#manual-setup).
+The same secret described there, should be deployed to the `build-service` and
+`integration-service` namespaces as well.
+
+To do that, repeat the `kubectl create secret` command described there for the
+`pipelines-as-code` namespace also to those namespace:
+
+```bash
+kubectl -n pipelines-as-code create secret generic pipelines-as-code-secret \
+...
+```
+
+```bash
+kubectl -n build-service create secret generic pipelines-as-code-secret \
+...
+```
+
+```bash
+kubectl -n integration-service create secret generic pipelines-as-code-secret \
+...
+```

--- a/docs/quay.md
+++ b/docs/quay.md
@@ -1,0 +1,98 @@
+Quay.io Configurations
+===
+
+<!-- toc -->
+
+- [Configuring a Push Secret for the Build Pipeline](#configuring-a-push-secret-for-the-build-pipeline)
+  * [Example - Extract Quay Push Secret:](#example---extract-quay-push-secret)
+- [Configuring a Push Secret for the Release Pipeline](#configuring-a-push-secret-for-the-release-pipeline)
+- [Automatically Provision Quay Repositories for Container Images](#automatically-provision-quay-repositories-for-container-images)
+
+<!-- tocstop -->
+
+# Configuring a Push Secret for the Build Pipeline
+
+After the build-pipeline builds an image, it will try to push it to a container registry.
+If using a registry that requires authentication, the namespace where the pipeline is
+running should be configured with a push secret for the registry.
+
+Tekton provides a way to inject push secrets into pipelines by attaching them to a
+service account.
+
+The service account used for running the pipelines is the namespace's
+`appstudio-pipeline` service account.
+
+1. Create the secret in the pipeline's namespace (see the
+   [example below](#example---extract-quay-push-secret) for extracting the
+   secret):
+
+```bash
+kubectl create -n $NS secret generic regcred \
+ --from-file=.dockerconfigjson=<path/to/.docker/config.json> \
+ --type=kubernetes.io/dockerconfigjson
+```
+
+2. Add the secret to the namespace's appstudio-pipeline service account
+
+```bash
+kubectl patch -n $NS serviceaccount appstudio-pipeline -p '{"secrets": [{"name": "regcred"}]}'
+```
+
+## Example - Extract Quay Push Secret:
+
+If using Quay.io, you can follow the procedure below to obtain the config.json file used
+for creating the secret. If not using quay, apply your registry's equivalent procedure.
+
+1. Log into quay.io and click your user icon on the top-right corner.
+
+2. Select Account Settings.
+
+3. Click on Generate Encrypted Password.
+
+4. Enter your login password and click Verify.
+
+5. Select Docker Configuration.
+
+6. Click Download `<your-username>-auth.json` and take note of the download location.
+
+7. Replace `<path/to/.docker/config.json>` on the `kubectl create secret` command with
+   this path.
+
+# Configuring a Push Secret for the Release Pipeline
+
+If the release pipeline used need to push image to a container registry, it needs to be
+configured with a push secret as well.
+
+In the `managed` namespace, repeat the same steps mentioned
+[above](#configuring-a-push-secret-for-the-build-pipeline) for configuring the push
+secret.
+
+# Automatically Provision Quay Repositories for Container Images
+
+**Note**: This step is mandatory for importing components using the UI.
+
+Konflux integrates with the
+[Image Controller](https://github.com/konflux-ci/image-controller)
+that can automatically create Quay repositories when onboarding a component.
+The image controller requires access to a Quay organization.
+Please follow the following steps for configuring it:
+
+1. [Create a user on Quay.io](https://quay.io/)
+
+2. [Create Quay Organization](https://docs.projectquay.io/use_quay.html#org-create)
+
+3. [Create Application and OAuth access token](https://docs.projectquay.io/use_quay.html#_create_oauth_access_token).
+   The application should have the following permissions:
+   - Administer Organization
+   - Administer Repositories
+   - Create Repositories
+
+4. Run the `deploy-image-controller.sh` script:
+
+`$TOKEN` - the token for the application you've created on step 3.
+
+`$ORGANIZATION` - the name of the organization you created on step 2.
+
+```bash
+./deploy-image-controller.sh $TOKEN $ORGANIZATION
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,199 @@
+Troubleshooting Common Issues
+===
+
+<!-- toc -->
+
+- [Using Podman with Kind while also having Docker Installed](#using-podman-with-kind-while-also-having-docker-installed)
+- [Unknown Field "replacements"](#unknown-field-replacements)
+- [PR changes are not Triggering Pipelines](#pr-changes-are-not-triggering-pipelines)
+- [Setup Scripts or Pipeline Execution Fail](#setup-scripts-or-pipeline-execution-fail)
+  * [Running out of Resources](#running-out-of-resources)
+  * [Unable to Bind PVCs](#unable-to-bind-pvcs)
+  * [Release Fails](#release-fails)
+    + [Common Release Issues](#common-release-issues)
+
+<!-- tocstop -->
+
+# Using Podman with Kind while also having Docker Installed
+
+If you have docker installed, Kind will try to use it by default, so if you want
+it to use Podman, you can do that by creating the cluster with the following command:
+
+```bash
+KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster --name konflux --config kind-config.yaml
+```
+
+# Unknown Field "replacements"
+
+If you get the following error: `error: json: unknown field "replacements"`, while
+executing any of the setup scripts, you will need to update your `kubectl`.
+
+# PR changes are not Triggering Pipelines
+
+Follow this procedure if you create a PR or make changes to a PR and a pipeline is not
+triggered:
+
+1. Confirm that events were logged to the smee channel. if not, verify your steps for
+   setting up the GitHub app and installing the app to your fork repository.
+
+2. Confirm that events are being relayed by the smee client: List the pods under the
+   `smee-client` namespace and check the logs of the pod on the namespace. Those should
+   have mentions of the channel events being forwarded to pipelines-as-code.
+
+```bash
+kubectl get pods -n smee-client
+kubectl logs -n smee-client gosmee-client-<some-id>
+```
+
+3. If the pod is not there or the logs do not include the mentioned entries, confirm you
+   properly set the **smee channel** on the smee-client manifest and that you deploy the
+   manifest to your cluster.
+
+```bash
+kubectl delete -f ./smee/smee-client.yaml
+<fix the manifests>
+kubectl create -f ./smee/smee-client.yaml
+```
+
+**Note:** if the host machine goes to sleep mode, the smee client might stop responding
+to events on the smee channel, once the host is up again. This can be addressed by
+deleting the client pod and waiting for it to be recreated:
+
+```bash
+kubectl get pods -n smee-client
+kubectl delete pods -n smee-client gosmee-client-<some-id>
+```
+
+4. Check the pipelines-as-code logs to see that events are being properly linked to the
+   Repository resource. If you see log entries mentioning a repository resource cannot
+   be found, compare the repository mentioned on the logs to the one deployed when
+   creating the application and component resources. Fix the Repository resource manifest and redeploy it.
+
+   **Note:** this should only be relevant if the application was onboarded manually
+   (i.e. not using the Konflux UI).
+
+```bash
+kubectl get pods -n pipelines-as-code
+kubectl logs -n pipelines-as-code pipelines-as-code-controller-<some-id>
+<fix the manifests>
+kubectl apply -f ./test/resources/demo-users/user/ns2/application-and-component.yaml
+```
+
+5. If the pipelines-as-code logs mention secret `pipelines-as-code-secret` is
+   missing/malformed, make sure you created the secret for the GitHub app, providing
+   values for fields `github-private-key`, `github-application-id` and `webhook.secret`
+   for the app your created. If the secret needs to be fixed, delete it (see command
+   below) and deploy it once more based on the Pipelines as Code
+   [instructions](../README.md#enable-pipelines-triggering-via-webhooks).
+
+```bash
+kubectl delete secret pipelines-as-code-secret -n pipelines-as-code
+```
+
+6. On the PR page, type `/retest` on the comment box and post the comment. Observe the
+   behavior once more.
+
+# Setup Scripts or Pipeline Execution Fail
+
+## Running out of Resources
+
+If setup scripts fail or pipelines are stuck or tend to fail at relatively random
+stages, it might be that the cluster is running out of resources.
+
+That could be:
+
+* Open files limit.
+* Open threads limit.
+* Cluster running out of memory.
+
+For mitigation steps, consult the notes at the top of the
+[cluster setup instructions](../README.md#bootstrapping-the-cluster).
+
+As last resort, you could restart the container running the cluster node. If you do
+that, you'd have to, once more, increase the PID limit for that container as explained
+in the [cluster setup instructions](../README.md#bootstrapping-the-cluster).
+
+To restart the container (if using Docker, replace `podman` with `docker`):
+
+```bash
+podman restart konflux-control-plane
+```
+
+**Note:** It might take a few minutes for the UI to become available once the container
+is restarted.
+
+## Unable to Bind PVCs
+The `deploy-deps.sh` script includes a check to verify whether PVCs on the default
+storage class can be bind. If volume claims are unable to be fulfilled, the script will
+fail, displaying:
+
+```bash
+error: timed out waiting for the condition on persistentvolumeclaims/test-pvc
+... Test PVC unable to bind on default storage class
+```
+
+If using Kind, try to [restart the container](#running-out-of-resources). Otherwise,
+ensure that PVCs (Persistent Volume Claims) can be allocated for the cluster's default
+storage class.
+
+## Release Fails
+
+If a release is triggered, but then fails, check the logs of the pods on the managed
+namespace (e.g. `managed-ns2`).
+
+List the pods and look for ones with status `Error`:
+
+```bash
+kubectl get pods -n managed-ns2
+```
+
+Check the logs of the pods with status `Error`:
+
+```bash
+kubectl logs -n managed-ns2 managed-7lxdn-push-snapshot-pod
+```
+
+Compare the logs to the [common release issues](#common-release-issues) below.
+
+Once you addressed the issue, create a PR and merge it, or directly push a change to the
+main branch, so that the on-push pipeline is triggered.
+
+### Common Release Issues
+
+The logs contain statements similar to this:
+
+```bash
+++ jq -r .containerImage
+parse error: Unfinished string at EOF at line 2, column 0
+```
+
+**Solution**: Verify that you provided a value to the `repository` field inside the
+[rpa.yaml file](../test/resources/demo-users/user/managed-ns2/rpa.yaml).
+
+Complete the value and redeploy the manifest:
+
+```bash
+kubectl apply -k ./test/resources/demo-users/user/managed-ns2
+```
+
+The logs contain statements similar to this:
+
+```bash
+Error: PUT https://quay.io/...: unexpected status code 400 Bad Request: <html>
+<head><title>400 Bad Request</title></head>
+<body>
+<center><h1>400 Bad Request</h1></center>
+</body>
+</html>
+
+main.go:74: error during command execution: PUT https://quay.io/...: unexpected status code 400 Bad Request: <html>
+<head><title>400 Bad Request</title></head>
+<body>
+<center><h1>400 Bad Request</h1></center>
+</body>
+</html>
+```
+
+**Solution**: verify that you
+[created the registry secret](./quay.md#configuring-a-push-secret-for-the-release-pipeline)
+also for the managed namespace.


### PR DESCRIPTION
Split the onboarding process to two options.
Move some of the common tasks to separate files to keep the README from exploding.

closes: #121 
closes: #125 