### PR TITLE
chore: ignore aggregated rules in clusterroles

### DIFF
--- a/konflux-ci/rbac/core/konflux-admin-user-actions.yaml
+++ b/konflux-ci/rbac/core/konflux-admin-user-actions.yaml
@@ -3,6 +3,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: konflux-admin-user-actions
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:

--- a/konflux-ci/rbac/core/konflux-viewer-user-actions.yaml
+++ b/konflux-ci/rbac/core/konflux-viewer-user-actions.yaml
@@ -3,6 +3,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: konflux-viewer-user-actions
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:


### PR DESCRIPTION
This should prevent sync issues in argoCD downstream.