### PR TITLE
Authorization bearer token for websockets - new UI

### DIFF
--- a/konflux-ci/ui/core/kustomization.yaml
+++ b/konflux-ci/ui/core/kustomization.yaml
@@ -9,6 +9,6 @@ images:
   - name: quay.io/konflux-ci/workspace-manager
     digest: sha256:a46d51b8a306f89eb36a63cb463b04324b3b59808361e10da3945a7ad961e0e6
   - name: quay.io/konflux-ci/konflux-ui
-    digest: sha256:4d638ff6ed4874de0406b200e671ebac72b3f03c4d46b92f02bf62809c1cbed3
+    digest: sha256:bc56e9ad05572b3bab1185133f5bf880dc9e39b29af76a6fe306da6413b36385
 
 namespace: konflux-ui

--- a/konflux-ci/ui/core/proxy/nginx.conf
+++ b/konflux-ci/ui/core/proxy/nginx.conf
@@ -144,7 +144,7 @@ http {
             proxy_set_header Connection $connection_upgrade;
             proxy_read_timeout 30m;
             proxy_set_header Impersonate-User $email;
-            include /mnt/nginx-generated-config/websocket.conf;
+            include /mnt/nginx-generated-config/bearer.conf;
         }
 
         location /api/k8s/ {
@@ -167,7 +167,7 @@ http {
             proxy_set_header Connection $connection_upgrade;
             proxy_read_timeout 30m;
             proxy_set_header Impersonate-User $email;
-            include /mnt/nginx-generated-config/websocket.conf;
+            include /mnt/nginx-generated-config/bearer.conf;
         }
 
         location /api/k8s/plugins/tekton-results/workspaces/ {

--- a/konflux-ci/ui/core/proxy/proxy.yaml
+++ b/konflux-ci/ui/core/proxy/proxy.yaml
@@ -61,11 +61,7 @@ spec:
             set -e
             
             token=$(cat /mnt/api-token/token)
-            token64=$(cat /mnt/api-token/token | base64 -w 0 | head -c-1)
-
             echo "proxy_set_header Authorization \"Bearer $token\";" > /mnt/nginx-generated-config/bearer.conf
-
-            echo "proxy_set_header Sec-WebSocket-Protocol \"base64url.bearer.authorization.k8s.io.${token64}, base64.binary.k8s.io\";" > /mnt/nginx-generated-config/websocket.conf
         volumeMounts:
         - name: nginx-generated-config
           mountPath: /mnt/nginx-generated-config


### PR DESCRIPTION
   
    kubernetes/kubernetes#47740 was misunderstood.
    it was implemented to support authentication from a web browser.
    Since we have a proxy, it can include the Authorization bearer token,
    so no special header is needed for websocket authentication.