### PR TITLE
Use ClusterIP service for keycloak's DB

### DIFF
--- a/dependencies/keycloak/deployment/db.yaml
+++ b/dependencies/keycloak/deployment/db.yaml
@@ -45,7 +45,7 @@ metadata:
 spec:
   selector:
     app: postgresql-db
-  type: LoadBalancer
+  type: ClusterIP
   ports:
   - port: 5432
     targetPort: 5432


### PR DESCRIPTION
It shouldn't use a load balancer since it shouldn't be accessed from outside of the cluster.