### PR TITLE
fix(RHTAPWATCH-1042): Remove mentions of private repos (git, quay) from all namespace files (e.g. ns1)

### DIFF
--- a/test/resources/demo-users/user/managed-ns1/rpa.yaml
+++ b/test/resources/demo-users/user/managed-ns1/rpa.yaml
@@ -16,14 +16,14 @@ spec:
     mapping:
       components:
         - name: sample-component
-          repository: "quay.io/gbenhaim0/managed/sample-component"
+          repository: <repository url>
   origin: user-ns1
   pipeline:
     pipelineRef:
       resolver: git
       params:
         - name: url
-          value: "https://github.com/gbenhaim/release-service-catalog.git"
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
         - name: revision
           value: f345fc8dcb855666200c5f21d12a9e02fd7ab791
         - name: pathInRepo

--- a/test/resources/demo-users/user/ns1/build-pipeline.yaml
+++ b/test/resources/demo-users/user/ns1/build-pipeline.yaml
@@ -20,9 +20,9 @@ spec:
   - name: dockerfile
     value: Dockerfile
   - name: git-url
-    value: https://github.com/gbenhaim/sample-component.git
+    value: <Git repository URL>
   - name: output-image
-    value: quay.io/gbenhaim0/sample-component:main
+    value: <Image repository URL>
   - name: path-context
     value: .
   - name: revision

--- a/test/resources/demo-users/user/ns1/ec-integration-test.yaml
+++ b/test/resources/demo-users/user/ns1/ec-integration-test.yaml
@@ -17,9 +17,9 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/gbenhaim/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
-        value: 997f4b966aae7d65e958e63ff5b1dbdd58e4dbc6
+        value: f3ac40bbc0230eccb8d98a4d54dabd55a4943c5d
       - name: pathInRepo
         value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/test/resources/demo-users/user/ns2/ec-integration-test.yaml
+++ b/test/resources/demo-users/user/ns2/ec-integration-test.yaml
@@ -17,9 +17,9 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/gbenhaim/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
-        value: 997f4b966aae7d65e958e63ff5b1dbdd58e4dbc6
+        value: f3ac40bbc0230eccb8d98a4d54dabd55a4943c5d
       - name: pathInRepo
         value: pipelines/enterprise-contract.yaml
     resolver: git


### PR DESCRIPTION
- Remove private git repositories
- fix [#53](https://github.com/konflux-ci/konflux-ci/issues/53)