### PR TITLE
fix: renovate configs for Conforma

### DIFF
--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_all.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_all.yaml
@@ -21,5 +21,4 @@ spec:
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:
-    # renovate: datasource=docker depName=quay.io/conforma/release-policy
     - oci::quay.io/conforma/release-policy:konflux@sha256:1fc38e278963af0f7b8a0f43944b60e64e00464177508457d0dbe20a9243deee

--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
@@ -21,5 +21,4 @@ spec:
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:
-    # renovate: datasource=docker depName=quay.io/conforma/release-policy
     - oci::quay.io/conforma/release-policy:konflux@sha256:1fc38e278963af0f7b8a0f43944b60e64e00464177508457d0dbe20a9243deee

--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-no-hermetic.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-no-hermetic.yaml
@@ -23,5 +23,4 @@ spec:
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:
-    # renovate: datasource=docker depName=quay.io/conforma/release-policy
     - oci::quay.io/conforma/release-policy:konflux@sha256:1fc38e278963af0f7b8a0f43944b60e64e00464177508457d0dbe20a9243deee

--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-trusted-tasks.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-trusted-tasks.yaml
@@ -15,5 +15,4 @@ spec:
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:
-    # renovate: datasource=docker depName=quay.io/conforma/task-policy
     - oci::quay.io/conforma/task-policy:konflux@sha256:5eedaf38feae3b899163a568dd0d382b8d32183d6851949aef5e8d9dcf6e5c8b

--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat.yaml
@@ -20,5 +20,4 @@ spec:
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:
-    # renovate: datasource=docker depName=quay.io/conforma/release-policy
     - oci::quay.io/conforma/release-policy:konflux@sha256:1fc38e278963af0f7b8a0f43944b60e64e00464177508457d0dbe20a9243deee

--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_slsa3.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_slsa3.yaml
@@ -22,5 +22,4 @@ spec:
     - github.com/release-engineering/rhtap-ec-policy//data
     name: Default
     policy:
-    # renovate: datasource=docker depName=quay.io/conforma/release-policy
     - oci::quay.io/conforma/release-policy:konflux@sha256:1fc38e278963af0f7b8a0f43944b60e64e00464177508457d0dbe20a9243deee

--- a/renovate.json
+++ b/renovate.json
@@ -118,13 +118,10 @@
     },
     {
       "customType": "regex",
-      "matchStringsStrategy": "combination",
       "fileMatch": ["konflux-ci/enterprise-contract/policies/.*\\.yaml$"],
       "matchStrings": [
-        "# renovate: datasource=docker depName=(?<depName>quay\\.io/conforma/[^\\s]+)",
-        "- oci::quay\\.io/conforma/[^:]+:konflux@(?<currentDigest>sha256:[a-f0-9]{64})"
+        "- oci::(?<depName>quay\\.io/conforma/[^:]+):konflux@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
-      "autoReplaceStringTemplate": "# renovate: datasource=docker depName={{depName}}\n    - oci::{{depName}}:konflux@{{newDigest}}",
       "datasourceTemplate": "docker",
       "currentValueTemplate": "konflux"
     }


### PR DESCRIPTION
The previous configs caused the comment lines that were added for renovate to be duplicated. It seems as we don't need those comments in this case. So this change is simplifying the implementation and dropping the comments.