### PR TITLE
fix: approve new bot to run e2e tests

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -17,7 +17,12 @@ jobs:
           exit 0
         fi
 
-        WHITELISTED_BOT_NAMES=("renovate[bot]" "red-hat-konflux[bot]" "github-actions[bot]")
+        WHITELISTED_BOT_NAMES=(
+          "renovate[bot]"
+          "red-hat-konflux[bot]"
+          "github-actions[bot]"
+          "konflux-ci-update-bot[bot]"
+        )
         REQUIRED_LABEL_NAME="ok-to-test"
 
         ORG="${{ github.repository_owner }}"

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -16,7 +16,12 @@ jobs:
           exit 0
         fi
 
-        WHITELISTED_BOT_NAMES=("renovate[bot]" "red-hat-konflux[bot]" "github-actions[bot]")
+        WHITELISTED_BOT_NAMES=(
+          "renovate[bot]"
+          "red-hat-konflux[bot]"
+          "github-actions[bot]"
+          "konflux-ci-update-bot[bot]"
+        )
         REQUIRED_LABEL_NAME="ok-to-test"
 
         ORG="${{ github.repository_owner }}"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add new bot `konflux-ci-update-bot[bot]` to whitelisted bots

- Update both E2E and sanity test workflows

- Improve array formatting for better readability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow Files"] -->|"Add bot to whitelist"| B["E2E Test Workflow"]
  A -->|"Add bot to whitelist"| C["Sanity Test Workflow"]
  B -->|"Allow bot to run"| D["konflux-ci-update-bot[bot]"]
  C -->|"Allow bot to run"| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator-test-e2e.yaml</strong><dd><code>Add konflux-ci-update-bot to E2E test whitelist</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/operator-test-e2e.yaml

<ul><li>Add <code>konflux-ci-update-bot[bot]</code> to the whitelisted bots array<br> <li> Reformat array to multi-line format for improved readability<br> <li> Maintain existing bot approvals (renovate, red-hat-konflux, <br>github-actions)</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4235/files#diff-4608c9a6806d47acb069a4d5586ed2091dc1e10d5f40a21f1d229f3053ff79a4">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sanity-test.yml</strong><dd><code>Add konflux-ci-update-bot to sanity test whitelist</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/sanity-test.yml

<ul><li>Add <code>konflux-ci-update-bot[bot]</code> to the whitelisted bots array<br> <li> Reformat array to multi-line format for improved readability<br> <li> Maintain existing bot approvals (renovate, red-hat-konflux, <br>github-actions)</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4235/files#diff-c68f5ef87662968636741c0c819fd08d5c7f2a1c020a572d10356b72e63f742f">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

