### PR TITLE
Use UBI nginx image and enable update for Redhat images

### DIFF
--- a/konflux-ci/ui/core/proxy/nginx.conf
+++ b/konflux-ci/ui/core/proxy/nginx.conf
@@ -21,14 +21,7 @@ http {
     types_hash_max_size 4096;
 
     default_type application/octet-stream;
-
-    client_body_temp_path /var/run/openresty/nginx-client-body;
-    proxy_temp_path       /var/run/openresty/nginx-proxy;
-    fastcgi_temp_path     /var/run/openresty/nginx-fastcgi;
-    uwsgi_temp_path       /var/run/openresty/nginx-uwsgi;
-    scgi_temp_path        /var/run/openresty/nginx-scgi;
-
-    include /usr/local/openresty/nginx/conf/mime.types;
+    include /etc/nginx/mime.types;
 
     map $http_upgrade $connection_upgrade {
         default upgrade;

--- a/konflux-ci/ui/core/proxy/proxy.yaml
+++ b/konflux-ci/ui/core/proxy/proxy.yaml
@@ -79,10 +79,10 @@ spec:
             cpu: 10m
             memory: 64Mi
       containers:
-      - image: openresty/openresty:1.25.3.1-0-jammy
-        name: nginx-120
+      - image: registry.access.redhat.com/ubi9/nginx-124@sha256:b924363ff07ee0f8fd4f680497da774ac0721722a119665998ff5b2111098ad1
+        name: nginx
         command: 
-          - "/usr/local/openresty/bin/openresty"
+          - nginx
           - "-g"
           - "daemon off;"
           - -c
@@ -136,8 +136,6 @@ spec:
             mountPath: /mnt
           - name: nginx-generated-config
             mountPath: /mnt/nginx-generated-config
-          - name: openresty
-            mountPath: /var/run/openresty
           - name: static-content
             mountPath: /opt/app-root/src/static-content
         securityContext:
@@ -236,8 +234,6 @@ spec:
         - name: api-token
           secret:
             secretName: proxy
-        - name: openresty
-          emptyDir: {}
         - name: static-content
           emptyDir: {}
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
         "https://github.com/enterprise-contract/*",
         "quay.io/konflux-ci/*",
         "quay.io/enterprise-contract/*",
-        "quay.io/konflux-ci/tekton-catalog/*"
+        "quay.io/konflux-ci/tekton-catalog/*",
+        "registry.access.redhat.com/*"
       ],
       "autoApprove": true,
       "automerge": true


### PR DESCRIPTION
    Use UBI nginx image
    
    With the old UI we needed to use OpenResty since it has LUA
    features that we needed for parsing the JWT token.
    
    This isn't the case anymore with the new UI, so we can use UBI
    nginx instead.


    Enable renovate for Redhat public registry
    
    Enable renovate for pulling updates from
    registry.access.redhat.com.
