### PR TITLE
Renovate add manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,12 +6,21 @@
       "customType": "regex",
       "fileMatch": ["(^|\/)kustomization\\.(yaml|yml)$"],
       "matchStrings": [
-        "- (?<pName>https:\/\/github\\.com\/[^/]+\/[^/]+)\/.*\\?ref=(?<currentDigest>[a-f0-9]{40})",
+        "- (?<packageName>https:\/\/github\\.com\/[^/]+\/[^/]+)\/.*\\?ref=(?<currentDigest>[a-f0-9]{40})"
+      ],
+      "datasourceTemplate": "git-refs",
+      "currentValueTemplate": "main"
+    },
+    {
+      "customType": "regex",
+      "matchStringsStrategy": "combination",
+      "fileMatch": ["(^|\/)kustomization\\.(yaml|yml)$"],
+      "matchStrings": [
+        "- (?<packageName>https:\/\/github\\.com\/[^/]+\/[^/]+)\/.*\\?ref=[a-f0-9]{40}",
         "newTag:\\s+(?<currentDigest>[a-f0-9]{40})"
       ],
       "datasourceTemplate": "git-refs",
-      "currentValueTemplate": "main",
-      "packageNameTemplate": "{{ pName }}"
+      "currentValueTemplate": "main"
     }
   ]
 }


### PR DESCRIPTION
A single manager can't update both the reference to the manifests and image in the kustomization file.