### PR TITLE
docs: add prints after expected errors

### DIFF
--- a/deploy-konflux.sh
+++ b/deploy-konflux.sh
@@ -74,13 +74,16 @@ deploy() {
 
 
 retry() {
-    for _ in {1..3}; do
+    for i in {1..3}; do
         local ret=0
         "$@" || ret="$?"
         if [[ "$ret" -eq 0 ]]; then
             return 0
         fi
-        sleep 3
+        if [[ "$i" -lt 3 ]]; then
+            echo "🔄 Retrying command (attempt $((i+1))/3)..." >&2
+            sleep 3
+        fi
     done
 
     return "$ret"


### PR DESCRIPTION
Some errors messages are an expected part of the deployment scripts, but they can be confusing for users, as it's hard to tell whether an error is expected or not. This change adds some prtints to clarify that the script is handling the error.

Closes: #2703 