### PR TITLE
feat: add PAC_WEBHOOK_URL to allow UI builds

### DIFF
--- a/deploy-konflux.sh
+++ b/deploy-konflux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-script_path="$(dirname -- "${BASH_SOURCE[0]}")" 
+script_path="$(dirname -- "${BASH_SOURCE[0]}")"
 
 main() {
     echo "Deploying Konflux" >&2

--- a/konflux-ci/build-service/core/build-service-env-patch.yaml
+++ b/konflux-ci/build-service/core/build-service-env-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: build-service-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+            - name: PAC_WEBHOOK_URL
+              value: http://pipelines-as-code-controller.pipelines-as-code.svc.cluster.local:8080

--- a/konflux-ci/build-service/core/kustomization.yaml
+++ b/konflux-ci/build-service/core/kustomization.yaml
@@ -38,3 +38,7 @@ patches:
     target:
       kind: Deployment
       name: build-service-controller-manager
+  - target:
+      kind: Deployment
+      name: build-service-controller-manager
+    path: build-service-env-patch.yaml


### PR DESCRIPTION
This PR adds a `kubectl` command to set the `PAC_WEBHOOK_URL` for the `build-service` so users can trigger builds directly from the UI. Currently if you try to trigger a build from the UI the `build-service` tries to reach for an OpenShift Route that does not exist, so this change is required.

PD: I'm not sure about the PR format, if any, let me know.