### PR TITLE
feat(RHTAPWATCH-1191): Mount custom CA bundle to tekton chains

### DIFF
--- a/dependencies/tekton-config/tekton-config.yml
+++ b/dependencies/tekton-config/tekton-config.yml
@@ -19,5 +19,27 @@ spec:
     artifacts.taskrun.format: in-toto
     artifacts.taskrun.storage: ""
     transparency.enabled: "false"
+    options:
+      disabled: false
+      deployments:
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                volumes:
+                  - name: trusted-ca
+                    configMap:
+                      name: trusted-ca
+                      items:
+                        - key: ca-bundle.crt
+                          path: ca-bundle.crt
+                      optional: true
+                containers:
+                  - name: tekton-chains-controller
+                    volumeMounts:
+                      - name: trusted-ca
+                        mountPath: /etc/ssl/certs/ca-custom-bundle.crt
+                        subPath: ca-bundle.crt
+                        readOnly: true
   pipeline:
     default-service-account: appstudio-pipeline


### PR DESCRIPTION
Tekton chains needs access to the custom CA. Otherwise, no attestations are pushed to the registry.