### PR TITLE
Make impersonation optional

### DIFF
--- a/konflux-ci/ui/core/proxy/kustomization.yaml
+++ b/konflux-ci/ui/core/proxy/kustomization.yaml
@@ -13,3 +13,6 @@ configMapGenerator:
   - name: proxy
     files:
       - nginx.conf
+  - name: proxy-init-config
+    literals:
+      - IMPERSONATE=true

--- a/konflux-ci/ui/core/proxy/nginx.conf
+++ b/konflux-ci/ui/core/proxy/nginx.conf
@@ -105,18 +105,15 @@ http {
 
         location /api/k8s/workspaces/ {
             # Kube-API
-            auth_request_set $email  $upstream_http_x_auth_request_email;
             auth_request /oauth2/auth;
 
             rewrite /api/k8s/workspaces/.+?/(.+) /$1 break;
             proxy_pass https://kubernetes.default.svc;
             proxy_read_timeout 30m;
-            proxy_set_header Impersonate-User $email;
-            include /mnt/nginx-generated-config/bearer.conf;
+            include /mnt/nginx-generated-config/auth.conf;
         }
 
         location /wss/k8s/workspaces/ {
-            auth_request_set $email  $upstream_http_x_auth_request_email;
             auth_request /oauth2/auth;
 
             rewrite /wss/k8s/workspaces/.+?/(.+) /$1 break;
@@ -125,42 +122,35 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             proxy_read_timeout 30m;
-            proxy_set_header Impersonate-User $email;
-            include /mnt/nginx-generated-config/bearer.conf;
+            include /mnt/nginx-generated-config/auth.conf;
         }
 
         location /api/k8s/ {
             # Kube-API
-            auth_request_set $email  $upstream_http_x_auth_request_email;
             auth_request /oauth2/auth;
 
             proxy_pass https://kubernetes.default.svc/;
             proxy_read_timeout 30m;
-            proxy_set_header Impersonate-User $email;
-            include /mnt/nginx-generated-config/bearer.conf;
+            include /mnt/nginx-generated-config/auth.conf;
         }
 
         location /wss/k8s/ {
-            auth_request_set $email  $upstream_http_x_auth_request_email;
             auth_request /oauth2/auth;
 
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             proxy_read_timeout 30m;
-            proxy_set_header Impersonate-User $email;
-            include /mnt/nginx-generated-config/bearer.conf;
+            include /mnt/nginx-generated-config/auth.conf;
         }
 
         location /api/k8s/plugins/tekton-results/workspaces/ {
-            auth_request_set $email  $upstream_http_x_auth_request_email;
             auth_request /oauth2/auth;
 
             rewrite /api/k8s/plugins/tekton-results/workspaces/.+?/(.+) /$1 break;
             proxy_pass https://tekton-results-api-service.tekton-pipelines.svc.cluster.local:8080;
             proxy_read_timeout 30m;
-            proxy_set_header Impersonate-User $email;
-            include /mnt/nginx-generated-config/bearer.conf;
+            include /mnt/nginx-generated-config/auth.conf;
         }
 
         location /health {

--- a/konflux-ci/ui/core/proxy/proxy.yaml
+++ b/konflux-ci/ui/core/proxy/proxy.yaml
@@ -52,16 +52,30 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-      - name: add-sva-token-to-nginx-config
+      - name: generate-nginx-configs
         image: registry.access.redhat.com/ubi9/ubi@sha256:66233eebd72bb5baa25190d4f55e1dc3fff3a9b77186c1f91a0abdb274452072
+        envFrom:
+          - configMapRef:
+              name: proxy-init-config
         command:
           - sh
           - -c
           - |
             set -e
+
+            auth_conf=/mnt/nginx-generated-config/auth.conf
             
-            token=$(cat /mnt/api-token/token)
-            echo "proxy_set_header Authorization \"Bearer $token\";" > /mnt/nginx-generated-config/bearer.conf
+            if [[ "$IMPERSONATE" == "true" ]]; then
+              token=$(cat /mnt/api-token/token)
+              echo 'auth_request_set $user  $upstream_http_x_auth_request_email;' > "$auth_conf"
+              echo 'proxy_set_header Impersonate-User $user;' >> "$auth_conf"
+              echo "proxy_set_header Authorization \"Bearer $token\";" >> "$auth_conf"
+            else
+              echo "# impersonation was disabled by config" > "$auth_conf"
+            fi
+
+            chmod 640 "$auth_conf"
+
         volumeMounts:
         - name: nginx-generated-config
           mountPath: /mnt/nginx-generated-config


### PR DESCRIPTION
It's possible to deploy Konflux without using impersonation for the proxy if the proxy and the cluster use the same IDP.

Allow this case by making impersonation optional.