### PR TITLE
fix: run kube-linter on generated operator manifests

### DIFF
--- a/.github/scripts/run-kube-linter.sh
+++ b/.github/scripts/run-kube-linter.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -euo pipefail
+
+# Kube-linter runner script
+# This script handles manifest generation, kube-linter installation, and scanning
+# The kube-linter version is tracked by Renovate for automatic updates
+
+# renovate: datasource=github-releases depName=stackrox/kube-linter
+KUBE_LINTER_VERSION="0.7.6"
+
+# Cleanup function for temporary files
+cleanup() {
+  echo "Cleaning up temporary files..."
+  rm -f dependencies/smee/smee-channel-id.yaml
+}
+
+# Set up trap to cleanup on exit
+trap cleanup EXIT
+
+echo "=== Kube-linter CI Script ==="
+echo "Using kube-linter version: ${KUBE_LINTER_VERSION}"
+
+# Step 1: Create output directory
+echo "Creating .kube-linter directory..."
+mkdir -p ./.kube-linter/
+
+# Step 2: Generate manifests
+echo "Generating Kubernetes manifests..."
+
+# workaround: create dummy patch for building the manifests for kube-linter
+echo "Creating temporary smee-channel-id.yaml for manifest generation..."
+cp dependencies/smee/smee-channel-id.tpl dependencies/smee/smee-channel-id.yaml
+
+# Exclude operator directory from kustomize builds
+find . \( -name "kustomization.yaml" -o -name "kustomization.yml" \) ! -path "*/operator/*" | while read -r file; do
+  dir=$(dirname "$file")
+  dir=${dir#./}
+  output_file=$(echo "out-$dir" | tr "/" "-")
+  echo "  Building $dir -> .kube-linter/$output_file.yaml"
+  kustomize build "$dir" > "./.kube-linter/$output_file.yaml"
+done
+
+# Copy pre-built operator manifests to .kube-linter directory
+echo "Copying pre-built operator manifests to .kube-linter/operator-manifests..."
+cp -r operator/pkg/manifests ./.kube-linter/operator-manifests
+
+echo "Manifest generation completed."
+
+# Step 3: Install kube-linter
+echo "Installing kube-linter version ${KUBE_LINTER_VERSION}..."
+
+# Download URL for Linux (GitHub Actions runner)
+DOWNLOAD_URL="https://github.com/stackrox/kube-linter/releases/download/v${KUBE_LINTER_VERSION}/kube-linter-linux.tar.gz"
+ARCHIVE_FILE="kube-linter-linux.tar.gz"
+
+echo "Downloading from: ${DOWNLOAD_URL}"
+wget -q "${DOWNLOAD_URL}" -O "${ARCHIVE_FILE}"
+
+echo "Extracting kube-linter binary"
+tar -xzf "${ARCHIVE_FILE}"
+
+echo "Installing kube-linter to /usr/local/bin/"
+sudo mv kube-linter /usr/local/bin/
+
+echo "Cleaning up download files"
+rm -f "${ARCHIVE_FILE}"
+
+echo "Verifying kube-linter installation"
+which kube-linter
+kube-linter version
+
+# Step 4: Run kube-linter scan
+echo "Running kube-linter scan..."
+echo "Config file: ./.github/.kube-linter-config.yaml"
+echo "Scan directory: ./.kube-linter/"
+
+# Show some debug info
+echo "Files to be scanned:"
+find ./.kube-linter -name "*.yaml" -o -name "*.yml" | head -5
+echo ""
+
+# Run the scan with verbose output
+kube-linter lint ./.kube-linter/ --config ./.github/.kube-linter-config.yaml --verbose
+
+echo "=== Kube-linter scan completed successfully! ==="

--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -13,25 +13,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Create ./.kube-linter/ directory
-        shell: bash
-        run: mkdir -p ./.kube-linter/
-      - name: Generate default configuration
-        shell: bash
-        run: |
-          # workaround: create dummy patch for building the manifests for kube-linter
-          cp dependencies/smee/smee-channel-id.tpl dependencies/smee/smee-channel-id.yaml
-
-          # Exclude operator/config/manifests as it requires generated files from 'make bundle'
-          find . -name "kustomization.yaml" -o -name "kustomization.yml" | grep -v "operator/config/manifests" | while read -r file; do
-            dir=$(dirname "$file")
-            dir=${dir#./}
-            output_file=$(echo "out-$dir" | tr "/" "-")
-            kustomize build "$dir" > "./.kube-linter/$output_file.yaml"
-          done
-      - name: Scan yaml files with kube-linter
-        uses: stackrox/kube-linter-action@v1
-        id: kube-linter-action-scan
-        with:
-          directory: ./.kube-linter/
-          config: ./.github/.kube-linter-config.yaml
+      - name: Run kube-linter
+        run: ./.github/scripts/run-kube-linter.sh

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ logs/
 __debug_bin*
 dependencies/smee/smee-channel-id.yaml
 .kube-linter/
+
+# Kube-linter binaries and archives
+kube-linter
+kube-linter-*.tar.gz
+kubelinter.log

--- a/renovate.json
+++ b/renovate.json
@@ -150,6 +150,17 @@
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "curlimages/curl"
+    },
+    {
+      "description": "Track kube-linter version in shell scripts",
+      "customType": "regex",
+      "matchStringsStrategy": "combination",
+      "fileMatch": ["\\.github/scripts/.*\\.sh$"],
+      "matchStrings": [
+        "# renovate: datasource=github-releases depName=(?<depName>[^\\s]+)",
+        "KUBE_LINTER_VERSION=\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
### **User description**
The kube-linter workflow was regenerating the operator manifests from the kustomization files before running the linter, which caused it report issues. Running the linter directly on the pre-generated files instead.

Assisted-by: Claude


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes kube-linter workflow to scan pre-generated operator manifests

- Excludes entire operator directory from kustomize builds

- Copies pre-built manifests from `operator/pkg/manifests` instead

- Prevents manifest regeneration that caused linter issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Kustomization files"] -->|"Build (exclude operator/)"| B["Generated manifests"]
  C["Pre-built operator manifests"] -->|"Copy to .kube-linter/"| D["Linter scan directory"]
  B --> D
  D -->|"Scan"| E["Kube-linter results"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kube-linter.yaml</strong><dd><code>Use pre-built operator manifests for linting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/kube-linter.yaml

<ul><li>Changed kustomize exclusion filter from <code>operator/config/manifests</code> to <br><code>operator/</code> to exclude entire operator directory<br> <li> Added step to copy pre-built operator manifests from <br><code>operator/pkg/manifests</code> to <code>.kube-linter/operator-manifests</code><br> <li> Prevents regeneration of operator manifests during workflow execution</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4104/files#diff-27956c264030e6ec101c9af9bbfca5a0c5e9bc6bbf6cb4de82ed807916bee19b">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

