### PR TITLE
Added script to restart kind cluster

### DIFF
--- a/restart-kind-cluster.sh
+++ b/restart-kind-cluster.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+script_path="$(dirname -- "${BASH_SOURCE[0]}")"
+
+main() {
+    echo "Restarting Kind cluster" >&2
+    podman restart konflux-control-plane
+    echo "Updating PID limit" >&2
+    podman update --pids-limit 4096 konflux-control-plane
+    echo "Increasing resource limit" >&2
+    sudo sysctl fs.inotify.max_user_watches=524288
+    sudo sysctl fs.inotify.max_user_instances=512
+    echo "Please wait for few minutes for the Konflux UI to be available." >&2
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
While troubleshotting Konflux CI, We often need to restart the cluster, increase the PID and open file limit.

Users may miss some of the step. By using restart-kind-cluster.sh script, it will make the restarting the cluster step easier.