### PR TITLE
chore: move gosmee image to kustomization file

### DIFF
--- a/dependencies/smee/kustomization.yml
+++ b/dependencies/smee/kustomization.yml
@@ -1,8 +1,15 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
   - smee-client.yaml
+
+images:
+  - name: ghcr.io/chmouel/gosmee
+    newName: ghcr.io/chmouel/gosmee
+    newTag: v0.21.0
+
 patches:
   - path: smee-channel-id.yaml
     target:

--- a/dependencies/smee/smee-client.yaml
+++ b/dependencies/smee/smee-client.yaml
@@ -20,7 +20,7 @@ spec:
         app: gosmee-client
     spec:
       containers:
-        - image: "ghcr.io/chmouel/gosmee:v0.21.0"
+        - image: ghcr.io/chmouel/gosmee:latest
           imagePullPolicy: Always
           name: gosmee
           args:


### PR DESCRIPTION
This is required for allowing renovate to track gosmee updates.

Closes: #2134