### PR TITLE
chore: enforce ui creates only its own namespace

### DIFF
--- a/operator/internal/controller/konfluxui_controller.go
+++ b/operator/internal/controller/konfluxui_controller.go
@@ -213,6 +213,11 @@ func (r *KonfluxUIReconciler) ensureNamespaceExists(ctx context.Context, owner *
 	for _, obj := range objects {
 		// Apply customizations for deployments
 		if namespace, ok := obj.(*corev1.Namespace); ok {
+			// Validate that the namespace name matches the expected uiNamespace
+			if namespace.Name != uiNamespace {
+				return fmt.Errorf(
+					"unexpected namespace name in manifest: expected %s, got %s", uiNamespace, namespace.Name)
+			}
 			// Set ownership labels and owner reference
 			if err := setOwnership(namespace, owner, string(manifests.UI), r.Scheme); err != nil {
 				return fmt.Errorf("failed to set ownership for %s/%s (%s) from %s: %w",


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add validation to ensure UI namespace matches expected name

- Prevent creation of namespaces with unexpected names in manifests

- Return descriptive error when namespace name mismatch detected


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Get UI manifests"] --> B["Iterate objects"]
  B --> C["Check if Namespace object"]
  C --> D["Validate namespace name"]
  D --> E{Name matches<br/>uiNamespace?}
  E -->|No| F["Return error"]
  E -->|Yes| G["Set ownership"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>konfluxui_controller.go</strong><dd><code>Add namespace name validation in ensureNamespaceExists</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/konfluxui_controller.go

<ul><li>Added validation check to ensure namespace name matches expected <br><code>uiNamespace</code><br> <li> Returns formatted error message when namespace name mismatch is <br>detected<br> <li> Validation occurs before setting ownership labels and references</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4312/files#diff-6f5f29dbe74096042cd8c822f09474ba5c4a89d4e76376250b120cacd62ddb4f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

