### PR TITLE
nslister: add egress NetworkPolicy

### DIFF
--- a/konflux-ci/namespace-lister/kustomization.yaml
+++ b/konflux-ci/namespace-lister/kustomization.yaml
@@ -5,13 +5,14 @@ resources:
 - namespace.yaml
 - rbac.yaml
 - service.yaml
-- network_policy.yaml
 - certificate.yaml
+- network_policy_allow_to_apiserver.yaml
+- network_policy_allow_from_konfluxui.yaml
 namespace: namespace-lister
 images:
-- name: quay.io/konflux-ci/namespace-lister
+- digest: sha256:f624cce3cdaf10856dbdcc27715425590087cf13a95e2313280db2e986166e7a
+  name: quay.io/konflux-ci/namespace-lister
   newName: quay.io/konflux-ci/namespace-lister
-  digest: sha256:f624cce3cdaf10856dbdcc27715425590087cf13a95e2313280db2e986166e7a
 patches:
 - path: ./patches/with-header-auth-email.yaml
   target:

--- a/konflux-ci/namespace-lister/network_policy_allow_from_konfluxui.yaml
+++ b/konflux-ci/namespace-lister/network_policy_allow_from_konfluxui.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: namespace-lister
+  name: namespace-lister-allow-from-konfluxui
   namespace: namespace-lister
 spec:
   podSelector:

--- a/konflux-ci/namespace-lister/network_policy_allow_to_apiserver.yaml
+++ b/konflux-ci/namespace-lister/network_policy_allow_to_apiserver.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: namespace-lister-allow-to-apiserver
+  namespace: namespace-lister
+spec:
+  podSelector:
+    matchLabels:
+      apps: namespace-lister
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - port: 6443
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          component: kube-apiserver
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system


### PR DESCRIPTION
this change allows the namespace-lister to only reach-out to the kube-apiserver

Signed-off-by: Francesco Ilario <filario@redhat.com>
