### PR TITLE
Add clusterinfo package for platform and capability detection

### DIFF
--- a/operator/pkg/clusterinfo/clusterinfo.go
+++ b/operator/pkg/clusterinfo/clusterinfo.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterinfo
+
+import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// DiscoveryClient is an interface for discovering server resources and version.
+// This interface is implemented by the Kubernetes discovery client and can be mocked for testing.
+type DiscoveryClient interface {
+	ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error)
+	ServerVersion() (*version.Info, error)
+}
+
+// Platform represents the Kubernetes distribution type.
+type Platform string
+
+const (
+	// OpenShift represents the OpenShift platform.
+	OpenShift Platform = "openshift"
+	// Default represents any non-OpenShift Kubernetes platform.
+	Default Platform = "default"
+)
+
+// IsOpenShift returns true if the platform is OpenShift.
+func (p Platform) IsOpenShift() bool {
+	return p == OpenShift
+}
+
+// Info holds cluster environment information including platform, version, and capabilities.
+type Info struct {
+	platform   Platform
+	k8sVersion *version.Info
+	client     DiscoveryClient
+}
+
+// Detect discovers cluster information by querying the Kubernetes API.
+func Detect(cfg *rest.Config) (*Info, error) {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create discovery client: %w", err)
+	}
+	return DetectWithClient(discoveryClient)
+}
+
+// DetectWithClient discovers cluster information using the provided discovery client.
+// This function is useful for testing with a mock client.
+func DetectWithClient(client DiscoveryClient) (*Info, error) {
+	info := &Info{
+		client: client,
+	}
+
+	// Detect platform
+	isOpenShift, err := detectOpenShift(client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect platform: %w", err)
+	}
+	if isOpenShift {
+		info.platform = OpenShift
+	} else {
+		info.platform = Default
+	}
+
+	// Get K8s version
+	serverVersion, err := client.ServerVersion()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server version: %w", err)
+	}
+	info.k8sVersion = serverVersion
+
+	return info, nil
+}
+
+// Platform returns the detected Kubernetes distribution.
+func (i *Info) Platform() Platform {
+	return i.platform
+}
+
+// IsOpenShift returns true if running on OpenShift.
+func (i *Info) IsOpenShift() bool {
+	return i.platform.IsOpenShift()
+}
+
+// K8sVersion returns the Kubernetes version info.
+func (i *Info) K8sVersion() *version.Info {
+	return i.k8sVersion
+}
+
+// HasResource checks if a specific resource kind exists in the given API group version.
+func (i *Info) HasResource(groupVersion, kind string) (bool, error) {
+	resourceList, err := i.client.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		// If the group doesn't exist, the resource doesn't exist
+		return false, nil
+	}
+
+	for _, resource := range resourceList.APIResources {
+		if resource.Kind == kind {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// HasTekton checks if Tekton Pipelines is installed.
+func (i *Info) HasTekton() (bool, error) {
+	return i.HasResource("tekton.dev/v1", "Pipeline")
+}
+
+// detectOpenShift checks if the operator is running on OpenShift by
+// verifying that the ClusterVersion resource exists in the config.openshift.io API group.
+func detectOpenShift(client DiscoveryClient) (bool, error) {
+	resourceList, err := client.ServerResourcesForGroupVersion("config.openshift.io/v1")
+	if err != nil {
+		// If the group doesn't exist, we're not on OpenShift
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		// For other errors (network issues, etc.), propagate them
+		return false, fmt.Errorf("failed to check for OpenShift API group: %w", err)
+	}
+
+	for _, resource := range resourceList.APIResources {
+		if resource.Kind == "ClusterVersion" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/operator/pkg/clusterinfo/clusterinfo_test.go
+++ b/operator/pkg/clusterinfo/clusterinfo_test.go
@@ -1,0 +1,310 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterinfo
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+)
+
+// mockDiscoveryClient implements DiscoveryClient for testing.
+type mockDiscoveryClient struct {
+	resources      map[string]*metav1.APIResourceList
+	resourceErrors map[string]error
+	serverVersion  *version.Info
+	versionErr     error
+}
+
+func (m *mockDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	// Check for specific errors first
+	if m.resourceErrors != nil {
+		if err, ok := m.resourceErrors[groupVersion]; ok {
+			return nil, err
+		}
+	}
+	if r, ok := m.resources[groupVersion]; ok {
+		return r, nil
+	}
+	// Return a NotFound error by default (simulates missing API group)
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: groupVersion}, "")
+}
+
+func (m *mockDiscoveryClient) ServerVersion() (*version.Info, error) {
+	if m.versionErr != nil {
+		return nil, m.versionErr
+	}
+	return m.serverVersion, nil
+}
+
+func TestDetectWithClient_OpenShift(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	mock := &mockDiscoveryClient{
+		resources: map[string]*metav1.APIResourceList{
+			"config.openshift.io/v1": {
+				APIResources: []metav1.APIResource{
+					{Kind: "ClusterVersion"},
+					{Kind: "Infrastructure"},
+				},
+			},
+		},
+		serverVersion: &version.Info{
+			GitVersion: "v1.29.4",
+			Major:      "1",
+			Minor:      "29",
+		},
+	}
+
+	info, err := DetectWithClient(mock)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(info.Platform()).To(gomega.Equal(OpenShift))
+	g.Expect(info.IsOpenShift()).To(gomega.BeTrue())
+}
+
+func TestDetectWithClient_Default(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	mock := &mockDiscoveryClient{
+		resources: map[string]*metav1.APIResourceList{
+			// No OpenShift resources
+		},
+		serverVersion: &version.Info{
+			GitVersion: "v1.30.0",
+			Major:      "1",
+			Minor:      "30",
+		},
+	}
+
+	info, err := DetectWithClient(mock)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(info.Platform()).To(gomega.Equal(Default))
+	g.Expect(info.IsOpenShift()).To(gomega.BeFalse())
+}
+
+func TestDetectWithClient_OpenShiftGroupWithoutClusterVersion(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	mock := &mockDiscoveryClient{
+		resources: map[string]*metav1.APIResourceList{
+			"config.openshift.io/v1": {
+				APIResources: []metav1.APIResource{
+					{Kind: "Infrastructure"},
+					// No ClusterVersion
+				},
+			},
+		},
+		serverVersion: &version.Info{GitVersion: "v1.29.0"},
+	}
+
+	info, err := DetectWithClient(mock)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(info.Platform()).To(gomega.Equal(Default), "should return Default when ClusterVersion is missing")
+}
+
+func TestDetectWithClient_ServerVersionError(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	mock := &mockDiscoveryClient{
+		resources:  map[string]*metav1.APIResourceList{},
+		versionErr: errors.New("connection refused"),
+	}
+
+	_, err := DetectWithClient(mock)
+	g.Expect(err).To(gomega.HaveOccurred())
+}
+
+func TestDetectWithClient_PlatformDetectionError(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	// Simulate a non-NotFound error (e.g., network failure, unauthorized)
+	mock := &mockDiscoveryClient{
+		resources: map[string]*metav1.APIResourceList{},
+		resourceErrors: map[string]error{
+			"config.openshift.io/v1": apierrors.NewServiceUnavailable("API server unavailable"),
+		},
+		serverVersion: &version.Info{GitVersion: "v1.29.0"},
+	}
+
+	_, err := DetectWithClient(mock)
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("failed to detect platform"))
+}
+
+func TestInfo_K8sVersion(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	expectedVersion := &version.Info{
+		GitVersion: "v1.29.4",
+		Major:      "1",
+		Minor:      "29",
+		Platform:   "linux/amd64",
+	}
+
+	mock := &mockDiscoveryClient{
+		resources:     map[string]*metav1.APIResourceList{},
+		serverVersion: expectedVersion,
+	}
+
+	info, err := DetectWithClient(mock)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(info.K8sVersion().GitVersion).To(gomega.Equal(expectedVersion.GitVersion))
+	g.Expect(info.K8sVersion().Major).To(gomega.Equal(expectedVersion.Major))
+	g.Expect(info.K8sVersion().Minor).To(gomega.Equal(expectedVersion.Minor))
+}
+
+func TestInfo_HasResource(t *testing.T) {
+	tests := []struct {
+		name         string
+		resources    map[string]*metav1.APIResourceList
+		groupVersion string
+		kind         string
+		expected     bool
+	}{
+		{
+			name: "resource exists",
+			resources: map[string]*metav1.APIResourceList{
+				"apps/v1": {
+					APIResources: []metav1.APIResource{
+						{Kind: "Deployment"},
+						{Kind: "StatefulSet"},
+					},
+				},
+			},
+			groupVersion: "apps/v1",
+			kind:         "Deployment",
+			expected:     true,
+		},
+		{
+			name: "resource does not exist in group",
+			resources: map[string]*metav1.APIResourceList{
+				"apps/v1": {
+					APIResources: []metav1.APIResource{
+						{Kind: "Deployment"},
+					},
+				},
+			},
+			groupVersion: "apps/v1",
+			kind:         "DaemonSet",
+			expected:     false,
+		},
+		{
+			name:         "group does not exist",
+			resources:    map[string]*metav1.APIResourceList{},
+			groupVersion: "nonexistent.io/v1",
+			kind:         "SomeResource",
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			mock := &mockDiscoveryClient{
+				resources:     tt.resources,
+				serverVersion: &version.Info{GitVersion: "v1.29.0"},
+			}
+
+			info, err := DetectWithClient(mock)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			result, err := info.HasResource(tt.groupVersion, tt.kind)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(result).To(gomega.Equal(tt.expected))
+		})
+	}
+}
+
+func TestInfo_HasTekton(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources map[string]*metav1.APIResourceList
+		expected  bool
+	}{
+		{
+			name: "Tekton installed",
+			resources: map[string]*metav1.APIResourceList{
+				"tekton.dev/v1": {
+					APIResources: []metav1.APIResource{
+						{Kind: "Pipeline"},
+						{Kind: "Task"},
+						{Kind: "PipelineRun"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:      "Tekton not installed",
+			resources: map[string]*metav1.APIResourceList{},
+			expected:  false,
+		},
+		{
+			name: "Tekton group exists but no Pipeline",
+			resources: map[string]*metav1.APIResourceList{
+				"tekton.dev/v1": {
+					APIResources: []metav1.APIResource{
+						{Kind: "Task"},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			mock := &mockDiscoveryClient{
+				resources:     tt.resources,
+				serverVersion: &version.Info{GitVersion: "v1.29.0"},
+			}
+
+			info, err := DetectWithClient(mock)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			result, err := info.HasTekton()
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(result).To(gomega.Equal(tt.expected))
+		})
+	}
+}
+
+func TestPlatform_IsOpenShift(t *testing.T) {
+	tests := []struct {
+		platform Platform
+		expected bool
+	}{
+		{OpenShift, true},
+		{Default, false},
+		{Platform("unknown"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.platform), func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			g.Expect(tt.platform.IsOpenShift()).To(gomega.Equal(tt.expected))
+		})
+	}
+}


### PR DESCRIPTION
Introduce a new pkg/clusterinfo package that provides runtime detection of the Kubernetes cluster environment. This enables the operator to adapt its behavior based on:

- Platform type: Distinguishes between OpenShift and vanilla Kubernetes by checking for the ClusterVersion resource in config.openshift.io/v1
- Kubernetes version: Retrieves server version information
- Cluster capabilities: Generic HasResource() method to check for installed CRDs/APIs (e.g., Tekton pipelines)

The motivation for these changes is to support deploying Konflux on multiple platforms. Different platforms may require different base manifests or configuration. For example, OpenShift provides Routes while vanilla Kubernetes uses Ingress.

The package is designed for testability with a DiscoveryClient interface that can be mocked in unit tests.

Assisted-By: Cursor