### PR TITLE
fix: bump kyverno version, RBAC, policy

### DIFF
--- a/dependencies/kyverno/kustomization.yaml
+++ b/dependencies/kyverno/kustomization.yaml
@@ -2,44 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 # renovate: datasource=git-refs depName=https://github.com/kyverno/kyverno versioning=semver
-- https://github.com/kyverno/kyverno/releases/download/v1.11.1/install.yaml
+- https://github.com/kyverno/kyverno/releases/download/v1.13.4/install.yaml
+- kyverno-rbac.yaml
 
 patches:
-- patch: |
-    - op: add
-      path: /rules/-
-      value:
-        apiGroups:
-        - ""
-        resources:
-        - pods
-        - serviceaccounts
-        verbs:
-        - create
-        - update
-        - patch
-        - delete
-        - get
-        - list
-        - watch
-    - op: add
-      path: /rules/-
-      value:
-        apiGroups:
-        - rbac.authorization.k8s.io
-        resources:
-        - rolebindings
-        verbs:
-        - create
-        - update
-        - patch
-        - delete
-        - get
-        - list
-        - watch
-  target:
-    kind: ClusterRole
-    name: kyverno:background-controller:core
 - patch: |-
     - op: replace
       path: /spec/replicas

--- a/dependencies/kyverno/kyverno-rbac.yaml
+++ b/dependencies/kyverno/kyverno-rbac.yaml
@@ -1,4 +1,5 @@
 # Copied from https://github.com/redhat-appstudio/infra-deployments/tree/da73b82a53bf491f178c06d87c1071d712f64105/components/policies/development/integration/bootstrap-namespace
+# and added rule for managing secrets.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/dependencies/kyverno/policy/kustomization.yaml
+++ b/dependencies/kyverno/policy/kustomization.yaml
@@ -2,5 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - kyverno-rbac.yaml
   - reduce-tekton-pr-taskrun-resource-requests.yaml

--- a/konflux-ci/integration/core/bootstrap-namespace.yaml
+++ b/konflux-ci/integration/core/bootstrap-namespace.yaml
@@ -1,4 +1,4 @@
-# Copied from https://github.com/redhat-appstudio/infra-deployments/tree/da73b82a53bf491f178c06d87c1071d712f64105/components/policies/development/integration/bootstrap-namespace
+# Copied from https://github.com/redhat-appstudio/infra-deployments/blob/53c2620f55a9ec321e8ef539f4ce8d71c6273dee/components/policies/production/base/integration/bootstrap-namespace/bootstrap-namespace.yaml
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
@@ -9,9 +9,9 @@ metadata:
       This policy creates a service account named konflux-integration-runner and
       binds it to the konflux-integration-runner cluster role in tenant namespaces.
 spec:
-  background: false
   rules:
   - name: create-konflux-integration-runner-serviceaccount
+    skipBackgroundRequests: true
     match:
       any:
       - resources:
@@ -20,16 +20,15 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
-    celPreconditions:
-    - name: "on update, oldObject had no konflux-ci.dev/type=tenant label"
-      expression: "request.operation != UPDATE || ! (has(oldObject.metadata.labels) && 'konflux-ci.dev/type' in oldObject.metadata.labels && oldObject.metadata.labels['konflux-ci.dev/type] == 'tenant')"
     generate:
+      generateExisting: true
       synchronize: false
       apiVersion: v1
       kind: ServiceAccount
       name: konflux-integration-runner
       namespace: '{{request.object.metadata.name}}'
   - name: create-konflux-integration-runner-rolebinding
+    skipBackgroundRequests: true
     match:
       any:
       - resources:
@@ -38,10 +37,8 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
-    celPreconditions:
-    - name: "on update, oldObject had no konflux-ci.dev/type=tenant label"
-      expression: "request.operation != UPDATE || ! (has(oldObject.metadata.labels) && 'konflux-ci.dev/type' in oldObject.metadata.labels && oldObject.metadata.labels['konflux-ci.dev/type] == 'tenant')"
     generate:
+      generateExisting: true
       synchronize: false
       apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding

--- a/konflux-ci/integration/core/kustomization.yaml
+++ b/konflux-ci/integration/core/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - https://github.com/konflux-ci/integration-service/config/default?ref=cc65bf09ea9d6296732981cc436304f91927f0ab
 - https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=cc65bf09ea9d6296732981cc436304f91927f0ab
 - konflux-integration-runner.yaml
+- kyverno-background-controller-binding.yaml
 - bootstrap-namespace.yaml
 
 namespace: integration-service

--- a/konflux-ci/integration/core/kyverno-background-controller-binding.yaml
+++ b/konflux-ci/integration/core/kyverno-background-controller-binding.yaml
@@ -1,0 +1,15 @@
+---
+# This allows the background controller to have all the permissions needed to create
+# RoleBindings that grant the konflux-integration-runner role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno-background-controller-konflux-integration-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-integration-runner
+subjects:
+- kind: ServiceAccount
+  name: kyverno-background-controller
+  namespace: kyverno


### PR DESCRIPTION
* bump kyverno to version 1.13.4
* update policy to generate SA in existing namespaces
* update kyverno cluster role to include secrets in the resources list
closes https://github.com/konflux-ci/konflux-ci/issues/3101