### PR TITLE
Require kubectl v1.34.2+ and use version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ additional resources.
 
 * [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (`v0.26.0` or
   newer) along with `podman` (`v5.3.1` or newer) or `docker` (`v27.0.1` or newer)
-* `kubectl` (`v1.31.1` or newer -- server-side apply support is required)
+* `kubectl` (`v1.31.4` or newer)
 * `git` (`v2.46` or newer)
 * `openssl` (`v3.0.13` or newer)
 


### PR DESCRIPTION
Require kubectl v1.31.4+ and use version check instead of feature detection

- Update minimum kubectl version from v1.31.1 to v1.31.4 (which is
used in the e2e test job).
- Replace server-side apply feature check with version comparison

Server-side apply support is guaranteed in kubectl v1.31.4+, so explicit
feature detection is no longer needed.

Ref: https://konflux-ci.slack.com/archives/C09LE7E20FP/p1765560818181239?thread_ts=1765552331.343709&cid=C09LE7E20FP
Assisted-By: Cursor
Signed-off-by: Gal Ben Haim <gbenhaim@redhat.com>