### PR TITLE
feat: add sealights integration to get coverage numbers about konflux and all core products

### DIFF
--- a/konflux-ci/build-service/core/kustomization.yaml
+++ b/konflux-ci/build-service/core/kustomization.yaml
@@ -42,3 +42,9 @@ patches:
       kind: Deployment
       name: build-service-controller-manager
     path: build-service-env-patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: build-service-controller-manager
+    path: sealights-envs.yaml

--- a/konflux-ci/build-service/core/sealights-envs.yaml
+++ b/konflux-ci/build-service/core/sealights-envs.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: build-service-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+          - name: SEALIGHTS_LAB_ID
+            value: ""
+          - name: SEALIGHTS_TOKEN
+            value: ""

--- a/konflux-ci/image-controller/core/kustomization.yaml
+++ b/konflux-ci/image-controller/core/kustomization.yaml
@@ -29,3 +29,9 @@ patches:
       kind: CronJob
       name: image-controller-image-pruner-cronjob
     path: replace-pruner-image.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: image-controller-controller-manager
+    path: sealights-envs.yaml

--- a/konflux-ci/image-controller/core/sealights-envs.yaml
+++ b/konflux-ci/image-controller/core/sealights-envs.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+            - name: SEALIGHTS_LAB_ID
+              value: ""
+            - name: SEALIGHTS_TOKEN
+              value: ""

--- a/konflux-ci/integration/core/kustomization.yaml
+++ b/konflux-ci/integration/core/kustomization.yaml
@@ -54,3 +54,9 @@ patches:
       kind: CronJob
       name: integration-service-snapshot-garbage-collector
     path: snapshot-gc-resource-patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: integration-service-controller-manager
+    path: sealights-envs.yaml

--- a/konflux-ci/integration/core/sealights-envs.yaml
+++ b/konflux-ci/integration/core/sealights-envs.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: integration-service-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+          - name: SEALIGHTS_LAB_ID
+            value: ""
+          - name: SEALIGHTS_TOKEN
+            value: ""

--- a/konflux-ci/release/core/kustomization.yaml
+++ b/konflux-ci/release/core/kustomization.yaml
@@ -76,3 +76,9 @@ patches:
     target:
       kind: Deployment
       name: release-service-controller-manager
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: release-service-controller-manager
+    path: sealights-envs.yaml

--- a/konflux-ci/release/core/sealights-envs.yaml
+++ b/konflux-ci/release/core/sealights-envs.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: release-service-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+          - name: SEALIGHTS_LAB_ID
+            value: ""
+          - name: SEALIGHTS_TOKEN
+            value: ""

--- a/test/e2e/coverage-metrics/create-test-session.sh
+++ b/test/e2e/coverage-metrics/create-test-session.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure necessary environment variables are set
+export SEALIGHTS_TOKEN="${SEALIGHTS_TOKEN:-""}"
+export SEALIGHTS_LAB_ID="${SEALIGHTS_LAB_ID:-""}"
+export SEALIGHTS_DOMAIN="${SEALIGHTS_DOMAIN:-""}"
+export SEALIGHTS_TEST_STAGE="${SEALIGHTS_TEST_STAGE:-""}"
+export TEST_SESSION_ID_FILE="${TEST_SESSION_ID_FILE:-"/tmp/test_session_id"}"
+
+export MISSING_VARS=()
+
+[[ -z "$SEALIGHTS_TOKEN" ]] && MISSING_VARS+=("SEALIGHTS_TOKEN")
+[[ -z "$SEALIGHTS_LAB_ID" ]] && MISSING_VARS+=("SEALIGHTS_LAB_ID")
+[[ -z "$SEALIGHTS_DOMAIN" ]] && MISSING_VARS+=("SEALIGHTS_DOMAIN")
+[[ -z "$SEALIGHTS_TEST_STAGE" ]] && MISSING_VARS+=("SEALIGHTS_TEST_STAGE")
+
+if [[ ${#MISSING_VARS[@]} -gt 0 ]]; then
+  echo "[ERROR] The following required environment variables are missing:"
+  for VAR in "${MISSING_VARS[@]}"; do
+    echo "  - $VAR"
+  done
+  exit 1
+fi
+
+TEST_SESSION_ID=$(curl -s -X POST "$SEALIGHTS_DOMAIN/sl-api/v1/test-sessions" \
+  -H "Authorization: Bearer $SEALIGHTS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg labId "$SEALIGHTS_LAB_ID" --arg testStage "$SEALIGHTS_TEST_STAGE" \
+    '{labId: $labId, testStage: $testStage, bsid: "", sessionTimeout: 10000}')" | jq -r '.data.testSessionId')
+
+if [[ -z "$TEST_SESSION_ID" || "$TEST_SESSION_ID" == "null" ]]; then
+  echo "[ERROR] Failed to retrieve test session ID"
+  exit 1
+fi
+
+echo "[INFO] Test session ID: $TEST_SESSION_ID"
+
+if [[ -n "$TEST_SESSION_ID_FILE" ]]; then
+  mkdir -p "$(dirname "$TEST_SESSION_ID_FILE")"
+fi
+
+echo "$TEST_SESSION_ID" > "$TEST_SESSION_ID_FILE"
+
+cat "$TEST_SESSION_ID_FILE"

--- a/test/e2e/coverage-metrics/konflux-deploy-ready.sh
+++ b/test/e2e/coverage-metrics/konflux-deploy-ready.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+export SEALIGHTS_TOKEN="${SEALIGHTS_TOKEN:-""}"
+export SEALIGHTS_LAB_ID="${SEALIGHTS_LAB_ID:-""}"
+export SEALIGHTS_DOMAIN="${SEALIGHTS_DOMAIN:-""}"
+
+# Creates a snapshot after finishing the deployment to get Konflux CI complete coverage metric
+SEALIGHTS_BUILD_NAME="$(date +"%Y.%m.%d.%H.%M.%S")"
+export SEALIGHTS_BUILD_NAME
+
+HTTP_RESPONSE=$(curl --write-out "%{http_code}" --silent --output /dev/null \
+  --location "${SEALIGHTS_DOMAIN}/sl-api/v1/agent-apis/lab-ids/${SEALIGHTS_LAB_ID}/integration-build" \
+  --header "Authorization: Bearer ${SEALIGHTS_TOKEN}" \
+  --header 'Content-Type: application/json' \
+  --data "{ \"buildName\": \"${SEALIGHTS_BUILD_NAME}\" }")
+
+if [[ "$HTTP_RESPONSE" -ge 200 && "$HTTP_RESPONSE" -lt 300 ]]; then
+  echo "[INFO] Curl request was successful. Exiting with status 0."
+  exit 0
+else
+  echo "[ERROR] Curl request failed with status code: $HTTP_RESPONSE"
+  exit 1
+fi

--- a/test/e2e/coverage-metrics/prepare-sl-images.sh
+++ b/test/e2e/coverage-metrics/prepare-sl-images.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export SEALIGHTS_TOKEN="${SEALIGHTS_TOKEN:-""}"
+export SEALIGHTS_LAB_ID="${SEALIGHTS_LAB_ID:-""}"
+
+TMP_FOLDER="$(mktemp -d)"
+export TMP_FOLDER
+
+# Define array with core components and the path in the root repo
+SERVICES_ENTRIES=(
+  "integration:konflux-ci/integration/core/kustomization.yaml"
+  "release:konflux-ci/release/core/kustomization.yaml"
+  "build-service:konflux-ci/build-service/core/kustomization.yaml"
+  "image-controller:konflux-ci/image-controller/core/kustomization.yaml"
+)
+
+for service_entry in "${SERVICES_ENTRIES[@]}"; do
+  component_name="${service_entry%%:*}"  # Extract service name (before ':')
+  kustomization_file="${service_entry#*:}"  # Extract file path (after ':')
+
+  echo "[INFO] Processing component: $component_name from kustomization file $kustomization_file"
+
+  PRISTINE_IMAGE=$(yq -r '.images[] | "\(.newName):\(.newTag)"' "$kustomization_file")
+
+  if [ -z "$PRISTINE_IMAGE" ]; then
+    echo "[INFO] No image found in $kustomization_file, skipping..."
+    continue
+  fi
+
+  echo "[INFO] Current pristine image: $PRISTINE_IMAGE"
+
+  # Download the image and fetch attestation using cosign
+  cosign download attestation "$PRISTINE_IMAGE" > "$TMP_FOLDER/cosign_${component_name}_metadata.json"
+
+  # Extract SOURCE_ARTIFACT from attestation metadata
+  SL_SOURCE_ARTIFACT=$(jq -r '
+    .payload | @base64d | fromjson | .predicate.buildConfig.tasks[] |
+    select(.invocation.environment.labels."konflux-ci/sealights" == "true") |
+    .results[] | select(.name == "SOURCE_ARTIFACT") | .value' "$TMP_FOLDER/cosign_${component_name}_metadata.json")
+
+  if [ -z "$SL_SOURCE_ARTIFACT" ]; then
+    echo "[ERROR] No SOURCE_ARTIFACT found, skipping..."
+    continue
+  fi
+
+  # Extract IMAGE_REF (which contains full Sealights image reference)
+  SL_CONTAINER_IMAGE=$(jq -r --arg sl_source_artifact "$SL_SOURCE_ARTIFACT" '
+    .payload | @base64d | fromjson | .predicate.buildConfig.tasks[] |
+    select(.invocation.parameters.SOURCE_ARTIFACT == $sl_source_artifact) |
+    select(.ref.params[].value == "buildah-oci-ta") | .results[] | select(.name == "IMAGE_REF") |
+    .value' "$TMP_FOLDER/cosign_${component_name}_metadata.json")
+
+  if [ -z "$SL_CONTAINER_IMAGE" ]; then
+    echo "[ERROR] No IMAGE_REF found in attestation, skipping..."
+    continue
+  fi
+
+  # Extract sealights image name and tag separately
+  SL_IMAGE_NAME=$(echo "$SL_CONTAINER_IMAGE" | cut -d':' -f1)
+  SL_IMAGE_TAG=$(echo "$SL_CONTAINER_IMAGE" | cut -d':' -f2 | cut -d'@' -f1)
+
+  echo "[INFO] Extracted Image Name: $SL_IMAGE_NAME"
+  echo "[INFO] Extracted Image Tag: $SL_IMAGE_TAG"
+
+  echo "[INFO] Updating kustomization file: $kustomization_file"
+
+  yq -i ".images[0].newName = \"$SL_IMAGE_NAME\" | .images[0].newTag = \"$SL_IMAGE_TAG\"" "$kustomization_file"
+
+  echo "[INFO] Updated kustomization file: $kustomization_file"
+
+  yq e "
+  (.spec.template.spec.containers[].env[] | select(.name == \"SEALIGHTS_LAB_ID\")).value = \"${SEALIGHTS_LAB_ID}\" |
+  (.spec.template.spec.containers[].env[] | select(.name == \"SEALIGHTS_TOKEN\")).value = \"${SEALIGHTS_TOKEN}\"
+" -i konflux-ci/"$component_name"/core/sealights-envs.yaml
+done

--- a/test/e2e/coverage-metrics/upload-ginkgo-results.sh
+++ b/test/e2e/coverage-metrics/upload-ginkgo-results.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -euo pipefail
+
+export SEALIGHTS_TOKEN="${SEALIGHTS_TOKEN:-""}"
+export SEALIGHTS_LAB_ID="${SEALIGHTS_LAB_ID:-""}"
+export SEALIGHTS_DOMAIN="${SEALIGHTS_DOMAIN:-""}"
+export SEALIGHTS_TEST_STAGE="${SEALIGHTS_TEST_STAGE:-""}"
+export GINKGO_JSON_REPORT_PATH="${GINKGO_JSON_REPORT_PATH:-""}"
+export TEST_SESSION_ID="${TEST_SESSION_ID:-""}"
+export TEST_SESSION_ID_FILE="${TEST_SESSION_ID_FILE:-"/tmp/test_session_id"}"
+
+MISSING_VARS=()
+
+[[ -z "$SEALIGHTS_TOKEN" ]] && MISSING_VARS+=("SEALIGHTS_TOKEN")
+[[ -z "$SEALIGHTS_LAB_ID" ]] && MISSING_VARS+=("SEALIGHTS_LAB_ID")
+[[ -z "$SEALIGHTS_DOMAIN" ]] && MISSING_VARS+=("SEALIGHTS_DOMAIN")
+[[ -z "$SEALIGHTS_TEST_STAGE" ]] && MISSING_VARS+=("SEALIGHTS_TEST_STAGE")
+[[ -z "$GINKGO_JSON_REPORT_PATH" ]] && MISSING_VARS+=("GINKGO_JSON_REPORT_PATH")
+
+# Exit if any required variables are missing
+if [[ ${#MISSING_VARS[@]} -gt 0 ]]; then
+  echo "[ERROR] The following required environment variables are missing:"
+  for VAR in "${MISSING_VARS[@]}"; do
+    echo "  - $VAR"
+  done
+  exit 1
+fi
+
+# Cleanup function to delete the test session
+cleanup() {
+  if [[ -n "$TEST_SESSION_ID" ]]; then
+    echo "[INFO] Closing the test session..."
+    curl -s -X DELETE "$SEALIGHTS_DOMAIN/sl-api/v1/test-sessions/$TEST_SESSION_ID" \
+      -H "Authorization: Bearer $SEALIGHTS_TOKEN" \
+      -H "Content-Type: application/json"
+    echo "[INFO] Test session closed successfully"
+  fi
+}
+
+trap cleanup EXIT
+
+if [[ -z "$TEST_SESSION_ID" && -n "$TEST_SESSION_ID_FILE" && -f "$TEST_SESSION_ID_FILE" ]]; then
+  if [[ ! -s "$TEST_SESSION_ID_FILE" ]]; then
+    echo "[INFO] File '$TEST_SESSION_ID_FILE' exists but is empty"
+    exit 1
+  fi
+fi
+
+TEST_SESSION_ID="$(cat "$TEST_SESSION_ID_FILE")"
+export TEST_SESSION_ID
+echo "[INFO] Loaded test session ID from file: $TEST_SESSION_ID_FILE: $TEST_SESSION_ID"
+
+# Function to process test report
+process_test_report() {
+  jq -c '.[] | .SpecReports[]' "$GINKGO_JSON_REPORT_PATH" | while IFS= read -r line; do
+    name=$(echo "$line" | jq -r '.LeafNodeText')
+    start_raw=$(echo "$line" | jq -r '.StartTime')
+    end_raw=$(echo "$line" | jq -r '.EndTime')
+    status=$(echo "$line" | jq -r '.State')
+
+    start=$(date --date="$start_raw" +%s%3N)
+    if [[ -z "$end_raw" || "$end_raw" == "0001-01-01T00:00:00Z" ]]; then
+      end=$(date +%s%3N)
+    else
+      end=$(date --date="$end_raw" +%s%3N)
+    fi
+
+    if [[ "$status" == "passed" || "$status" == "failed" ]]; then
+      echo "{\"name\": \"$name\", \"start\": $start, \"end\": $end, \"status\": \"$status\"}"
+    fi
+  done | jq -s '.'
+}
+
+PROCESSED_JSON=$(process_test_report)
+echo "[INFO] Test report processed successfully"
+
+echo "$PROCESSED_JSON" | jq .
+
+echo "[INFO] Sending test results to Sealights..."
+curl -s -X POST "$SEALIGHTS_DOMAIN/sl-api/v2/test-sessions/$TEST_SESSION_ID" \
+  -H "Authorization: Bearer $SEALIGHTS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$PROCESSED_JSON"
+
+echo "[INFO] Test Results upload succeeded!"

--- a/test/e2e/run-e2e.sh
+++ b/test/e2e/run-e2e.sh
@@ -9,7 +9,7 @@ main() {
     local github_org="${GH_ORG:?A GitHub org where the https://github.com/redhat-appstudio-qe/konflux-ci-sample repo is present/forked should be provided}"
     local github_token="${GH_TOKEN:?A GitHub token should be provided}"
     local quay_dockerconfig="${QUAY_DOCKERCONFIGJSON:?quay.io credentials in .dockerconfig format should be provided}"
-    docker run --network=host -v ~/.kube/config:/kube/config --env KUBECONFIG=/kube/config -e GITHUB_TOKEN="$github_token" -e QUAY_TOKEN="$(base64 <<< "$quay_dockerconfig")" -e MY_GITHUB_ORG="$github_org" -e E2E_APPLICATIONS_NAMESPACE=user-ns2 "$E2E_TEST_IMAGE" /konflux-e2e/konflux-e2e.test "--ginkgo.label-filter=upstream-konflux" "--ginkgo.focus=Test local" "--ginkgo.v"
+    docker run --network=host -e ARTIFACT_DIR=/home -v /tmp/:/home -v ~/.kube/config:/kube/config --env KUBECONFIG=/kube/config -e GITHUB_TOKEN="$github_token" -e QUAY_TOKEN="$(base64 <<< "$quay_dockerconfig")" -e MY_GITHUB_ORG="$github_org" -e E2E_APPLICATIONS_NAMESPACE=user-ns2 "$E2E_TEST_IMAGE" /konflux-e2e/konflux-e2e.test "--ginkgo.label-filter=upstream-konflux" "--ginkgo.json-report=/home/e2e-report.json" "--ginkgo.focus=Test local" "--ginkgo.v"
 }
 
 


### PR DESCRIPTION
Creates script that will get coverage metrics about Konflux CI product and in the future we want to get it at PR level when sealights is ready to do it.