### PR TITLE
feat(KFLUXVNGD-175): deploy integration with helm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ logs/
 __debug_bin*
 dependencies/smee/smee-channel-id.yaml
 .kube-linter/
+deploy/konflux-ci/charts/*

--- a/deploy/konflux-ci/.helmignore
+++ b/deploy/konflux-ci/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/konflux-ci/Chart.lock
+++ b/deploy/konflux-ci/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: integration-service
+  repository: oci://quay.io/yftacherzog/yftacherzog-konflux-integration-service
+  version: 0.1.0
+digest: sha256:bd62e1984832e76b3ad3425d7600faac4c54a0f423ea88e40c3637f8b61a8e19
+generated: "2025-01-29T16:20:25.349854492+02:00"

--- a/deploy/konflux-ci/Chart.yaml
+++ b/deploy/konflux-ci/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: konflux-ci
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"
+
+dependencies:
+  - name: integration-service
+    version: "0.1.0"
+    # repository: "file:///home/yherzog/src/github.com/konflux-ci/integration-service/dist/chart"
+    # repository: "https://artifacthub.io/packages/helm/yftacherzog-konflux-integration-service/integration-service"
+    repository: "oci://quay.io/yftacherzog/yftacherzog-konflux-integration-service"

--- a/deploy/konflux-ci/values.yaml
+++ b/deploy/konflux-ci/values.yaml
@@ -1,0 +1,22 @@
+integration-service:
+  certmanager:
+    enable: true
+  namespace: integration-service
+  controllerManager:
+    container:
+      image:
+        repository: quay.io/konflux-ci/integration-service
+        tag: caf6fe676510074c37338b26d69570247f7fa162
+  snapshotgc:
+    image:
+      repository: quay.io/konflux-ci/integration-service
+      tag: caf6fe676510074c37338b26d69570247f7fa162
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 1000m
+        memory: 500Mi
+  prometheus:
+    enable: false


### PR DESCRIPTION
Use Helm to deploy integration-service.
For now, the command for deploying with Helm is placed inside deploy-konflux.sh, but once all services are deployed with Helm, the script will be replaced by a call to Helm.