### PR TITLE
removing livenessProbe

### DIFF
--- a/dependencies/smee/smee-client.yaml
+++ b/dependencies/smee/smee-client.yaml
@@ -23,20 +23,10 @@ spec:
         - image: "ghcr.io/chmouel/gosmee:v0.21.0"
           imagePullPolicy: Always
           name: gosmee
-          ports:
-           - containerPort: 8080
           args:
             - "client"
             - <smee-channel>
             - "http://pipelines-as-code-controller.pipelines-as-code:8080"
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 8080
-            initialDelaySeconds: 30
-            periodSeconds: 5
-            timeoutSeconds: 2
-            failureThreshold: 3
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true


### PR DESCRIPTION
It seems Pod is on CrashLooping state, removing the livenessProbe recently added to come back to initial setup and look for a better solution of implementation in case is needed.