### PR TITLE
chore(RHTAPWATCH-1184): distribute root certificate

### DIFF
--- a/dependencies/cluster-issuer/self-signed-cluster-issuer.yaml
+++ b/dependencies/cluster-issuer/self-signed-cluster-issuer.yaml
@@ -5,3 +5,29 @@ metadata:
   name: self-signed-cluster-issuer
 spec:
   selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: selfsigned-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: selfsigned-ca
+  secretName: root-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: self-signed-cluster-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ca-issuer
+  namespace: cert-manager
+spec:
+  ca:
+    secretName: root-secret

--- a/dependencies/registry/certificate.yaml
+++ b/dependencies/registry/certificate.yaml
@@ -14,6 +14,6 @@ spec:
   - registry-service.kind-registry
   issuerRef:
     kind: ClusterIssuer
-    name: self-signed-cluster-issuer
+    name: ca-issuer
   secretName: local-registry-tls
   

--- a/dependencies/registry/trust-bundle.yaml
+++ b/dependencies/registry/trust-bundle.yaml
@@ -7,7 +7,7 @@ spec:
   sources:
   - useDefaultCAs: true
   - secret:
-      name: "local-registry-tls"
+      name: "root-secret"
       key: "ca.crt"
   target:
     configMap:

--- a/deploy-deps.sh
+++ b/deploy-deps.sh
@@ -132,11 +132,6 @@ deploy_registry() {
     kubectl apply -k "${script_path}/dependencies/registry"
     retry "kubectl wait --for=condition=Ready --timeout=240s -n kind-registry -l run=registry pod" \
           "The local registry did not become available within the allocated time"
-    # Copy the registry secret to cert-manager ns so the ca cert can be distrubuted
-    kubectl delete secret -n cert-manager --ignore-not-found=true local-registry-tls
-    kubectl get secret local-registry-tls --namespace=kind-registry -o yaml \
-        | grep -v '^\s*namespace:\s' | kubectl apply --namespace=cert-manager -f -
-
 }
 
 retry() {


### PR DESCRIPTION
Distribute the root certificate and use it for creating the registry's own certificate, rather than using the root cluster issuer for creating the registry certificate.

This allows us to avoid copying the certificate's secret from the registry namespace to the cert-manager namespace for distribution.