### PR TITLE
renovate: Mention packageNameTemplate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,8 @@
         "newTag:\\s+(?<currentDigest>[a-f0-9]{40})"
       ],
       "datasourceTemplate": "git-refs",
-      "currentValueTemplate": "main"
+      "currentValueTemplate": "main",
+      "packageNameTemplate": "{{{ packageName }}}"
     }
   ]
 }


### PR DESCRIPTION
By explicitly setting the "packageNameTemplate" its value will be used for each dependency matched using the match strings.