### PR TITLE
Enable tekton chains deep inspection

### DIFF
--- a/dependencies/tekton-config/tekton-config.yml
+++ b/dependencies/tekton-config/tekton-config.yml
@@ -14,6 +14,7 @@ spec:
     schedule: "0 8 * * *"
   chain:
     artifacts.oci.storage: oci
+    artifacts.pipelinerun.enable-deep-inspection: "true"
     artifacts.pipelinerun.format: in-toto
     artifacts.pipelinerun.storage: oci
     artifacts.taskrun.format: in-toto


### PR DESCRIPTION
See https://tekton.dev/docs/chains/config/#pipelinerun-configuration

Certain enterprise contract rules depend on this, in particular for deployments that have multi-arch builds enabled. There, we need the provenance associated not just with the final image index but also with all per-arch image manifests.