### PR TITLE
Show the user's first and last name on the UI

### DIFF
--- a/dependencies/keycloak/deployment/configure-keycloak.yaml
+++ b/dependencies/keycloak/deployment/configure-keycloak.yaml
@@ -41,6 +41,33 @@ spec:
   keycloakCRName: keycloak
   realm:
     clientScopes:
+      - name: first-and-last-name
+        protocol: openid-connect
+        protocolMappers:
+          - name: first_name
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            config:
+              user.attribute: firstName
+              claim.name: first_name
+              jsonType.label: String
+              id.token.claim: 'true'
+              access.token.claim: 'true'
+              lightweight.claim: 'false'
+              userinfo.token.claim: 'true'
+              introspection.token.claim: 'true'
+          - name: last_name
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            config:
+              user.attribute: lastName
+              claim.name: last_name
+              jsonType.label: String
+              id.token.claim: 'true'
+              access.token.claim: 'true'
+              lightweight.claim: 'false'
+              userinfo.token.claim: 'true'
+              introspection.token.claim: 'true'
       - name: aud 
         protocol: openid-connect
         attributes:
@@ -345,6 +372,7 @@ spec:
           - roles
           - email
           - aud
+          - first-and-last-name
         implicitFlowEnabled: false
         secret: client-secret
         publicClient: true


### PR DESCRIPTION
There was bug where the user's first and last name were not visible in the UI since they weren't included in the JWT token. Include the "first_name" and "last_name" claims in the JWT token.

![image](https://github.com/konflux-ci/konflux-ci/assets/17479229/afcb3923-8f65-4770-86d2-74234353dbeb)
