### PR TITLE
Adding new livenessProbe to smee client

### DIFF
--- a/dependencies/smee/smee-client.yaml
+++ b/dependencies/smee/smee-client.yaml
@@ -27,6 +27,14 @@ spec:
             - "client"
             - <smee-channel>
             - "http://pipelines-as-code-controller.pipelines-as-code:8080"
+          livenessProbe:
+            exec:
+              command:
+                - echo "Service up"
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true


### PR DESCRIPTION
We have created a new livenessProbe for smee-client, based on a simple echo "Service up" instead of choosing http check due to port forwarding issue.
Tracking ticket: https://issues.redhat.com/browse/SPRE-1255 