### PR TITLE
Make idp proxying optional

### DIFF
--- a/konflux-ci/ui/core/proxy/nginx.conf
+++ b/konflux-ci/ui/core/proxy/nginx.conf
@@ -43,18 +43,6 @@ http {
         location = /404.html {
         }
 
-        location /idp/ {
-            # Identity Provider
-            proxy_set_header    Host               $host;
-            proxy_set_header    X-Real-IP          $remote_addr;
-            proxy_set_header    X-Forwarded-For    $proxy_add_x_forwarded_for;
-            proxy_set_header    X-Forwarded-Host   $host;
-            proxy_set_header    X-Forwarded-Server $host;
-            proxy_set_header    X-Forwarded-Port   9443;
-            proxy_set_header    X-Forwarded-Proto  $scheme;
-            proxy_pass https://dex.dex.svc.cluster.local:9443;
-        }
-
         location = /oauth2/auth {
             internal; 
             proxy_pass       http://127.0.0.1:6000;
@@ -157,5 +145,7 @@ http {
             # Used for liveness probes
             return 200;
         }
+
+        include /mnt/nginx-additional-location-configs/*.conf;
     }
 }

--- a/konflux-ci/ui/kustomization.yaml
+++ b/konflux-ci/ui/kustomization.yaml
@@ -4,6 +4,11 @@ resources:
   - core
   - certmanager
 
+configMapGenerator:
+  - name: nginx-idp-location
+    files:
+      - nginx-idp-location.conf
+
 patches:
   - path: node-port-patch.yaml
     target:
@@ -11,3 +16,11 @@ patches:
       version: v1
       kind: Service
       name: proxy
+  - path: nginx-idp-location-patch.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: proxy
+
+namespace: konflux-ui

--- a/konflux-ci/ui/nginx-idp-location-patch.yaml
+++ b/konflux-ci/ui/nginx-idp-location-patch.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy
+spec:
+  template:
+    spec:
+      containers:
+        - name: nginx
+          volumeMounts:
+            - name: nginx-idp-location
+              mountPath: /mnt/nginx-additional-location-configs
+      volumes:
+        - name: nginx-idp-location
+          configMap:
+            defaultMode: 420
+            name: nginx-idp-location
+            items:
+              - key: nginx-idp-location.conf
+                path: nginx-idp-location.conf

--- a/konflux-ci/ui/nginx-idp-location.conf
+++ b/konflux-ci/ui/nginx-idp-location.conf
@@ -1,0 +1,11 @@
+location /idp/ {
+    # Identity Provider
+    proxy_set_header    Host               $host;
+    proxy_set_header    X-Real-IP          $remote_addr;
+    proxy_set_header    X-Forwarded-For    $proxy_add_x_forwarded_for;
+    proxy_set_header    X-Forwarded-Host   $host;
+    proxy_set_header    X-Forwarded-Server $host;
+    proxy_set_header    X-Forwarded-Port   9443;
+    proxy_set_header    X-Forwarded-Proto  $scheme;
+    proxy_pass https://dex.dex.svc.cluster.local:9443;
+}


### PR DESCRIPTION
The IDP deployment is useful for a local setup. Not all Konflux deployments will need it. Make it optional.