### PR TITLE
add custom-console-url-namespace

### DIFF
--- a/dependencies/pipelines-as-code/custom-console-patch.yaml
+++ b/dependencies/pipelines-as-code/custom-console-patch.yaml
@@ -9,6 +9,9 @@
   path: /data/custom-console-url
   value: 'https://localhost:9443'
 - op: add
+  path: /data/custom-console-url-namespace
+  value: 'https://localhost:9443/ns/{{ namespace }}'
+- op: add
   path: /data/custom-console-url-pr-details
   value: 'https://localhost:9443/ns/{{ namespace }}/pipelinerun/{{ pr }}'
 - op: add


### PR DESCRIPTION
'Namespace' link in PRs detail is broken. This should fix.

Example PR: https://github.com/konflux-ci/namespace-lister/pull/154/checks
Actual value in Namespace Field: https://detailurl.setting.custom-console-url-namespace.is.not.configured/

Signed-off-by: Francesco Ilario <filario@redhat.com>
