### PR TITLE
fix: smee client liveliness probe

### DIFF
--- a/dependencies/smee/smee-client.yaml
+++ b/dependencies/smee/smee-client.yaml
@@ -30,7 +30,8 @@ spec:
           livenessProbe:
             exec:
               command:
-                - echo "Service up"
+                - echo
+                - "Hello smee client"
             initialDelaySeconds: 30
             periodSeconds: 5
             timeoutSeconds: 2


### PR DESCRIPTION
Probe was failing, as it turns out the command field should be provided as a list of words.

Error message: OCI runtime exec failed: exec failed: unable to start container process: exec: "echo \"Service up\"": executable file not found in $PATH