### PR TITLE
Add mise configuration for tool autmation

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+kind = "0.22.0"
+kubectl = "1.30.0"


### PR DESCRIPTION
Using [mise][1] to setup kind and kubectl.

[1]: https://mise.jdx.dev/