### PR TITLE
Authorization bearer token for websockets

### DIFF
--- a/konflux-ci/ui/core/proxy/nginx.conf
+++ b/konflux-ci/ui/core/proxy/nginx.conf
@@ -154,7 +154,8 @@ http {
             proxy_set_header Connection $connection_upgrade;
             proxy_read_timeout 30m;
             proxy_set_header Impersonate-User $email;
-            include /mnt/nginx-generated-config/websocket.conf;
+            proxy_set_header Sec-Websocket-Protocol base64.binary.k8s.io;
+            include /mnt/nginx-generated-config/bearer.conf;
         }
 
         location /api/k8s/ {
@@ -177,7 +178,8 @@ http {
             proxy_set_header Connection $connection_upgrade;
             proxy_read_timeout 30m;
             proxy_set_header Impersonate-User $email;
-            include /mnt/nginx-generated-config/websocket.conf;
+            proxy_set_header Sec-Websocket-Protocol base64.binary.k8s.io;
+            include /mnt/nginx-generated-config/bearer.conf;
         }
 
         location /api/k8s/plugins/tekton-results/workspaces/ {

--- a/konflux-ci/ui/core/proxy/proxy.yaml
+++ b/konflux-ci/ui/core/proxy/proxy.yaml
@@ -61,12 +61,7 @@ spec:
             set -e
             
             token=$(cat /mnt/api-token/token)
-            # for websocket connections padding should be removed from a base64 encoded token
-            token64=$(base64 -w 0 /mnt/api-token/token | sed -E  s,=+$,,g)
-
             echo "proxy_set_header Authorization \"Bearer $token\";" > /mnt/nginx-generated-config/bearer.conf
-
-            echo "proxy_set_header Sec-WebSocket-Protocol \"base64url.bearer.authorization.k8s.io.${token64}, base64.binary.k8s.io\";" > /mnt/nginx-generated-config/websocket.conf
         volumeMounts:
         - name: nginx-generated-config
           mountPath: /mnt/nginx-generated-config


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/47740 was misunderstood. it was implemented to support authentication from a web browser. Since we have a proxy, it can include the Authorization bearer token, so no special header is needed for websocket authentication.

Since the UI already includes the "Sec-Websocket-Protocol" with a token, it should be redefined (in the new UI this won't be needed).