### PR TITLE
WIP: chore(KFLUXSPRT-617) Move reconcilers to their own packages

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -43,6 +43,7 @@ import (
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/buildservice"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 	// +kubebuilder:scaffold:imports
@@ -261,7 +262,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Konflux")
 		os.Exit(1)
 	}
-	if err = (&controller.KonfluxBuildServiceReconciler{
+	if err = (&buildservice.Reconciler{
 		Client:      mgr.GetClient(),
 		Scheme:      mgr.GetScheme(),
 		ObjectStore: objectStore,

--- a/operator/internal/controller/buildservice/customization_test.go
+++ b/operator/internal/controller/buildservice/customization_test.go
@@ -1,0 +1,390 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildservice
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
+)
+
+var (
+	testObjectStore     *manifests.ObjectStore
+	testObjectStoreOnce sync.Once
+	testObjectStoreErr  error
+)
+
+// getTestObjectStore returns a shared ObjectStore for tests.
+// It is initialized once and reused across all tests.
+func getTestObjectStore(t *testing.T) *manifests.ObjectStore {
+	t.Helper()
+	testObjectStoreOnce.Do(func() {
+		// Add our types to the scheme
+		err := konfluxv1alpha1.AddToScheme(scheme.Scheme)
+		if err != nil {
+			testObjectStoreErr = err
+			return
+		}
+		testObjectStore, testObjectStoreErr = manifests.NewObjectStore(scheme.Scheme)
+	})
+	if testObjectStoreErr != nil {
+		t.Fatalf("failed to create ObjectStore: %v", testObjectStoreErr)
+	}
+	return testObjectStore
+}
+
+// getDeployment returns a deep copy of the BuildService controller-manager deployment from the manifests.
+func getDeployment(t *testing.T) *appsv1.Deployment {
+	t.Helper()
+	store := getTestObjectStore(t)
+	objects, err := store.GetForComponent(manifests.BuildService)
+	if err != nil {
+		t.Fatalf("failed to get BuildService manifests: %v", err)
+	}
+
+	for _, obj := range objects {
+		if deployment, ok := obj.(*appsv1.Deployment); ok {
+			if deployment.Name == controllerManagerDeploymentName {
+				return deployment
+			}
+		}
+	}
+	t.Fatalf("deployment %q not found in BuildService manifests", controllerManagerDeploymentName)
+	return nil
+}
+
+// findContainer finds a container by name in a slice of containers.
+func findContainer(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+func TestBuildControllerManagerOverlay(t *testing.T) {
+	t.Run("nil spec returns empty overlay", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		overlay := buildControllerManagerOverlay(nil)
+		g.Expect(overlay).NotTo(gomega.BeNil())
+	})
+
+	t.Run("empty spec returns overlay without customizations", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := &konfluxv1alpha1.ControllerManagerDeploymentSpec{}
+		overlay := buildControllerManagerOverlay(spec)
+		g.Expect(overlay).NotTo(gomega.BeNil())
+	})
+
+	t.Run("manager resources are applied", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+			Manager: &konfluxv1alpha1.ContainerSpec{
+				Resources: &corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+				},
+			},
+		}
+
+		deployment := getDeployment(t)
+		overlay := buildControllerManagerOverlay(spec)
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := findContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(managerContainer.Resources.Limits.Cpu().String()).To(gomega.Equal("500m"))
+		g.Expect(managerContainer.Resources.Limits.Memory().String()).To(gomega.Equal("256Mi"))
+		g.Expect(managerContainer.Resources.Requests.Cpu().String()).To(gomega.Equal("100m"))
+		g.Expect(managerContainer.Resources.Requests.Memory().String()).To(gomega.Equal("128Mi"))
+	})
+
+	t.Run("preserves existing container fields", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+			Manager: &konfluxv1alpha1.ContainerSpec{
+				Resources: &corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("500m"),
+					},
+				},
+			},
+		}
+
+		deployment := getDeployment(t)
+		managerContainer := findContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil(), "manager container must exist in controller-manager deployment")
+		originalImage := managerContainer.Image
+
+		overlay := buildControllerManagerOverlay(spec)
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer = findContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(managerContainer.Image).To(gomega.Equal(originalImage))
+	})
+}
+
+func TestApplyDeploymentCustomizations(t *testing.T) {
+	t.Run("applies customizations to controller-manager deployment", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			BuildControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Manager: &konfluxv1alpha1.ContainerSpec{
+					Resources: &corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		}
+
+		deployment := getDeployment(t)
+		err := applyDeploymentCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := findContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(managerContainer.Resources.Limits.Cpu().String()).To(gomega.Equal("1"))
+	})
+
+	t.Run("ignores unknown deployment names", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			BuildControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Manager: &konfluxv1alpha1.ContainerSpec{
+					Resources: &corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		}
+
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "unknown-deployment"},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "app", Image: "app:v1"},
+						},
+					},
+				},
+			},
+		}
+
+		err := applyDeploymentCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Should not panic and container should be unchanged
+		g.Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits).To(gomega.BeNil())
+	})
+
+	t.Run("handles nil controller-manager spec", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			BuildControllerManager: nil,
+		}
+
+		deployment := getDeployment(t)
+		err := applyDeploymentCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Should not panic
+		managerContainer := findContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+	})
+
+	t.Run("handles empty spec", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{}
+
+		deployment := getDeployment(t)
+		err := applyDeploymentCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Should not panic
+		g.Expect(deployment.Spec.Template.Spec.Containers).NotTo(gomega.BeEmpty())
+	})
+
+	t.Run("applies replicas to controller-manager deployment", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			BuildControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Replicas: 3,
+			},
+		}
+
+		deployment := getDeployment(t)
+		err := applyDeploymentCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		g.Expect(deployment.Spec.Replicas).NotTo(gomega.BeNil())
+		g.Expect(*deployment.Spec.Replicas).To(gomega.Equal(int32(3)))
+	})
+
+	t.Run("applies default replicas when using default value", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			BuildControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Replicas: 1, // default value
+			},
+		}
+
+		deployment := getDeployment(t)
+		err := applyDeploymentCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		g.Expect(deployment.Spec.Replicas).NotTo(gomega.BeNil())
+		g.Expect(*deployment.Spec.Replicas).To(gomega.Equal(int32(1)))
+	})
+
+	t.Run("does not modify replicas when controller-manager spec is nil", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			BuildControllerManager: nil,
+		}
+
+		deployment := getDeployment(t)
+		originalReplicas := deployment.Spec.Replicas
+		err := applyDeploymentCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		g.Expect(deployment.Spec.Replicas).To(gomega.Equal(originalReplicas))
+	})
+
+	t.Run("applies replicas together with container resources", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			BuildControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Replicas: 5,
+				Manager: &konfluxv1alpha1.ContainerSpec{
+					Resources: &corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					},
+				},
+			},
+		}
+
+		deployment := getDeployment(t)
+		err := applyDeploymentCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Check replicas
+		g.Expect(deployment.Spec.Replicas).NotTo(gomega.BeNil())
+		g.Expect(*deployment.Spec.Replicas).To(gomega.Equal(int32(5)))
+
+		// Check container resources
+		managerContainer := findContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(managerContainer.Resources.Limits.Cpu().String()).To(gomega.Equal("2"))
+	})
+}
+
+func TestApplyDeploymentCustomizations_ResourceMerging(t *testing.T) {
+	t.Run("merges limits without affecting requests", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		// Get deployment and set existing requests
+		deployment := getDeployment(t)
+		managerContainer := findContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil(), "manager container must exist")
+		managerContainer.Resources.Requests = corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
+		}
+
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			BuildControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Manager: &konfluxv1alpha1.ContainerSpec{
+					Resources: &corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("500m"),
+						},
+					},
+				},
+			},
+		}
+
+		err := applyDeploymentCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer = findContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(managerContainer.Resources.Limits.Cpu().String()).To(gomega.Equal("500m"))
+		g.Expect(managerContainer.Resources.Requests.Cpu().String()).To(gomega.Equal("50m"))
+		g.Expect(managerContainer.Resources.Requests.Memory().String()).To(gomega.Equal("64Mi"))
+	})
+
+	t.Run("merges requests without affecting limits", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		// Get deployment and set existing limits
+		deployment := getDeployment(t)
+		managerContainer := findContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil(), "manager container must exist")
+		managerContainer.Resources.Limits = corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		}
+
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			BuildControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Manager: &konfluxv1alpha1.ContainerSpec{
+					Resources: &corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("100m"),
+						},
+					},
+				},
+			},
+		}
+
+		err := applyDeploymentCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer = findContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(managerContainer.Resources.Limits.Cpu().String()).To(gomega.Equal("1"))
+		g.Expect(managerContainer.Resources.Limits.Memory().String()).To(gomega.Equal("512Mi"))
+		g.Expect(managerContainer.Resources.Requests.Cpu().String()).To(gomega.Equal("100m"))
+	})
+}
+

--- a/operator/internal/controller/buildservice/reconciler.go
+++ b/operator/internal/controller/buildservice/reconciler.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package buildservice provides the reconciler for KonfluxBuildService resources.
+package buildservice
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/common"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/customization"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
+)
+
+const (
+	// ConditionTypeReady is the condition type for overall readiness
+	ConditionTypeReady = "Ready"
+
+	// Deployment names
+	controllerManagerDeploymentName = "build-service-controller-manager"
+
+	// Container names
+	managerContainerName = "manager"
+)
+
+// Reconciler reconciles a KonfluxBuildService object
+type Reconciler struct {
+	client.Client
+	Scheme      *runtime.Scheme
+	ObjectStore *manifests.ObjectStore
+}
+
+// +kubebuilder:rbac:groups=konflux.konflux-ci.dev,resources=konfluxbuildservices,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=konflux.konflux-ci.dev,resources=konfluxbuildservices/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=konflux.konflux-ci.dev,resources=konfluxbuildservices/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the KonfluxBuildService object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.0/pkg/reconcile
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	// Fetch the KonfluxBuildService instance
+	buildService := &konfluxv1alpha1.KonfluxBuildService{}
+	if err := r.Get(ctx, req.NamespacedName, buildService); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	log.Info("Reconciling KonfluxBuildService", "name", buildService.Name)
+
+	// Apply all embedded manifests
+	if err := r.applyManifests(ctx, buildService); err != nil {
+		log.Error(err, "Failed to apply manifests")
+		common.SetFailedCondition(buildService, ConditionTypeReady, "ApplyFailed", err)
+		if updateErr := r.Status().Update(ctx, buildService); updateErr != nil {
+			log.Error(updateErr, "Failed to update status")
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Check the status of owned deployments and update KonfluxBuildService status
+	if err := common.UpdateComponentStatuses(ctx, r.Client, buildService, ConditionTypeReady); err != nil {
+		log.Error(err, "Failed to update component statuses")
+		common.SetFailedCondition(buildService, ConditionTypeReady, "FailedToGetDeploymentStatus", err)
+		if updateErr := r.Status().Update(ctx, buildService); updateErr != nil {
+			log.Error(updateErr, "Failed to update status")
+		}
+		return ctrl.Result{}, err
+	}
+
+	log.Info("Successfully reconciled KonfluxBuildService")
+	return ctrl.Result{}, nil
+}
+
+// applyManifests loads and applies all embedded manifests to the cluster.
+// Manifests are parsed once and cached; deep copies are used during reconciliation.
+func (r *Reconciler) applyManifests(ctx context.Context, owner *konfluxv1alpha1.KonfluxBuildService) error {
+	log := logf.FromContext(ctx)
+
+	objects, err := r.ObjectStore.GetForComponent(manifests.BuildService)
+	if err != nil {
+		return fmt.Errorf("failed to get parsed manifests for BuildService: %w", err)
+	}
+
+	for _, obj := range objects {
+		// Apply customizations for deployments
+		if deployment, ok := obj.(*appsv1.Deployment); ok {
+			if err := applyDeploymentCustomizations(deployment, owner.Spec); err != nil {
+				return fmt.Errorf("failed to apply customizations to deployment %s: %w", deployment.Name, err)
+			}
+		}
+
+		// Set ownership labels and owner reference
+		if err := common.SetOwnership(obj, owner, string(manifests.BuildService), r.Scheme); err != nil {
+			return fmt.Errorf("failed to set ownership for %s/%s (%s) from %s: %w",
+				obj.GetNamespace(), obj.GetName(), common.GetKind(obj), manifests.BuildService, err)
+		}
+
+		if err := common.ApplyObject(ctx, r.Client, obj); err != nil {
+			gvk := obj.GetObjectKind().GroupVersionKind()
+			if gvk.Group == common.CertManagerGroup || gvk.Group == common.KyvernoGroup {
+				// TODO: Remove this once we decide how to install cert-manager crds in envtest
+				// TODO: Remove this once we decide if we want to have a dependency on Kyverno
+				log.Info("Skipping resource: CRD not installed",
+					"kind", gvk.Kind,
+					"apiVersion", gvk.GroupVersion().String(),
+					"namespace", obj.GetNamespace(),
+					"name", obj.GetName(),
+				)
+				continue
+			}
+			return fmt.Errorf("failed to apply object %s/%s (%s) from %s: %w",
+				obj.GetNamespace(), obj.GetName(), common.GetKind(obj), manifests.BuildService, err)
+		}
+	}
+	return nil
+}
+
+// applyDeploymentCustomizations applies user-defined customizations to BuildService deployments.
+func applyDeploymentCustomizations(deployment *appsv1.Deployment, spec konfluxv1alpha1.KonfluxBuildServiceSpec) error {
+	switch deployment.Name {
+	case controllerManagerDeploymentName:
+		if spec.BuildControllerManager != nil {
+			deployment.Spec.Replicas = &spec.BuildControllerManager.Replicas
+		}
+		if err := buildControllerManagerOverlay(spec.BuildControllerManager).ApplyToDeployment(deployment); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// buildControllerManagerOverlay builds the pod overlay for the controller-manager deployment.
+func buildControllerManagerOverlay(spec *konfluxv1alpha1.ControllerManagerDeploymentSpec) *customization.PodOverlay {
+	if spec == nil {
+		return customization.NewPodOverlay()
+	}
+
+	return customization.BuildPodOverlay(
+		customization.DeploymentContext{Replicas: spec.Replicas},
+		customization.WithContainerBuilder(
+			managerContainerName,
+			customization.FromContainerSpec(spec.Manager),
+			customization.WithLeaderElection(),
+		),
+	)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&konfluxv1alpha1.KonfluxBuildService{}).
+		Named("konfluxbuildservice").
+		// Use predicates to filter out unnecessary updates and prevent reconcile loops
+		// Deployments: watch spec changes AND readiness status changes
+		Owns(&appsv1.Deployment{}, builder.WithPredicates(common.DeploymentReadinessPredicate)).
+		Owns(&corev1.Service{}, builder.WithPredicates(common.GenerationChangedPredicate)).
+		Owns(&corev1.ConfigMap{}, builder.WithPredicates(common.LabelsOrAnnotationsChangedPredicate)).
+		Owns(&corev1.Secret{}, builder.WithPredicates(common.LabelsOrAnnotationsChangedPredicate)).
+		Owns(&corev1.Namespace{}, builder.WithPredicates(common.GenerationChangedPredicate)).
+		Owns(&rbacv1.Role{}, builder.WithPredicates(common.GenerationChangedPredicate)).
+		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(common.GenerationChangedPredicate)).
+		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(common.GenerationChangedPredicate)).
+		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(common.GenerationChangedPredicate)).
+		Complete(r)
+}
+

--- a/operator/internal/controller/buildservice/reconciler_test.go
+++ b/operator/internal/controller/buildservice/reconciler_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildservice
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/common"
+)
+
+var _ = Describe("KonfluxBuildService Controller", func() {
+	Context("When reconciling a resource", func() {
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      common.KonfluxBuildServiceCRName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		konfluxbuildservice := &konfluxv1alpha1.KonfluxBuildService{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind KonfluxBuildService")
+			err := k8sClient.Get(ctx, typeNamespacedName, konfluxbuildservice)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &konfluxv1alpha1.KonfluxBuildService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      common.KonfluxBuildServiceCRName,
+						Namespace: "default",
+					},
+					Spec: konfluxv1alpha1.KonfluxBuildServiceSpec{},
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &konfluxv1alpha1.KonfluxBuildService{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance KonfluxBuildService")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &Reconciler{
+				Client:      k8sClient,
+				Scheme:      k8sClient.Scheme(),
+				ObjectStore: objectStore,
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})
+

--- a/operator/internal/controller/buildservice/suite_test.go
+++ b/operator/internal/controller/buildservice/suite_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildservice
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	ctx         context.Context
+	cancel      context.CancelFunc
+	testEnv     *envtest.Environment
+	cfg         *rest.Config
+	k8sClient   client.Client
+	objectStore *manifests.ObjectStore
+)
+
+func TestBuildServiceController(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "BuildService Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	var err error
+	err = konfluxv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Parse all embedded manifests into an ObjectStore
+	objectStore, err = manifests.NewObjectStore(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{getCRDPath()},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	// Retrieve the first found binary directory to allow running tests from IDEs
+	if getFirstFoundEnvTestBinaryDir() != "" {
+		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
+	}
+
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+// getCRDPath returns the path to CRD files.
+// It first checks the CRD_PATH environment variable, then falls back to a relative path.
+// TODO: Consider using go:embed or a more robust path resolution mechanism.
+func getCRDPath() string {
+	if crdPath := os.Getenv("CRD_PATH"); crdPath != "" {
+		return crdPath
+	}
+	// Fallback to relative path - this works when running from operator/ directory
+	return filepath.Join("..", "..", "..", "config", "crd", "bases")
+}
+
+// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
+// ENVTEST-based tests depend on specific binaries, usually located in paths set by
+// controller-runtime. When running tests directly (e.g., via an IDE) without using
+// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
+//
+// This function streamlines the process by finding the required binaries, similar to
+// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
+// properly set up, run 'make setup-envtest' beforehand.
+func getFirstFoundEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}
+

--- a/operator/internal/controller/common/conditions.go
+++ b/operator/internal/controller/common/conditions.go
@@ -1,0 +1,308 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+)
+
+// SetCondition updates or adds a condition to a resource's status.
+// It automatically sets LastTransitionTime and ObservedGeneration.
+// If the condition status hasn't changed, LastTransitionTime is preserved.
+func SetCondition(obj konfluxv1alpha1.ConditionAccessor, condition metav1.Condition) {
+	condition.ObservedGeneration = obj.GetGeneration()
+
+	conditions := obj.GetConditions()
+	apimeta.SetStatusCondition(&conditions, condition)
+	obj.SetConditions(conditions)
+}
+
+// SetFailedCondition sets a failed condition with ConditionFalse status on the resource.
+// This is a convenience function for error handling in reconcilers.
+// The caller is responsible for persisting the status update.
+func SetFailedCondition(obj konfluxv1alpha1.ConditionAccessor, conditionType string, reason string, err error) {
+	SetCondition(obj, metav1.Condition{
+		Type:    conditionType,
+		Status:  metav1.ConditionFalse,
+		Reason:  reason,
+		Message: err.Error(),
+	})
+}
+
+// CleanupStaleConditions removes conditions that don't match the shouldKeep predicate.
+// This is useful for removing conditions for resources that no longer exist.
+func CleanupStaleConditions(obj konfluxv1alpha1.ConditionAccessor, shouldKeep func(cond metav1.Condition) bool) {
+	var newConditions []metav1.Condition
+	for _, cond := range obj.GetConditions() {
+		if shouldKeep(cond) {
+			newConditions = append(newConditions, cond)
+		}
+	}
+	obj.SetConditions(newConditions)
+}
+
+// IsDeploymentReady returns true if the deployment has all replicas ready and updated.
+func IsDeploymentReady(deployment *appsv1.Deployment) bool {
+	return deployment.Status.ReadyReplicas == deployment.Status.Replicas &&
+		deployment.Status.Replicas > 0 &&
+		deployment.Status.UpdatedReplicas == deployment.Status.Replicas
+}
+
+// DeploymentCondition creates a condition representing the current state of a deployment.
+// The condition type is formatted as "namespace/name".
+func DeploymentCondition(deployment *appsv1.Deployment) metav1.Condition {
+	conditionType := fmt.Sprintf("%s/%s", deployment.Namespace, deployment.Name)
+
+	if IsDeploymentReady(deployment) {
+		return metav1.Condition{
+			Type:    conditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  "DeploymentReady",
+			Message: fmt.Sprintf("Deployment has %d/%d replicas ready", deployment.Status.ReadyReplicas, deployment.Status.Replicas),
+		}
+	}
+
+	message := fmt.Sprintf("Ready: %d/%d, Updated: %d/%d",
+		deployment.Status.ReadyReplicas, deployment.Status.Replicas,
+		deployment.Status.UpdatedReplicas, deployment.Status.Replicas)
+
+	// Check for specific conditions that indicate problems
+	for _, cond := range deployment.Status.Conditions {
+		if cond.Type == appsv1.DeploymentProgressing && cond.Status == corev1.ConditionFalse {
+			message = fmt.Sprintf("%s - %s: %s", message, cond.Reason, cond.Message)
+		}
+		if cond.Type == appsv1.DeploymentReplicaFailure && cond.Status == corev1.ConditionTrue {
+			message = fmt.Sprintf("%s - ReplicaFailure: %s", message, cond.Message)
+		}
+	}
+
+	return metav1.Condition{
+		Type:    conditionType,
+		Status:  metav1.ConditionFalse,
+		Reason:  "DeploymentNotReady",
+		Message: message,
+	}
+}
+
+// DeploymentStatusSummary contains aggregated status information about a set of deployments.
+type DeploymentStatusSummary struct {
+	// AllReady is true if all deployments are ready.
+	AllReady bool
+	// TotalCount is the total number of deployments.
+	TotalCount int
+	// NotReadyNames contains the names of deployments that are not ready.
+	NotReadyNames []string
+	// SeenConditionTypes contains the condition types for all processed deployments.
+	SeenConditionTypes map[string]bool
+}
+
+// SetDeploymentConditions sets conditions on the object for each deployment in the list
+// and returns a summary of the deployment statuses.
+func SetDeploymentConditions(obj konfluxv1alpha1.ConditionAccessor, deployments []appsv1.Deployment) DeploymentStatusSummary {
+	summary := DeploymentStatusSummary{
+		AllReady:           true,
+		TotalCount:         len(deployments),
+		SeenConditionTypes: make(map[string]bool),
+	}
+
+	for i := range deployments {
+		deployment := &deployments[i]
+		cond := DeploymentCondition(deployment)
+		summary.SeenConditionTypes[cond.Type] = true
+
+		if !IsDeploymentReady(deployment) {
+			summary.AllReady = false
+			summary.NotReadyNames = append(summary.NotReadyNames, deployment.Name)
+		}
+
+		SetCondition(obj, cond)
+	}
+
+	return summary
+}
+
+// SetOverallReadyCondition sets the overall Ready condition based on the deployment status summary.
+func SetOverallReadyCondition(obj konfluxv1alpha1.ConditionAccessor, readyConditionType string, summary DeploymentStatusSummary) {
+	if summary.AllReady {
+		SetCondition(obj, metav1.Condition{
+			Type:    readyConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  "AllComponentsReady",
+			Message: fmt.Sprintf("All %d deployments are ready", summary.TotalCount),
+		})
+	} else {
+		SetCondition(obj, metav1.Condition{
+			Type:    readyConditionType,
+			Status:  metav1.ConditionFalse,
+			Reason:  "ComponentsNotReady",
+			Message: fmt.Sprintf("Deployments not ready: %v", summary.NotReadyNames),
+		})
+	}
+}
+
+// IsConditionTrue returns true if the specified condition type has status True.
+func IsConditionTrue(obj konfluxv1alpha1.ConditionAccessor, conditionType string) bool {
+	cond := apimeta.FindStatusCondition(obj.GetConditions(), conditionType)
+	return cond != nil && cond.Status == metav1.ConditionTrue
+}
+
+// SubCRStatus represents the readiness status of a sub-CR.
+type SubCRStatus struct {
+	// Name is the name/identifier of the sub-CR (e.g., "KonfluxBuildService")
+	Name string
+	// Ready indicates if the sub-CR is ready
+	Ready bool
+}
+
+// AggregateReadiness computes the overall readiness from sub-CR statuses.
+// Returns whether all components are ready and a slice of reasons for any not-ready components.
+func AggregateReadiness(subCRStatuses []SubCRStatus) (allReady bool, notReadyReasons []string) {
+	allReady = true
+
+	for _, status := range subCRStatuses {
+		if !status.Ready {
+			allReady = false
+			notReadyReasons = append(notReadyReasons, fmt.Sprintf("%s is not ready", status.Name))
+		}
+	}
+
+	return allReady, notReadyReasons
+}
+
+// SetAggregatedReadyCondition sets the overall Ready condition based on aggregated sub-CR readiness.
+// All deployments are managed by component-specific reconcilers, so we only aggregate sub-CR statuses.
+func SetAggregatedReadyCondition(
+	obj konfluxv1alpha1.ConditionAccessor,
+	readyConditionType string,
+	subCRStatuses []SubCRStatus,
+) {
+	allReady, notReadyReasons := AggregateReadiness(subCRStatuses)
+
+	if allReady {
+		// Count total components (sub-CRs)
+		totalComponents := len(subCRStatuses)
+		SetCondition(obj, metav1.Condition{
+			Type:    readyConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  "AllComponentsReady",
+			Message: fmt.Sprintf("All %d components are ready", totalComponents),
+		})
+	} else {
+		SetCondition(obj, metav1.Condition{
+			Type:    readyConditionType,
+			Status:  metav1.ConditionFalse,
+			Reason:  "ComponentsNotReady",
+			Message: strings.Join(notReadyReasons, "; "),
+		})
+	}
+}
+
+// CopySubCRStatus copies conditions from a sub-CR to a parent CR with a prefix.
+// It removes existing conditions with the prefix, copies new ones, and returns the sub-CR's ready status.
+// The caller is responsible for fetching the sub-CR before calling this function.
+func CopySubCRStatus(
+	parent konfluxv1alpha1.ConditionAccessor,
+	subCR konfluxv1alpha1.ConditionAccessor,
+	conditionPrefix string,
+) SubCRStatus {
+	// Remove existing conditions with this prefix
+	prefixWithDot := conditionPrefix + "."
+	var newConditions []metav1.Condition
+	for _, cond := range parent.GetConditions() {
+		if !strings.HasPrefix(cond.Type, prefixWithDot) {
+			newConditions = append(newConditions, cond)
+		}
+	}
+	parent.SetConditions(newConditions)
+
+	// Copy conditions from sub-CR to parent, prefixing with the condition prefix
+	for _, cond := range subCR.GetConditions() {
+		// Replace slashes with dots in the condition type to avoid multiple slashes
+		sanitizedType := strings.ReplaceAll(cond.Type, "/", ".")
+		// Prefix the condition type to namespace it under the sub-CR
+		prefixedType := fmt.Sprintf("%s.%s", conditionPrefix, sanitizedType)
+		SetCondition(parent, metav1.Condition{
+			Type:               prefixedType,
+			Status:             cond.Status,
+			Reason:             cond.Reason,
+			Message:            cond.Message,
+			ObservedGeneration: cond.ObservedGeneration,
+		})
+	}
+
+	return SubCRStatus{
+		Name:  conditionPrefix,
+		Ready: IsConditionTrue(subCR, "Ready"),
+	}
+}
+
+// UpdateComponentStatuses is a generic helper that checks the status of all owned Deployments
+// and updates the CR's status conditions. It can be used by any controller that manages
+// deployments and implements ConditionAccessor.
+//
+// Parameters:
+//   - ctx: The context for the operation
+//   - k8sClient: The Kubernetes client for listing deployments and updating status
+//   - cr: The custom resource that implements ConditionAccessor (e.g., KonfluxBuildService, KonfluxIntegrationService)
+//   - readyConditionType: The condition type to use for the overall Ready condition (e.g., "Ready")
+func UpdateComponentStatuses(
+	ctx context.Context,
+	k8sClient client.Client,
+	cr konfluxv1alpha1.ConditionAccessor,
+	readyConditionType string,
+) error {
+	log := logf.FromContext(ctx)
+
+	// List all deployments owned by this CR instance
+	deploymentList := &appsv1.DeploymentList{}
+	if err := k8sClient.List(ctx, deploymentList, client.MatchingLabels{
+		KonfluxOwnerLabel: cr.GetName(),
+	}); err != nil {
+		return fmt.Errorf("failed to list owned deployments: %w", err)
+	}
+
+	// Set conditions for each deployment and get summary
+	summary := SetDeploymentConditions(cr, deploymentList.Items)
+
+	// Remove conditions for deployments that no longer exist
+	CleanupStaleConditions(cr, func(cond metav1.Condition) bool {
+		return cond.Type == readyConditionType || summary.SeenConditionTypes[cond.Type]
+	})
+
+	// Set the overall Ready condition
+	SetOverallReadyCondition(cr, readyConditionType, summary)
+
+	// Update the status subresource
+	if err := k8sClient.Status().Update(ctx, cr); err != nil {
+		log.Error(err, "Failed to update status")
+		return err
+	}
+
+	return nil
+}
+

--- a/operator/internal/controller/common/constants.go
+++ b/operator/internal/controller/common/constants.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package common provides shared utilities for all Konflux reconcilers.
+package common
+
+const (
+	// KonfluxOwnerLabel is the label used to identify resources owned by the Konflux operator.
+	// Resources are owned either directly by the Konflux CR (e.g., ApplicationAPI CRDs) or
+	// indirectly via component-specific CRs (e.g., deployments owned by KonfluxImageController CR).
+	KonfluxOwnerLabel = "konflux.konflux-ci.dev/owner"
+	// KonfluxComponentLabel is the label used to identify which component a resource belongs to.
+	KonfluxComponentLabel = "konflux.konflux-ci.dev/component"
+	// KonfluxCRName is the singleton name for the Konflux CR.
+	KonfluxCRName = "konflux"
+	// ConditionTypeReady is the condition type for overall readiness
+	ConditionTypeReady = "Ready"
+	// KonfluxBuildServiceCRName is the name for the KonfluxBuildService CR.
+	KonfluxBuildServiceCRName = "konflux-build-service"
+	// KonfluxIntegrationServiceCRName is the name for the KonfluxIntegrationService CR.
+	KonfluxIntegrationServiceCRName = "konflux-integration-service"
+	// KonfluxReleaseServiceCRName is the name for the KonfluxReleaseService CR.
+	KonfluxReleaseServiceCRName = "konflux-release-service"
+	// KonfluxUICRName is the namespace for UI resources
+	KonfluxUICRName = "konflux-ui"
+	// KonfluxRBACCRName is the name for the KonfluxRBAC CR.
+	KonfluxRBACCRName = "konflux-rbac"
+	// KonfluxNamespaceListerCRName is the name for the KonfluxNamespaceLister CR.
+	KonfluxNamespaceListerCRName = "konflux-namespace-lister"
+	// KonfluxEnterpriseContractCRName is the name for the KonfluxEnterpriseContract CR.
+	KonfluxEnterpriseContractCRName = "konflux-enterprise-contract"
+	// KonfluxImageControllerCRName is the name for the KonfluxImageController CR.
+	KonfluxImageControllerCRName = "konflux-image-controller"
+	// KonfluxApplicationAPICRName is the name for the KonfluxApplicationAPI CR.
+	KonfluxApplicationAPICRName = "konflux-application-api"
+	// CertManagerGroup is the API group for cert-manager resources
+	CertManagerGroup = "cert-manager.io"
+	// KyvernoGroup is the API group for Kyverno resources
+	KyvernoGroup = "kyverno.io"
+)
+

--- a/operator/internal/controller/common/ownership.go
+++ b/operator/internal/controller/common/ownership.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// GetKind returns the Kind of a client.Object.
+// For unstructured objects, it uses the GVK directly.
+// For typed objects, it uses the GVK from the object's metadata.
+func GetKind(obj client.Object) string {
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		return u.GetKind()
+	}
+	return obj.GetObjectKind().GroupVersionKind().Kind
+}
+
+// SetOwnership sets owner reference and labels on the object to establish ownership.
+func SetOwnership(obj client.Object, owner client.Object, component string, scheme *runtime.Scheme) error {
+	// Set ownership labels
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[KonfluxOwnerLabel] = owner.GetName()
+	labels[KonfluxComponentLabel] = component
+	obj.SetLabels(labels)
+
+	// Set owner reference for garbage collection and watch triggers
+	// Since Konflux CR is cluster-scoped, it can own both cluster-scoped and namespaced resources
+	if err := controllerutil.SetControllerReference(owner, obj, scheme); err != nil {
+		return fmt.Errorf("failed to set controller reference: %w", err)
+	}
+
+	return nil
+}
+
+// ApplyObject applies a single object to the cluster using server-side apply.
+// Server-side apply is idempotent and only triggers updates when there are actual changes,
+// preventing reconcile loops when watching owned resources.
+func ApplyObject(ctx context.Context, k8sClient client.Client, obj client.Object) error {
+	return k8sClient.Patch(ctx, obj, client.Apply, client.FieldOwner("konflux-operator"), client.ForceOwnership)
+}
+

--- a/operator/internal/controller/common/predicates.go
+++ b/operator/internal/controller/common/predicates.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"reflect"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// GenerationChangedPredicate filters out events where the generation hasn't changed
+// (i.e., status-only updates that shouldn't trigger reconciliation)
+var GenerationChangedPredicate = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		if e.ObjectOld == nil || e.ObjectNew == nil {
+			return true
+		}
+		// Only reconcile if the generation changed (spec was modified)
+		// This filters out status-only updates
+		return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+	},
+	CreateFunc: func(e event.CreateEvent) bool {
+		return true
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return true
+	},
+	GenericFunc: func(e event.GenericEvent) bool {
+		return true
+	},
+}
+
+// DeploymentReadinessPredicate triggers reconciliation when:
+// - Spec changes (generation changed)
+// - Readiness status changes (ReadyReplicas, AvailableReplicas, UnavailableReplicas)
+// This allows us to react to deployment health changes without polling
+var DeploymentReadinessPredicate = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		if e.ObjectOld == nil || e.ObjectNew == nil {
+			return true
+		}
+		// Always reconcile on spec changes
+		if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+			return true
+		}
+		// Check for meaningful status changes
+		oldDep, ok1 := e.ObjectOld.(*appsv1.Deployment)
+		newDep, ok2 := e.ObjectNew.(*appsv1.Deployment)
+		if !ok1 || !ok2 {
+			return true
+		}
+		// Trigger on readiness changes
+		return oldDep.Status.ReadyReplicas != newDep.Status.ReadyReplicas ||
+			oldDep.Status.AvailableReplicas != newDep.Status.AvailableReplicas ||
+			oldDep.Status.UnavailableReplicas != newDep.Status.UnavailableReplicas ||
+			oldDep.Status.UpdatedReplicas != newDep.Status.UpdatedReplicas ||
+			oldDep.Status.Replicas != newDep.Status.Replicas
+	},
+	CreateFunc: func(e event.CreateEvent) bool {
+		return true
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return true
+	},
+	GenericFunc: func(e event.GenericEvent) bool {
+		return true
+	},
+}
+
+// LabelsOrAnnotationsChangedPredicate triggers reconciliation when labels or annotations change
+// Used for resources like ConfigMaps that don't have a generation field that changes on data updates
+var LabelsOrAnnotationsChangedPredicate = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		if e.ObjectOld == nil || e.ObjectNew == nil {
+			return true
+		}
+		// Check if generation changed
+		if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+			return true
+		}
+		// Also check labels and annotations for resources without generation updates
+		return !reflect.DeepEqual(e.ObjectOld.GetLabels(), e.ObjectNew.GetLabels()) ||
+			!reflect.DeepEqual(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations())
+	},
+	CreateFunc: func(e event.CreateEvent) bool {
+		return true
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return true
+	},
+	GenericFunc: func(e event.GenericEvent) bool {
+		return true
+	},
+}
+


### PR DESCRIPTION
POC for a reconstruction on the packages in the repo, containing:

1. common package: contains shared utilities used by all reconcilers.
2. buildservice pacage: contains only the buildservice reconciler and its tests

also changed in main how the buildservice controller is created.

kept the old files for the sake of keeping this a draft.

* the separated pacage can oly access common
* dependencies are explicit

assisted by: cursor