### PR TITLE
Improve nginx deployment

### DIFF
--- a/konflux-ci/ui/core/proxy/proxy.yaml
+++ b/konflux-ci/ui/core/proxy/proxy.yaml
@@ -12,10 +12,11 @@ spec:
   selector:
     matchLabels:
       app: proxy
+  minReadySeconds: 30
   strategy:
     rollingUpdate:
       maxSurge: 25%
-      maxUnavailable: 25%
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -96,8 +97,18 @@ spec:
             path: /health
             port: 9443
             scheme: HTTPS
-          initialDelaySeconds: 10
+          initialDelaySeconds: 30
           periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 9443
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 30
           successThreshold: 1
           timeoutSeconds: 1
         ports:


### PR DESCRIPTION
1. For 30 seconds, check if no containers in the pod crash loop and only then declare that the pod ready.

2. Add readiness probe. Traffic will be forwarded only to pods that pass the readiness check.

3. Adjust probes to start only after 30 seconds to match the change mention in 1.

4. Don't allow the deployment to have less than the desired replica count, even during upgrade.