### PR TITLE
fix: rename pipeline to tenantPipeline

### DIFF
--- a/konflux-ci/release/core/kustomization.yaml
+++ b/konflux-ci/release/core/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/konflux-ci/release-service/config/default?ref=3ba2cdd0e333d9bbbe94de4fa39ebffee6d9c8a3
+  - https://github.com/konflux-ci/release-service/config/default?ref=6a89738bc38398d16ceacbb35f179e2b213c8131
   - release-pipeline-resources-clusterrole.yaml
   - release-service-config-rbac.yaml
 
 images:
   - name: quay.io/konflux-ci/release-service
     newName: quay.io/konflux-ci/release-service
-    newTag: 3ba2cdd0e333d9bbbe94de4fa39ebffee6d9c8a3
+    newTag: 6a89738bc38398d16ceacbb35f179e2b213c8131
 
 namespace: release-service
 

--- a/test/resources/demo-users/user/ns1/release-plan.yaml
+++ b/test/resources/demo-users/user/ns1/release-plan.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: user-ns1
 spec:
   application: sample-component
-  pipeline:
+  tenantPipeline:
     pipelineRef:
       resolver: git
       params:


### PR DESCRIPTION
For local releases, pipeline was renamed to tenantPipeline. This need to be reflected in our configs to be able to update release-service.

Closes: #631