### PR TITLE
fix(KONFLUX-10618): restore regcred-empty secret in user-ns2

### DIFF
--- a/test/resources/demo-users/user/ns2/kustomization.yaml
+++ b/test/resources/demo-users/user/ns2/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - ns.yaml
   - rbac.yaml
   - release-pipeline-sa.yaml
+  - regcred-empty.yaml
   - appstudio-pipeline-integration-runner-rbac.yaml

--- a/test/resources/demo-users/user/ns2/regcred-empty.yaml
+++ b/test/resources/demo-users/user/ns2/regcred-empty.yaml
@@ -1,0 +1,21 @@
+# Empty secret for registry that does not use authentication
+# This secret is required by tasks like ecosystem-cert-preflight-checks
+# which expect a Docker config file even when working with registries
+# that don't require authentication.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: regcred-empty
+  namespace: user-ns2
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJ4Ijp7ImVtYWlsIjoiIn19fQ==
+---
+# Add regcred-empty to default ServiceAccount
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: user-ns2
+secrets:
+- name: regcred-empty


### PR DESCRIPTION
The regcred-empty secret was incorrectly removed from user-ns2 namespace in PR #3263. This secret is required by the ecosystem-cert-preflight-checks task which expects a Docker config file to exist even when working with registries that don't require authentication.

Without this secret, pipelines fail with:
  "could not find authfile: /root/.docker/config.json"

Closes: #3408

Assisted-by: Claude-3.5-Sonnet (via Claude Code)