### PR TITLE
fix: renovate configs for kind updates

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -34,7 +34,7 @@ jobs:
     if: needs.check-changes.outputs.operator == 'true'
     env:
       # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-      KIND_VERSION: "v0.29.0"
+      KIND_VERSION: "0.29.0"
     defaults:
       run:
         working-directory: operator
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install kind
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-linux-amd64
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
 

--- a/renovate.json
+++ b/renovate.json
@@ -133,7 +133,7 @@
       "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
       "matchStrings": [
         "# renovate: datasource=github-releases depName=kubernetes-sigs/kind",
-        "KIND_VERSION:\\s*\"(?<currentValue>v?[^\"]+)\""
+        "KIND_VERSION:\\s*\"(?<currentValue>[^\"]+)\""
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "kubernetes-sigs/kind",


### PR DESCRIPTION
### **User description**
Renovate generated a PR for kind, but the update dropped the leading `v` from the version, causing the update to fail. This commit fixes the renovate configuration to ensure the leading `v` is preserved in future updates.

Assisted-by: Cursor


___

### **PR Type**
Bug fix


___

### **Description**
- Remove leading `v` from KIND_VERSION environment variable

- Update curl command to prepend `v` to version string

- Fix renovate regex pattern to not capture optional `v` prefix

- Ensures renovate correctly updates kind version without duplication


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Renovate Config"] -->|"Captures version without v"| B["KIND_VERSION env var"]
  B -->|"Prepends v in curl"| C["Download URL"]
  D["Regex Pattern"] -->|"Matches any version format"| A
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator-test-e2e.yaml</strong><dd><code>Adjust kind version handling in workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/operator-test-e2e.yaml

<ul><li>Changed KIND_VERSION from <code>"v0.29.0"</code> to <code>"0.29.0"</code> (removed leading v)<br> <li> Updated curl command to prepend <code>v</code> prefix: <code>v${KIND_VERSION}</code> instead of <br><code>${KIND_VERSION}</code><br> <li> Ensures the download URL always has correct v-prefixed version format</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4034/files#diff-4608c9a6806d47acb069a4d5586ed2091dc1e10d5f40a21f1d229f3053ff79a4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Fix renovate regex for kind version extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renovate.json

<ul><li>Modified KIND_VERSION regex pattern from <code>v?[^\"]+</code> to <code>[^\"]+</code> to not <br>capture optional v prefix<br> <li> Ensures renovate extracts version without the leading v character<br> <li> Prevents double v prefix when combined with extractVersionTemplate</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4034/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

