### PR TITLE
Refactor code base to use proper URL struct

### DIFF
--- a/operator/pkg/dex/builder.go
+++ b/operator/pkg/dex/builder.go
@@ -19,6 +19,8 @@ package dex
 import (
 	"fmt"
 
+	"net/url"
+
 	"k8s.io/utils/ptr"
 )
 
@@ -63,11 +65,9 @@ type DexParams struct {
 
 // NewDexConfig creates a Dex configuration for the Konflux UI.
 // This configuration uses Kubernetes storage, HTTPS with TLS, and an oauth2-proxy client.
-func NewDexConfig(params *DexParams) *Config {
-	baseURL := fmt.Sprintf("https://%s", params.Hostname)
-	if params.Port != "" {
-		baseURL = fmt.Sprintf("https://%s:%s", params.Hostname, params.Port)
-	}
+// endpoint is the base URL for the Dex issuer (e.g., https://dex.example.com).
+func NewDexConfig(endpoint *url.URL, params *DexParams) *Config {
+	baseURL := endpoint.String()
 
 	defaultRedirectURI := fmt.Sprintf("%s/idp/callback", baseURL)
 

--- a/operator/pkg/dex/builder_test.go
+++ b/operator/pkg/dex/builder_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dex
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -27,11 +28,10 @@ func TestNewDexConfig(t *testing.T) {
 	t.Run("creates config with hostname only", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		params := &DexParams{
-			Hostname: "dex.example.com",
-		}
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
+		params := &DexParams{}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config).NotTo(gomega.BeNil())
 		g.Expect(config.Issuer).To(gomega.Equal("https://dex.example.com/idp/"))
@@ -42,12 +42,10 @@ func TestNewDexConfig(t *testing.T) {
 	t.Run("creates config with hostname and port", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		params := &DexParams{
-			Hostname: "dex.example.com",
-			Port:     "9443",
-		}
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com:9443"}
+		params := &DexParams{}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config).NotTo(gomega.BeNil())
 		g.Expect(config.Issuer).To(gomega.Equal("https://dex.example.com:9443/idp/"))
@@ -59,11 +57,10 @@ func TestNewDexConfig(t *testing.T) {
 	t.Run("configures kubernetes storage", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		params := &DexParams{
-			Hostname: "dex.example.com",
-		}
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
+		params := &DexParams{}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.Storage).NotTo(gomega.BeNil())
 		g.Expect(config.Storage.Type).To(gomega.Equal("kubernetes"))
@@ -74,11 +71,10 @@ func TestNewDexConfig(t *testing.T) {
 	t.Run("configures HTTPS with TLS", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		params := &DexParams{
-			Hostname: "dex.example.com",
-		}
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
+		params := &DexParams{}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.Web).NotTo(gomega.BeNil())
 		g.Expect(config.Web.HTTPS).To(gomega.Equal("0.0.0.0:9443"))
@@ -89,11 +85,10 @@ func TestNewDexConfig(t *testing.T) {
 	t.Run("configures oauth2-proxy client", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		params := &DexParams{
-			Hostname: "dex.example.com",
-		}
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
+		params := &DexParams{}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.StaticClients).To(gomega.HaveLen(1))
 		client := config.StaticClients[0]
@@ -105,11 +100,10 @@ func TestNewDexConfig(t *testing.T) {
 	t.Run("configures telemetry", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		params := &DexParams{
-			Hostname: "dex.example.com",
-		}
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
+		params := &DexParams{}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.Telemetry).NotTo(gomega.BeNil())
 		g.Expect(config.Telemetry.HTTP).To(gomega.Equal("0.0.0.0:5558"))
@@ -118,11 +112,10 @@ func TestNewDexConfig(t *testing.T) {
 	t.Run("skips approval screen", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		params := &DexParams{
-			Hostname: "dex.example.com",
-		}
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
+		params := &DexParams{}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.OAuth2).NotTo(gomega.BeNil())
 		g.Expect(config.OAuth2.SkipApprovalScreen).To(gomega.BeTrue())
@@ -133,12 +126,13 @@ func TestNewDexConfig_OpenShiftConnector(t *testing.T) {
 	t.Run("adds OpenShift connector when enabled", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
 			Hostname:                    "dex.example.com",
 			ConfigureLoginWithOpenShift: ptr.To(true),
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.Connectors).To(gomega.HaveLen(1))
 		connector := config.Connectors[0]
@@ -150,12 +144,13 @@ func TestNewDexConfig_OpenShiftConnector(t *testing.T) {
 	t.Run("configures OpenShift connector with correct issuer", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
 			Hostname:                    "dex.example.com",
 			ConfigureLoginWithOpenShift: ptr.To(true),
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		connector := config.Connectors[0]
 		g.Expect(connector.Config).NotTo(gomega.BeNil())
@@ -165,12 +160,13 @@ func TestNewDexConfig_OpenShiftConnector(t *testing.T) {
 	t.Run("configures OpenShift connector with service account client ID", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
 			Hostname:                    "dex.example.com",
 			ConfigureLoginWithOpenShift: ptr.To(true),
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		connector := config.Connectors[0]
 		g.Expect(connector.Config.ClientID).To(gomega.Equal("system:serviceaccount:konflux-ui:dex-client"))
@@ -180,12 +176,13 @@ func TestNewDexConfig_OpenShiftConnector(t *testing.T) {
 	t.Run("configures OpenShift connector with root CA for API server TLS", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
 			Hostname:                    "dex.example.com",
 			ConfigureLoginWithOpenShift: ptr.To(true),
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		connector := config.Connectors[0]
 		g.Expect(connector.Config.RootCA).To(gomega.Equal("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"))
@@ -194,12 +191,13 @@ func TestNewDexConfig_OpenShiftConnector(t *testing.T) {
 	t.Run("configures OpenShift connector redirect URI without port", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
 			Hostname:                    "dex.example.com",
 			ConfigureLoginWithOpenShift: ptr.To(true),
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		connector := config.Connectors[0]
 		g.Expect(connector.Config.RedirectURI).To(gomega.Equal("https://dex.example.com/idp/callback"))
@@ -208,13 +206,14 @@ func TestNewDexConfig_OpenShiftConnector(t *testing.T) {
 	t.Run("configures OpenShift connector redirect URI with port", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com:9443"}
 		params := &DexParams{
 			Hostname:                    "dex.example.com",
 			Port:                        "9443",
 			ConfigureLoginWithOpenShift: ptr.To(true),
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		connector := config.Connectors[0]
 		g.Expect(connector.Config.RedirectURI).To(gomega.Equal("https://dex.example.com:9443/idp/callback"))
@@ -223,12 +222,13 @@ func TestNewDexConfig_OpenShiftConnector(t *testing.T) {
 	t.Run("does not add OpenShift connector when disabled", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
 			Hostname:                    "dex.example.com",
 			ConfigureLoginWithOpenShift: ptr.To(false),
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.Connectors).To(gomega.BeEmpty())
 	})
@@ -238,8 +238,8 @@ func TestNewDexConfig_CustomConnectors(t *testing.T) {
 	t.Run("includes custom connectors", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
-			Hostname: "dex.example.com",
 			Connectors: []Connector{
 				{
 					Type: "github",
@@ -253,7 +253,7 @@ func TestNewDexConfig_CustomConnectors(t *testing.T) {
 			},
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.Connectors).To(gomega.HaveLen(1))
 		g.Expect(config.Connectors[0].Type).To(gomega.Equal("github"))
@@ -263,8 +263,8 @@ func TestNewDexConfig_CustomConnectors(t *testing.T) {
 	t.Run("appends OpenShift connector to custom connectors", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
-			Hostname: "dex.example.com",
 			Connectors: []Connector{
 				{
 					Type: "github",
@@ -275,7 +275,7 @@ func TestNewDexConfig_CustomConnectors(t *testing.T) {
 			ConfigureLoginWithOpenShift: ptr.To(true),
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.Connectors).To(gomega.HaveLen(2))
 		g.Expect(config.Connectors[0].Type).To(gomega.Equal("github"))
@@ -285,8 +285,8 @@ func TestNewDexConfig_CustomConnectors(t *testing.T) {
 	t.Run("supports multiple custom connectors", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
-			Hostname: "dex.example.com",
 			Connectors: []Connector{
 				{Type: "github", ID: "github", Name: "GitHub"},
 				{Type: "ldap", ID: "ldap", Name: "LDAP"},
@@ -294,7 +294,7 @@ func TestNewDexConfig_CustomConnectors(t *testing.T) {
 			},
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.Connectors).To(gomega.HaveLen(3))
 	})
@@ -304,8 +304,8 @@ func TestNewDexConfig_ConnectorRedirectURI(t *testing.T) {
 	t.Run("sets default RedirectURI when not provided (hostname only)", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
-			Hostname: "dex.example.com",
 			Connectors: []Connector{
 				{
 					Type: "github",
@@ -319,7 +319,7 @@ func TestNewDexConfig_ConnectorRedirectURI(t *testing.T) {
 			},
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.Connectors).To(gomega.HaveLen(1))
 		g.Expect(config.Connectors[0].Config.RedirectURI).To(gomega.Equal("https://dex.example.com/idp/callback"))
@@ -328,9 +328,8 @@ func TestNewDexConfig_ConnectorRedirectURI(t *testing.T) {
 	t.Run("sets default RedirectURI when not provided (hostname with port)", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com:9443"}
 		params := &DexParams{
-			Hostname: "dex.example.com",
-			Port:     "9443",
 			Connectors: []Connector{
 				{
 					Type: "github",
@@ -344,7 +343,7 @@ func TestNewDexConfig_ConnectorRedirectURI(t *testing.T) {
 			},
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.Connectors).To(gomega.HaveLen(1))
 		g.Expect(config.Connectors[0].Config.RedirectURI).To(gomega.Equal("https://dex.example.com:9443/idp/callback"))
@@ -353,9 +352,8 @@ func TestNewDexConfig_ConnectorRedirectURI(t *testing.T) {
 	t.Run("preserves explicit RedirectURI when provided", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com:9443"}
 		params := &DexParams{
-			Hostname: "dex.example.com",
-			Port:     "9443",
 			Connectors: []Connector{
 				{
 					Type: "github",
@@ -370,7 +368,7 @@ func TestNewDexConfig_ConnectorRedirectURI(t *testing.T) {
 			},
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.Connectors).To(gomega.HaveLen(1))
 		g.Expect(config.Connectors[0].Config.RedirectURI).To(gomega.Equal("https://custom.example.com/callback"))
@@ -379,8 +377,8 @@ func TestNewDexConfig_ConnectorRedirectURI(t *testing.T) {
 	t.Run("handles connector with nil Config", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
-			Hostname: "dex.example.com",
 			Connectors: []Connector{
 				{
 					Type:   "mock",
@@ -391,7 +389,7 @@ func TestNewDexConfig_ConnectorRedirectURI(t *testing.T) {
 			},
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.Connectors).To(gomega.HaveLen(1))
 		g.Expect(config.Connectors[0].Config).To(gomega.BeNil())
@@ -400,9 +398,8 @@ func TestNewDexConfig_ConnectorRedirectURI(t *testing.T) {
 	t.Run("handles multiple connectors with mixed RedirectURI settings", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com:9443"}
 		params := &DexParams{
-			Hostname: "dex.example.com",
-			Port:     "9443",
 			Connectors: []Connector{
 				{
 					Type: "github",
@@ -436,7 +433,7 @@ func TestNewDexConfig_ConnectorRedirectURI(t *testing.T) {
 			},
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.Connectors).To(gomega.HaveLen(3))
 		// GitHub connector should have default RedirectURI
@@ -450,8 +447,8 @@ func TestNewDexConfig_ConnectorRedirectURI(t *testing.T) {
 	t.Run("does not modify original params connectors", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
-			Hostname: "dex.example.com",
 			Connectors: []Connector{
 				{
 					Type: "github",
@@ -465,7 +462,7 @@ func TestNewDexConfig_ConnectorRedirectURI(t *testing.T) {
 			},
 		}
 
-		_ = NewDexConfig(params)
+		_ = NewDexConfig(endpoint, params)
 
 		// Original params should not be modified
 		// Note: Since Config is a pointer, the original is modified in the current implementation.
@@ -478,12 +475,12 @@ func TestNewDexConfig_PasswordDB(t *testing.T) {
 	t.Run("enables password database", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
-			Hostname:         "dex.example.com",
 			EnablePasswordDB: true,
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.EnablePasswordDB).To(gomega.BeTrue())
 	})
@@ -491,12 +488,12 @@ func TestNewDexConfig_PasswordDB(t *testing.T) {
 	t.Run("disables password database when explicitly set", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
-			Hostname:         "dex.example.com",
 			EnablePasswordDB: false,
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.EnablePasswordDB).To(gomega.BeFalse())
 	})
@@ -504,8 +501,8 @@ func TestNewDexConfig_PasswordDB(t *testing.T) {
 	t.Run("includes static passwords", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
-			Hostname:         "dex.example.com",
 			EnablePasswordDB: true,
 			StaticPasswords: []Password{
 				{
@@ -523,7 +520,7 @@ func TestNewDexConfig_PasswordDB(t *testing.T) {
 			},
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.StaticPasswords).To(gomega.HaveLen(2))
 		g.Expect(config.StaticPasswords[0].Email).To(gomega.Equal("admin@example.com"))
@@ -533,13 +530,13 @@ func TestNewDexConfig_PasswordDB(t *testing.T) {
 	t.Run("configures password connector", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
-			Hostname:          "dex.example.com",
 			EnablePasswordDB:  true,
 			PasswordConnector: "local",
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 
 		g.Expect(config.OAuth2.PasswordConnector).To(gomega.Equal("local"))
 	})
@@ -549,6 +546,7 @@ func TestNewDexConfig_YAML_Output(t *testing.T) {
 	t.Run("generates valid YAML", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com:9443"}
 		params := &DexParams{
 			Hostname:                    "dex.example.com",
 			Port:                        "9443",
@@ -565,7 +563,7 @@ func TestNewDexConfig_YAML_Output(t *testing.T) {
 			},
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 		yamlData, err := config.ToYAML()
 
 		g.Expect(err).NotTo(gomega.HaveOccurred())
@@ -581,12 +579,12 @@ func TestNewDexConfig_YAML_Output(t *testing.T) {
 	t.Run("omits empty fields in YAML", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		endpoint := &url.URL{Scheme: "https", Host: "dex.example.com"}
 		params := &DexParams{
-			Hostname:         "dex.example.com",
 			EnablePasswordDB: false,
 		}
 
-		config := NewDexConfig(params)
+		config := NewDexConfig(endpoint, params)
 		yamlData, err := config.ToYAML()
 
 		g.Expect(err).NotTo(gomega.HaveOccurred())

--- a/operator/pkg/dex/openshift.go
+++ b/operator/pkg/dex/openshift.go
@@ -17,7 +17,7 @@ limitations under the License.
 package dex
 
 import (
-	"fmt"
+	"net/url"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,15 +39,10 @@ const (
 // BuildOpenShiftOAuthServiceAccount creates a ServiceAccount for OpenShift OAuth integration.
 // The ServiceAccount includes the oauth-redirecturi annotation that configures
 // OpenShift OAuth with the exact redirect URI for the Dex callback.
-// hostname and port are used to construct the full redirect URI.
-func BuildOpenShiftOAuthServiceAccount(namespace, hostname, port string) *corev1.ServiceAccount {
+// endpoint is the base URL used to construct the full redirect URI.
+func BuildOpenShiftOAuthServiceAccount(namespace string, endpoint *url.URL) *corev1.ServiceAccount {
 	// Build the redirect URI with the Dex callback path
-	var redirectURI string
-	if port != "" {
-		redirectURI = fmt.Sprintf("https://%s:%s%s", hostname, port, DexCallbackPath)
-	} else {
-		redirectURI = fmt.Sprintf("https://%s%s", hostname, DexCallbackPath)
-	}
+	redirectURI := endpoint.JoinPath(DexCallbackPath).String()
 
 	return &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{

--- a/operator/pkg/dex/openshift_test.go
+++ b/operator/pkg/dex/openshift_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dex
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -26,8 +27,9 @@ import (
 func TestBuildOpenShiftOAuthServiceAccount(t *testing.T) {
 	t.Run("creates service account with correct name and namespace", func(t *testing.T) {
 		g := gomega.NewWithT(t)
+		endpoint, _ := url.Parse("https://example.com")
 
-		sa := BuildOpenShiftOAuthServiceAccount("konflux-ui", "example.com", "")
+		sa := BuildOpenShiftOAuthServiceAccount("konflux-ui", endpoint)
 
 		g.Expect(sa.Name).To(gomega.Equal(DexClientServiceAccountName))
 		g.Expect(sa.Namespace).To(gomega.Equal("konflux-ui"))
@@ -35,8 +37,9 @@ func TestBuildOpenShiftOAuthServiceAccount(t *testing.T) {
 
 	t.Run("includes oauth redirect uri annotation without port", func(t *testing.T) {
 		g := gomega.NewWithT(t)
+		endpoint, _ := url.Parse("https://example.com")
 
-		sa := BuildOpenShiftOAuthServiceAccount("konflux-ui", "example.com", "")
+		sa := BuildOpenShiftOAuthServiceAccount("konflux-ui", endpoint)
 
 		g.Expect(sa.Annotations).To(gomega.HaveKeyWithValue(
 			"serviceaccounts.openshift.io/oauth-redirecturi.dex",
@@ -46,8 +49,9 @@ func TestBuildOpenShiftOAuthServiceAccount(t *testing.T) {
 
 	t.Run("includes oauth redirect uri annotation with port", func(t *testing.T) {
 		g := gomega.NewWithT(t)
+		endpoint, _ := url.Parse("https://example.com:9443")
 
-		sa := BuildOpenShiftOAuthServiceAccount("konflux-ui", "example.com", "9443")
+		sa := BuildOpenShiftOAuthServiceAccount("konflux-ui", endpoint)
 
 		g.Expect(sa.Annotations).To(gomega.HaveKeyWithValue(
 			"serviceaccounts.openshift.io/oauth-redirecturi.dex",
@@ -57,8 +61,9 @@ func TestBuildOpenShiftOAuthServiceAccount(t *testing.T) {
 
 	t.Run("sets correct TypeMeta", func(t *testing.T) {
 		g := gomega.NewWithT(t)
+		endpoint, _ := url.Parse("https://example.com")
 
-		sa := BuildOpenShiftOAuthServiceAccount("konflux-ui", "example.com", "")
+		sa := BuildOpenShiftOAuthServiceAccount("konflux-ui", endpoint)
 
 		g.Expect(sa.APIVersion).To(gomega.Equal("v1"))
 		g.Expect(sa.Kind).To(gomega.Equal("ServiceAccount"))


### PR DESCRIPTION
### **User description**
instead of manipulating strings, use the URL struct from the standard library.

Assisted-By: Cursor


___

### **PR Type**
Enhancement


___

### **Description**
- Replace string-based hostname/port parameters with `net/url.URL` struct

- Simplify URL construction using `url.URL` methods like `JoinPath()` and `String()`

- Update function signatures across controller, dex, oauth2proxy, and ingress packages

- Refactor tests to use `url.URL` instead of separate hostname/port parameters


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["String-based<br/>hostname/port"] -->|Refactor| B["net/url.URL<br/>struct"]
  B -->|Used in| C["Controller"]
  B -->|Used in| D["Dex Config"]
  B -->|Used in| E["OAuth2Proxy"]
  B -->|Used in| F["Ingress"]
  C -->|Simplifies| G["URL Construction"]
  D -->|Simplifies| G
  E -->|Simplifies| G
  F -->|Simplifies| G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>konfluxui_controller.go</strong><dd><code>Replace hostname/port parameters with endpoint URL struct</code></dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4327/files#diff-6f5f29dbe74096042cd8c822f09474ba5c4a89d4e76376250b120cacd62ddb4f">+48/-51</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>builder.go</strong><dd><code>Accept endpoint URL instead of hostname/port parameters</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4327/files#diff-45dea9ea81260d38d16e4517edebd7a3308d362efcd3a845f51fbb1eb844cc85">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>openshift.go</strong><dd><code>Use url.URL.JoinPath() for redirect URI construction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4327/files#diff-5f9546fd9e890b149d3959fe1c34dbc4a977866abc21d09225c9cc652e7b4170">+4/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingress.go</strong><dd><code>Return url.URL from DetermineEndpointURL function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4327/files#diff-b234c899dd590d5d7b3f7a4f7f6e74cd7496c8620f25f6325e35b6db1f745545">+22/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.go</strong><dd><code>Replace hostname/port with url.URL and use JoinPath()</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4327/files#diff-30d5b502efaacbdb8c3b86628bde99c3a8340db9b7d1659fb20f902047df562e">+16/-29</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>konfluxui_customization_test.go</strong><dd><code>Update tests to use url.URL endpoint parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4327/files#diff-3eccecb21b1d43fd3d29d1dacce32321cf676cfd6f75a566f0e7855fac99e803">+28/-24</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>builder_test.go</strong><dd><code>Refactor tests to use url.URL endpoint parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4327/files#diff-cb2225162a492f14e3a78bc41626c2f1084faba2ac69ac49872b79d82f0f24c9">+66/-68</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>openshift_test.go</strong><dd><code>Update tests to use url.URL endpoint parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4327/files#diff-73cf24960baf3cfa89579bcde5ed799e14911f94b8bc9b7d6e7d2cda9afd3474">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingress_test.go</strong><dd><code>Update tests for DetermineEndpointURL returning url.URL</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4327/files#diff-c5e8120f8a6a52a6f71668c505a64061e57c2b9f9a631411e3a4c643f2301af0">+24/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>config_test.go</strong><dd><code>Refactor tests to use url.URL endpoint parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4327/files#diff-2f28cef9c5027003c84f686b01282e15b3cd08e52cc4c73f096067a82567cec6">+12/-54</a>&nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

