### PR TITLE
chore(RHTAPWATCH-1182): create secret for local registry

### DIFF
--- a/konflux-ci/build-service/core/kustomization.yaml
+++ b/konflux-ci/build-service/core/kustomization.yaml
@@ -24,3 +24,9 @@ patches:
       kind: ClusterRole
       name: build-service-metrics-reader
     path: remove-metrics-reader-cluster-role.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: build-service-controller-manager
+    path: mount-custom-ca-bundle.yaml

--- a/konflux-ci/build-service/core/mount-custom-ca-bundle.yaml
+++ b/konflux-ci/build-service/core/mount-custom-ca-bundle.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: build-service-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        volumeMounts:
+          - name: trusted-ca
+            mountPath: /etc/ssl/certs/ca-custom-bundle.crt
+            subPath: ca-bundle.crt
+            readOnly: true
+      volumes:
+      - name: trusted-ca
+        configMap:
+          name: trusted-ca
+          items:
+            - key: ca-bundle.crt
+              path: ca-bundle.crt

--- a/test/e2e/customize-docker-pipeline.sh
+++ b/test/e2e/customize-docker-pipeline.sh
@@ -10,11 +10,13 @@ main() {
     local original_docker_build_bundle_ref
 
     # This is required in order to push the modified pipeline to local registry
-    kubectl port-forward -n kind-registry svc/registry-service 30001:80 &
+    kubectl port-forward -n kind-registry svc/registry-service 30001:443 &
     original_docker_build_bundle_ref=$(yq ".data[\"config.yaml\"]" konflux-ci/build-service/core/build-pipeline-config.yaml | yq ".pipelines[] | select(.name == \"docker-build\").bundle")
     # Remove the problematic "clair-scan" task from the docker pipeline
-    tkn bundle list "$original_docker_build_bundle_ref" -o yaml | yq 'del(.spec.tasks[] | select(.name == "clair-scan"))' > "/tmp/customized-docker-pipeline.yaml"
-    tkn bundle push "$CUSTOMIZED_DOCKER_PIPELINE_IMAGE_REF_LOCALHOST" -f "/tmp/customized-docker-pipeline.yaml"
+    tkn bundle list --remote-skip-tls "$original_docker_build_bundle_ref" -o yaml \
+        | yq 'del(.spec.tasks[] | select(.name == "clair-scan"))' > "/tmp/customized-docker-pipeline.yaml"
+    tkn bundle push --remote-skip-tls "$CUSTOMIZED_DOCKER_PIPELINE_IMAGE_REF_LOCALHOST" \
+        -f "/tmp/customized-docker-pipeline.yaml"
     # Update the bundle ref in build-service pipeline configmap
     sed -i "s|bundle:.*docker-build.*|bundle: ${CUSTOMIZED_DOCKER_PIPELINE_IMAGE_REF_CLUSTER}|g" konflux-ci/build-service/core/build-pipeline-config.yaml
 }

--- a/test/e2e/vars.sh
+++ b/test/e2e/vars.sh
@@ -3,4 +3,4 @@ export E2E_TEST_IMAGE CUSTOMIZED_DOCKER_PIPELINE_IMAGE_REF_LOCALHOST CUSTOMIZED_
 # https://github.com/konflux-ci/e2e-tests/commit/<COMMIT>
 E2E_TEST_IMAGE=quay.io/konflux-ci/e2e-tests:f6e28a7aeab5a227d1a7b31079f27a58ad75ef58
 CUSTOMIZED_DOCKER_PIPELINE_IMAGE_REF_LOCALHOST="localhost:30001/test/test:customized-docker-pipeline"
-CUSTOMIZED_DOCKER_PIPELINE_IMAGE_REF_CLUSTER="registry-service.kind-registry.svc.cluster.local/test/test:customized-docker-pipeline"
+CUSTOMIZED_DOCKER_PIPELINE_IMAGE_REF_CLUSTER="registry-service.kind-registry/test/test:customized-docker-pipeline"

--- a/test/resources/demo-users/user/managed-ns2/appstudio-pipeline-sa.yaml
+++ b/test/resources/demo-users/user/managed-ns2/appstudio-pipeline-sa.yaml
@@ -1,5 +1,17 @@
+# Empty secret for registry that does not use authentication
+apiVersion: v1
+kind: Secret
+metadata:
+  name: regcred-empty
+  namespace: managed-ns2
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJ4Ijp7ImVtYWlsIjoiIn19fQ==
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: appstudio-pipeline
   namespace: managed-ns2
+secrets:
+- name: regcred-empty

--- a/test/resources/demo-users/user/ns2/appstudio-pipeline-sa.yaml
+++ b/test/resources/demo-users/user/ns2/appstudio-pipeline-sa.yaml
@@ -1,8 +1,20 @@
+# Empty secret for registry that does not use authentication
+apiVersion: v1
+kind: Secret
+metadata:
+  name: regcred-empty
+  namespace: user-ns2
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJ4Ijp7ImVtYWlsIjoiIn19fQ==
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: appstudio-pipeline
   namespace: user-ns2
+secrets:
+- name: regcred-empty
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
The dockerconfigjson file that is used by some of the pipelines to hold info for authentication with the registry is still needed even though the registry is not using any authentication.

With this change, we introduce a dummy secret that allows this file to be created without any authentication info.