### PR TITLE
add go proxy test placeholder

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -95,6 +95,10 @@ jobs:
         run: |
           ./deploy-test-resources.sh
 
+      - name: Run Go Tests
+        run: |
+          go test ./test/go-tests/
+
       - name: Prepare resources for E2E tests
         env:
           APP_ID: ${{ secrets.APP_ID }}
@@ -113,7 +117,7 @@ jobs:
           QUAY_DOCKERCONFIGJSON: ${{ secrets.QUAY_DOCKERCONFIGJSON }}
         run: |
           ./test/e2e/run-e2e.sh
-      
+
       - name: Generate error logs
         if: ${{ !cancelled() }}
         run: |

--- a/dependencies/dex/config.yaml
+++ b/dependencies/dex/config.yaml
@@ -9,6 +9,7 @@ web:
   tlsKey: /etc/dex/tls/tls.key
 oauth2:
   skipApprovalScreen: true
+  passwordConnector: local
 staticClients:
 - id: oauth2-proxy
   redirectURIs:

--- a/konflux-ci/ui/core/proxy/proxy.yaml
+++ b/konflux-ci/ui/core/proxy/proxy.yaml
@@ -215,6 +215,7 @@ spec:
           - "true"
           - --whitelist-domain
           - localhost:9443
+          - --skip-jwt-bearer-tokens
         ports:
           - containerPort: 6000
             name: web

--- a/test/go-tests/proxy_suite_test.go
+++ b/test/go-tests/proxy_suite_test.go
@@ -1,0 +1,24 @@
+package go_tests
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGoTests(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "GoTests Suite")
+}
+
+var _ = Describe("Proxy Unit testing", func() {
+	Describe("Test dummy", func() {
+		Context("When a test dummy is running", func() {
+			It("Test should return true", func() {
+				got := true
+				Expect(got).To(BeTrue())
+			})
+		})
+	})
+})


### PR DESCRIPTION
add a placeholder in actions for go proxy tests:

- Add a dummy test in go as a placeholder to proxy tests
- Update some parameters we need for the tests