### PR TITLE
doc: list supported platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ your local machine.
 
 ## Machine Minimum Requirements
 
+The deployment is currently only supported on **x86_64 Linux** platforms.
+
 The deployment requires the following **free** resources:
 
 **CPU**: 4 cores\


### PR DESCRIPTION
Users mentioned they are unable to deploy on ARM macos, so we should specify that we only support x86_64 Linux at the moment.