### PR TITLE
feat: rewrite conditions for running sanity test

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -2,11 +2,32 @@ name: Sanity Test
 
 on:
   pull_request_target:
-    types: [auto_merge_enabled]
+    types: [opened, synchronize, reopened, labeled]
   merge_group:
     types: [checks_requested]
 jobs:
+  check-org-membership:
+    runs-on: ubuntu-latest
+    outputs:
+      org-member: ${{ steps.org-check.outputs.org-member }}
+    steps:
+      - name: Check if PR author is a member of the organization
+        continue-on-error: true
+        id: org-check
+        run: |
+          ORG="${{ github.repository_owner }}"
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+          if ! gh api /orgs/$ORG/members/$AUTHOR; then
+            echo '### ❌ PR author is not a member of GitHub organization' >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+          echo "org-member=true" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
   sanity-test:
+    if: ${{ (needs.check-org-membership.outputs.org-member == 'true') || (github.event.pull_request.user.login == 'renovate[bot]') || contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
+    needs: check-org-membership
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)


### PR DESCRIPTION
run if:
* a PR author is a member of the organization
* or a PR author is "renovate[bot]"
* or a PR contains "ok-to-test" label

closes https://github.com/konflux-ci/konflux-ci/issues/254

PR for testing org membership: https://github.com/psturc-org/konflux-ci/pull/7
PR for testing "ok-to-test" label presence: https://github.com/psturc-org/konflux-ci/pull/8