### PR TITLE
use konflux-ci.dev/type=tenant as user ns label

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,7 +864,7 @@ according to our needs and limitations.
 # Replace $NS with the name of the new namespace
 
 kubectl create namespace $NS
-kubectl label namespace "$NS konflux.ci/type=user
+kubectl label namespace "$NS konflux-ci.dev/type=tenant
 kubectl create serviceaccount appstudio-pipeline -n $NS
 ```
 
@@ -872,7 +872,7 @@ Example:
 
 ```bash
 kubectl create namespace user-ns3
-kubectl label namespace user-ns3 konflux.ci/type=user
+kubectl label namespace user-ns3 konflux-ci.dev/type=tenant
 kubectl create serviceaccount appstudio-pipeline -n user-ns3
 ```
 

--- a/konflux-ci/namespace-lister/kustomization.yaml
+++ b/konflux-ci/namespace-lister/kustomization.yaml
@@ -14,6 +14,12 @@ images:
   name: quay.io/konflux-ci/namespace-lister
   newName: quay.io/konflux-ci/namespace-lister
 patches:
+- path: ./patches/with_cachenamespacelabelselector.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: namespace-lister
+    namespace: namespace-lister
 - path: ./patches/with-header-auth-impersonate-user.yaml
   target:
     group: apps

--- a/konflux-ci/namespace-lister/patches/with_cachenamespacelabelselector.yaml
+++ b/konflux-ci/namespace-lister/patches/with_cachenamespacelabelselector.yaml
@@ -1,0 +1,5 @@
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: CACHE_NAMESPACE_LABELSELECTOR
+    value: 'konflux-ci.dev/type=tenant'

--- a/test/resources/demo-users/user/managed-ns1/ns.yaml
+++ b/test/resources/demo-users/user/managed-ns1/ns.yaml
@@ -4,4 +4,4 @@ kind: Namespace
 metadata:
   name: managed-ns1
   labels:
-    konflux.ci/type: user
+    konflux-ci.dev/type: tenant

--- a/test/resources/demo-users/user/managed-ns2/ns.yaml
+++ b/test/resources/demo-users/user/managed-ns2/ns.yaml
@@ -4,4 +4,4 @@ kind: Namespace
 metadata:
   name: managed-ns2
   labels:
-    konflux.ci/type: user
+    konflux-ci.dev/type: tenant

--- a/test/resources/demo-users/user/ns1/ns.yaml
+++ b/test/resources/demo-users/user/ns1/ns.yaml
@@ -4,4 +4,4 @@ kind: Namespace
 metadata:
   name: user-ns1
   labels:
-    konflux.ci/type: user
+    konflux-ci.dev/type: tenant

--- a/test/resources/demo-users/user/ns2/ns.yaml
+++ b/test/resources/demo-users/user/ns2/ns.yaml
@@ -4,4 +4,4 @@ kind: Namespace
 metadata:
   name: user-ns2
   labels:
-    konflux.ci/type: user
+    konflux-ci.dev/type: tenant


### PR DESCRIPTION
The label for user namespaces has moved from `konflux.ci/type=user` to `konflux-ci.dev/type=tenant`.  Update namespace-lister, documentation, and tests to use this new label.