### PR TITLE
fix: remove service account created by kyverno policy

### DIFF
--- a/test/resources/demo-users/user/ns2/appstudio-pipeline-integration-runner-rbac.yaml
+++ b/test/resources/demo-users/user/ns2/appstudio-pipeline-integration-runner-rbac.yaml
@@ -18,12 +18,6 @@ rules:
     - pods/log
   verbs: ["get", "list"]
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: konflux-integration-runner
-  namespace: user-ns2
----
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
Service account konflux-integration-runner was created by the test resources script and by the Kyverno policy which caused the script to fail.

Assisted-by: Cursor

Closes: #3407