### PR TITLE
chore: track some github release with renovate

### DIFF
--- a/dependencies/cert-manager/kustomization.yml
+++ b/dependencies/cert-manager/kustomization.yml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # Disabled in renovate.json until we're able to auto-update trust-manager as well.
+  # renovate: datasource=git-refs depName=https://github.com/cert-manager/cert-manager versioning=semver
   - https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml
 
 patches:

--- a/dependencies/kyverno/kustomization.yaml
+++ b/dependencies/kyverno/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+# renovate: datasource=git-refs depName=https://github.com/kyverno/kyverno versioning=semver
 - https://github.com/kyverno/kyverno/releases/download/v1.11.1/install.yaml
 
 patches:

--- a/dependencies/pipelines-as-code/kustomization.yml
+++ b/dependencies/pipelines-as-code/kustomization.yml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # renovate: datasource=git-refs depName=https://github.com/openshift-pipelines/pipelines-as-code versioning=semver
   - https://github.com/openshift-pipelines/pipelines-as-code/releases/download/v0.33.0/release.k8s.yaml
 patches:
   - path: custom-console-patch.yaml

--- a/dependencies/tekton-operator/kustomization.yml
+++ b/dependencies/tekton-operator/kustomization.yml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   # Install Tekton pipelines, triggers and and Chains
+  # renovate: datasource=git-refs depName=https://github.com/tektoncd/operator versioning=semver
   - https://storage.googleapis.com/tekton-releases/operator/previous/v0.75.0/release.yaml
 patches:
   - patch: |

--- a/dependencies/tekton-results/kustomization.yml
+++ b/dependencies/tekton-results/kustomization.yml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # renovate: datasource=git-refs depName=https://github.com/tektoncd/results versioning=semver
   - https://storage.googleapis.com/tekton-releases/results/previous/v0.14.0/release.yaml
   - certificate.yaml
 patches:

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,20 @@
       ],
       "autoApprove": true,
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["https://github.com/cert-manager/cert-manager"],
+      "enabled": false,
+      "description": "Disable until we're able to auto-update trust-manager as well"
+    },
+    {
+      "groupName": "tekton-core",
+      "matchPackageNames": [
+        "https://github.com/tektoncd/operator",
+        "https://github.com/tektoncd/pipeline",
+        "https://github.com/tektoncd/results"
+      ],
+      "description": "Group core Tekton components for coordinated updates"
     }
   ],
   "enabledManagers": ["regex", "kustomize"],
@@ -79,6 +93,28 @@
       "autoReplaceStringTemplate": "E2E_TEST_IMAGE={{depName}}@{{newDigest}}",
       "datasourceTemplate": "docker",
       "currentValueTemplate": "latest"
+    },
+    {
+      "customType": "regex",
+      "matchStringsStrategy": "combination",
+      "fileMatch": ["(^|\/)kustomization\\.(yaml|yml)$"],
+      "matchStrings": [
+        "# renovate: datasource=git-refs depName=(?<packageName>https:\\/\\/github\\.com\\/[^\\s]+)",
+        "- https:\\/\\/github\\.com\\/[^/]+\\/[^/]+\\/releases\\/download\\/v(?<currentValue>[^/]+)\\/"
+      ],
+      "datasourceTemplate": "git-refs",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "matchStringsStrategy": "combination",
+      "fileMatch": ["(^|\/)kustomization\\.(yaml|yml)$"],
+      "matchStrings": [
+        "# renovate: datasource=git-refs depName=(?<packageName>https:\\/\\/github\\.com\\/[^\\s]+)",
+        "- https:\\/\\/storage\\.googleapis\\.com\\/tekton-releases\\/[^/]+\\/previous\\/v(?<currentValue>[^/]+)\\/"
+      ],
+      "datasourceTemplate": "git-refs",
+      "versioningTemplate": "semver"
     }
   ]
 }


### PR DESCRIPTION
Adding kyverno, cert-manager and pipelines-as-code to be tracked with Renovate. Disabling cert-manager updates until we introduce Helm and then we can track trust-manager as well.

Closes: #1435