### PR TITLE
fix: tekton-chains job fails to start

### DIFF
--- a/konflux-ci/rbac/core/tekton-chains.yaml
+++ b/konflux-ci/rbac/core/tekton-chains.yaml
@@ -220,6 +220,8 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          runAsGroup: 1001
+          runAsUser: 1001
       dnsPolicy: ClusterFirst
       restartPolicy: OnFailure
       serviceAccount: chains-secrets-admin


### PR DESCRIPTION
Configuring the job to run as non-root caused it to fail to start. Setting a specific user should address this.

closes: #240 