### PR TITLE
fix(STONEINTG-1215): konflux-integration-runner creates pipelineruns and secrets 

### DIFF
--- a/konflux-ci/integration/core/konflux-integration-runner.yaml
+++ b/konflux-ci/integration/core/konflux-integration-runner.yaml
@@ -8,6 +8,10 @@ rules:
   - verbs:
       - get
       - list
+      - create
+      - watch
+      - update
+      - patch
     apiGroups:
       - ''
     resources:
@@ -22,6 +26,10 @@ rules:
   - verbs:
       - get
       - list
+      - create
+      - watch
+      - update
+      - patch
     apiGroups:
       - tekton.dev
     resources:


### PR DESCRIPTION
* Allow creating nested tekton pipelineRuns during integration testing
* The konflux-integration-runner service account needs to be able to create and patch secrets to support environment provisioning