### PR TITLE
Adding livenessProbe to smee-client

### DIFF
--- a/dependencies/smee/smee-client.yaml
+++ b/dependencies/smee/smee-client.yaml
@@ -31,10 +31,10 @@ spec:
             httpGet:
               path: /
               port: 8080
-          initialDelaySeconds: 30
-          periodSeconds: 5
-          timeoutSeconds: 2
-          failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true

--- a/dependencies/smee/smee-client.yaml
+++ b/dependencies/smee/smee-client.yaml
@@ -27,6 +27,14 @@ spec:
             - "client"
             - <smee-channel>
             - "http://pipelines-as-code-controller.pipelines-as-code:8080"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true

--- a/dependencies/smee/smee-client.yaml
+++ b/dependencies/smee/smee-client.yaml
@@ -31,7 +31,7 @@ spec:
             httpGet:
               path: /
               port: 8080
-          initialDelaySeconds: 10
+          initialDelaySeconds: 30
           periodSeconds: 5
           timeoutSeconds: 2
           failureThreshold: 3

--- a/dependencies/smee/smee-client.yaml
+++ b/dependencies/smee/smee-client.yaml
@@ -30,7 +30,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 8080
+              port: 80
             initialDelaySeconds: 30
             periodSeconds: 5
             timeoutSeconds: 2


### PR DESCRIPTION
As part of https://issues.redhat.com/browse/SPRE-1255, we need to create a livenessProbe for smee-client.