### PR TITLE
feat(KFLUXVNGD-564): enforce specific CR name

### DIFF
--- a/operator/api/v1alpha1/konflux_types.go
+++ b/operator/api/v1alpha1/konflux_types.go
@@ -37,6 +37,8 @@ type KonfluxStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'konflux'",message="Konflux CR must be named 'konflux'. Only one instance is allowed per cluster."
 
 // Konflux is the Schema for the konfluxes API.
 type Konflux struct {

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: KonfluxList
     plural: konfluxes
     singular: konflux
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:
@@ -43,6 +43,10 @@ spec:
             description: KonfluxStatus defines the observed state of Konflux.
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Konflux CR must be named 'konflux'. Only one instance is allowed
+            per cluster.
+          rule: self.metadata.name == 'konflux'
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
### **User description**
Add a validating webhook to ensure an instance can only have a specific name. This is used to make sure we only have one instance of Konflux.

Assisted-by: Cursor


___

### **PR Type**
Enhancement


___

### **Description**
- Add validating webhook to enforce Konflux CR naming constraint

- Implement webhook validation for create and update operations

- Configure cert-manager for webhook certificate management

- Enable webhook infrastructure with network policies and service configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Konflux CR"] -->|"ValidatingWebhook"| B["Name Validation"]
  B -->|"Must be 'konflux'"| C["Allow/Reject"]
  D["cert-manager"] -->|"Issues Certs"| E["webhook-server-cert"]
  E -->|"Mounts in Pod"| F["Manager Container"]
  F -->|"Serves on 9443"| G["webhook-service"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td><strong>konflux_types.go</strong><dd><code>Mark Konflux resource as cluster-scoped</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-a7d4ba5de8820e3f2f30bee75a671565952b34ba1cdb0cabdca27654eaf991a2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PROJECT</strong><dd><code>Enable webhook configuration in project metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-781d50110538816f36042845dabc22d6f7d166e71c9de0de4169ffbf1d29c303">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>certificate-metrics.yaml</strong><dd><code>Create self-signed certificate for metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-0f6edcee2c06c0034e9023f27276936e817fad12687a8247056ca31966488543">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>certificate-webhook.yaml</strong><dd><code>Create self-signed certificate for webhook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-52d2fcd049d7e78ba428be028d2770f644b016ae61320fb261a76f34a6c5f214">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>issuer.yaml</strong><dd><code>Define self-signed issuer for certificates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-5fe231f6f583da4a233861d11d8e1cbb82e0e36a726e488fda2c9e683e5744af">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>kustomization.yaml</strong><dd><code>Configure cert-manager resources with kustomize</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-1a55380da7efb020faa6bf53dbf61dd6fbddde1016c04e43c5f02addeb3f8e78">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>kustomizeconfig.yaml</strong><dd><code>Setup kustomize name reference substitution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-5ef99105a78339ea8397c86533a9b2aaf2b0785fa7230c1cd0d96cef4d663868">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konflux.konflux-ci.dev_konfluxes.yaml</strong><dd><code>Change Konflux CRD scope from Namespaced to Cluster</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-c22a171c86409d090dcf1485382392693731723cbb0f96a1f87065e845435239">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>kustomization.yaml</strong><dd><code>Enable webhook and cert-manager overlays</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-4d661300291c62c54543d2877f907674b80360e5e94aa67ca2a2e649a140cc26">+73/-73</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>manager_webhook_patch.yaml</strong><dd><code>Configure webhook certificate mounting in manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-ea55056dd61ccbe195acac5c32d36ed6465845041c01852f342a60793f70a7ca">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>allow-webhook-traffic.yaml</strong><dd><code>Add network policy for webhook traffic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-01ec112cc05dbe91c153b4ad449c83153d7c3065947945153d74a1c08f810f44">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>kustomization.yaml</strong><dd><code>Include webhook network policy in kustomization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-a4c7a6b023798a533047a27b455e9fdcf0b6344218c836a43df873a4a9511ac3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>kustomization.yaml</strong><dd><code>Configure webhook resources with kustomize</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-3a7b539153ebd17d8aa563ad36c66dcdceb597cb687d70192ad15166d8ff54f5">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>kustomizeconfig.yaml</strong><dd><code>Setup kustomize substitution for webhook service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-54e7f0cf2044f5e91501794edb28702b9870df64d211a7580e0339ee2671a209">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>manifests.yaml</strong><dd><code>Define ValidatingWebhookConfiguration for Konflux</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-db6035339143451a19ba80c4a5f94f8641ec3048d07f81b7569bb4eee6c611b3">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>service.yaml</strong><dd><code>Create webhook service for admission controller</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-c446d2febce718abc4931da20f74e869793c4ef57d30e3a1d30a87b92e6a6384">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>main.go</strong><dd><code>Register webhook setup in manager initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-6951a7b3b8a59603497b68b62013a806397c640ce0a42a3862f6a4ffad4fda89">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konflux_webhook.go</strong><dd><code>Implement validating webhook for Konflux CR</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-3383298729054ffadd0c5ddceebe7845d169868656487fe3b5c7ff35ed8fde92">+126/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>konflux_webhook_test.go</strong><dd><code>Add webhook validation test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-bcd52c7e6f185bc6d04e86b15dc45960e181c31dce6da00458e1703f81bdfde4">+112/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>webhook_suite_test.go</strong><dd><code>Setup webhook test environment with envtest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-5f06bb5822379f57072b7f868a81e514314e33b35d18cc77399fad781131c313">+164/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>e2e_test.go</strong><dd><code>Add e2e tests for cert-manager and CA injection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4014/files#diff-ed640686ae3b2627b8576a3dfaeb1bbc9f58cdc4ee9a367bdd452e47cb9c1249">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

