### PR TITLE
fix: track build pipeline refs with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "ignorePaths": [
     "operator/upstream-kustomizations/application-api/**",
-    "operator/upstream-kustomizations/build-service/**",
+    "operator/upstream-kustomizations/build-service/monitoring/**",
+    "operator/upstream-kustomizations/build-service/core/kustomization.yaml",
+    "operator/upstream-kustomizations/build-service/kustomization.yaml",
     "operator/upstream-kustomizations/enterprise-contract/core/**",
     "operator/upstream-kustomizations/image-controller/**",
     "operator/upstream-kustomizations/integration/**",
@@ -89,7 +91,10 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["konflux-ci/build-service/core/build-pipeline-config.yaml"],
+      "fileMatch": [
+        "konflux-ci/build-service/core/build-pipeline-config.yaml",
+        "operator/upstream-kustomizations/build-service/core/build-pipeline-config.yaml"
+      ],
       "matchStrings": [
         "bundle: (?<depName>quay\\.io/konflux-ci/tekton-catalog/pipeline-[^@]+)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refine Renovate ignore paths for build-service directory
  - Replace broad ignore pattern with specific subdirectories
  - Exclude only monitoring and core kustomization files

- Extend build pipeline config tracking to operator upstream
  - Add operator upstream build-service path to Renovate regex matcher
  - Enable dependency updates for operator build pipeline configurations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Renovate Configuration"] -->|Refine ignore paths| B["Build-service directory"]
  B -->|Exclude monitoring| C["monitoring/**"]
  B -->|Exclude core kustomization| D["core/kustomization.yaml"]
  A -->|Extend file matching| E["Build pipeline config"]
  E -->|Add operator path| F["operator/upstream-kustomizations/build-service/core/build-pipeline-config.yaml"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Refine Renovate build-service tracking and ignore patterns</code></dd></summary>
<hr>

renovate.json

<ul><li>Changed build-service ignore pattern from broad directory exclusion to <br>specific subdirectory and file exclusions<br> <li> Added monitoring directory and two kustomization.yaml files to <br>ignorePaths for more granular control<br> <li> Extended build-pipeline-config.yaml file matching to include operator <br>upstream path alongside konflux-ci path<br> <li> Enables Renovate to track and update build pipeline references in <br>operator upstream configurations</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4326/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

