### PR TITLE
fix: flaky proxy test

### DIFF
--- a/deploy-deps.sh
+++ b/deploy-deps.sh
@@ -105,7 +105,7 @@ deploy_dex() {
     kubectl apply -k "${script_path}/dependencies/dex"
     if ! kubectl get secret oauth2-proxy-client-secret -n dex; then
         local client_secret
-        client_secret="$(openssl rand -base64 20)"
+        client_secret="$(openssl rand -base64 20 | tr '+/' '-_' | tr -d '\n' | tr -d '=')"
         kubectl create secret generic oauth2-proxy-client-secret \
             --namespace=dex \
             --from-literal=client-secret="$client_secret"


### PR DESCRIPTION
Test suite will sometimes fail after fetching the token as it appears to be empty. This is caused by failed authentication, which seems to be related to a inconsistently-escaped characters when Dex is comparing the client secret.

To address this, we remove the characters that should cause such inconsistencies.