### PR TITLE
fix: undo GH_TOKEN for creating PRs and issues

### DIFF
--- a/.github/workflows/update-upstream-manifests.yaml
+++ b/.github/workflows/update-upstream-manifests.yaml
@@ -58,8 +58,7 @@ jobs:
       - name: Process all components
         id: process
         env:
-          # Use GH_TOKEN if available, otherwise fall back to GITHUB_TOKEN
-          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd "${{ github.workspace }}"
 


### PR DESCRIPTION
### **User description**
This did not work


___

### **PR Type**
Bug fix


___

### **Description**
- Revert GH_TOKEN fallback logic to use GITHUB_TOKEN directly

- Remove conditional token selection that was not working


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GH_TOKEN with fallback logic"] -- "Remove non-functional fallback" --> B["Direct GITHUB_TOKEN usage"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update-upstream-manifests.yaml</strong><dd><code>Simplify GH_TOKEN to use GITHUB_TOKEN directly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/update-upstream-manifests.yaml

<ul><li>Removed conditional GH_TOKEN assignment that attempted to fallback <br>from GH_TOKEN to GITHUB_TOKEN<br> <li> Simplified environment variable to directly use <code>secrets.GITHUB_TOKEN</code><br> <li> Removed comment explaining the fallback logic</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4179/files#diff-b1d71943f21a158eae02d0fecd2f0a748545a399e28349c58cc74425023c6802">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

