### PR TITLE
Add konflux-integration-runner SA and RBAC

### DIFF
--- a/konflux-ci/integration/core/konflux-integration-runner.yaml
+++ b/konflux-ci/integration/core/konflux-integration-runner.yaml
@@ -1,0 +1,6 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-integration-runner
+rules: []

--- a/konflux-ci/integration/core/kustomization.yaml
+++ b/konflux-ci/integration/core/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - https://github.com/konflux-ci/integration-service/config/default?ref=ae5e2d25d629410705f5adddcdb44df27758a804
 - https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=ae5e2d25d629410705f5adddcdb44df27758a804
+- konflux-integration-runner.yaml
 
 namespace: integration-service
 

--- a/test/resources/demo-users/user/managed-ns1/konflux-integration-runner-sa.yaml
+++ b/test/resources/demo-users/user/managed-ns1/konflux-integration-runner-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: konflux-integration-runner
+  namespace: managed-ns1

--- a/test/resources/demo-users/user/managed-ns1/kustomization.yaml
+++ b/test/resources/demo-users/user/managed-ns1/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ns.yaml
   - ../../../../../konflux-ci/enterprise-contract/policies
   - appstudio-pipeline-sa.yaml
+  - konflux-integration-runner-sa.yaml
   - pvc.yaml
   - rbac.yaml
   - role-binding.yaml

--- a/test/resources/demo-users/user/managed-ns1/rbac.yaml
+++ b/test/resources/demo-users/user/managed-ns1/rbac.yaml
@@ -40,4 +40,17 @@ subjects:
   - kind: User
     name: user2@konflux.dev
     apiGroup: rbac.authorization.k8s.io
-
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: konflux-integration-runner-rolebinding
+  namespace: managed-ns1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-integration-runner
+subjects:
+  - kind: ServiceAccount
+    namespace: managed-ns1
+    name: konflux-integration-runner

--- a/test/resources/demo-users/user/managed-ns2/konflux-integration-runner-sa.yaml
+++ b/test/resources/demo-users/user/managed-ns2/konflux-integration-runner-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: konflux-integration-runner
+  namespace: managed-ns2

--- a/test/resources/demo-users/user/managed-ns2/kustomization.yaml
+++ b/test/resources/demo-users/user/managed-ns2/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ns.yaml
   - ../../../../../konflux-ci/enterprise-contract/policies
   - appstudio-pipeline-sa.yaml
+  - konflux-integration-runner-sa.yaml
   - rbac.yaml
   - role-binding.yaml
   - rpa.yaml

--- a/test/resources/demo-users/user/managed-ns2/rbac.yaml
+++ b/test/resources/demo-users/user/managed-ns2/rbac.yaml
@@ -13,7 +13,6 @@ subjects:
   name: managed2@konflux.dev
   apiGroup: rbac.authorization.k8s.io
 ---
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -41,3 +40,17 @@ subjects:
   - kind: User
     name: user2@konflux.dev
     apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: konflux-integration-runner-rolebinding
+  namespace: managed-ns2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-integration-runner
+subjects:
+  - kind: ServiceAccount
+    namespace: managed-ns2
+    name: konflux-integration-runner

--- a/test/resources/demo-users/user/ns1/konflux-integration-runner-sa.yaml
+++ b/test/resources/demo-users/user/ns1/konflux-integration-runner-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: konflux-integration-runner
+  namespace: user-ns1

--- a/test/resources/demo-users/user/ns1/kustomization.yaml
+++ b/test/resources/demo-users/user/ns1/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ns.yaml
   - rbac.yaml
   - appstudio-pipeline-sa.yaml
+  - konflux-integration-runner-sa.yaml
   - application-and-component.yaml
   - ec-integration-test.yaml
   - release-plan.yaml

--- a/test/resources/demo-users/user/ns1/rbac.yaml
+++ b/test/resources/demo-users/user/ns1/rbac.yaml
@@ -40,3 +40,17 @@ subjects:
   - kind: ServiceAccount
     name: appstudio-pipeline
     namespace: user-ns1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: konflux-integration-runner-rolebinding
+  namespace: user-ns1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-integration-runner
+subjects:
+  - kind: ServiceAccount
+    namespace: user-ns1
+    name: konflux-integration-runner

--- a/test/resources/demo-users/user/ns2/konflux-integration-runner-sa.yaml
+++ b/test/resources/demo-users/user/ns2/konflux-integration-runner-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: konflux-integration-runner
+  namespace: user-ns2

--- a/test/resources/demo-users/user/ns2/kustomization.yaml
+++ b/test/resources/demo-users/user/ns2/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - ns.yaml
   - rbac.yaml
   - appstudio-pipeline-sa.yaml
+  - konflux-integration-runner-sa.yaml

--- a/test/resources/demo-users/user/ns2/rbac.yaml
+++ b/test/resources/demo-users/user/ns2/rbac.yaml
@@ -40,3 +40,17 @@ subjects:
   - kind: ServiceAccount
     name: appstudio-pipeline
     namespace: user-ns2
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: konflux-integration-runner-rolebinding
+  namespace: user-ns2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-integration-runner
+subjects:
+  - kind: ServiceAccount
+    namespace: user-ns2
+    name: konflux-integration-runner


### PR DESCRIPTION
This is preparation for an upcoming change from integration service. All integration pipelines will use a konflux-integration-runner SA which must be deployed in each tenant namespace and bound to the ClusterRole of the same name.

Assisted-by: cursor(claude-3.5-sonnet)