### PR TITLE
Allow to configure tekton-results URL 

### DIFF
--- a/konflux-ci/ui/core/proxy/kustomization.yaml
+++ b/konflux-ci/ui/core/proxy/kustomization.yaml
@@ -16,3 +16,4 @@ configMapGenerator:
   - name: proxy-init-config
     literals:
       - IMPERSONATE=true
+      - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-pipelines.svc.cluster.local:8080

--- a/konflux-ci/ui/core/proxy/nginx.conf
+++ b/konflux-ci/ui/core/proxy/nginx.conf
@@ -148,8 +148,8 @@ http {
             auth_request /oauth2/auth;
 
             rewrite /api/k8s/plugins/tekton-results/workspaces/.+?/(.+) /$1 break;
-            proxy_pass https://tekton-results-api-service.tekton-pipelines.svc.cluster.local:8080;
             proxy_read_timeout 30m;
+            include /mnt/nginx-generated-config/tekton-results.conf;
             include /mnt/nginx-generated-config/auth.conf;
         }
 

--- a/konflux-ci/ui/core/proxy/proxy.yaml
+++ b/konflux-ci/ui/core/proxy/proxy.yaml
@@ -76,6 +76,10 @@ spec:
 
             chmod 640 "$auth_conf"
 
+            echo \
+              "proxy_pass ${TEKTON_RESULTS_URL:?tekton results url must be provided};" \
+              > /mnt/nginx-generated-config/tekton-results.conf
+
         volumeMounts:
         - name: nginx-generated-config
           mountPath: /mnt/nginx-generated-config


### PR DESCRIPTION
Tekton results URL may differ between installations.
Allow to configure it using a configmap.


depends on https://github.com/konflux-ci/konflux-ci/pull/831