### PR TITLE
Add tracking client for declarative resource cleanup

### DIFF
--- a/operator/internal/controller/konfluxui_controller_test.go
+++ b/operator/internal/controller/konfluxui_controller_test.go
@@ -34,6 +34,7 @@ import (
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/ingress"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
 )
 
 var _ = Describe("KonfluxUI Controller", func() {
@@ -197,7 +198,8 @@ var _ = Describe("KonfluxUI Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
 			By("calling ensureUISecrets")
-			err := reconciler.ensureUISecrets(ctx, ui)
+			tc := tracking.NewClient(k8sClient, k8sClient.Scheme())
+			err := reconciler.ensureUISecrets(ctx, tc, ui)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying the secret data was preserved")
@@ -228,7 +230,8 @@ var _ = Describe("KonfluxUI Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
 			By("calling ensureUISecrets")
-			err := reconciler.ensureUISecrets(ctx, ui)
+			tc := tracking.NewClient(k8sClient, k8sClient.Scheme())
+			err := reconciler.ensureUISecrets(ctx, tc, ui)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying the ownership labels were updated")
@@ -258,7 +261,8 @@ var _ = Describe("KonfluxUI Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
 			By("calling ensureUISecrets")
-			err := reconciler.ensureUISecrets(ctx, ui)
+			tc := tracking.NewClient(k8sClient, k8sClient.Scheme())
+			err := reconciler.ensureUISecrets(ctx, tc, ui)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying the secret data was generated")
@@ -274,7 +278,8 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 		It("Should use URL-safe base64 encoding for client-secret", func(ctx context.Context) {
 			By("calling ensureUISecrets")
-			err := reconciler.ensureUISecrets(ctx, ui)
+			tc := tracking.NewClient(k8sClient, k8sClient.Scheme())
+			err := reconciler.ensureUISecrets(ctx, tc, ui)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying the client-secret uses URL-safe encoding")
@@ -294,7 +299,8 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 		It("Should use standard base64 encoding for cookie-secret", func(ctx context.Context) {
 			By("calling ensureUISecrets")
-			err := reconciler.ensureUISecrets(ctx, ui)
+			tc := tracking.NewClient(k8sClient, k8sClient.Scheme())
+			err := reconciler.ensureUISecrets(ctx, tc, ui)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying the cookie-secret uses standard encoding")
@@ -312,7 +318,8 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 		It("Should create both secrets in a single call", func(ctx context.Context) {
 			By("calling ensureUISecrets")
-			err := reconciler.ensureUISecrets(ctx, ui)
+			tc := tracking.NewClient(k8sClient, k8sClient.Scheme())
+			err := reconciler.ensureUISecrets(ctx, tc, ui)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying both secrets were created")
@@ -333,7 +340,8 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 		It("Should be idempotent when called multiple times", func(ctx context.Context) {
 			By("calling ensureUISecrets first time")
-			err := reconciler.ensureUISecrets(ctx, ui)
+			tc := tracking.NewClient(k8sClient, k8sClient.Scheme())
+			err := reconciler.ensureUISecrets(ctx, tc, ui)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("getting the first secret value")
@@ -346,7 +354,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 			firstValue := secret1.Data["client-secret"]
 
 			By("calling ensureUISecrets second time")
-			err = reconciler.ensureUISecrets(ctx, ui)
+			err = reconciler.ensureUISecrets(ctx, tc, ui)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying the secret value was not changed")

--- a/operator/pkg/tracking/tracking_test.go
+++ b/operator/pkg/tracking/tracking_test.go
@@ -1,0 +1,504 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracking
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testOwnerLabel = "test.example.com/owner"
+	testOwnerValue = "test-owner"
+	testNamespace  = "test-namespace"
+)
+
+var configMapGVK = schema.GroupVersionKind{
+	Group:   "",
+	Version: "v1",
+	Kind:    "ConfigMap",
+}
+
+func TestNewClient(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme := setupScheme(g)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	tc := NewClient(fakeClient, scheme)
+
+	g.Expect(tc).NotTo(BeNil())
+	g.Expect(tc.tracked).NotTo(BeNil())
+	g.Expect(tc.tracked).To(BeEmpty())
+}
+
+func TestClient_ApplyObject(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	scheme := setupScheme(g)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	tc := NewClient(fakeClient, scheme)
+
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cm",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				testOwnerLabel: testOwnerValue,
+			},
+		},
+		Data: map[string]string{
+			"key": "value",
+		},
+	}
+
+	err := tc.ApplyObject(ctx, cm, "test-manager")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Verify the resource is tracked
+	g.Expect(tc.IsTracked(configMapGVK, testNamespace, "test-cm")).To(BeTrue())
+
+	// Verify the resource exists in the cluster
+	var fetched corev1.ConfigMap
+	err = fakeClient.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "test-cm"}, &fetched)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(fetched.Data["key"]).To(Equal("value"))
+}
+
+func TestClient_Patch(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	scheme := setupScheme(g)
+
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-cm",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				testOwnerLabel: testOwnerValue,
+			},
+		},
+		Data: map[string]string{
+			"key": "old-value",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	tc := NewClient(fakeClient, scheme)
+
+	// Patch the ConfigMap using server-side apply
+	patched := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-cm",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				testOwnerLabel: testOwnerValue,
+			},
+		},
+		Data: map[string]string{
+			"key": "new-value",
+		},
+	}
+
+	err := tc.Patch(ctx, patched, client.Apply, client.FieldOwner("test-manager"), client.ForceOwnership)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Verify the resource is tracked
+	g.Expect(tc.IsTracked(configMapGVK, testNamespace, "existing-cm")).To(BeTrue())
+}
+
+func TestClient_Create(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	scheme := setupScheme(g)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	tc := NewClient(fakeClient, scheme)
+
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "created-cm",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				testOwnerLabel: testOwnerValue,
+			},
+		},
+	}
+
+	err := tc.Create(ctx, cm)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Verify the resource is tracked
+	g.Expect(tc.IsTracked(configMapGVK, testNamespace, "created-cm")).To(BeTrue())
+}
+
+func TestClient_Update(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	scheme := setupScheme(g)
+
+	existing := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "update-cm",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				testOwnerLabel: testOwnerValue,
+			},
+		},
+		Data: map[string]string{
+			"key": "old-value",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	tc := NewClient(fakeClient, scheme)
+
+	// First fetch the object to get its resourceVersion
+	var fetched corev1.ConfigMap
+	err := fakeClient.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "update-cm"}, &fetched)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Update it
+	fetched.Data["key"] = "new-value"
+	err = tc.Update(ctx, &fetched)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Verify the resource is tracked
+	g.Expect(tc.IsTracked(configMapGVK, testNamespace, "update-cm")).To(BeTrue())
+}
+
+func TestClient_TrackedResources(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	scheme := setupScheme(g)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	tc := NewClient(fakeClient, scheme)
+
+	// Apply multiple resources
+	for i, name := range []string{"cm-1", "cm-2", "cm-3"} {
+		cm := &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+			},
+			Data: map[string]string{
+				"index": string(rune('0' + i)),
+			},
+		}
+		err := tc.ApplyObject(ctx, cm, "test-manager")
+		g.Expect(err).NotTo(HaveOccurred())
+	}
+
+	// Verify all resources are tracked
+	tracked := tc.TrackedResources()
+	g.Expect(tracked).To(HaveLen(3))
+
+	// Verify each resource is tracked
+	for _, name := range []string{"cm-1", "cm-2", "cm-3"} {
+		g.Expect(tc.IsTracked(configMapGVK, testNamespace, name)).To(BeTrue())
+	}
+}
+
+func TestClient_CleanupOrphans(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	scheme := setupScheme(g)
+
+	// Create pre-existing resources - some will be "orphans"
+	existing1 := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "keep-this",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				testOwnerLabel: testOwnerValue,
+			},
+		},
+	}
+	existing2 := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "delete-this",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				testOwnerLabel: testOwnerValue,
+			},
+		},
+	}
+	existing3 := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "different-owner",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				testOwnerLabel: "different-owner", // Different owner - should not be deleted
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing1, existing2, existing3).
+		Build()
+	tc := NewClient(fakeClient, scheme)
+
+	// Apply only one of the owned resources - the other becomes an orphan
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "keep-this",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				testOwnerLabel: testOwnerValue,
+			},
+		},
+	}
+	err := tc.ApplyObject(ctx, cm, "test-manager")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Run cleanup
+	err = tc.CleanupOrphans(ctx, testOwnerLabel, testOwnerValue, []schema.GroupVersionKind{configMapGVK})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Verify "keep-this" still exists
+	var kept corev1.ConfigMap
+	err = fakeClient.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "keep-this"}, &kept)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Verify "delete-this" was deleted
+	var deleted corev1.ConfigMap
+	err = fakeClient.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "delete-this"}, &deleted)
+	g.Expect(errors.IsNotFound(err)).To(BeTrue(), "expected NotFound error")
+
+	// Verify "different-owner" still exists (different owner label value)
+	var differentOwner corev1.ConfigMap
+	err = fakeClient.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "different-owner"}, &differentOwner)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func TestClient_CleanupOrphans_ClusterScoped(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	scheme := setupScheme(g)
+
+	// Create cluster-scoped resources (Namespaces)
+	ns1 := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "keep-ns",
+			Labels: map[string]string{
+				testOwnerLabel: testOwnerValue,
+			},
+		},
+	}
+	ns2 := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "delete-ns",
+			Labels: map[string]string{
+				testOwnerLabel: testOwnerValue,
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ns1, ns2).
+		Build()
+	tc := NewClient(fakeClient, scheme)
+
+	// Apply only one namespace
+	ns := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "keep-ns",
+			Labels: map[string]string{
+				testOwnerLabel: testOwnerValue,
+			},
+		},
+	}
+	err := tc.ApplyObject(ctx, ns, "test-manager")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Run cleanup for Namespace GVK
+	namespaceGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
+	err = tc.CleanupOrphans(ctx, testOwnerLabel, testOwnerValue, []schema.GroupVersionKind{namespaceGVK})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Verify "keep-ns" still exists
+	var keptNS corev1.Namespace
+	err = fakeClient.Get(ctx, client.ObjectKey{Name: "keep-ns"}, &keptNS)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Verify "delete-ns" was deleted
+	var deletedNS corev1.Namespace
+	err = fakeClient.Get(ctx, client.ObjectKey{Name: "delete-ns"}, &deletedNS)
+	g.Expect(errors.IsNotFound(err)).To(BeTrue(), "expected NotFound error")
+}
+
+func TestClient_CleanupOrphans_MultipleGVKs(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	scheme := setupScheme(g)
+
+	// Create ConfigMaps and Secrets
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "orphan-cm",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				testOwnerLabel: testOwnerValue,
+			},
+		},
+	}
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "orphan-secret",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				testOwnerLabel: testOwnerValue,
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cm, secret).
+		Build()
+	tc := NewClient(fakeClient, scheme)
+
+	// Don't apply anything - both resources are orphans
+
+	// Run cleanup for both GVKs
+	secretGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
+	err := tc.CleanupOrphans(ctx, testOwnerLabel, testOwnerValue, []schema.GroupVersionKind{configMapGVK, secretGVK})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Verify both were deleted
+	var deletedCM corev1.ConfigMap
+	err = fakeClient.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "orphan-cm"}, &deletedCM)
+	g.Expect(errors.IsNotFound(err)).To(BeTrue(), "expected NotFound error for ConfigMap")
+
+	var deletedSecret corev1.Secret
+	err = fakeClient.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "orphan-secret"}, &deletedSecret)
+	g.Expect(errors.IsNotFound(err)).To(BeTrue(), "expected NotFound error for Secret")
+}
+
+func TestResourceKey_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      ResourceKey
+		expected string
+	}{
+		{
+			name: "namespaced resource",
+			key: ResourceKey{
+				GVK:       configMapGVK,
+				Namespace: "my-namespace",
+				Name:      "my-configmap",
+			},
+			expected: "ConfigMap/my-namespace/my-configmap",
+		},
+		{
+			name: "cluster-scoped resource",
+			key: ResourceKey{
+				GVK:       schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"},
+				Namespace: "",
+				Name:      "my-namespace",
+			},
+			expected: "Namespace/my-namespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.key.String()).To(Equal(tt.expected))
+		})
+	}
+}
+
+func setupScheme(g *WithT) *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	err := corev1.AddToScheme(scheme)
+	g.Expect(err).NotTo(HaveOccurred())
+	return scheme
+}


### PR DESCRIPTION
### **User description**
Introduce a new `pkg/tracking` package that wraps the controller-runtime client and tracks all resources applied during a reconciliation. This enables automatic cleanup of orphaned resources at the end of a successful reconcile loop.

Key features:
- Implements client.Client interface for drop-in compatibility
- Automatically tracks Create/Update/Patch operations
- CleanupOrphans method deletes resources with owner label that weren't applied during the current reconcile
- Derives GVK from scheme when TypeMeta is not set (common after client ops)

Integrate tracking client into KonfluxUI controller:
- Remove explicit Ingress deletion logic in reconcileIngress
- Ingress is now automatically deleted when disabled (not applied = orphaned)
- All write operations go through tracking client for consistent tracking

This pattern simplifies reconciliation logic by making it purely declarative: just apply what should exist, and cleanup handles the rest.

Assisted-By: Cursor


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce tracking client package for declarative resource cleanup
  - Wraps controller-runtime client to track applied resources
  - Implements CleanupOrphans to delete orphaned resources automatically
  - Derives GVK from scheme when TypeMeta not set

- Integrate tracking client into KonfluxUI controller
  - Remove explicit Ingress deletion logic, now automatic via cleanup
  - Pass tracking client through all reconciliation methods
  - Add uiCleanupGVKs configuration for cleanup targets

- Add comprehensive unit tests for tracking client functionality
  - Test ApplyObject, Patch, Create, Update operations
  - Test CleanupOrphans for namespaced and cluster-scoped resources
  - Test multiple GVK cleanup scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Reconcile Loop"] -->|creates| B["Tracking Client"]
  B -->|wraps| C["Controller-Runtime Client"]
  B -->|tracks| D["Applied Resources"]
  A -->|calls| E["Apply Methods"]
  E -->|uses| B
  E -->|updates| D
  A -->|calls| F["CleanupOrphans"]
  F -->|compares| D
  F -->|deletes| G["Orphaned Resources"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>konfluxui_controller.go</strong><dd><code>Integrate tracking client into KonfluxUI reconciliation</code>&nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/konfluxui_controller.go

<ul><li>Import tracking package and schema for GVK handling<br> <li> Create tracking client at start of Reconcile method<br> <li> Define uiCleanupGVKs list for Ingress cleanup configuration<br> <li> Pass tracking client to all reconciliation helper methods<br> <li> Replace explicit Ingress deletion with automatic cleanup via <br>CleanupOrphans<br> <li> Update all client operations to use tracking client for consistent <br>tracking</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4310/files#diff-6f5f29dbe74096042cd8c822f09474ba5c4a89d4e76376250b120cacd62ddb4f">+49/-30</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tracking.go</strong><dd><code>New tracking client package implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/pkg/tracking/tracking.go

<ul><li>Implement Client type wrapping controller-runtime client with resource <br>tracking<br> <li> Implement ApplyObject method for server-side apply with automatic <br>tracking<br> <li> Override Create, Update, Patch methods to track operations<br> <li> Implement track method with GVK derivation from scheme when needed<br> <li> Implement CleanupOrphans to delete untracked resources with owner <br>label<br> <li> Provide IsTracked and TrackedResources helper methods for testing</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4310/files#diff-b17c4fd99cc067eaa572457a96eaeaf8d0d226c083933b4368fc82e8f9139f7e">+279/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>konfluxui_controller_test.go</strong><dd><code>Update tests to use tracking client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/konfluxui_controller_test.go

<ul><li>Import tracking package<br> <li> Update ensureUISecrets test calls to create and use tracking client<br> <li> Maintain existing test logic while adapting to new tracking client <br>interface</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4310/files#diff-a11907156460c18c422a020ccbf50bcfe2dccbddc8447ea4d9ff29da5a8561af">+16/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tracking_test.go</strong><dd><code>Comprehensive unit tests for tracking client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/pkg/tracking/tracking_test.go

<ul><li>Test NewClient initialization<br> <li> Test ApplyObject, Patch, Create, Update tracking functionality<br> <li> Test TrackedResources and IsTracked helper methods<br> <li> Test CleanupOrphans for namespaced resources with owner label matching<br> <li> Test CleanupOrphans for cluster-scoped resources like Namespaces<br> <li> Test CleanupOrphans with multiple GVKs<br> <li> Test ResourceKey string representation for both namespaced and <br>cluster-scoped resources</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4310/files#diff-23708af2dee5b32591e69af440bf058812607ceb230317ae3c04fd2db61e6430">+504/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

