### PR TITLE
test(KFLUXVNGD-586): run kube-linter for operator manifests

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -13,5 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: operator/go.mod
+          cache-dependency-path: operator/go.sum
       - name: Run kube-linter
         run: ./.github/scripts/run-kube-linter.sh


### PR DESCRIPTION
The kube-linter script was not running kustomize build for anything under the operator directory. Instead we now exclude the upstream kustomizations which are pre-built by automation and include the rest (e.g. operator's own manifests).