### PR TITLE
chore: try GH_TOKEN for creating PRs and issues

### DIFF
--- a/.github/workflows/update-upstream-manifests.yaml
+++ b/.github/workflows/update-upstream-manifests.yaml
@@ -58,7 +58,8 @@ jobs:
       - name: Process all components
         id: process
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use GH_TOKEN if available, otherwise fall back to GITHUB_TOKEN
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           cd "${{ github.workspace }}"
 


### PR DESCRIPTION
### **User description**
GITHUB_TOKEN is not enough for creating PRs and issues in some cases. Try using GH_TOKEN instead.


___

### **PR Type**
Enhancement


___

### **Description**
- Use GH_TOKEN with fallback to GITHUB_TOKEN for GitHub operations

- Improves PR and issue creation reliability in workflows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GH_TOKEN available"] -->|Use| B["GH_TOKEN"]
  A -->|Not available| C["Fall back to GITHUB_TOKEN"]
  B --> D["Create PRs and Issues"]
  C --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update-upstream-manifests.yaml</strong><dd><code>Add GH_TOKEN fallback for GitHub operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/update-upstream-manifests.yaml

<ul><li>Modified GH_TOKEN environment variable to use GH_TOKEN secret with <br>fallback to GITHUB_TOKEN<br> <li> Added clarifying comment explaining the token priority logic<br> <li> Improves workflow reliability for PR and issue creation operations</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4178/files#diff-b1d71943f21a158eae02d0fecd2f0a748545a399e28349c58cc74425023c6802">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

