### PR TITLE
fix: renovate should ignore operator manifests

### DIFF
--- a/operator/upstream-kustomizations/integration/core/kustomization.yaml
+++ b/operator/upstream-kustomizations/integration/core/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/integration-service/config/default?ref=4583feb1c8547eb583c063564078ed322ea0149f
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=4583feb1c8547eb583c063564078ed322ea0149f
+- https://github.com/konflux-ci/integration-service/config/default?ref=2fc3af73319771804f7afd112c8871f38c7c3be4
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=2fc3af73319771804f7afd112c8871f38c7c3be4
 - konflux-integration-runner.yaml
 - kyverno-background-controller-binding.yaml
 - bootstrap-namespace.yaml
@@ -12,7 +12,7 @@ namespace: integration-service
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: 4583feb1c8547eb583c063564078ed322ea0149f
+  newTag: 2fc3af73319771804f7afd112c8871f38c7c3be4
 
 patches:
   - target:

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "ignorePaths": [
+    "operator/upstream-kustomizations/**",
+    "operator/pkg/manifests/**"
+  ],
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
Those manifests are tracked by a different automation which also vendors the upstream manifests, generated by the kustomizations.

Also reverting a change made by renovate so the kustomizations are in sync with the vendored manifests.