### PR TITLE
fix(KONFLUX-9697): konflux-info namespace is missing

### DIFF
--- a/dependencies/konflux-info/banner-content.yaml
+++ b/dependencies/konflux-info/banner-content.yaml
@@ -1,0 +1,3 @@
+# Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
+- summary: "Welcome to Konflux-CI! This is a development environment for testing and development purposes."
+  type: "info"

--- a/dependencies/konflux-info/base/kustomization.yaml
+++ b/dependencies/konflux-info/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - rbac.yaml
+
+namespace: konflux-info

--- a/dependencies/konflux-info/base/namespace.yaml
+++ b/dependencies/konflux-info/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: konflux-info

--- a/dependencies/konflux-info/base/rbac.yaml
+++ b/dependencies/konflux-info/base/rbac.yaml
@@ -1,0 +1,28 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-public-info-view-role
+rules:
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resourceNames:
+      - konflux-public-info
+      - konflux-banner-configmap
+    resources:
+      - configmaps
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-public-info-view-rb
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:authenticated'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: konflux-public-info-view-role

--- a/dependencies/konflux-info/info.json
+++ b/dependencies/konflux-info/info.json
@@ -1,0 +1,33 @@
+{
+    "environment": "development",
+    "rbac": [
+        {
+            "displayName": "admin",
+            "description": "Full access to Konflux resources including secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-admin-user-actions"
+            }
+        },
+        {
+            "displayName": "maintainer",
+            "description": "Partial access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-maintainer-user-actions"
+            }
+        },
+        {
+            "displayName": "contributor",
+            "description": "View access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-contributor-user-actions"
+            }
+        }
+    ],
+    "visibility": "public"
+}

--- a/dependencies/konflux-info/kustomization.yaml
+++ b/dependencies/konflux-info/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: konflux-public-info
+    files:
+      - info.json
+  - name: konflux-banner-configmap
+    files:
+      - banner-content.yaml
+
+namespace: konflux-info

--- a/deploy-deps.sh
+++ b/deploy-deps.sh
@@ -69,6 +69,8 @@ deploy() {
     deploy_smee
     echo "🛡️  Deploying Kyverno..." >&2
     deploy_kyverno
+    echo "📋 Deploying Konflux Info..." >&2
+    deploy_konflux_info
 }
 
 test_pvc_binding(){
@@ -167,6 +169,10 @@ deploy_kyverno() {
     # Wait for policy CRD to be installed. Don't need to wait for everything to be up
     sleep 5
     kubectl apply -k "${script_path}/dependencies/kyverno/policy"
+}
+
+deploy_konflux_info() {
+    kubectl apply -k "${script_path}/dependencies/konflux-info"
 }
 
 retry() {


### PR DESCRIPTION
Adding Konflux Info namespace and resources.

- Define only rbac rules in the `info.json` file
- Not defining `sbom-server` and `github` (for github application)
- Add  `banner-content.yaml` with proper message
