### PR TITLE
feat(KFLUXVNGD-3): automate smee channel creation

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -19,6 +19,7 @@ jobs:
       - name: Generate default configuration
         shell: bash
         run: |
+          cp dependencies/smee/smee-channel-id.tpl dependencies/smee/smee-channel-id.yaml
           find . -name "kustomization.yaml" -o -name "kustomization.yml" | while read -r file; do
             dir=$(dirname "$file")
             dir=${dir#./}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 logs/
 .vscode/
 __debug_bin*
+dependencies/smee/smee-channel-id.yaml

--- a/README.md
+++ b/README.md
@@ -190,8 +190,19 @@ events to a channel we create on a public `smee` server, and we deploy a client
 within the cluster to listen to those events. The client will relay those events to
 pipelines-as-code (Tekton) inside the cluster.
 
-1. :gear: Start a new channel in [smee](https://smee.io/), and take a note of the webhook
-   proxy URL.
+When the dependencies were deployed, a smee channel was created for you, a client was
+deployed to listen to it, and the channel's webhook Proxy URL was stored in a patch
+file.
+
+1. :gear: Take note of the smee channel's webhook Proxy URL created for you:
+
+```
+grep value dependencies/smee/smee-channel-id.yaml
+```
+
+**NOTE:** if you already have a channel that you'd like to keep using, copy its URL to
+the `value` field inside the `smee-channel-id.yaml` file and rerun `deploy-deps.sh`.
+The script will not recreate the patch file if it already exists.
 
 2. :gear: Create a GitHub app following
    [Pipelines-as-Code documentation](https://pipelinesascode.com/docs/install/github_apps/#manual-setup).
@@ -208,17 +219,6 @@ pipelines-as-code (Tekton) inside the cluster.
    should be created inside the `build-service` and the `integration-service`
    namespaces. See additional details under
    [Configuring GitHub Application Secrets](./docs/github-secrets.md).
-
-4. :gear: Deploy the smee-client on the cluster:
-
-   Edit the [smee-client manifest](./smee/smee-client.yaml), replacing `<smee-channel>`
-   with the webhook proxy URL generated when creating the channel.
-
-   Deploy the manifest:
-
-```bash
-kubectl create -f ./smee/smee-client.yaml
-```
 
 ## Onboard a new Application
 

--- a/dependencies/smee/kustomization.yml
+++ b/dependencies/smee/kustomization.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - smee-client.yaml
+patches:
+  - path: smee-channel-id.yaml
+    target:
+      kind: Deployment
+      name: gosmee-client

--- a/dependencies/smee/smee-channel-id.tpl
+++ b/dependencies/smee/smee-channel-id.tpl
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/0/args/1
+  value: https://smee.io/CHANNELID

--- a/dependencies/smee/smee-client.yaml
+++ b/dependencies/smee/smee-client.yaml
@@ -29,7 +29,8 @@ spec:
             - "http://pipelines-as-code-controller.pipelines-as-code:8080"
           securityContext:
             readOnlyRootFilesystem: true
-            runAsNonRoot: false
+            runAsNonRoot: true
+            runAsUser: 1001
           resources:
             limits:
               cpu: 100m

--- a/test/e2e/prepare-e2e.sh
+++ b/test/e2e/prepare-e2e.sh
@@ -17,8 +17,10 @@ main() {
         --from-literal github-private-key="$app_private_key" \
         --from-literal github-application-id="$app_id" \
         --from-literal webhook.secret="$app_webhook_secret"; done
-    sed -i "s|<smee-channel>|$smee_channel|g" "${script_path}/../../smee/smee-client.yaml"
-    kubectl create -f "${script_path}/../../smee/smee-client.yaml"
+    sed "s|https://smee.io/CHANNELID|$smee_channel|g" \
+        "${script_path}/../../dependencies/smee/smee-channel-id.tpl" \
+        > "${script_path}/../../dependencies/smee/smee-channel-id.yaml"
+    kubectl apply -k "${script_path}/../../dependencies/smee"
 }
 
 


### PR DESCRIPTION
Randomize the smee channel ID and create the client providing that ID. The ID is stored in a kustomize patch file (ignored by git). The channel will not be created if the patch already exists, so users can store their pre-existing channels in the patch and keep using them.

closes: #169 