### PR TITLE
chore(RHTAPWATCH-1076): use released workspace-manager images

### DIFF
--- a/konflux-ci/ui/core/proxy/proxy.yaml
+++ b/konflux-ci/ui/core/proxy/proxy.yaml
@@ -148,7 +148,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1001
-      - image: quay.io/redhat-user-workloads/rhtap-o11y-tenant/workspace-manager/workspace-manager:06df38da81280ba2cf6b4a532d494f1ead8670fe
+      - image: quay.io/konflux-ci/workspace-manager@sha256:6b7bfcf197cbff2ae9b1d84abd73636ce5733921524fb550438d8a8143a536b5
         name: workspace-manager
         ports:
           - containerPort: 5000


### PR DESCRIPTION
Use proper released images for workspace-manager instead of the dev image that was used up until now.