### PR TITLE
feat(KFLUXVNGD-615): add orphan resource cleanup after upgrades

### DIFF
--- a/operator/internal/controller/konfluxnamespacelister_controller.go
+++ b/operator/internal/controller/konfluxnamespacelister_controller.go
@@ -127,6 +127,13 @@ func (r *KonfluxNamespaceListerReconciler) applyManifests(ctx context.Context, o
 				obj.GetNamespace(), obj.GetName(), getKind(obj), manifests.NamespaceLister, err)
 		}
 	}
+
+	// Clean up orphaned resources from previous operator versions
+	if err := PruneOrphanedResources(ctx, r.Client, string(manifests.NamespaceLister)); err != nil {
+		log.Error(err, "Failed to prune orphaned resources")
+		// Don't fail the reconciliation if pruning fails
+	}
+
 	return nil
 }
 

--- a/operator/internal/controller/orphan_cleanup.go
+++ b/operator/internal/controller/orphan_cleanup.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// orphan_cleanup.go provides functionality to detect and remove orphaned resources
+// after operator upgrades. When the operator is upgraded and its manifests change
+// (resources removed or renamed), the old resources would remain in the cluster.
+// This file implements a label-based approach to identify and clean up such orphans:
+//
+// 1. Each applied resource is labeled with the operator binary's SHA-256 digest
+// 2. After applying current manifests, we query resources with our component label
+// 3. Resources with a different (older) operator-version label are deleted
+//
+// This implementation uses the unstructured client to query resources dynamically
+// by GroupVersionKind (GVK), avoiding the need for typed imports and switch statements.
+// This approach is ideal for generic utilities like orphan cleanup where we only
+// need to read labels and delete resources.
+
+package controller
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/konflux-ci/konflux-ci/operator/pkg/version"
+)
+
+// resourceGVKs defines all resource types that should be checked for orphaned resources.
+// These are the common Kubernetes resource types that the operator manages.
+// To support additional resource types (e.g., CRDs), add their GVKs here.
+var resourceGVKs = []schema.GroupVersionKind{
+	// Namespaced resources
+	{Group: "apps", Version: "v1", Kind: "Deployment"},
+	{Group: "", Version: "v1", Kind: "Service"},
+	{Group: "", Version: "v1", Kind: "ConfigMap"},
+	{Group: "", Version: "v1", Kind: "Secret"},
+	{Group: "", Version: "v1", Kind: "ServiceAccount"},
+	// Cluster-scoped resources
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"},
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"},
+}
+
+// PruneOrphanedResources deletes resources that were created by a previous operator version
+// but are no longer part of the current manifests. It identifies orphaned resources by
+// comparing the operator-version label on existing resources against the current operator's
+// binary digest.
+//
+// Resources are considered orphaned if:
+// 1. They have the component label matching the specified component
+// 2. They have an operator-version label that differs from the current operator version
+//
+// Resources without the operator-version label are skipped (could be user-created or from
+// older operator versions before this feature was added).
+func PruneOrphanedResources(ctx context.Context, k8sClient client.Client, component string) error {
+	log := logf.FromContext(ctx)
+
+	currentDigest, err := version.GetBinaryDigest()
+	if err != nil {
+		log.Error(err, "Failed to get operator binary digest, skipping orphan cleanup")
+		return nil // Don't fail reconciliation if we can't get the digest
+	}
+
+	// Iterate over all resource types and prune orphaned resources
+	for _, gvk := range resourceGVKs {
+		if err := pruneResourcesOfKind(ctx, k8sClient, gvk, component, currentDigest); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// pruneResourcesOfKind lists resources of a specific GVK and deletes orphaned ones.
+// It uses the unstructured client to dynamically query resources without requiring
+// typed imports for each resource kind.
+func pruneResourcesOfKind(ctx context.Context, k8sClient client.Client, gvk schema.GroupVersionKind, component string, currentDigest string) error {
+	log := logf.FromContext(ctx)
+
+	// Create an unstructured list with the List kind
+	uList := &unstructured.UnstructuredList{}
+	uList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   gvk.Group,
+		Version: gvk.Version,
+		Kind:    gvk.Kind + "List",
+	})
+
+	// List all resources with our component label
+	if err := k8sClient.List(ctx, uList, client.MatchingLabels{
+		KonfluxComponentLabel: component,
+	}); err != nil {
+		// If we can't list, just log and continue - don't fail the whole reconcile
+		log.V(1).Info("Failed to list resources for orphan cleanup",
+			"gvk", gvk.String(),
+			"error", err,
+		)
+		return nil
+	}
+
+	// Iterate over items and delete orphaned ones
+	for i := range uList.Items {
+		item := &uList.Items[i]
+		labels := item.GetLabels()
+
+		// Skip resources without operator-version label (pre-existing or user-created)
+		resourceVersion, hasLabel := labels[OperatorVersionLabel]
+		if !hasLabel {
+			continue
+		}
+
+		// Skip resources with matching version (current)
+		if resourceVersion == currentDigest {
+			continue
+		}
+
+		// This resource has an old version - it's orphaned
+		log.Info("Deleting orphaned resource",
+			"kind", gvk.Kind,
+			"name", item.GetName(),
+			"namespace", item.GetNamespace(),
+			"oldVersion", resourceVersion,
+			"currentVersion", currentDigest,
+		)
+
+		if err := k8sClient.Delete(ctx, item); err != nil && !errors.IsNotFound(err) {
+			log.Error(err, "Failed to delete orphaned resource",
+				"kind", gvk.Kind,
+				"name", item.GetName(),
+				"namespace", item.GetNamespace(),
+			)
+			// Continue with other resources even if one fails
+		}
+	}
+
+	return nil
+}

--- a/operator/pkg/version/digest.go
+++ b/operator/pkg/version/digest.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package version provides utilities for identifying the running operator version.
+package version
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"sync"
+)
+
+var (
+	binaryDigest     string
+	binaryDigestOnce sync.Once
+	binaryDigestErr  error
+)
+
+// GetBinaryDigest returns a truncated SHA-256 digest of the running operator binary.
+// The digest is computed once at first call and cached for the lifetime of the process.
+// The returned digest is 16 hex characters (64 bits), which is sufficient for uniqueness
+// while staying well under Kubernetes label value limits (63 chars).
+func GetBinaryDigest() (string, error) {
+	binaryDigestOnce.Do(func() {
+		binaryDigest, binaryDigestErr = computeBinaryDigest()
+	})
+	return binaryDigest, binaryDigestErr
+}
+
+// computeBinaryDigest computes the SHA-256 digest of the currently running executable.
+func computeBinaryDigest() (string, error) {
+	// Get the path to the currently running executable
+	path, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	// Open the file for reading
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+
+	// Create a new SHA-256 hasher
+	hash := sha256.New()
+
+	// Stream the file content into the hasher
+	// io.Copy is memory-efficient as it doesn't load the whole file into RAM
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+
+	// Compute the final digest and return first 16 hex chars
+	fullDigest := hex.EncodeToString(hash.Sum(nil))
+	return fullDigest[:16], nil
+}

--- a/operator/pkg/version/digest_test.go
+++ b/operator/pkg/version/digest_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"testing"
+)
+
+func TestGetBinaryDigest(t *testing.T) {
+	digest, err := GetBinaryDigest()
+	if err != nil {
+		t.Fatalf("GetBinaryDigest() returned error: %v", err)
+	}
+
+	// Check that we got a non-empty digest
+	if digest == "" {
+		t.Error("GetBinaryDigest() returned empty digest")
+	}
+
+	// Check that the digest is exactly 16 hex characters
+	if len(digest) != 16 {
+		t.Errorf("GetBinaryDigest() returned digest of length %d, want 16", len(digest))
+	}
+
+	// Check that all characters are valid hex
+	for _, c := range digest {
+		isDigit := c >= '0' && c <= '9'
+		isHexLower := c >= 'a' && c <= 'f'
+		if !isDigit && !isHexLower {
+			t.Errorf("GetBinaryDigest() returned invalid hex character: %c", c)
+		}
+	}
+}
+
+func TestGetBinaryDigestIsCached(t *testing.T) {
+	// Call twice and verify we get the same result
+	digest1, err1 := GetBinaryDigest()
+	if err1 != nil {
+		t.Fatalf("First GetBinaryDigest() returned error: %v", err1)
+	}
+
+	digest2, err2 := GetBinaryDigest()
+	if err2 != nil {
+		t.Fatalf("Second GetBinaryDigest() returned error: %v", err2)
+	}
+
+	if digest1 != digest2 {
+		t.Errorf("GetBinaryDigest() not cached: got %q then %q", digest1, digest2)
+	}
+}


### PR DESCRIPTION
When the operator is upgraded and its manifests change (resources removed or renamed), the old resources would remain in the cluster. This change implements a label-based approach to detect and clean up such orphans.

Flow:
```
                    ┌─────────────────────────────┐
                    │    Operator Starts          │
                    │  (compute binary digest)    │
                    └──────────────┬──────────────┘
                                   │
                                   ▼
                    ┌─────────────────────────────┐
                    │    Reconcile Component      │
                    └──────────────┬──────────────┘
                                   │
                    ┌──────────────┴──────────────┐
                    ▼                             │
         ┌──────────────────────┐                 │
         │  Apply Resource      │                 │
         │  (set labels:        │                 │
         │   component=X        │                 │
         │   operator-version=  │                 │
         │     abc123...)       │                 │
         └──────────┬───────────┘                 │
                    │                             │
                    │ ◄────── repeat ─────────────┘
                    ▼
         ┌──────────────────────┐
         │ PruneOrphanedResources                │
         └──────────┬───────────┘
                    │
                    ▼
    ┌───────────────────────────────────┐
    │  For each resource type:          │
    │  List where component=X           │
    │                                   │
    │  operator-version != current?     │
    │  YES ──► DELETE (orphaned)        │
    │  NO  ──► KEEP                     │
    │  MISSING ──► SKIP                 │
    └───────────────────────────────────┘
```
New files:
- pkg/version/digest.go: Binary digest computation with caching
- internal/controller/orphan_cleanup.go: Orphan detection and cleanup

Integrated with namespace-lister controller as the first implementation. Other controllers can adopt the same pattern.

assisted-by: Cursor