### PR TITLE
add self-signed certificate to local registry

### DIFF
--- a/dependencies/cert-manager/self-signed-cluster-issuer.yaml
+++ b/dependencies/cert-manager/self-signed-cluster-issuer.yaml
@@ -1,7 +1,0 @@
----
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: self-signed-cluster-issuer
-spec:
-  selfSigned: {}

--- a/dependencies/registry/certificate.yaml
+++ b/dependencies/registry/certificate.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: registry-cert
+  namespace: kind-registry
+spec:
+  isCA: true
+  subject:
+    organizations:
+      - konflux
+  dnsNames:
+  - localhost
+  - registry-service.kind-registry
+  issuerRef:
+    kind: ClusterIssuer
+    name: self-signed-cluster-issuer
+  secretName: local-registry-tls
+  

--- a/dependencies/registry/kustomization.yml
+++ b/dependencies/registry/kustomization.yml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - registry.yaml
+  - certificate.yaml

--- a/dependencies/registry/registry.yaml
+++ b/dependencies/registry/registry.yaml
@@ -29,6 +29,18 @@ spec:
         image: registry:2
         ports:
         - containerPort: 5000
+        env:
+        - name: REGISTRY_HTTP_TLS_CERTIFICATE
+          value: "/certs/tls.crt"
+        - name: REGISTRY_HTTP_TLS_KEY
+          value: "/certs/tls.key"
+        volumeMounts:
+        - name: certs
+          mountPath: /certs
+      volumes:
+        - name: certs
+          secret:
+            secretName: local-registry-tls
 ---
 apiVersion: v1
 kind: Service
@@ -42,5 +54,5 @@ spec:
   ports:
     - protocol: TCP
       nodePort: 30001
-      port: 80
+      port: 443
       targetPort: 5000


### PR DESCRIPTION
This will eventually be used for allowing a flow that uses the internal registry instead of quay.io, which should be easier to follow.

Note: this PR is opened toward a feature branch (not main). It can potentially break the e2e flow. The e2e flow will be verified before this is merged to main.