### PR TITLE
fix: kyverno policy for steps with undefined resources

### DIFF
--- a/dependencies/kyverno/policy/pod-requests-del.yaml
+++ b/dependencies/kyverno/policy/pod-requests-del.yaml
@@ -17,7 +17,7 @@ spec:
       foreach:
       - list: "request.object.spec.containers"
         patchesJson6902: |-
-          - op: replace
+          - op: add
             path: /spec/containers/{{elementIndex}}/resources/requests
             value:
               memory: 1Mi


### PR DESCRIPTION
The policy will fail to be deployed if the pod it captures had some containers with resource requests undefined. This change should address that.