### PR TITLE
chore: Update the root user id

### DIFF
--- a/konflux-ci/rbac/chains/tekton-chains.yaml
+++ b/konflux-ci/rbac/chains/tekton-chains.yaml
@@ -217,11 +217,8 @@ spec:
           requests:
             cpu: 10m
             memory: 10Mi
-        securityContext:
+        securityContext: 
           readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsGroup: 1001
-          runAsUser: 1001
       dnsPolicy: ClusterFirst
       restartPolicy: OnFailure
       serviceAccount: chains-secrets-admin


### PR DESCRIPTION
When deploying rbac to ArgoCD it's failing due to
root user so updated the user id.