### PR TITLE
fix: add role binding for build service pipelines-runner

### DIFF
--- a/konflux-ci/build-service/core/build-pipeline-runner-rolebinding.yaml
+++ b/konflux-ci/build-service/core/build-pipeline-runner-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: build-pipeline-runner-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: build-service-controller-manager
+    namespace: build-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipelines-runner

--- a/konflux-ci/build-service/core/kustomization.yaml
+++ b/konflux-ci/build-service/core/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - build-pipeline-config.yaml
   - build-config-rolebinding.yaml
   - appstudio-pipelines-runner.yaml
+  - build-pipeline-runner-rolebinding.yaml
 
 namespace: build-service
 


### PR DESCRIPTION
The Fedora cluster is missing the role binding for tying the appstudio-pipelines-runner cluster role to the build service service account.

This is meaningless in konflux-ci/konflux-ci, but is required when the build-service is deployed on an openshift cluster, such as the case of the Fedora cluster.