### PR TITLE
fix: release service config name

### DIFF
--- a/konflux-ci/release/core/release-service-config.yaml
+++ b/konflux-ci/release/core/release-service-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleaseServiceConfig
 metadata:
-  name: config
+  name: release-service-config
   namespace: release-service
 spec:
   debug: false

--- a/test/resources/demo-users/user/managed-ns2/rpa.yaml
+++ b/test/resources/demo-users/user/managed-ns2/rpa.yaml
@@ -23,7 +23,7 @@ spec:
       resolver: git
       params:
         - name: url
-          value: "https://github.com/gbenhaim/release-service-catalog.git"
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
         - name: revision
           value: production
         - name: pathInRepo


### PR DESCRIPTION
The name of the release service config resource that is expected during the release pipeline has changed. This change addresses that. We also move to using the upstream release pipeline as it is no longer needed to use a modified version of it.