### PR TITLE
chore: update conforma policies

### DIFF
--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_all.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_all.yaml
@@ -21,4 +21,4 @@ spec:
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:
-    - oci::quay.io/enterprise-contract/ec-release-policy:git-fe45153@sha256:94b62b263b947a762b08d5aa2715f37ff3ba25ff7462850dba9d9a8eec1b4c49
+    - oci::quay.io/conforma/release-policy@sha256:1fc38e278963af0f7b8a0f43944b60e64e00464177508457d0dbe20a9243deee

--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
@@ -21,4 +21,4 @@ spec:
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:
-    - oci::quay.io/enterprise-contract/ec-release-policy:git-fe45153@sha256:94b62b263b947a762b08d5aa2715f37ff3ba25ff7462850dba9d9a8eec1b4c49
+    - oci::quay.io/conforma/release-policy@sha256:1fc38e278963af0f7b8a0f43944b60e64e00464177508457d0dbe20a9243deee

--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-no-hermetic.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-no-hermetic.yaml
@@ -23,4 +23,4 @@ spec:
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:
-    - oci::quay.io/enterprise-contract/ec-release-policy:git-fe45153@sha256:94b62b263b947a762b08d5aa2715f37ff3ba25ff7462850dba9d9a8eec1b4c49
+    - oci::quay.io/conforma/release-policy@sha256:1fc38e278963af0f7b8a0f43944b60e64e00464177508457d0dbe20a9243deee

--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-trusted-tasks.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-trusted-tasks.yaml
@@ -15,4 +15,4 @@ spec:
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:
-    - oci::quay.io/enterprise-contract/ec-task-policy:git-fe45153@sha256:0ec4be1ec7c841af09e7b368ff1978d271d7a426946846c9fb38ef9be17f9616
+    - oci::quay.io/conforma/task-policy@sha256:5eedaf38feae3b899163a568dd0d382b8d32183d6851949aef5e8d9dcf6e5c8b

--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat.yaml
@@ -20,4 +20,4 @@ spec:
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:
-    - oci::quay.io/enterprise-contract/ec-release-policy:git-fe45153@sha256:94b62b263b947a762b08d5aa2715f37ff3ba25ff7462850dba9d9a8eec1b4c49
+    - oci::quay.io/conforma/release-policy@sha256:1fc38e278963af0f7b8a0f43944b60e64e00464177508457d0dbe20a9243deee

--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_slsa3.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_slsa3.yaml
@@ -22,4 +22,4 @@ spec:
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:
-    - oci::quay.io/enterprise-contract/ec-release-policy:git-fe45153@sha256:94b62b263b947a762b08d5aa2715f37ff3ba25ff7462850dba9d9a8eec1b4c49
+    - oci::quay.io/conforma/release-policy@sha256:1fc38e278963af0f7b8a0f43944b60e64e00464177508457d0dbe20a9243deee


### PR DESCRIPTION
EC policies were not updated for almost a year

This PR updates them to the (currently) latest policies

Up next: automate updating EC policies via renovate: https://github.com/konflux-ci/konflux-ci/issues/2942