### PR TITLE
chore: use public image for image-controller pruner job

### DIFF
--- a/konflux-ci/image-controller/core/kustomization.yaml
+++ b/konflux-ci/image-controller/core/kustomization.yaml
@@ -23,3 +23,9 @@ patches:
       kind: ClusterRole
       name: image-controller-metrics-reader
     path: remove-metrics-reader-cluster-role.yaml
+  - target:
+      group: batch
+      version: v1
+      kind: CronJob
+      name: image-controller-image-pruner-cronjob
+    path: replace-pruner-image.yaml

--- a/konflux-ci/image-controller/core/replace-pruner-image.yaml
+++ b/konflux-ci/image-controller/core/replace-pruner-image.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/jobTemplate/spec/template/spec/containers/0/image
+  value: registry.access.redhat.com/ubi8/python-39:1-201.1729679484


### PR DESCRIPTION
The image-controller configs that we use references an image that requires authentication. This change patches the relevant manifest so it uses an image that does not require authentication.

closes: #573 