### PR TITLE
Update minimum kind and kubectl versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ additional resources.
 
 :gear: Verify that the applications below are installed on the host machine:
 
-* [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (`v0.22.0` or
+* [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (`v0.26.0` or
   newer) along with `podman` (`v5.3.1` or newer) or `docker` (`v27.0.1` or newer)
-* `kubectl` (`v1.26.1` or newer)
+* `kubectl` (`v1.31.1` or newer)
 * `git` (`v2.46` or newer)
 * `openssl` (`v3.2.2` or newer)
 


### PR DESCRIPTION
Update README with minimum required versions
kubectl: 1.31.1
Kind: 0.26.0

Close #1654 