### PR TITLE
fix(KFLUXVNGD-620): Components without deployments report status about deployments

### DIFF
--- a/operator/internal/controller/conditions.go
+++ b/operator/internal/controller/conditions.go
@@ -149,11 +149,17 @@ func SetDeploymentConditions(obj konfluxv1alpha1.ConditionAccessor, deployments 
 // SetOverallReadyCondition sets the overall Ready condition based on the deployment status summary.
 func SetOverallReadyCondition(obj konfluxv1alpha1.ConditionAccessor, readyConditionType string, summary DeploymentStatusSummary) {
 	if summary.AllReady {
+		var message string
+		if summary.TotalCount == 0 {
+			message = "Component ready (no deployments to track)"
+		} else {
+			message = fmt.Sprintf("All %d deployments are ready", summary.TotalCount)
+		}
 		SetCondition(obj, metav1.Condition{
 			Type:    readyConditionType,
 			Status:  metav1.ConditionTrue,
 			Reason:  "AllComponentsReady",
-			Message: fmt.Sprintf("All %d deployments are ready", summary.TotalCount),
+			Message: message,
 		})
 	} else {
 		SetCondition(obj, metav1.Condition{

--- a/operator/internal/controller/conditions_test.go
+++ b/operator/internal/controller/conditions_test.go
@@ -1,0 +1,345 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+)
+
+var _ = Describe("Conditions Helper Functions", func() {
+	Describe("SetOverallReadyCondition", func() {
+		var testObject *konfluxv1alpha1.KonfluxRBAC
+
+		BeforeEach(func() {
+			// Use KonfluxRBAC as a test object since it implements ConditionAccessor
+			testObject = &konfluxv1alpha1.KonfluxRBAC{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-rbac",
+					Namespace:  "default",
+					Generation: 1,
+				},
+			}
+		})
+
+		Context("when components have deployments", func() {
+			It("should set Ready condition with deployment count when all deployments are ready", func() {
+				summary := DeploymentStatusSummary{
+					AllReady:      true,
+					TotalCount:    3,
+					NotReadyNames: []string{},
+				}
+
+				SetOverallReadyCondition(testObject, "Ready", summary)
+
+				condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+				Expect(condition).NotTo(BeNil())
+				Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+				Expect(condition.Reason).To(Equal("AllComponentsReady"))
+				Expect(condition.Message).To(Equal("All 3 deployments are ready"))
+				Expect(condition.ObservedGeneration).To(Equal(int64(1)))
+			})
+
+			It("should set Ready condition with deployment count when multiple deployments are ready", func() {
+				summary := DeploymentStatusSummary{
+					AllReady:      true,
+					TotalCount:    5,
+					NotReadyNames: []string{},
+				}
+
+				SetOverallReadyCondition(testObject, "Ready", summary)
+
+				condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+				Expect(condition).NotTo(BeNil())
+				Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+				Expect(condition.Message).To(Equal("All 5 deployments are ready"))
+			})
+
+			It("should set NotReady condition when some deployments are not ready", func() {
+				summary := DeploymentStatusSummary{
+					AllReady:      false,
+					TotalCount:    3,
+					NotReadyNames: []string{"deployment-1", "deployment-2"},
+				}
+
+				SetOverallReadyCondition(testObject, "Ready", summary)
+
+				condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+				Expect(condition).NotTo(BeNil())
+				Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+				Expect(condition.Reason).To(Equal("ComponentsNotReady"))
+				Expect(condition.Message).To(Equal("Deployments not ready: [deployment-1 deployment-2]"))
+			})
+		})
+
+		Context("when components have no deployments", func() {
+			It("should set Ready condition with descriptive message for zero deployments", func() {
+				summary := DeploymentStatusSummary{
+					AllReady:      true,
+					TotalCount:    0,
+					NotReadyNames: []string{},
+				}
+
+				SetOverallReadyCondition(testObject, "Ready", summary)
+
+				condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+				Expect(condition).NotTo(BeNil())
+				Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+				Expect(condition.Reason).To(Equal("AllComponentsReady"))
+				Expect(condition.Message).To(Equal("Component ready (no deployments to track)"))
+				Expect(condition.ObservedGeneration).To(Equal(int64(1)))
+			})
+
+			It("should use the correct message format instead of 'All 0 deployments are ready'", func() {
+				summary := DeploymentStatusSummary{
+					AllReady:   true,
+					TotalCount: 0,
+				}
+
+				SetOverallReadyCondition(testObject, "Ready", summary)
+
+				condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+				Expect(condition).NotTo(BeNil())
+				Expect(condition.Message).NotTo(Equal("All 0 deployments are ready"))
+				Expect(condition.Message).To(Equal("Component ready (no deployments to track)"))
+			})
+		})
+
+		Context("when using custom condition types", func() {
+			It("should respect the custom ready condition type", func() {
+				summary := DeploymentStatusSummary{
+					AllReady:   true,
+					TotalCount: 0,
+				}
+
+				SetOverallReadyCondition(testObject, "CustomReady", summary)
+
+				condition := apimeta.FindStatusCondition(testObject.GetConditions(), "CustomReady")
+				Expect(condition).NotTo(BeNil())
+				Expect(condition.Type).To(Equal("CustomReady"))
+				Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+			})
+		})
+	})
+
+	Describe("SetCondition", func() {
+		var testObject *konfluxv1alpha1.KonfluxRBAC
+
+		BeforeEach(func() {
+			testObject = &konfluxv1alpha1.KonfluxRBAC{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-rbac",
+					Namespace:  "default",
+					Generation: 5,
+				},
+			}
+		})
+
+		It("should add a new condition", func() {
+			SetCondition(testObject, metav1.Condition{
+				Type:    "Ready",
+				Status:  metav1.ConditionTrue,
+				Reason:  "TestReason",
+				Message: "Test message",
+			})
+
+			conditions := testObject.GetConditions()
+			Expect(conditions).To(HaveLen(1))
+			Expect(conditions[0].Type).To(Equal("Ready"))
+			Expect(conditions[0].Status).To(Equal(metav1.ConditionTrue))
+			Expect(conditions[0].Reason).To(Equal("TestReason"))
+			Expect(conditions[0].Message).To(Equal("Test message"))
+			Expect(conditions[0].ObservedGeneration).To(Equal(int64(5)))
+		})
+
+		It("should update an existing condition", func() {
+			// Add initial condition
+			SetCondition(testObject, metav1.Condition{
+				Type:    "Ready",
+				Status:  metav1.ConditionFalse,
+				Reason:  "InitialReason",
+				Message: "Initial message",
+			})
+
+			// Update the condition
+			SetCondition(testObject, metav1.Condition{
+				Type:    "Ready",
+				Status:  metav1.ConditionTrue,
+				Reason:  "UpdatedReason",
+				Message: "Updated message",
+			})
+
+			conditions := testObject.GetConditions()
+			Expect(conditions).To(HaveLen(1))
+			Expect(conditions[0].Status).To(Equal(metav1.ConditionTrue))
+			Expect(conditions[0].Reason).To(Equal("UpdatedReason"))
+			Expect(conditions[0].Message).To(Equal("Updated message"))
+		})
+	})
+
+	Describe("IsConditionTrue", func() {
+		var testObject *konfluxv1alpha1.KonfluxRBAC
+
+		BeforeEach(func() {
+			testObject = &konfluxv1alpha1.KonfluxRBAC{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-rbac",
+					Namespace: "default",
+				},
+			}
+		})
+
+		It("should return true when condition exists and status is True", func() {
+			SetCondition(testObject, metav1.Condition{
+				Type:   "Ready",
+				Status: metav1.ConditionTrue,
+				Reason: "AllReady",
+			})
+
+			Expect(IsConditionTrue(testObject, "Ready")).To(BeTrue())
+		})
+
+		It("should return false when condition exists but status is False", func() {
+			SetCondition(testObject, metav1.Condition{
+				Type:   "Ready",
+				Status: metav1.ConditionFalse,
+				Reason: "NotReady",
+			})
+
+			Expect(IsConditionTrue(testObject, "Ready")).To(BeFalse())
+		})
+
+		It("should return false when condition does not exist", func() {
+			Expect(IsConditionTrue(testObject, "NonExistent")).To(BeFalse())
+		})
+	})
+
+	Describe("AggregateReadiness", func() {
+		It("should return true when all sub-CRs are ready", func() {
+			subCRStatuses := []SubCRStatus{
+				{Name: "component-1", Ready: true},
+				{Name: "component-2", Ready: true},
+				{Name: "component-3", Ready: true},
+			}
+
+			allReady, notReadyReasons := AggregateReadiness(subCRStatuses)
+
+			Expect(allReady).To(BeTrue())
+			Expect(notReadyReasons).To(BeEmpty())
+		})
+
+		It("should return false and reasons when some sub-CRs are not ready", func() {
+			subCRStatuses := []SubCRStatus{
+				{Name: "component-1", Ready: true},
+				{Name: "component-2", Ready: false},
+				{Name: "component-3", Ready: false},
+			}
+
+			allReady, notReadyReasons := AggregateReadiness(subCRStatuses)
+
+			Expect(allReady).To(BeFalse())
+			Expect(notReadyReasons).To(HaveLen(2))
+			Expect(notReadyReasons).To(ContainElement("component-2 is not ready"))
+			Expect(notReadyReasons).To(ContainElement("component-3 is not ready"))
+		})
+
+		It("should handle empty sub-CR list", func() {
+			subCRStatuses := []SubCRStatus{}
+
+			allReady, notReadyReasons := AggregateReadiness(subCRStatuses)
+
+			Expect(allReady).To(BeTrue())
+			Expect(notReadyReasons).To(BeEmpty())
+		})
+	})
+
+	Describe("SetAggregatedReadyCondition", func() {
+		var testObject *konfluxv1alpha1.KonfluxRBAC
+
+		BeforeEach(func() {
+			testObject = &konfluxv1alpha1.KonfluxRBAC{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-rbac",
+					Namespace:  "default",
+					Generation: 1,
+				},
+			}
+		})
+
+		It("should set Ready condition when all components are ready", func() {
+			subCRStatuses := []SubCRStatus{
+				{Name: "component-1", Ready: true},
+				{Name: "component-2", Ready: true},
+			}
+
+			SetAggregatedReadyCondition(testObject, "Ready", subCRStatuses)
+
+			condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(condition.Reason).To(Equal("AllComponentsReady"))
+			Expect(condition.Message).To(Equal("All 2 components are ready"))
+		})
+
+		It("should set NotReady condition when some components are not ready", func() {
+			subCRStatuses := []SubCRStatus{
+				{Name: "component-1", Ready: true},
+				{Name: "component-2", Ready: false},
+			}
+
+			SetAggregatedReadyCondition(testObject, "Ready", subCRStatuses)
+
+			condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal("ComponentsNotReady"))
+			Expect(condition.Message).To(ContainSubstring("component-2 is not ready"))
+		})
+	})
+
+	Describe("SetFailedCondition", func() {
+		var testObject *konfluxv1alpha1.KonfluxRBAC
+
+		BeforeEach(func() {
+			testObject = &konfluxv1alpha1.KonfluxRBAC{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-rbac",
+					Namespace:  "default",
+					Generation: 1,
+				},
+			}
+		})
+
+		It("should set a failed condition with error message", func() {
+			testErr := fmt.Errorf("something went wrong")
+
+			SetFailedCondition(testObject, "Ready", "ReconciliationFailed", testErr)
+
+			condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal("ReconciliationFailed"))
+			Expect(condition.Message).To(Equal("something went wrong"))
+		})
+	})
+})


### PR DESCRIPTION
### **User description**
Update the status message to report that the component is ready (no deployments to track) when there are no deployments to track.

Example of the status message:
```
  - lastTransitionTime: "2026-01-04T12:23:21Z"
    message: Component ready (no deployments to track)
    observedGeneration: 1
    reason: AllComponentsReady
    status: "True"
    type: info.Ready
  - lastTransitionTime: "2026-01-04T12:23:21Z"
    message: Deployment has 1/1 replicas ready
    observedGeneration: 1
    reason: DeploymentReady
    status: "True"
    type: namespace-lister.namespace-lister.namespace-lister
  - lastTransitionTime: "2026-01-04T12:23:21Z"
    message: All 1 deployments are ready
    observedGeneration: 1
    reason: AllComponentsReady
    status: "True"
    type: namespace-lister.Ready
```

Assisted-By: Cursor


___

### **PR Type**
Bug fix


___

### **Description**
- Update status message for components without deployments

- Report "Component ready (no deployments to track)" when TotalCount is zero

- Maintain existing message format for components with deployments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SetOverallReadyCondition called"] --> B{"summary.TotalCount == 0?"}
  B -->|Yes| C["Set message: Component ready<br/>no deployments to track"]
  B -->|No| D["Set message: All N deployments<br/>are ready"]
  C --> E["SetCondition with message"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conditions.go</strong><dd><code>Add deployment count check for status message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/conditions.go

<ul><li>Added conditional logic to check if <code>summary.TotalCount</code> is zero<br> <li> Set message to "Component ready (no deployments to track)" when no <br>deployments exist<br> <li> Preserve existing message format "All N deployments are ready" for <br>components with deployments<br> <li> Improved status reporting clarity for components without tracked <br>deployments</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4320/files#diff-d4dad1c305ea20ed6ecfb10830dc9d1ddba5a54106177c876e17c73bbddd7f9d">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

