### PR TITLE
fix: run prereqs check only on PRs

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -2,14 +2,20 @@ name: Sanity Test
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
 jobs:
   check-prerequisites:
     runs-on: ubuntu-latest
     steps:
-    - run: |
+    - name: Check prerequisites for running Sanity test
+      run: |
+        if [ "${{ github.event_name }}" != 'pull_request_target' ]; then
+          echo "The workflow is not triggered from PR, but ${{ github.event_name }} - skipping further checks."
+          exit 0
+        fi
+
         WHITELISTED_BOT_NAME="renovate[bot]"
         REQUIRED_LABEL_NAME="ok-to-test"
 


### PR DESCRIPTION
Closes https://github.com/konflux-ci/konflux-ci/issues/1124
Addresses issue mentioned in https://github.com/konflux-ci/konflux-ci/issues/1111#issuecomment-2603997316

Tested in a merge queue in my GitHub org [here](https://github.com/psturc-org/konflux-ci/actions/runs/12885104845/job/35922830633) and in [this PR](https://github.com/psturc-org/konflux-ci/actions/runs/12885079288/job/35922750387)