### PR TITLE
feat(KFLUXVNGD-616): unique field owners per reconciler

### DIFF
--- a/operator/internal/controller/konflux_controller.go
+++ b/operator/internal/controller/konflux_controller.go
@@ -65,6 +65,20 @@ const (
 	CertManagerGroup = "cert-manager.io"
 	// KyvernoGroup is the API group for Kyverno resources
 	KyvernoGroup = "kyverno.io"
+
+	// Field manager identifiers for server-side apply.
+	// Each controller uses a unique field manager to make it clear which controller
+	// manages which fields when inspecting managedFields on resources.
+	FieldManagerKonflux            = "konflux-controller"
+	FieldManagerBuildService       = "konflux-buildservice-controller"
+	FieldManagerIntegrationService = "konflux-integrationservice-controller"
+	FieldManagerReleaseService     = "konflux-releaseservice-controller"
+	FieldManagerUI                 = "konflux-ui-controller"
+	FieldManagerRBAC               = "konflux-rbac-controller"
+	FieldManagerNamespaceLister    = "konflux-namespacelister-controller"
+	FieldManagerImageController    = "konflux-imagecontroller-controller"
+	FieldManagerEnterpriseContract = "konflux-enterprisecontract-controller"
+	FieldManagerApplicationAPI     = "konflux-applicationapi-controller"
 )
 
 // KonfluxReconciler reconciles a Konflux object
@@ -347,7 +361,7 @@ func (r *KonfluxReconciler) applyKonfluxBuildService(ctx context.Context, owner 
 	}
 
 	log.Info("Applying KonfluxBuildService CR", "name", buildService.Name)
-	return r.Patch(ctx, buildService, client.Apply, client.FieldOwner("konflux-operator"), client.ForceOwnership)
+	return r.Patch(ctx, buildService, client.Apply, client.FieldOwner(FieldManagerKonflux), client.ForceOwnership)
 }
 
 // applyKonfluxIntegrationService creates or updates the KonfluxIntegrationService CR.
@@ -380,7 +394,7 @@ func (r *KonfluxReconciler) applyKonfluxIntegrationService(ctx context.Context, 
 	}
 
 	log.Info("Applying KonfluxIntegrationService CR", "name", integrationService.Name)
-	return r.Patch(ctx, integrationService, client.Apply, client.FieldOwner("konflux-operator"), client.ForceOwnership)
+	return r.Patch(ctx, integrationService, client.Apply, client.FieldOwner(FieldManagerKonflux), client.ForceOwnership)
 }
 
 // applyKonfluxReleaseService creates or updates the KonfluxReleaseService CR.
@@ -413,7 +427,7 @@ func (r *KonfluxReconciler) applyKonfluxReleaseService(ctx context.Context, owne
 	}
 
 	log.Info("Applying KonfluxReleaseService CR", "name", releaseService.Name)
-	return r.Patch(ctx, releaseService, client.Apply, client.FieldOwner("konflux-operator"), client.ForceOwnership)
+	return r.Patch(ctx, releaseService, client.Apply, client.FieldOwner(FieldManagerKonflux), client.ForceOwnership)
 }
 
 // applyKonfluxUI creates or updates the KonfluxUI CR.
@@ -445,7 +459,7 @@ func (r *KonfluxReconciler) applyKonfluxUI(ctx context.Context, owner *konfluxv1
 	}
 
 	log.Info("Applying KonfluxUI CR", "name", ui.Name)
-	return r.Patch(ctx, ui, client.Apply, client.FieldOwner("konflux-operator"), client.ForceOwnership)
+	return r.Patch(ctx, ui, client.Apply, client.FieldOwner(FieldManagerKonflux), client.ForceOwnership)
 }
 
 // applyKonfluxRBAC creates or updates the KonfluxRBAC CR.
@@ -472,7 +486,7 @@ func (r *KonfluxReconciler) applyKonfluxRBAC(ctx context.Context, owner *konflux
 	}
 
 	log.Info("Applying KonfluxRBAC CR", "name", konfluxRBAC.Name)
-	return r.Patch(ctx, konfluxRBAC, client.Apply, client.FieldOwner("konflux-operator"), client.ForceOwnership)
+	return r.Patch(ctx, konfluxRBAC, client.Apply, client.FieldOwner(FieldManagerKonflux), client.ForceOwnership)
 }
 
 // applyKonfluxNamespaceLister creates or updates the KonfluxNamespaceLister CR.
@@ -499,7 +513,7 @@ func (r *KonfluxReconciler) applyKonfluxNamespaceLister(ctx context.Context, own
 	}
 
 	log.Info("Applying KonfluxNamespaceLister CR", "name", konfluxNamespaceLister.Name)
-	return r.Patch(ctx, konfluxNamespaceLister, client.Apply, client.FieldOwner("konflux-operator"), client.ForceOwnership)
+	return r.Patch(ctx, konfluxNamespaceLister, client.Apply, client.FieldOwner(FieldManagerKonflux), client.ForceOwnership)
 }
 
 // applyKonfluxEnterpriseContract creates or updates the KonfluxEnterpriseContract CR.
@@ -526,7 +540,7 @@ func (r *KonfluxReconciler) applyKonfluxEnterpriseContract(ctx context.Context, 
 	}
 
 	log.Info("Applying KonfluxEnterpriseContract CR", "name", konfluxEnterpriseContract.Name)
-	return r.Patch(ctx, konfluxEnterpriseContract, client.Apply, client.FieldOwner("konflux-operator"), client.ForceOwnership)
+	return r.Patch(ctx, konfluxEnterpriseContract, client.Apply, client.FieldOwner(FieldManagerKonflux), client.ForceOwnership)
 }
 
 // applyKonfluxApplicationAPI creates or updates the KonfluxApplicationAPI CR.
@@ -553,7 +567,7 @@ func (r *KonfluxReconciler) applyKonfluxApplicationAPI(ctx context.Context, owne
 	}
 
 	log.Info("Applying KonfluxApplicationAPI CR", "name", applicationAPI.Name)
-	return r.Patch(ctx, applicationAPI, client.Apply, client.FieldOwner("konflux-operator"), client.ForceOwnership)
+	return r.Patch(ctx, applicationAPI, client.Apply, client.FieldOwner(FieldManagerKonflux), client.ForceOwnership)
 }
 
 // applyKonfluxImageController creates or updates the KonfluxImageController CR if enabled,
@@ -597,7 +611,7 @@ func (r *KonfluxReconciler) applyKonfluxImageController(ctx context.Context, own
 	}
 
 	log.Info("Applying KonfluxImageController CR", "name", imageController.Name)
-	return r.Patch(ctx, imageController, client.Apply, client.FieldOwner("konflux-operator"), client.ForceOwnership)
+	return r.Patch(ctx, imageController, client.Apply, client.FieldOwner(FieldManagerKonflux), client.ForceOwnership)
 }
 
 // getKind returns the Kind of a client.Object.
@@ -633,8 +647,10 @@ func setOwnership(obj client.Object, owner client.Object, component string, sche
 // applyObject applies a single object to the cluster using server-side apply.
 // Server-side apply is idempotent and only triggers updates when there are actual changes,
 // preventing reconcile loops when watching owned resources.
-func applyObject(ctx context.Context, k8sClient client.Client, obj client.Object) error {
-	return k8sClient.Patch(ctx, obj, client.Apply, client.FieldOwner("konflux-operator"), client.ForceOwnership)
+// The fieldManager parameter identifies which controller manages the fields being applied,
+// making it clear when different reconcilers try to manage the same resource.
+func applyObject(ctx context.Context, k8sClient client.Client, obj client.Object, fieldManager string) error {
+	return k8sClient.Patch(ctx, obj, client.Apply, client.FieldOwner(fieldManager), client.ForceOwnership)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/operator/internal/controller/konfluxapplicationapi_controller.go
+++ b/operator/internal/controller/konfluxapplicationapi_controller.go
@@ -102,7 +102,7 @@ func (r *KonfluxApplicationAPIReconciler) applyManifests(ctx context.Context, ow
 				obj.GetNamespace(), obj.GetName(), getKind(obj), manifests.ApplicationAPI, err)
 		}
 
-		if err := applyObject(ctx, r.Client, obj); err != nil {
+		if err := applyObject(ctx, r.Client, obj, FieldManagerApplicationAPI); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			if gvk.Group == CertManagerGroup || gvk.Group == KyvernoGroup {
 				// TODO: Remove this once we decide how to install cert-manager crds in envtest

--- a/operator/internal/controller/konfluxbuildservice_controller.go
+++ b/operator/internal/controller/konfluxbuildservice_controller.go
@@ -124,7 +124,7 @@ func (r *KonfluxBuildServiceReconciler) applyManifests(ctx context.Context, owne
 				obj.GetNamespace(), obj.GetName(), getKind(obj), manifests.BuildService, err)
 		}
 
-		if err := applyObject(ctx, r.Client, obj); err != nil {
+		if err := applyObject(ctx, r.Client, obj, FieldManagerBuildService); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			if gvk.Group == CertManagerGroup || gvk.Group == KyvernoGroup {
 				// TODO: Remove this once we decide how to install cert-manager crds in envtest

--- a/operator/internal/controller/konfluxenterprisecontract_controller.go
+++ b/operator/internal/controller/konfluxenterprisecontract_controller.go
@@ -110,7 +110,7 @@ func (r *KonfluxEnterpriseContractReconciler) applyManifests(ctx context.Context
 				obj.GetNamespace(), obj.GetName(), getKind(obj), manifests.EnterpriseContract, err)
 		}
 
-		if err := applyObject(ctx, r.Client, obj); err != nil {
+		if err := applyObject(ctx, r.Client, obj, FieldManagerEnterpriseContract); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			if gvk.Group == CertManagerGroup || gvk.Group == KyvernoGroup {
 				// TODO: Remove this once we decide how to install cert-manager crds in envtest

--- a/operator/internal/controller/konfluximagecontroller_controller.go
+++ b/operator/internal/controller/konfluximagecontroller_controller.go
@@ -106,7 +106,7 @@ func (r *KonfluxImageControllerReconciler) applyManifests(ctx context.Context, o
 				obj.GetNamespace(), obj.GetName(), getKind(obj), manifests.ImageController, err)
 		}
 
-		if err := applyObject(ctx, r.Client, obj); err != nil {
+		if err := applyObject(ctx, r.Client, obj, FieldManagerImageController); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			if gvk.Group == CertManagerGroup || gvk.Group == KyvernoGroup {
 				// TODO: Remove this once we decide how to install cert-manager crds in envtest

--- a/operator/internal/controller/konfluxintegrationservice_controller.go
+++ b/operator/internal/controller/konfluxintegrationservice_controller.go
@@ -120,7 +120,7 @@ func (r *KonfluxIntegrationServiceReconciler) applyManifests(ctx context.Context
 				obj.GetNamespace(), obj.GetName(), getKind(obj), manifests.Integration, err)
 		}
 
-		if err := applyObject(ctx, r.Client, obj); err != nil {
+		if err := applyObject(ctx, r.Client, obj, FieldManagerIntegrationService); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			if gvk.Group == CertManagerGroup || gvk.Group == KyvernoGroup {
 				// TODO: Remove this once we decide how to install cert-manager crds in envtest

--- a/operator/internal/controller/konfluxnamespacelister_controller.go
+++ b/operator/internal/controller/konfluxnamespacelister_controller.go
@@ -110,7 +110,7 @@ func (r *KonfluxNamespaceListerReconciler) applyManifests(ctx context.Context, o
 				obj.GetNamespace(), obj.GetName(), getKind(obj), manifests.NamespaceLister, err)
 		}
 
-		if err := applyObject(ctx, r.Client, obj); err != nil {
+		if err := applyObject(ctx, r.Client, obj, FieldManagerNamespaceLister); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			if gvk.Group == CertManagerGroup || gvk.Group == KyvernoGroup {
 				// TODO: Remove this once we decide how to install cert-manager crds in envtest

--- a/operator/internal/controller/konfluxrbac_controller.go
+++ b/operator/internal/controller/konfluxrbac_controller.go
@@ -109,7 +109,7 @@ func (r *KonfluxRBACReconciler) applyManifests(ctx context.Context, owner *konfl
 				obj.GetNamespace(), obj.GetName(), getKind(obj), manifests.RBAC, err)
 		}
 
-		if err := applyObject(ctx, r.Client, obj); err != nil {
+		if err := applyObject(ctx, r.Client, obj, FieldManagerRBAC); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			// TODO: Remove this once we decide how to install cert-manager crds in envtest
 			// TODO: Remove this once we decide if we want to have a dependency on Kyverno

--- a/operator/internal/controller/konfluxreleaseservice_controller.go
+++ b/operator/internal/controller/konfluxreleaseservice_controller.go
@@ -120,7 +120,7 @@ func (r *KonfluxReleaseServiceReconciler) applyManifests(ctx context.Context, ow
 				obj.GetNamespace(), obj.GetName(), getKind(obj), manifests.Release, err)
 		}
 
-		if err := applyObject(ctx, r.Client, obj); err != nil {
+		if err := applyObject(ctx, r.Client, obj, FieldManagerReleaseService); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			if gvk.Group == CertManagerGroup || gvk.Group == KyvernoGroup {
 				// TODO: Remove this once we decide how to install cert-manager crds in envtest

--- a/operator/internal/controller/konfluxui_controller.go
+++ b/operator/internal/controller/konfluxui_controller.go
@@ -159,7 +159,7 @@ func (r *KonfluxUIReconciler) ensureNamespaceExists(ctx context.Context, owner *
 				return fmt.Errorf("failed to set ownership for %s/%s (%s) from %s: %w",
 					namespace.GetNamespace(), namespace.GetName(), getKind(namespace), manifests.UI, err)
 			}
-			if err := applyObject(ctx, r.Client, namespace); err != nil {
+			if err := applyObject(ctx, r.Client, namespace, FieldManagerUI); err != nil {
 				return fmt.Errorf("failed to apply object %s/%s (%s) from %s: %w",
 					namespace.GetNamespace(), namespace.GetName(), getKind(namespace), manifests.UI, err)
 			}
@@ -193,7 +193,7 @@ func (r *KonfluxUIReconciler) applyManifests(ctx context.Context, owner *konflux
 				obj.GetNamespace(), obj.GetName(), getKind(obj), manifests.UI, err)
 		}
 
-		if err := applyObject(ctx, r.Client, obj); err != nil {
+		if err := applyObject(ctx, r.Client, obj, FieldManagerUI); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			if gvk.Group == CertManagerGroup || gvk.Group == KyvernoGroup {
 				// TODO: Remove this once we decide how to install cert-manager crds in envtest
@@ -359,6 +359,7 @@ func (r *KonfluxUIReconciler) reconcileDexConfigMap(ctx context.Context, ui *kon
 		uiNamespace,
 		dexConfigKey,
 		dexConfigMapLabel,
+		FieldManagerUI,
 	)
 
 	result, err := hcm.Apply(ctx, string(configYAML), ui)

--- a/operator/pkg/hashedconfigmap/hashedconfigmap_test.go
+++ b/operator/pkg/hashedconfigmap/hashedconfigmap_test.go
@@ -108,11 +108,12 @@ func newOwner() *corev1.ConfigMap {
 }
 
 const (
-	testBaseName  = "test-config"
-	testNamespace = "test-ns"
-	testDataKey   = "config.yaml"
-	testLabel     = "app.kubernetes.io/managed-by-test"
-	testContent   = "key: value"
+	testBaseName     = "test-config"
+	testNamespace    = "test-ns"
+	testDataKey      = "config.yaml"
+	testLabel        = "app.kubernetes.io/managed-by-test"
+	testContent      = "key: value"
+	testFieldManager = "test-controller"
 )
 
 func TestHashedConfigMapApply(t *testing.T) {
@@ -130,7 +131,7 @@ func TestHashedConfigMapApply(t *testing.T) {
 		owner := newOwner()
 		c := newFakeClient(scheme, owner)
 
-		hcm := New(c, scheme, baseName, namespace, dataKey, label)
+		hcm := New(c, scheme, baseName, namespace, dataKey, label, testFieldManager)
 		content := testContent
 
 		result, err := hcm.Apply(ctx, content, owner)
@@ -153,7 +154,7 @@ func TestHashedConfigMapApply(t *testing.T) {
 		owner := newOwner()
 		c := newFakeClient(scheme, owner)
 
-		hcm := New(c, scheme, baseName, namespace, dataKey, label)
+		hcm := New(c, scheme, baseName, namespace, dataKey, label, testFieldManager)
 		content := testContent
 
 		result, err := hcm.Apply(ctx, content, owner)
@@ -187,7 +188,7 @@ func TestHashedConfigMapApply(t *testing.T) {
 		}
 		c := newFakeClient(scheme, owner, existingCM)
 
-		hcm := New(c, scheme, baseName, namespace, dataKey, label)
+		hcm := New(c, scheme, baseName, namespace, dataKey, label, testFieldManager)
 		result, err := hcm.Apply(ctx, content, owner)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(result.ConfigMapName).To(gomega.Equal(expectedName))
@@ -216,7 +217,7 @@ func TestHashedConfigMapApply(t *testing.T) {
 		}
 		c := newFakeClient(scheme, owner, oldCM)
 
-		hcm := New(c, scheme, baseName, namespace, dataKey, label)
+		hcm := New(c, scheme, baseName, namespace, dataKey, label, testFieldManager)
 		newContent := "new content"
 
 		result, err := hcm.Apply(ctx, newContent, owner)
@@ -250,7 +251,7 @@ func TestHashedConfigMapApply(t *testing.T) {
 		}
 		c := newFakeClient(scheme, owner, unmanagedCM)
 
-		hcm := New(c, scheme, baseName, namespace, dataKey, label)
+		hcm := New(c, scheme, baseName, namespace, dataKey, label, testFieldManager)
 		_, err := hcm.Apply(ctx, "new content", owner)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -277,7 +278,7 @@ func TestHashedConfigMapApply(t *testing.T) {
 		}
 		c := newFakeClient(scheme, owner, differentBaseCM)
 
-		hcm := New(c, scheme, baseName, namespace, dataKey, label)
+		hcm := New(c, scheme, baseName, namespace, dataKey, label, testFieldManager)
 		_, err := hcm.Apply(ctx, "new content", owner)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -294,7 +295,7 @@ func TestHashedConfigMapApply(t *testing.T) {
 		owner := newOwner()
 		c := newFakeClient(scheme, owner)
 
-		hcm := New(c, scheme, baseName, namespace, dataKey, label)
+		hcm := New(c, scheme, baseName, namespace, dataKey, label, testFieldManager)
 		content := testContent
 
 		result, err := hcm.Apply(ctx, content, owner)
@@ -321,7 +322,7 @@ func TestHashedConfigMapApplyIdempotent(t *testing.T) {
 		owner := newOwner()
 		c := newFakeClient(scheme, owner)
 
-		hcm := New(c, scheme, baseName, namespace, dataKey, label)
+		hcm := New(c, scheme, baseName, namespace, dataKey, label, testFieldManager)
 		content := testContent
 
 		// First apply


### PR DESCRIPTION
Each reconciler now uses a unique FieldOwner value when applying resources via server-side apply.
This makes it clear in the resource's managedFields which controller owns which fields.

Previously all reconcilers used "konflux-operator" as the field owner, making it impossible to distinguish which controller applied which fields çwhen inspecting a resource's metadata.managedFields.

assisted-by: cursor