### PR TITLE
Remove duplicate auth endpoint

### DIFF
--- a/konflux-ci/ui/core/proxy/nginx.conf
+++ b/konflux-ci/ui/core/proxy/nginx.conf
@@ -80,17 +80,6 @@ http {
             proxy_set_header X-Scheme         $scheme;
         }
 
-        location /wss/oauth2/auth {
-            internal; 
-            proxy_pass       http://127.0.0.1:6000/oauth2/auth;
-            proxy_set_header Host             $host;
-            proxy_set_header X-Real-IP        $remote_addr;
-            proxy_set_header X-Scheme         $scheme;
-            # nginx auth_request includes headers but not body
-            proxy_set_header Content-Length   "";
-            proxy_pass_request_body           off;
-        }
-
         location /api/k8s/registration/ {
            # Registration Service registration endpoint
             auth_request_set $email  $upstream_http_x_auth_request_email;
@@ -135,7 +124,7 @@ http {
 
         location /wss/k8s/workspaces/ {
             auth_request_set $email  $upstream_http_x_auth_request_email;
-            auth_request /wss/oauth2/auth;
+            auth_request /oauth2/auth;
 
             rewrite /wss/k8s/workspaces/.+?/(.+) /$1 break;
             proxy_pass https://kubernetes.default.svc/;
@@ -160,7 +149,7 @@ http {
 
         location /wss/k8s/ {
             auth_request_set $email  $upstream_http_x_auth_request_email;
-            auth_request /wss/oauth2/auth;
+            auth_request /oauth2/auth;
 
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
We had two endpoints that are the same but one was used for regular requests and the other fo websockets.

We can use the same endpoint for both.