### PR TITLE
chore(KONFLUX-9778): Add version checks to deploy-deps.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ additional resources.
 
 * [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (`v0.26.0` or
   newer) along with `podman` (`v5.3.1` or newer) or `docker` (`v27.0.1` or newer)
-* `kubectl` (`v1.31.1` or newer)
+* `kubectl` (`v1.31.1` or newer -- server-side apply support is required)
 * `git` (`v2.46` or newer)
-* `openssl` (`v3.2.2` or newer)
+* `openssl` (`v3.0.13` or newer)
 
 ## Bootstrapping the Cluster
 :gear: Clone this repository:

--- a/deploy-deps.sh
+++ b/deploy-deps.sh
@@ -21,11 +21,25 @@ check_req(){
     # check if requirements are installed
     for i in "${requirements[@]}"; do
         if ! command -v "$i" &> /dev/null; then
-                uninstalled_requirements+=("$i")
+                if [ "$i" == "kubectl" ]; then
+                    uninstalled_requirements+=("kubectl (server-side support required - v1.31.1 or newer)")
+                else
+                    uninstalled_requirements+=("$i")
+                fi
         else
                 echo -e "$i is installed"
         fi
     done
+
+    # check if kubectl has server-side support
+    if command -v kubectl &> /dev/null; then
+        echo -e "Checking if kubectl has server-side support"
+        if ! kubectl apply --help | grep -q -- --server-side; then
+            uninstalled_requirements+=("kubectl (server-side support required - v1.31.1 or newer)")
+        else
+            echo -e "kubectl supports server-side apply"
+        fi
+    fi
 
     if (( ${#uninstalled_requirements[@]} == 0 )); then
         echo -e "\nAll requirements are met\nContinue"


### PR DESCRIPTION
This PR adds version checks to the deploy-deps.sh script.
It checks if the kubectl and openssl commands are installed and
that kubectl has server-side apply support.

Close #2936 

Assisted-by: Cursor