### PR TITLE
add a default releaseserviceconfig

### DIFF
--- a/konflux-ci/release/core/kustomization.yaml
+++ b/konflux-ci/release/core/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - https://github.com/konflux-ci/release-service/config/default?ref=5954f10a8c86134fca5f70fc1d9898254ee1f082
   - release-pipeline-resources-clusterrole.yaml
   - release-service-config-rbac.yaml
+  - release-service-config.yaml
 
 images:
   - name: quay.io/konflux-ci/release-service

--- a/konflux-ci/release/core/release-service-config.yaml
+++ b/konflux-ci/release/core/release-service-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseServiceConfig
+metadata:
+  name: release-service-config
+spec:
+  debug: false


### PR DESCRIPTION
- with https://github.com/konflux-ci/release-service/pull/669 and https://github.com/redhat-appstudio/infra-deployments/pull/5508 we need to ensure that a default ReleaseServiceConfig is present when the release controller is running.