### PR TITLE
chore: set workflow context for operator-lint job

### DIFF
--- a/.github/workflows/operator-lint.yaml
+++ b/.github/workflows/operator-lint.yaml
@@ -3,21 +3,35 @@ name: Operator Lint
 on:
   push:
     branches: [ "main" ]
-    paths:
-      - 'operator/**'
-      - '.github/workflows/operator-lint.yaml'
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'operator/**'
-      - '.github/workflows/operator-lint.yaml'
   merge_group:
     types: [checks_requested]
 
 jobs:
+  check-changes:
+    name: Check for relevant changes
+    runs-on: ubuntu-slim
+    outputs:
+      operator: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for changes
+        uses: tj-actions/changed-files@v46
+        id: changed-files
+        with:
+          files: |
+            operator/**
+            .github/workflows/operator-lint.yaml
+
   lint:
     name: Run Operator Lint
     runs-on: ubuntu-latest
+    needs: check-changes
+    if: needs.check-changes.outputs.operator == 'true'
     defaults:
       run:
         working-directory: operator


### PR DESCRIPTION
### **User description**
Same as we did for other operator-related workflows.


___

### **PR Type**
Enhancement


___

### **Description**
- Implement workflow context checking for operator-lint job

- Replace path-based triggers with dynamic change detection

- Add check-changes job to evaluate relevant file modifications

- Conditionally run lint job based on detected changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Push/PR/Merge Event"] --> B["check-changes Job"]
  B --> C["Detect operator/** or workflow changes"]
  C --> D["Set operator output flag"]
  D --> E["lint Job"]
  E --> F["Conditional execution based on flag"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator-lint.yaml</strong><dd><code>Add dynamic change detection workflow context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/operator-lint.yaml

<ul><li>Removed static <code>paths</code> filters from push, pull_request, and merge_group <br>triggers<br> <li> Added new <code>check-changes</code> job that dynamically detects changes in <br><code>operator/**</code> and workflow file<br> <li> Made <code>lint</code> job dependent on <code>check-changes</code> job output<br> <li> Added conditional execution to <code>lint</code> job using <br><code>needs.check-changes.outputs.operator == 'true'</code></ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4066/files#diff-7021a70d6fff99c144b592e7027d8f4a9c67432216b6963089ef38047c5b0bf4">+20/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

