### PR TITLE
Remove runAsUser from UI deployments

### DIFF
--- a/konflux-ci/ui/core/chrome/chrome-frontend.yaml
+++ b/konflux-ci/ui/core/chrome/chrome-frontend.yaml
@@ -82,7 +82,6 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: 1001
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/konflux-ci/ui/core/hac/hac-core-frontend.yaml
+++ b/konflux-ci/ui/core/hac/hac-core-frontend.yaml
@@ -81,7 +81,6 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: 1001
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/konflux-ci/ui/core/hac/hac-dev.yaml
+++ b/konflux-ci/ui/core/hac/hac-dev.yaml
@@ -82,7 +82,6 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: 1001
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/konflux-ci/ui/core/proxy/proxy.yaml
+++ b/konflux-ci/ui/core/proxy/proxy.yaml
@@ -43,7 +43,6 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          runAsUser: 1001
         resources:
           limits:
             cpu: 50m
@@ -73,7 +72,6 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          runAsUser: 1001
         resources:
           limits:
             cpu: 50m
@@ -136,7 +134,6 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          runAsUser: 1001
       - image: quay.io/redhat-user-workloads/rhtap-o11y-tenant/workspace-manager/workspace-manager:06df38da81280ba2cf6b4a532d494f1ead8670fe
         name: workspace-manager
         ports:
@@ -153,7 +150,6 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          runAsUser: 1001
       - image: quay.io/oauth2-proxy/oauth2-proxy@sha256:3da33b9670c67bd782277f99acadf7026f75b9507bfba2088eb2d497266ef7fc
         name: oauth2-proxy
         args:
@@ -195,7 +191,6 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          runAsUser: 1001
       volumes:
         - configMap:
             defaultMode: 420


### PR DESCRIPTION
In Openshift, additional Security context constraint should be applied on the service account to run with user outside the range [1001080000, 1001089999].

Remove the use of user 1001 from the UI deployments to be compatible with the deployment on Openshift.

When running on k8s, it's not required to use user 1001.