### PR TITLE
Added FailedScheduling symptom for pending pod to the troubeshotting doc

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -172,7 +172,11 @@ The symptoms may include:
 * Setup scripts fail.
 * Pipelines are triggered, but seem stuck and listing the pods on the user namespace
   (e.g. running `kubectl get pods -n user-ns2`) shows pods stuck in pending for a long
-  time.
+  time. Checking the detailed output of pods with pending status `kubectl describe
+  pods/<pod name with pending status> -n user-ns2`, shows following error:
+  ```
+  Warning  FailedScheduling  5m59s  default-scheduler  running PreBind plugin "VolumeBinding": binding volumes: context deadline exceeded
+  ```
 * Pipelines fail at inconsistent stages.
 
 :gear: For mitigation steps, consult the notes at the top of the


### PR DESCRIPTION
Triggered pipeline may be stuck for longer time. On checking the pod status on the user namespace. The pod will be in pending state.

This pr includes the pending pods describe output error message and how to reuse the instructions to fix it.

Closes: https://github.com/konflux-ci/konflux-ci/issues/281