### PR TITLE
chore: use kyverno for ci workaround - different logic

### DIFF
--- a/dependencies/kyverno/kustomization.yaml
+++ b/dependencies/kyverno/kustomization.yaml
@@ -44,6 +44,16 @@ patches:
     kind: Deployment
     name: kyverno-reports-controller
     namespace: kyverno
+# Reserving more CPU resources comparing to the default 100m seems to provide shorter
+# overall execution time for the e2e tests.
+- patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/resources/requests/cpu
+      value: 200m
+  target:
+    kind: Deployment
+    name: kyverno-admission-controller
+    namespace: kyverno
 - patch: |-
     - op: add
       path: /spec/jobTemplate/spec/template/spec/containers/0/resources

--- a/dependencies/kyverno/policy/e2e-reduce-resources.yaml
+++ b/dependencies/kyverno/policy/e2e-reduce-resources.yaml
@@ -1,0 +1,41 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: reduce-tekton-pr-taskrun-resource-requests
+  annotations:
+    policies.kyverno.io/description: >-
+      This policy applies to pods created for the on-push pipeline running for the e2e
+      tests. It will apply a small set value for CPU requests whenever memory is defined
+      and vice versa (the underlying assumption is that either both are defined or
+      neither are).
+spec:
+  background: false
+  rules:
+  - name: reduce-tekton-pr-taskrun-resource-requests
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+          operations:
+          - CREATE
+          selector:
+            matchLabels:
+              pipelinesascode.tekton.dev/original-prname: "konflux-ci-upstream-*-on-push"
+    mutate:
+      foreach:
+      - list: "request.object.spec.containers"
+        preconditions:
+          any:
+          - key: "{{ element.resources.requests.memory || '' }}"
+            operator: NotEquals
+            value: ""
+          - key: "{{ element.resources.requests.cpu || '' }}"
+            operator: NotEquals
+            value: ""
+        patchesJson6902: |-
+          - op: add
+            path: /spec/containers/{{elementIndex}}/resources/requests
+            value:
+              memory: 256Mi
+              cpu: 100m

--- a/dependencies/kyverno/policy/pod-requests-del.yaml
+++ b/dependencies/kyverno/policy/pod-requests-del.yaml
@@ -2,7 +2,18 @@ apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: remove-tekton-taskrun-resource-requests
+  annotations:
+    policies.kyverno.io/description: >-
+      This policy applies to pods created for the verify-enterprise-contract task.
+      It will reduce the requested cpu and memory resources for all containers created
+      by the task to a minimum.
+      This is to address a change in the task definition in which the task steps were
+      provided with resource requests. This task has many steps, and adding even
+      relatively-modest resource requests prevents it from running on setups with
+      limited resources, as Tekton creates pods for all steps in a task at the same
+      time.
 spec:
+  background: false
   rules:
   - name: remove-resource-requests-for-tekton-taskrun-pods
     match:
@@ -10,6 +21,8 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
           selector:
             matchLabels:
               tekton.dev/task: verify-enterprise-contract

--- a/test/e2e/customize-docker-pipeline.sh
+++ b/test/e2e/customize-docker-pipeline.sh
@@ -3,51 +3,9 @@ set -euo pipefail
 
 script_path="$(dirname -- "${BASH_SOURCE[0]}")"
 
-update_pipeline() {
-    local pipeline_name=$1
-    local tmp_pipeline_path="/tmp/customized-${pipeline_name}.yaml"
-    local original_pipeline_bundle_ref
-
-    original_pipeline_bundle_ref=$(yq ".data[\"config.yaml\"]" konflux-ci/build-service/core/build-pipeline-config.yaml | yq ".pipelines[] | select(.name == \"${pipeline_name}\").bundle")
-    tkn bundle list --remote-skip-tls "$original_pipeline_bundle_ref" -o yaml > "${tmp_pipeline_path}"
-
-    for task_name in $(yq "(.spec.tasks[] | .name)" "${tmp_pipeline_path}");
-    do
-        local original_task_bundle_ref
-        local tmp_task_path="/tmp/customized-task.yaml"
-        local customized_task_image_ref_localhost="localhost:30001/test/test:customized-task-${task_name}-${pipeline_name}"
-        local customized_task_image_ref_cluster="registry-service.kind-registry/test/test:customized-task-${task_name}-${pipeline_name}"
-
-        original_task_bundle_ref=$(yq "(.spec.tasks[] | select(.name == \"${task_name}\").taskRef.params[] | select(.name == \"bundle\").value)" "${tmp_pipeline_path}")
-        tkn bundle list --remote-skip-tls "$original_task_bundle_ref" -o yaml > $tmp_task_path || continue
-
-        yq e -i '(.spec.steps[] | select(has("computeResources")) | .computeResources.requests.cpu) |= "100m"' $tmp_task_path
-        yq e -i '(.spec.steps[] | select(has("computeResources")) | .computeResources.requests.memory) |= "256Mi"' $tmp_task_path
-        yq e -i '(.spec.steps[] | select(has("resources")) | .resources.requests.cpu) |= "100m"' $tmp_task_path
-        yq e -i '(.spec.steps[] | select(has("resources")) | .resources.requests.memory) |= "256Mi"' $tmp_task_path
-
-        yq e -i "(.spec.tasks[] | select(.name == \"${task_name}\").taskRef.params[] | select(.name == \"bundle\").value) |= \"${customized_task_image_ref_cluster}\"" "${tmp_pipeline_path}"
-
-        tkn bundle push --remote-skip-tls "$customized_task_image_ref_localhost" -f $tmp_task_path
-    done
-
-    local customized_pipeline_image_ref_localhost="localhost:30001/test/test:customized-${pipeline_name}-pipeline"
-    tkn bundle push --remote-skip-tls "$customized_pipeline_image_ref_localhost" -f "${tmp_pipeline_path}"
-
-    # Update the bundle ref in build-service pipeline configmap
-    local customized_pipeline_image_ref_cluster="registry-service.kind-registry/test/test:customized-${pipeline_name}-pipeline"
-    sed -i "s|bundle:.*${pipeline_name}@.*|bundle: ${customized_pipeline_image_ref_cluster}|g" konflux-ci/build-service/core/build-pipeline-config.yaml
-}
-
 main() {
-    echo "Updating docker-build pipeline to workaround the issues with and cpu/mem requests for build task" >&2
-    # shellcheck disable=SC1091
-    source "${script_path}/vars.sh"
-
-    # This is required in order to push the modified pipeline to local registry
-    kubectl port-forward -n kind-registry svc/registry-service 30001:443 &
-
-    update_pipeline docker-build-oci-ta
+    echo "Apply Kyverno policy"
+    kubectl apply -f  "${script_path}/../../dependencies/kyverno/policy/e2e-reduce-resources.yaml"
 }
 
 


### PR DESCRIPTION
Replace the script used for reducing task resources in CI with a kyverno policy.

This is an optimization attempt for [another PR](https://github.com/konflux-ci/konflux-ci/pull/1840).