### PR TITLE
test: add red-hat-konflux to the whitelisted bots

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -16,15 +16,24 @@ jobs:
           exit 0
         fi
 
-        WHITELISTED_BOT_NAME="renovate[bot]"
+        WHITELISTED_BOT_NAMES=("renovate[bot]" "red-hat-konflux")
         REQUIRED_LABEL_NAME="ok-to-test"
 
         ORG="${{ github.repository_owner }}"
         PR_AUTHOR=$(jq --raw-output .pull_request.user.login $GITHUB_EVENT_PATH)
         PR_LABELS=$(jq --raw-output .pull_request.labels[].name $GITHUB_EVENT_PATH)
 
-        if [ "$PR_AUTHOR" == "$WHITELISTED_BOT_NAME" ]; then
-          echo "PR author is "$WHITELISTED_BOT_NAME", skipping further checks."
+        # Check if PR author is in the whitelisted bots list
+        BOT_WHITELISTED=false
+        for BOT_NAME in "${WHITELISTED_BOT_NAMES[@]}"; do
+          if [ "$PR_AUTHOR" == "$BOT_NAME" ]; then
+            BOT_WHITELISTED=true
+            echo "PR author is $BOT_NAME, skipping further checks."
+            break
+          fi
+        done
+
+        if [ "$BOT_WHITELISTED" == "true" ]; then
           exit 0
         fi
 
@@ -38,10 +47,13 @@ jobs:
           exit 0
         fi
 
+        # Create comma-separated list for error message
+        BOT_LIST=$(IFS=','; echo "${WHITELISTED_BOT_NAMES[*]}")
+
         ERROR_SUMMARY=$(cat <<EOF
 
         ### ❌ Cannot run Sanity test - at least one of the following conditions must be met:
-        * PR author is '$WHITELISTED_BOT_NAME'
+        * PR author is one of: $BOT_LIST
         * PR has label '$REQUIRED_LABEL_NAME'
         * PR author is a public member of '$ORG' GitHub organization
         EOF


### PR DESCRIPTION
### **User description**
add red-hat-konflux to the whitelisted bots


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor whitelisted bots check to support multiple bots

- Add red-hat-konflux to the whitelisted bots list

- Implement loop-based validation for extensible bot checking

- Improve error message to display all whitelisted bots


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Single bot check"] -->|"Refactor to array"| B["Multiple bots array"]
  B -->|"Loop through bots"| C["Bot whitelisted flag"]
  C -->|"Check flag"| D["Skip sanity test"]
  B -->|"Format list"| E["Error message"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sanity-test.yml</strong><dd><code>Extend bot whitelist to support multiple bots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/sanity-test.yml

<ul><li>Changed <code>WHITELISTED_BOT_NAME</code> string to <code>WHITELISTED_BOT_NAMES</code> array <br>containing renovate[bot] and red-hat-konflux<br> <li> Replaced single string comparison with loop-based validation using <br><code>BOT_WHITELISTED</code> flag<br> <li> Added comment explaining bot whitelist check logic<br> <li> Updated error message to display comma-separated list of all <br>whitelisted bots instead of single bot name</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4031/files#diff-c68f5ef87662968636741c0c819fd08d5c7f2a1c020a572d10356b72e63f742f">+16/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

