### PR TITLE
Fix revision for Release Service repo

### DIFF
--- a/test/resources/demo-users/user/managed-ns1/rpa.yaml
+++ b/test/resources/demo-users/user/managed-ns1/rpa.yaml
@@ -25,7 +25,7 @@ spec:
         - name: url
           value: "https://github.com/konflux-ci/release-service-catalog.git"
         - name: revision
-          value: b0586bdee6e5721d773f4b5be6ca8cd8f70ddd32
+          value: 0cbe8aebf8b85763b724dc292641d2c587f13b6e
         - name: pathInRepo
           value: "pipelines/managed/push-to-external-registry/push-to-external-registry.yaml"
     serviceAccountName: appstudio-pipeline

--- a/test/resources/demo-users/user/managed-ns2/rpa.yaml
+++ b/test/resources/demo-users/user/managed-ns2/rpa.yaml
@@ -23,7 +23,7 @@ spec:
         - name: url
           value: "https://github.com/konflux-ci/release-service-catalog.git"
         - name: revision
-          value: b0586bdee6e5721d773f4b5be6ca8cd8f70ddd32
+          value: 0cbe8aebf8b85763b724dc292641d2c587f13b6e
         - name: pathInRepo
           value: "pipelines/managed/push-to-external-registry/push-to-external-registry.yaml"
     serviceAccountName: appstudio-pipeline


### PR DESCRIPTION
This PR changes the revision specified for the pipelines on the example ReleasePlanAdmissions because the SHA specified is not on the repository. See https://github.com/konflux-ci/release-service-catalog/commit/b0586bdee6e5721d773f4b5be6ca8cd8f70ddd32 and the warning at the top. The current SHA references a fix for a PR that is already merged, so I searched for the corresponding PR and used the SHA created by that PR when merged on their default branch.

cc @johnbieren @scoheb 