### PR TITLE
fix: undo adding of default service account

### DIFF
--- a/dependencies/pre-deployment-pvc-binding/pre-deployment-pvc-binding.yaml
+++ b/dependencies/pre-deployment-pvc-binding/pre-deployment-pvc-binding.yaml
@@ -4,15 +4,6 @@ kind: Namespace
 metadata:
   name: test-pvc-ns
 ---
-# The pod sometimes fails to be created as it depends on the default SA to be created
-# for the new namespace, which causes the retry command to fail immediately.
-# So, creating it here explicitly to avoid this.
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: default
-  namespace: test-pvc-ns
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:


### PR DESCRIPTION
There was a bug in which the default service account was sometimes created too late when testing creation of PVC. To address that, we're now creating the SA explicitly.

Having said that, there's still seem to be a race condition between the time the SA is created automatically and explicitly, which now causes the opposite error: serviceaccounts "default" already exists.

closes: #206 