### PR TITLE
Create the managed namespaces by default

### DIFF
--- a/test/resources/demo-users/user/kustomization.yaml
+++ b/test/resources/demo-users/user/kustomization.yaml
@@ -3,4 +3,6 @@ kind: Kustomization
 resources:
   - ns1
   - ns2
+  - managed-ns1
+  - managed-ns2
   - cluster-rbac.yaml


### PR DESCRIPTION
One of the ReleasePlans expects that they are present.

I ran into this in a practical way while working on https://github.com/konflux-ci/konflux-ui/pull/153