### PR TITLE
docs: release to external or internal registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,8 +610,7 @@ test being executed.
 
 ### Configure Releases
 
-You will now configure Konflux to release your application to the external registry
-configured in previous steps.
+You will now configure Konflux to release your application to the registry.
 
 This requires:
 


### PR DESCRIPTION
The README specifically mentions an external registry when configuring releases. This is no longer the case, and the internal registry can be used for releases as well.

closes: #601 