### PR TITLE
feat: e2e test

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -1,11 +1,19 @@
 name: Sanity Test
 
-on: pull_request
+on: pull_request_target
 
 jobs:
   sanity-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+          
+          docker-images: false
       - name: Checkout Repository
         uses: actions/checkout@v3
   
@@ -35,6 +43,15 @@ jobs:
         run: |
           ./wait-for-all.sh
 
+      - name: WORKAROUND - Set up tkn cli for the following task
+        uses: tektoncd/actions/setup-tektoncd-cli@main
+        with:
+          version: latest
+
+      - name: WORKAROUND - Remove clair-scan task from docker-pipeline
+        run: |
+          ./test/e2e/customize-docker-pipeline.sh
+
       - name: Deploying Konflux
         run: |
           ./deploy-konflux.sh
@@ -46,6 +63,25 @@ jobs:
       - name: Deploy test resources
         run: |
           ./deploy-test-resources.sh
+
+      - name: Prepare resources for E2E tests
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          APP_WEBHOOK_SECRET: ${{ secrets.APP_WEBHOOK_SECRET }}
+          QUAY_ORG: ${{ secrets.QUAY_ORG }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+          SMEE_CHANNEL: ${{ secrets.SMEE_CHANNEL }}
+        run: |
+          ./test/e2e/prepare-e2e.sh
+
+      - name: Run E2E tests
+        env:
+          GH_ORG: ${{ secrets.GH_ORG }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          QUAY_DOCKERCONFIGJSON: ${{ secrets.QUAY_DOCKERCONFIGJSON }}
+        run: |
+          ./test/e2e/run-e2e.sh
       
       - name: Generate error logs
         if: ${{ !cancelled() }}

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -1,6 +1,8 @@
 name: Sanity Test
 
-on: pull_request_target
+on:
+  pull_request_target:
+    types: [auto_merge_enabled]
 
 jobs:
   sanity-test:

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -16,6 +16,8 @@ jobs:
           docker-images: false
       - name: Checkout Repository
         uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.pull_request.head.sha }}"
   
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,10 @@ Contributing Guidelines
 
 - [Editing Markdown Files](#editing-markdown-files)
 - [Using KubeLinter](#using-kubelinter)
+- [Running E2E test](#running-e2e-test)
+  * [Prerequisites](#prerequisites)
+  * [Setup](#setup)
+  * [Running the test](#running-the-test)
 
 <!-- tocstop -->
 
@@ -42,3 +46,50 @@ finally, run `kube-linter lint ./.kube-linter` to recursively apply KubeLinter c
 It may be also recommended to create a configuration file. To do so please check
 [KubeLinter config documentation](https://docs.kubelinter.io/#/configuring-kubelinter)
 this file will allow you to ignore or include specific KubeLinter checks.
+
+# Running E2E test
+In order to validate changes quicker, it is possible to run E2E test, which validates that:
+* Application and Component can be created
+* Build PipelineRun is triggered and can finish successfully
+* Integration test gets triggered and finishes successfully
+* Application Snapshot can be released successfully
+
+## Prerequisites
+* Fork of https://github.com/konflux-ci/testrepo is created and your GitHub App is installed there
+* Konflux is deployed on `kind` cluster (follow the guide in README)
+* quay.io organization that has `test-images` repository created, with robot account that has admin access to that repo
+
+## Setup
+Export following environment variables
+```
+# quay.io org where the built and released image will be pushed to
+export QUAY_ORG="" \
+# quay.io org OAuth access token
+QUAY_TOKEN="" \
+# Content of quay.io credentials config generated (ideally) for the robot account 
+# that has access to $QUAY_ORG/test-images repository
+QUAY_DOCKERCONFIGJSON="$(< /path/to/docker/config.json)" \
+# Your GitHub App's ID
+APP_ID="" \
+# Your GitHub App's private key
+APP_PRIVATE_KEY="" \
+# Your GitHub App's webhook secret
+APP_WEBHOOK_SECRET="" \
+# URL of the smee.io channel you created
+SMEE_CHANNEL="" \
+# Name of the GitHub org/username where the https://github.com/konflux-ci/testrepo is forked
+GH_ORG="" \
+# GitHub token with permissions to merge PRs in your GH_ORG
+GH_TOKEN=""
+```
+
+## Running the test
+
+Run (from the root of the repository directory):
+```
+./deploy-test-resources.sh
+./test/e2e/prepare-e2e.sh
+./test/e2e/run-e2e.sh
+```
+
+The source code of the test is located [.](https://github.com/konflux-ci/e2e-tests/tree/main/tests/konflux-demo)

--- a/test/e2e/customize-docker-pipeline.sh
+++ b/test/e2e/customize-docker-pipeline.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+set -x
+
+script_path="$(dirname -- "${BASH_SOURCE[0]}")"
+
+main() {
+    echo "Updating docker-build pipeline to workaround issue with clair-scan" >&2
+    # shellcheck disable=SC1091
+    source "${script_path}/vars.sh"
+    local original_docker_build_bundle_ref
+
+    # This is required in order to push the modified pipeline to local registry
+    kubectl port-forward -n kind-registry svc/registry-service 30001:80 &
+    original_docker_build_bundle_ref=$(yq ".data[\"config.yaml\"]" konflux-ci/build-service/build-pipeline-config.yaml | yq ".pipelines[] | select(.name == \"docker-build\").bundle")
+    # Remove the problematic "clair-scan" task from the docker pipeline
+    tkn bundle list "$original_docker_build_bundle_ref" -o yaml | yq 'del(.spec.tasks[] | select(.name == "clair-scan"))' > "/tmp/customized-docker-pipeline.yaml"
+    tkn bundle push "$CUSTOMIZED_DOCKER_PIPELINE_IMAGE_REF_LOCALHOST" -f "/tmp/customized-docker-pipeline.yaml"
+    # Update the bundle ref in build-service pipeline configmap
+    sed -i "s|bundle:.*docker-build.*|bundle: ${CUSTOMIZED_DOCKER_PIPELINE_IMAGE_REF_CLUSTER}|g" konflux-ci/build-service/build-pipeline-config.yaml
+}
+
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/test/e2e/prepare-e2e.sh
+++ b/test/e2e/prepare-e2e.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+script_path="$(dirname -- "${BASH_SOURCE[0]}")"
+
+main() {
+    echo "Preparing resources for E2E tests" >&2
+    local quay_token="${QUAY_TOKEN:?A token for quay should be provided}"
+    local quay_org=${QUAY_ORG:?Quay organization name should be provided}
+    local app_private_key=${APP_PRIVATE_KEY:?GitHub App private key should be provided}
+    local app_id=${APP_ID:?GitHub App ID should be provided}
+    local app_webhook_secret=${APP_WEBHOOK_SECRET:?GitHub App webhook secret should be provided}
+    local smee_channel=${SMEE_CHANNEL:?Link to the smee.io channel should be provided}
+
+    "${script_path}/../../deploy-image-controller.sh" "$quay_token" "$quay_org"
+    for ns in pipelines-as-code build-service integration-service; do 
+        kubectl -n $ns create secret generic pipelines-as-code-secret \
+        --from-literal github-private-key="$app_private_key" \
+        --from-literal github-application-id="$app_id" \
+        --from-literal webhook.secret="$app_webhook_secret"; done
+    sed -i "s|<smee-channel>|$smee_channel|g" "${script_path}/../../smee/smee-client.yaml"
+    kubectl create -f "${script_path}/../../smee/smee-client.yaml"
+}
+
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/test/e2e/run-e2e.sh
+++ b/test/e2e/run-e2e.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+script_path="$(dirname -- "${BASH_SOURCE[0]}")"
+
+main() {
+    echo "Running E2E tests" >&2
+    # shellcheck disable=SC1091
+    source "${script_path}/vars.sh"
+    local github_org="${GH_ORG:?A GitHub org where the https://github.com/redhat-appstudio-qe/konflux-ci-sample repo is present/forked should be provided}"
+    local github_token="${GH_TOKEN:?A GitHub token should be provided}"
+    local quay_dockerconfig="${QUAY_DOCKERCONFIGJSON:?quay.io credentials in .dockerconfig format should be provided}"
+    docker run --network=host -v ~/.kube/config:/kube/config --env KUBECONFIG=/kube/config -e GITHUB_TOKEN="$github_token" -e QUAY_TOKEN="$(base64 <<< "$quay_dockerconfig")" -e MY_GITHUB_ORG="$github_org" -e E2E_APPLICATIONS_NAMESPACE=user-ns2 "$E2E_TEST_IMAGE" "--ginkgo.label-filter=upstream-konflux" "--ginkgo.focus=Test local" "--ginkgo.v"
+}
+
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/test/e2e/vars.sh
+++ b/test/e2e/vars.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+export E2E_TEST_IMAGE CUSTOMIZED_DOCKER_PIPELINE_IMAGE_REF_LOCALHOST CUSTOMIZED_DOCKER_PIPELINE_IMAGE_REF_CLUSTER
+
+E2E_TEST_IMAGE=quay.io/konflux-ci/e2e-tests:5de23fe3dd41985e6ea1039f053f4165a60a414c
+CUSTOMIZED_DOCKER_PIPELINE_IMAGE_REF_LOCALHOST="localhost:30001/test/test:customized-docker-pipeline"
+CUSTOMIZED_DOCKER_PIPELINE_IMAGE_REF_CLUSTER="registry-service.kind-registry.svc.cluster.local/test/test:customized-docker-pipeline"


### PR DESCRIPTION
### Description
Add e2e test for validating the build->integration-test->release scenario (similar to the one described in the [readme of this repo](https://github.com/konflux-ci/konflux-ci?tab=readme-ov-file#onboard-a-new-application))

The test is using https://github.com/konflux-ci/testrepo as a component repository and this GitHub app: https://github.com/apps/konflux-ci-test-app

### Notes:
There are currently [issues with running `clair-scan` task in github actions](https://github.com/konflux-ci/konflux-ci/issues/241) (see comments below for more info). The task just hangs in `Running` state until it times out (after 1h). Due to that I introduced a workaround to temporarily remove this task from the build pipeline.

### Current status
* ~after rebase the test is failing on `"couldn't get the secret public-key from openshift-pipelines namespace: secrets \"public-key\" not found"` (see the checkrun [here](https://github.com/psturc/konflux-ci/actions/runs/10071422234/job/27842067606?pr=6)) - probably due to issue https://github.com/konflux-ci/konflux-ci/issues/240~
* since this PR introduces `pull_request_target` type of workflow (due to fact that it requires to load repository secrets like github app ID, private key etc.), the workflow **can't be tested in this PR**, because `pull_request_target` expects this type of workflow to be present on the base (`main`) branch.