### PR TITLE
chore: authenticate as app bot when updating upstream manifests

### DIFF
--- a/.github/workflows/update-upstream-manifests.yaml
+++ b/.github/workflows/update-upstream-manifests.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Install Kustomize
         run: |
@@ -75,6 +75,13 @@ jobs:
           # Configure Git
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+
+          # Configure git to use app token for authentication (so pushes trigger CI)
+          # This ensures pushes are authenticated as the app, which triggers synchronize events
+          if [ -n "${GH_TOKEN}" ]; then
+            git config --local credential.helper store
+            echo "https://x-access-token:${GH_TOKEN}@github.com" > ~/.git-credentials
+          fi
 
           # Ensure we're on main branch and up to date
           git checkout main


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Use app bot token for GitHub authentication in workflow

- Configure git credentials to enable CI triggers on pushes

- Replace default GITHUB_TOKEN with app-generated token fallback


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow Trigger"] --> B["Generate App Token"]
  B --> C["Checkout with App Token"]
  C --> D["Configure Git Credentials"]
  D --> E["Push Triggers CI Events"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update-upstream-manifests.yaml</strong><dd><code>Configure app bot authentication for git operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/update-upstream-manifests.yaml

<ul><li>Updated checkout step to use app token instead of default GITHUB_TOKEN<br> <li> Added git credential configuration to authenticate pushes as the app <br>bot<br> <li> Configured credential helper to store app token for git operations<br> <li> Added comments explaining the purpose of app token authentication for <br>CI triggers</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4239/files#diff-b1d71943f21a158eae02d0fecd2f0a748545a399e28349c58cc74425023c6802">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

