### PR TITLE
chore: allow user admin to manage jobs and cronjobs

### DIFF
--- a/konflux-ci/rbac/core/konflux-admin-user-actions-batch.yaml
+++ b/konflux-ci/rbac/core/konflux-admin-user-actions-batch.yaml
@@ -1,0 +1,23 @@
+---
+# Allow triggering periodic pipelines as documented in
+# https://konflux-ci.dev/docs/testing/integration/periodic-integration-tests/
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-admin-user-actions-batch
+  labels:
+    rbac.konflux-ci.dev/aggregate-to-admin: "true"
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs

--- a/konflux-ci/rbac/core/kustomization.yaml
+++ b/konflux-ci/rbac/core/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - konflux-admin-user-actions.yaml
 - konflux-admin-user-actions-core.yaml
+- konflux-admin-user-actions-batch.yaml
 - konflux-contributor-user-actions.yaml
 - konflux-contributor-user-actions-core.yaml
 - konflux-maintainer-user-actions.yaml


### PR DESCRIPTION
This allows users to trigger periodic pipelines.

Assisted-by: Cursor