### PR TITLE
docs: 404 Not Found when creating application

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ to configure a Quay.io application and deploy `image-controller`.
 7. Under the Pipeline drop-down list, select `docker-build`.
 8. Click `Create application`.
 
+**NOTE:** If you encounter `404 Not Found` error, refer to the
+[troubleshooting guide](./docs/troubleshooting.md#unable-to-create-application-with-component-using-the-konflux-ui).
+
 The UI should now display the Lifecycle diagram for your application. In the Components
 tab you should be able to see your component listed and you'll be prompted to merge the
 automatically-created Pull Request (don't do that just yet).
@@ -509,7 +512,7 @@ E.g. [Docker Hub](https://hub.docker.com/), [Quay.io](https://quay.io/repository
 You can add integration tests either via the Konflux UI, or by applying the equivalent
 Kubernetes resource.
 
-**NOTE:** If you have imported your component via the UI, a similiar Integration Test is
+**NOTE:** If you have imported your component via the UI, a similar Integration Test is
 pre-installed.
 
 In our case, the resource is defined in

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,6 +6,7 @@ Troubleshooting Common Issues
 - [Using Podman with Kind while also having Docker Installed](#using-podman-with-kind-while-also-having-docker-installed)
 - [Unknown Field "replacements"](#unknown-field-replacements)
 - [Restarting the Cluster](#restarting-the-cluster)
+- [Unable to Create Application with Component Using the Konflux UI](#unable-to-create-application-with-component-using-the-konflux-ui)
 - [PR changes are not Triggering Pipelines](#pr-changes-are-not-triggering-pipelines)
 - [Setup Scripts Fail or Pipeline Execution Stuck or Fails](#setup-scripts-fail-or-pipeline-execution-stuck-or-fails)
   * [Running out of Resources](#running-out-of-resources)
@@ -55,6 +56,14 @@ podman restart konflux-control-plane
 
 **Note:** It might take a few minutes for the UI to become available once the container
 is restarted.
+
+# Unable to Create Application with Component Using the Konflux UI
+
+If you see error `404 Not Found` when trying to create an Application with a Component
+using the Konflux UI, this is most probably because image-controller was not properly
+installed before trying to onboard the application. Refer to the Quay.io application
+[setup step](../README.md#option-1-onboard-application-with-the-konflux-ui) and try
+again.
 
 # PR changes are not Triggering Pipelines
 


### PR DESCRIPTION
If quay setup is skipped, the user will encounter a 404 Not Found error when trying to create an application. This change documents that.

closes: #150 