### PR TITLE
chore: use renovate to maintain ec configmap

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,27 @@
       ],
       "datasourceTemplate": "git-refs",
       "currentValueTemplate": "main"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["konflux-ci/enterprise-contract/core/kustomization.yaml"],
+      "matchStrings": [
+        "- verify_ec_task_bundle=(?<depName>quay\\.io/enterprise-contract/ec-task-bundle)@(?<currentDigest>sha256:[a-f0-9]{64})"
+      ],
+      "autoReplaceStringTemplate": "- verify_ec_task_bundle={{depName}}@{{newDigest}}",
+      "datasourceTemplate": "docker",
+      "currentValueTemplate": "snapshot"
+    },
+    {
+      "customType": "regex",
+      "matchStringsStrategy": "combination",
+      "fileMatch": ["konflux-ci/enterprise-contract/core/kustomization.yaml"],
+      "matchStrings": [
+        "- verify_ec_task_git_url=(?<packageName>https:\/\/github\\.com\/enterprise-contract\/ec-cli)\\.git",
+        "- verify_ec_task_git_revision=(?<currentDigest>[a-f0-9]{40})"
+      ],
+      "datasourceTemplate": "git-refs",
+      "currentValueTemplate": "main"
     }
   ]
 }


### PR DESCRIPTION
Update renovate configs so they update the ec-task-bundle image
and git ref used in the ec controller configs.

https://github.com/konflux-ci/konflux-ci/blob/d1d7260d49e7245ce53503e81f39537b5a8c50bb/konflux-ci/enterprise-contract/core/kustomization.yaml#L16-L18