### PR TITLE
fix: explicitly create default sa for test pvc

### DIFF
--- a/dependencies/pre-deployment-pvc-binding/pre-deployment-pvc-binding.yaml
+++ b/dependencies/pre-deployment-pvc-binding/pre-deployment-pvc-binding.yaml
@@ -4,6 +4,15 @@ kind: Namespace
 metadata:
   name: test-pvc-ns
 ---
+# The pod sometimes fails to be created as it depends on the default SA to be created
+# for the new namespace, which causes the retry command to fail immediately.
+# So, creating it here explicitly to avoid this.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: test-pvc-ns
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:


### PR DESCRIPTION
Explicitly create the default service account for the namespace in which the test PVC is created. This is to avoid cases when it takes too long for that service account to be created, causing creating of the test pod to fail, requiring the user to run deploy-deps again.

closes: #161 