### PR TITLE
chore(KONFLUX-7649): add rolebinding to read from build configmap

### DIFF
--- a/konflux-ci/build-service/core/build-config-rolebinding.yaml
+++ b/konflux-ci/build-service/core/build-config-rolebinding.yaml
@@ -1,0 +1,15 @@
+# role in build-service https://github.com/konflux-ci/build-service/pull/296
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-pipeline-config-read-only-binding
+  namespace: build-service
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated
+roleRef:
+  kind: Role
+  name: build-pipeline-config-read-only
+  apiGroup: rbac.authorization.k8s.io

--- a/konflux-ci/build-service/core/kustomization.yaml
+++ b/konflux-ci/build-service/core/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - https://github.com/konflux-ci/build-service/config/default?ref=cdd5c475cdbc96bb79231df7e42da40ab0e01c26
   - build-pipeline-config.yaml
+  - build-config-rolebinding.yaml
 
 namespace: build-service
 


### PR DESCRIPTION
Add a rolebinding to allow us to read from the build config map to create the list of available pipelines