### PR TITLE
chore(KFLUXVNGD-329): deploy smee sidecar

### DIFF
--- a/dependencies/smee/kustomization.yml
+++ b/dependencies/smee/kustomization.yml
@@ -9,6 +9,9 @@ images:
   - name: ghcr.io/chmouel/gosmee
     newName: ghcr.io/chmouel/gosmee
     newTag: v0.26.1
+  - name: quay.io/konflux-ci/smee-sidecar
+    newName: quay.io/konflux-ci/smee-sidecar
+    newTag: latest@sha256:25a4a1380e90b66968056eb036d1c6173662652c6422b9dfb968e150f70c8e2d
 
 patches:
   - path: smee-channel-id.yaml

--- a/dependencies/smee/smee-channel-id.tpl
+++ b/dependencies/smee/smee-channel-id.tpl
@@ -2,3 +2,6 @@
 - op: replace
   path: /spec/template/spec/containers/0/args/1
   value: https://smee.io/CHANNELID
+- op: replace
+  path: /spec/template/spec/containers/1/env/1/value
+  value: https://smee.io/CHANNELID

--- a/dependencies/smee/smee-client.yaml
+++ b/dependencies/smee/smee-client.yaml
@@ -9,6 +9,8 @@ kind: Deployment
 metadata:
   name: gosmee-client
   namespace: smee-client
+  annotations:
+    ignore-check.kube-linter.io/liveness-port: "gosmee probes sidecar port"
 spec:
   replicas: 1
   selector:
@@ -26,11 +28,53 @@ spec:
           args:
             - "client"
             - <smee-channel>
-            - "http://pipelines-as-code-controller.pipelines-as-code:8080"
+            - "http://localhost:8080"
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1001
+          resources:
+            limits:
+              cpu: 100m
+              memory: 32Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9100
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 25 # Must be > the healthz handler's timeout
+            failureThreshold: 2
+        - name: health-check-sidecar
+          image: quay.io/konflux-ci/smee-sidecar:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: metrics
+              containerPort: 9100
+          env:
+          - name: DOWNSTREAM_SERVICE_URL
+            value: "http://pipelines-as-code-controller.pipelines-as-code:8080"
+          - name: SMEE_CHANNEL_URL
+            value: "<smee-channel>"
+          - name: INSECURE_SKIP_VERIFY
+            value: "true"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9100
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 25 # Must be > the healthz handler's timeout
+            failureThreshold: 2
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
This will track smee health and verify it's serving request.