### PR TITLE
cleanup RBAC permissions

### DIFF
--- a/konflux-ci/rbac/core/konflux-admin-user-actions-core.yaml
+++ b/konflux-ci/rbac/core/konflux-admin-user-actions-core.yaml
@@ -20,7 +20,6 @@ rules:
     resources:
       - applications
       - components
-      - componentdetectionqueries
       - imagerepositories
   - verbs:
       - get
@@ -33,34 +32,15 @@ rules:
     apiGroups:
       - appstudio.redhat.com
     resources:
-      - promotionruns
-      - snapshotenvironmentbindings
       - snapshots
-      - environments
-  - verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-    apiGroups:
-      - appstudio.redhat.com
-    resources:
-      - deploymenttargets
-      - deploymenttargetclaims
   - verbs:
       - get
       - list
       - watch
     apiGroups:
-      - managed-gitops.redhat.com
+      - tekton.dev
     resources:
-      - gitopsdeployments
-      - gitopsdeploymentmanagedenvironments
-      - gitopsdeploymentrepositorycredentials
-      - gitopsdeploymentsyncruns
+      - taskruns
   - verbs:
       - get
       - list
@@ -73,7 +53,6 @@ rules:
       - tekton.dev
     resources:
       - pipelineruns
-      - taskruns
   - verbs:
       - get
       - list
@@ -97,50 +76,8 @@ rules:
       - enterprisecontractpolicies
       - integrationtestscenarios
       - releases
-      - releasestrategies
       - releaseplans
       - releaseplanadmissions
-  - verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-    apiGroups:
-      - jvmbuildservice.io
-    resources:
-      - jbsconfigs
-      - artifactbuilds
-  - verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-    apiGroups:
-      - appstudio.redhat.com
-    resources:
-      - spiaccesstokenbindings
-      - spiaccesschecks
-      - spiaccesstokens
-      - spifilecontentrequests
-      - spiaccesstokendataupdates
-  - verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-    apiGroups:
-      - appstudio.redhat.com
-    resources:
-      - remotesecrets
   - verbs:
       - get
       - list
@@ -169,17 +106,21 @@ rules:
       - get
       - list
       - watch
-      - create
-      - update
-      - patch
-      - delete
     apiGroups:
-      - appstudio.redhat.com
+      - ''
     resources:
-      - buildpipelineselectors
+      - pods
+      - pods/log
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
   - verbs:
       - get
       - list
+      - watch
       - create
       - update
       - patch
@@ -208,47 +149,10 @@ rules:
     resources:
       - serviceaccounts/token
   - verbs:
-      - create
+    - get
+    - list
+    - watch
     apiGroups:
-      - ''
+      - pipelinesascode.tekton.dev
     resources:
-      - pods/exec
-  - verbs:
-      - get
-    apiGroups:
-      - ''
-    resources:
-      - pods
-      - pods/log
-  - verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-    apiGroups:
-      - toolchain.dev.openshift.com
-    resources:
-      - spacebindingrequests
-  - verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-    apiGroups:
-      - projctl.konflux.dev
-    resources:
-      - projects
-      - projectdevelopmentstreams
-      - projectdevelopmentstreamtemplates
-  - verbs:
-      - get
-    apiGroups:
-      - ""
-    resources:
-      - namespaces
+      - repositories

--- a/konflux-ci/rbac/core/konflux-admin-user-actions-extra.yaml
+++ b/konflux-ci/rbac/core/konflux-admin-user-actions-extra.yaml
@@ -1,0 +1,31 @@
+---
+# Deprecated
+#
+# This ClusterRole extends `konflux-admin-user-actions` with permissions
+# on `projctl` resources.
+# 
+# As these CustomResources are not installed as part of `konflux-ci/konflux-ci`,
+# this ClusterRole will be eventually removed.
+# The only purpose of this ClusterRole is to allow anyone relying on these
+# permissions to migrate.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-admin-user-actions-extra
+  labels:
+    rbac.konflux-ci.dev/aggregate-to-admin: "true"
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - projctl.konflux.dev
+    resources:
+      - projects
+      - projectdevelopmentstreams
+      - projectdevelopmentstreamtemplates

--- a/konflux-ci/rbac/core/konflux-viewer-user-actions-core.yaml
+++ b/konflux-ci/rbac/core/konflux-viewer-user-actions-core.yaml
@@ -80,30 +80,11 @@ rules:
       - list
       - watch
     apiGroups:
-      - jvmbuildservice.io
-    resources:
-      - jbsconfigs
-      - artifactbuilds
-  - verbs:
-      - get
-      - list
-      - watch
-    apiGroups:
       - ''
     resources:
       - configmaps
       - pods
       - pods/log
-  - verbs:
-      - get
-      - list
-      - watch
-    apiGroups:
-      - projctl.konflux.dev
-    resources:
-      - projects
-      - projectdevelopmentstreams
-      - projectdevelopmentstreamtemplates
   - verbs:
       - get
     apiGroups:

--- a/konflux-ci/rbac/core/konflux-viewer-user-actions-extra.yaml
+++ b/konflux-ci/rbac/core/konflux-viewer-user-actions-extra.yaml
@@ -1,0 +1,27 @@
+---
+# Deprecated
+#
+# This ClusterRole extends `konflux-viewer-user-actions` with permissions
+# on `projctl` resources.
+# 
+# As these CustomResources are not installed as part of `konflux-ci/konflux-ci`,
+# this ClusterRole will be eventually removed.
+# The only purpose of this ClusterRole is to allow anyone relying on these
+# permissions to migrate.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-viewer-user-actions-extra
+  labels:
+    rbac.konflux-ci.dev/aggregate-to-viewer: "true"
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - projctl.konflux.dev
+    resources:
+      - projects
+      - projectdevelopmentstreams
+      - projectdevelopmentstreamtemplates

--- a/konflux-ci/rbac/core/kustomization.yaml
+++ b/konflux-ci/rbac/core/kustomization.yaml
@@ -6,3 +6,7 @@ resources:
 - konflux-self-access-reviewer.yaml
 - konflux-viewer-user-actions.yaml
 - konflux-viewer-user-actions-core.yaml
+# Deprecated
+# These ClusterRoles will be removed eventually
+- konflux-admin-user-actions-extra.yaml
+- konflux-viewer-user-actions-extra.yaml


### PR DESCRIPTION
This change removes permissions on outdated resources and deprecates permissions on resources not installed as part of `konflux-ci`.

Signed-off-by: Francesco Ilario <filario@redhat.com>
