### PR TITLE
fix: custom ca cert not picked

### DIFF
--- a/dependencies/tekton-config/tekton-config.yml
+++ b/dependencies/tekton-config/tekton-config.yml
@@ -38,8 +38,7 @@ spec:
                   - name: tekton-chains-controller
                     volumeMounts:
                       - name: trusted-ca
-                        mountPath: /etc/ssl/certs/ca-custom-bundle.crt
-                        subPath: ca-bundle.crt
+                        mountPath: /etc/ssl/certs
                         readOnly: true
   pipeline:
     default-service-account: appstudio-pipeline


### PR DESCRIPTION
We were mounting the CA bundle to /etc/ssl/certs/ca-custom-bundle.crt, but this file was ignored. Trying to find an alternative which adds a single file instead of overwriting the content of the entire /etc/ssl/certs dir did not work.

So, this change overrides the entire content of the /etc/ssl/certs dir. As the bundle that we're mounting also contains the default CA certs, this should not be an issue.

The current setup was tested against both local registry and quay, and confirmed work with both.