### PR TITLE
Better token handling for websockets

### DIFF
--- a/konflux-ci/ui/core/proxy/proxy.yaml
+++ b/konflux-ci/ui/core/proxy/proxy.yaml
@@ -61,7 +61,8 @@ spec:
             set -e
             
             token=$(cat /mnt/api-token/token)
-            token64=$(cat /mnt/api-token/token | base64 -w 0 | head -c-1)
+            # for websocket connections padding should be removed from a base64 encoded token
+            token64=$(base64 -w 0 /mnt/api-token/token | sed -E  s,=+$,,g)
 
             echo "proxy_set_header Authorization \"Bearer $token\";" > /mnt/nginx-generated-config/bearer.conf
 


### PR DESCRIPTION
For websockets the token should be processed in a certain way before sending it to the k8s API. It should be based64 encoded without padding [1].

The current implementation assumed a padding of 1 char, but it was seen that it can be 2 chars. Adjust the processing to remove any padding from the token.

[1] - https://github.com/kubernetes/kubernetes/pull/47740