### PR TITLE
chore: ensure logs are generated on task failure

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -48,5 +48,6 @@ jobs:
           ./deploy-test-resources.sh
       
       - name: Generate error logs
+        if: ${{ !cancelled() }}
         run: |
           ./generate-err-logs.sh


### PR DESCRIPTION
ensures the `Generate error logs` step executes even, even if some of the tasks fail.