### PR TITLE
namespace-lister: add healthz and readyz probes

### DIFF
--- a/konflux-ci/namespace-lister/deployment.yaml
+++ b/konflux-ci/namespace-lister/deployment.yaml
@@ -37,6 +37,18 @@ spec:
           value: "0"
         - name: CACHE_RESYNC_PERIOD
           value: 10m
+        livenessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTPS
+        readinessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /readyz
+            port: 8080
+            scheme: HTTPS
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
Add healthz and readyz probe checks into the namespace-lister deployment, so kubernetes has an idea of when pods are healthy and available to respond to requests.