### PR TITLE
refactor: decouple status update from UpdateComponentStatuses

### DIFF
--- a/operator/internal/controller/konfluxapplicationapi_controller.go
+++ b/operator/internal/controller/konfluxapplicationapi_controller.go
@@ -83,6 +83,12 @@ func (r *KonfluxApplicationAPIReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
+	// Update status
+	if err := r.Status().Update(ctx, applicationAPI); err != nil {
+		log.Error(err, "Failed to update status")
+		return ctrl.Result{}, err
+	}
+
 	log.Info("Successfully reconciled KonfluxApplicationAPI")
 	return ctrl.Result{}, nil
 }

--- a/operator/internal/controller/konfluxbuildservice_controller.go
+++ b/operator/internal/controller/konfluxbuildservice_controller.go
@@ -109,6 +109,12 @@ func (r *KonfluxBuildServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, err
 	}
 
+	// Update status
+	if err := r.Status().Update(ctx, buildService); err != nil {
+		log.Error(err, "Failed to update status")
+		return ctrl.Result{}, err
+	}
+
 	log.Info("Successfully reconciled KonfluxBuildService")
 	return ctrl.Result{}, nil
 }

--- a/operator/internal/controller/konfluxcertmanager_controller.go
+++ b/operator/internal/controller/konfluxcertmanager_controller.go
@@ -123,6 +123,12 @@ func (r *KonfluxCertManagerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
+	// Update status
+	if err := r.Status().Update(ctx, certManager); err != nil {
+		log.Error(err, "Failed to update status")
+		return ctrl.Result{}, err
+	}
+
 	log.Info("Successfully reconciled KonfluxCertManager")
 	return ctrl.Result{}, nil
 }

--- a/operator/internal/controller/konfluxenterprisecontract_controller.go
+++ b/operator/internal/controller/konfluxenterprisecontract_controller.go
@@ -98,6 +98,12 @@ func (r *KonfluxEnterpriseContractReconciler) Reconcile(ctx context.Context, req
 		return ctrl.Result{}, err
 	}
 
+	// Update status
+	if err := r.Status().Update(ctx, konfluxEnterpriseContract); err != nil {
+		log.Error(err, "Failed to update status")
+		return ctrl.Result{}, err
+	}
+
 	log.Info("Successfully reconciled KonfluxEnterpriseContract")
 	return ctrl.Result{}, nil
 }

--- a/operator/internal/controller/konfluximagecontroller_controller.go
+++ b/operator/internal/controller/konfluximagecontroller_controller.go
@@ -98,6 +98,12 @@ func (r *KonfluxImageControllerReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
+	// Update status
+	if err := r.Status().Update(ctx, imageController); err != nil {
+		log.Error(err, "Failed to update status")
+		return ctrl.Result{}, err
+	}
+
 	log.Info("Successfully reconciled KonfluxImageController")
 	return ctrl.Result{}, nil
 }

--- a/operator/internal/controller/konfluxinfo_controller.go
+++ b/operator/internal/controller/konfluxinfo_controller.go
@@ -130,6 +130,12 @@ func (r *KonfluxInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
+	// Update status
+	if err := r.Status().Update(ctx, konfluxInfo); err != nil {
+		log.Error(err, "Failed to update status")
+		return ctrl.Result{}, err
+	}
+
 	log.Info("Successfully reconciled KonfluxInfo")
 	return ctrl.Result{}, nil
 }

--- a/operator/internal/controller/konfluxintegrationservice_controller.go
+++ b/operator/internal/controller/konfluxintegrationservice_controller.go
@@ -108,6 +108,12 @@ func (r *KonfluxIntegrationServiceReconciler) Reconcile(ctx context.Context, req
 		return ctrl.Result{}, err
 	}
 
+	// Update status
+	if err := r.Status().Update(ctx, integrationService); err != nil {
+		log.Error(err, "Failed to update status")
+		return ctrl.Result{}, err
+	}
+
 	log.Info("Successfully reconciled KonfluxIntegrationService")
 	return ctrl.Result{}, nil
 }

--- a/operator/internal/controller/konfluxinternalregistry_controller.go
+++ b/operator/internal/controller/konfluxinternalregistry_controller.go
@@ -130,6 +130,12 @@ func (r *KonfluxInternalRegistryReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{}, err
 	}
 
+	// Update status
+	if err := r.Status().Update(ctx, registry); err != nil {
+		log.Error(err, "Failed to update status")
+		return ctrl.Result{}, err
+	}
+
 	log.Info("Successfully reconciled KonfluxInternalRegistry")
 	return ctrl.Result{}, nil
 }

--- a/operator/internal/controller/konfluxnamespacelister_controller.go
+++ b/operator/internal/controller/konfluxnamespacelister_controller.go
@@ -102,6 +102,12 @@ func (r *KonfluxNamespaceListerReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
+	// Update status
+	if err := r.Status().Update(ctx, konfluxNamespaceLister); err != nil {
+		log.Error(err, "Failed to update status")
+		return ctrl.Result{}, err
+	}
+
 	log.Info("Successfully reconciled KonfluxNamespaceLister")
 	return ctrl.Result{}, nil
 }

--- a/operator/internal/controller/konfluxrbac_controller.go
+++ b/operator/internal/controller/konfluxrbac_controller.go
@@ -92,6 +92,12 @@ func (r *KonfluxRBACReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
+	// Update status
+	if err := r.Status().Update(ctx, konfluxRBAC); err != nil {
+		log.Error(err, "Failed to update status")
+		return ctrl.Result{}, err
+	}
+
 	log.Info("Successfully reconciled KonfluxRBAC")
 	return ctrl.Result{}, nil
 }

--- a/operator/internal/controller/konfluxreleaseservice_controller.go
+++ b/operator/internal/controller/konfluxreleaseservice_controller.go
@@ -107,6 +107,12 @@ func (r *KonfluxReleaseServiceReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
+	// Update status
+	if err := r.Status().Update(ctx, releaseService); err != nil {
+		log.Error(err, "Failed to update status")
+		return ctrl.Result{}, err
+	}
+
 	log.Info("Successfully reconciled KonfluxReleaseService")
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
### **User description**
Move the Kubernetes API status update out of UpdateComponentStatuses and into each reconciler. This allows callers to batch multiple status changes and perform a single update at the end of the reconcile loop, avoiding "Operation cannot be fulfilled" conflicts when multiple status modifications occur during reconciliation.

Changes:
- conditions.go: Remove k8sClient.Status().Update() call from UpdateComponentStatuses, making it only modify the CR in memory
- Update all 11 reconcilers to explicitly call r.Status().Update() after UpdateComponentStatuses:
  - konfluxapplicationapi_controller.go
  - konfluxbuildservice_controller.go
  - konfluxcertmanager_controller.go
  - konfluxenterprisecontract_controller.go
  - konfluximagecontroller_controller.go
  - konfluxinfo_controller.go
  - konfluxintegrationservice_controller.go
  - konfluxinternalregistry_controller.go
  - konfluxnamespacelister_controller.go
  - konfluxrbac_controller.go
  - konfluxreleaseservice_controller.go

Assisted-By: Cursor


___

### **PR Type**
Enhancement


___

### **Description**
- Decouple Kubernetes API status updates from UpdateComponentStatuses function

- Function now only modifies CR in memory, allowing status batching

- Add explicit r.Status().Update() calls in all 11 reconcilers

- Prevents "Operation cannot be fulfilled" conflicts during reconciliation

- Remove unused logf import from conditions.go


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UpdateComponentStatuses<br/>In-memory only"] --> B["Reconciler calls<br/>r.Status().Update()"]
  B --> C["Single API update<br/>per reconcile loop"]
  C --> D["Avoid conflicts<br/>from multiple changes"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>conditions.go</strong><dd><code>Remove status update and logging from function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4392/files#diff-d4dad1c305ea20ed6ecfb10830dc9d1ddba5a54106177c876e17c73bbddd7f9d">+7/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>konfluxapplicationapi_controller.go</strong><dd><code>Add explicit status update after UpdateComponentStatuses</code>&nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4392/files#diff-234687c6b9e6a19bd6a8e598f0fa9be8fab64b6c02ed75d6a1765f3e7dabfa02">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxbuildservice_controller.go</strong><dd><code>Add explicit status update after UpdateComponentStatuses</code>&nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4392/files#diff-65fb49be09e9389255ffa6d0b5425da83af3e6040b4be2813ebd70cfcd80f205">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxcertmanager_controller.go</strong><dd><code>Add explicit status update after UpdateComponentStatuses</code>&nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4392/files#diff-e01f177462be9326342dbb0267eeea28f74b7ad3fcc39bf9c1020bc174deef2f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxenterprisecontract_controller.go</strong><dd><code>Add explicit status update after UpdateComponentStatuses</code>&nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4392/files#diff-3db02087417c14a7230e9e3b0d63b429ea5d63cb1015ca0154dbd3735adb020f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluximagecontroller_controller.go</strong><dd><code>Add explicit status update after UpdateComponentStatuses</code>&nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4392/files#diff-9c201299460bbc68f46e57b072517af6d8f15ac44770a91c50fb90fee4f1b873">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxinfo_controller.go</strong><dd><code>Add explicit status update after UpdateComponentStatuses</code>&nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4392/files#diff-04aaed1c83aece35c6881cddde382689072119032b4be082f5ae31a75cc6559c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxintegrationservice_controller.go</strong><dd><code>Add explicit status update after UpdateComponentStatuses</code>&nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4392/files#diff-8472d40d856ef7d1dab9d2f2cb7568f6240d4bed2303fa47bac9303c91fa1191">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxinternalregistry_controller.go</strong><dd><code>Add explicit status update after UpdateComponentStatuses</code>&nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4392/files#diff-e95e13aed38b0c2bafa44f43256b4eee266c6e77b23bc2fe553c4b148e1a0991">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxnamespacelister_controller.go</strong><dd><code>Add explicit status update after UpdateComponentStatuses</code>&nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4392/files#diff-3a62806bdf88017ff177cd5c02423fa920b93e82dc6de0f99df9e41d8fc1baf4">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxrbac_controller.go</strong><dd><code>Add explicit status update after UpdateComponentStatuses</code>&nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4392/files#diff-5af1fbb5b81f61f56fa2f0357c1b05d875f0dd672ebe5b62e4dd70b83d7caf7b">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxreleaseservice_controller.go</strong><dd><code>Add explicit status update after UpdateComponentStatuses</code>&nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4392/files#diff-818b43dab9a9caa3663fa5c631ccf1315249fda7c6022c731ac7645751ab5403">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

