### PR TITLE
chore(RHTAPWATCH-1110): solve KubeLinter's resource allocation issues

### DIFF
--- a/.github/.kube-linter-config.yaml
+++ b/.github/.kube-linter-config.yaml
@@ -3,8 +3,6 @@ checks:
   include: [ ]
 
   exclude: 
-    - "unset-cpu-requirements"
-    - "unset-memory-requirements"
     - "env-var-secret"
     - "liveness-port"
     - "readiness-port"

--- a/dependencies/cert-manager/kustomization.yml
+++ b/dependencies/cert-manager/kustomization.yml
@@ -3,3 +3,44 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml
+
+patches:
+  - patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 90m
+            memory: 90Mi
+          limits:
+            cpu: 120m
+            memory: 120Mi
+    target:
+      kind: Deployment
+      name: cert-manager
+  - patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 90m
+            memory: 90Mi
+          limits:
+            cpu: 120m
+            memory: 120Mi
+    target:
+      kind: Deployment
+      name: cert-manager-cainjector
+  - patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 90m
+            memory: 90Mi
+          limits:
+            cpu: 120m
+            memory: 120Mi
+    target:
+      kind: Deployment
+      name: cert-manager-webhook

--- a/dependencies/keycloak/deployment/db.yaml
+++ b/dependencies/keycloak/deployment/db.yaml
@@ -37,6 +37,13 @@ spec:
               value: /data/pgdata
             - name: POSTGRES_DB
               value: keycloak
+          resources:
+            requests:
+              cpu: 90m
+              memory: 90Mi
+            limits:
+              cpu: 120m
+              memory: 120Mi
       volumes:
         - name: cache-volume
           emptyDir: {}

--- a/dependencies/keycloak/deployment/kustomization.yml
+++ b/dependencies/keycloak/deployment/kustomization.yml
@@ -23,3 +23,16 @@ patches:
     target:
       kind: Deployment
       name: keycloak-operator
+  - patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 200m
+            memory: 200Mi
+          limits:
+            cpu: 300m
+            memory: 300Mi
+    target:
+      kind: Deployment
+      name: keycloak-operator

--- a/dependencies/pipelines-as-code/kustomization.yml
+++ b/dependencies/pipelines-as-code/kustomization.yml
@@ -36,3 +36,42 @@ patches:
     target:
       kind: Deployment
       name: pipelines-as-code-webhook
+  - patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 50m
+            memory: 50Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi
+    target:
+      kind: Deployment
+      name: pipelines-as-code-controller
+  - patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 50m
+            memory: 50Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi
+    target:
+      kind: Deployment
+      name: pipelines-as-code-watcher
+  - patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 50m
+            memory: 50Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi
+    target:
+      kind: Deployment
+      name: pipelines-as-code-webhook

--- a/dependencies/pre-deployment-pvc-binding/pre-deployment-pvc-binding.yaml
+++ b/dependencies/pre-deployment-pvc-binding/pre-deployment-pvc-binding.yaml
@@ -25,6 +25,13 @@ spec:
   containers:
   - name: test-pvc-consumer
     image: registry:2
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+      limits:
+        cpu: 50m
+        memory: 100Mi
     securityContext:
       readOnlyRootFilesystem: true
       runAsNonRoot: true

--- a/dependencies/registry/registry.yaml
+++ b/dependencies/registry/registry.yaml
@@ -27,6 +27,13 @@ spec:
       containers:
       - name: registry
         image: registry:2
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+          limits:
+            cpu: 100m
+            memory: 250Mi
         ports:
         - containerPort: 5000
 ---

--- a/dependencies/tekton-operator/kustomization.yml
+++ b/dependencies/tekton-operator/kustomization.yml
@@ -32,3 +32,42 @@ patches:
     target:
       kind: Deployment
       name: tekton-operator-webhook
+  - patch: |
+     - op: add
+       path: /spec/template/spec/containers/0/resources
+       value:
+         requests:
+           cpu: 10m
+           memory: 10Mi
+         limits:
+           cpu: 100m
+           memory: 100Mi
+    target:
+      kind: Deployment
+      name: tekton-operator
+  - patch: |
+     - op: add
+       path: /spec/template/spec/containers/1/resources
+       value:
+         requests:
+           cpu: 10m
+           memory: 10Mi
+         limits:
+           cpu: 100m
+           memory: 100Mi
+    target:
+      kind: Deployment
+      name: tekton-operator
+  - patch: |
+     - op: add
+       path: /spec/template/spec/containers/0/resources
+       value:
+         requests:
+           cpu: 10m
+           memory: 10Mi
+         limits:
+           cpu: 100m
+           memory: 100Mi
+    target:
+      kind: Deployment
+      name: tekton-operator-webhook

--- a/dependencies/tekton-results/kustomization.yml
+++ b/dependencies/tekton-results/kustomization.yml
@@ -26,3 +26,42 @@ patches:
     target:
       kind: StatefulSet
       name: tekton-results-postgres
+  - patch: |
+       - op: add
+         path: /spec/template/spec/containers/0/resources
+         value:
+           requests:
+             cpu: 10m
+             memory: 10Mi
+           limits:
+             cpu: 100m
+             memory: 100Mi
+    target:
+      kind: Deployment
+      name: tekton-results-api
+  - patch: |
+       - op: add
+         path: /spec/template/spec/containers/0/resources
+         value:
+           requests:
+             cpu: 10m
+             memory: 10Mi
+           limits:
+             cpu: 100m
+             memory: 100Mi
+    target:
+      kind: Deployment
+      name: tekton-results-watcher
+  - patch: |
+       - op: add
+         path: /spec/template/spec/containers/0/resources
+         value:
+           requests:
+             cpu: 10m
+             memory: 10Mi
+           limits:
+             cpu: 100m
+             memory: 100Mi
+    target:
+      kind: StatefulSet
+      name: tekton-results-postgres


### PR DESCRIPTION
Allocating resources to solve Kubelinter's resource allocation issues.

I tested those changed during and after all changes were made, I was also able to release using my local Konflux-ci.

**Resource allocation tests and results:**
**dependencies/cert-manager/Kustomization.yml + dependencies/keycloak/deployment/db.yaml:**

Raised all cpu and memory requests from 10m to 90m and from 10Mi to 90Mi accordingly.

Tests tried : 30m,30Mi - build-container step failed from insufficient resources, same happened for 50. for 80 and 85 build-container passed but the next steps were flaky and each time different step failed because of lacking resources.


**dependencies/keycloak/deployment/kustomization.yml:**
cpu and memory set to 50

**dependencies/pipelines-as-code/kustomization.yml:**
cpu and memory set to 50

**Testing release with all the values above - success**

**dependencies/pre-deployment-pvc-binding/pre-deployment-pvc-binding.yaml:**
requests:
cpu: 10m
memory: 50Mi
limits:
cpu: 50m
memory: 100Mi

**dependencies/registry/registry.yaml:**
requests:
cpu: 10m
memory: 50Mi
limits:
cpu: 100m
memory: 250Mi

**dependencies/tekton-operator/kustomization.yml:**
requests:
cpu: 10m
memory: 10Mi
limits:
cpu: 100m
memory: 100Mi
 
**Testing release with all the values above - success**

**dependencies/tekton-results/kustomization.yml:**
requests:
cpu: 10m
memory: 10Mi
limits:
cpu: 100m
memory: 100Mi

**Testing release with all the values above - success**