### PR TITLE
chore: skip on-push pipeline check tasks

### DIFF
--- a/dependencies/kyverno/policy/kustomization.yaml
+++ b/dependencies/kyverno/policy/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - reduce-tekton-pr-taskrun-resource-requests.yaml
+  - set-skip-checks-parameter.yaml

--- a/dependencies/kyverno/policy/set-skip-checks-parameter.yaml
+++ b/dependencies/kyverno/policy/set-skip-checks-parameter.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations:
+    policies.kyverno.io/description: This policy changes the default value of the skip-checks
+      parameter to true in the pipelineSpec for Tekton PipelineRuns with the label
+      pipelines.appstudio.openshift.io/type=build. This skips security scanning tasks
+      including clair-scan, which is useful for CI environments where these steps
+      consume excessive resources and frequently timeout.
+  name: set-skip-checks-parameter
+spec:
+  background: false
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - PipelineRun
+          operations:
+          - CREATE
+          selector:
+            matchLabels:
+              pipelinesascode.tekton.dev/original-prname: "konflux-ci-upstream-*-on-push"
+    mutate:
+      foreach:
+      - list: request.object.spec.pipelineSpec.params
+        preconditions:
+          any:
+          - key: '{{ element.name }}'
+            operator: Equals
+            value: "skip-checks"
+        patchesJson6902: |-
+          - path: /spec/pipelineSpec/params/{{elementIndex}}/default
+            op: replace
+            value: "true"
+    name: change-skip-checks-default


### PR DESCRIPTION
The checks are taking too long or taking too many resources, which is causing CI flakiness.