### PR TITLE
update PaC version

### DIFF
--- a/dependencies/pipelines-as-code/kustomization.yml
+++ b/dependencies/pipelines-as-code/kustomization.yml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/openshift-pipelines/pipelines-as-code/releases/download/v0.24.1/release.k8s.yaml
+  - https://github.com/openshift-pipelines/pipelines-as-code/releases/download/v0.33.0/release.k8s.yaml
 patches:
   - path: custom-console-patch.yaml
     target:


### PR DESCRIPTION
The current PaC version is one year old and is missing some significant features.
Updating the version as part of stabilization of UI tests. https://issues.redhat.com/browse/KFLUXUI-338