### PR TITLE
Migrate build-definitions redhat-appstudio images

### DIFF
--- a/konflux-ci/build-service/build-pipeline-config.yaml
+++ b/konflux-ci/build-service/build-pipeline-config.yaml
@@ -8,6 +8,6 @@ data:
     default-pipeline-name: docker-build
     pipelines:
     - name: fbc-builder
-      bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-fbc-builder:668382ea32335cecf67d89953b59f27ab994f3c7
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-fbc-builder:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9
     - name: docker-build
-      bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-docker-build:668382ea32335cecf67d89953b59f27ab994f3c7
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9

--- a/konflux-ci/build-service/core/appstudio.redhat.com_v1alpha1_buildpipelineselector_build-pipeline-selector.yaml
+++ b/konflux-ci/build-service/core/appstudio.redhat.com_v1alpha1_buildpipelineselector_build-pipeline-selector.yaml
@@ -13,7 +13,7 @@ spec:
       - name: name
         value: fbc-builder
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-fbc-builder:6c0dade45d84fd1244da79db04a97f1a846d273c
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-fbc-builder:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9
       - name: kind
         value: pipeline
       resolver: bundles
@@ -25,7 +25,7 @@ spec:
       - name: name
         value: docker-build
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-docker-build:6c0dade45d84fd1244da79db04a97f1a846d273c
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9
       - name: kind
         value: pipeline
       resolver: bundles
@@ -37,7 +37,7 @@ spec:
       - name: name
         value: java-builder
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-java-builder:6c0dade45d84fd1244da79db04a97f1a846d273c
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-java-builder:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9
       - name: kind
         value: pipeline
       resolver: bundles
@@ -49,7 +49,7 @@ spec:
       - name: name
         value: nodejs-builder
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-nodejs-builder:6c0dade45d84fd1244da79db04a97f1a846d273c
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-nodejs-builder:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9
       - name: kind
         value: pipeline
       resolver: bundles

--- a/konflux-ci/enterprise-contract/core/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_all.yaml
+++ b/konflux-ci/enterprise-contract/core/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_all.yaml
@@ -17,7 +17,7 @@ spec:
       include:
       - '*'
     data:
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:

--- a/konflux-ci/enterprise-contract/core/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
+++ b/konflux-ci/enterprise-contract/core/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
@@ -17,7 +17,7 @@ spec:
       include:
       - '@slsa3'
     data:
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:

--- a/konflux-ci/enterprise-contract/core/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-no-hermetic.yaml
+++ b/konflux-ci/enterprise-contract/core/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-no-hermetic.yaml
@@ -19,7 +19,7 @@ spec:
       include:
       - '@redhat'
     data:
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:

--- a/konflux-ci/enterprise-contract/core/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat.yaml
+++ b/konflux-ci/enterprise-contract/core/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat.yaml
@@ -16,7 +16,7 @@ spec:
       include:
       - '@redhat'
     data:
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:

--- a/konflux-ci/enterprise-contract/core/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_slsa3.yaml
+++ b/konflux-ci/enterprise-contract/core/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_slsa3.yaml
@@ -18,7 +18,7 @@ spec:
       - '@minimal'
       - '@slsa3'
     data:
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:

--- a/konflux-ci/rbac/core/tekton-chains.yaml
+++ b/konflux-ci/rbac/core/tekton-chains.yaml
@@ -207,7 +207,7 @@ spec:
             )" \
             --dry-run=client \
             -o yaml | kubectl apply -f -
-        image: quay.io/redhat-appstudio/appstudio-utils:dbbdd82734232e6289e8fbae5b4c858481a7c057
+        image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
         imagePullPolicy: Always
         name: chains-secret-generation
         resources:

--- a/test/resources/demo-users/user/managed-ns1/ec-policy.yaml
+++ b/test/resources/demo-users/user/managed-ns1/ec-policy.yaml
@@ -16,7 +16,7 @@ spec:
       include:
       - '@slsa3'
     data:
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:

--- a/test/resources/demo-users/user/managed-ns2/ec-policy.yaml
+++ b/test/resources/demo-users/user/managed-ns2/ec-policy.yaml
@@ -16,7 +16,7 @@ spec:
       include:
       - '@slsa3'
     data:
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:


### PR DESCRIPTION
STONEBLD-2339

All the images built in build-definitions CI now get released to the
quay.io/konflux-ci organization.

Replace the relevant redhat-appstudio[-tekton-catalog] references in
this repo with konflux-ci[/tekton-catalog] references.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
