### PR TITLE
Add rules to appstudio-runner cluster role

### DIFF
--- a/operator/pkg/manifests/build-service/manifests.yaml
+++ b/operator/pkg/manifests/build-service/manifests.yaml
@@ -76,7 +76,53 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: appstudio-pipelines-runner
-rules: null
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - appstudio-pipelines-scc
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - enterprisecontractpolicies
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - eaas.konflux-ci.dev
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - create
+  - delete
+  - list
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns
+  - taskruns
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ci.openshift.org
+  resources:
+  - testplatformclusters
+  verbs:
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/operator/upstream-kustomizations/build-service/core/appstudio-pipelines-runner.yaml
+++ b/operator/upstream-kustomizations/build-service/core/appstudio-pipelines-runner.yaml
@@ -1,6 +1,52 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: appstudio-pipelines-runner
 rules:
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - secrets
+  - verbs:
+      - use
+    apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - appstudio-pipelines-scc
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - enterprisecontractpolicies
+  - verbs:
+      - get
+      - create
+      - delete
+      - list
+      - watch
+    apiGroups:
+      - eaas.konflux-ci.dev
+    resources:
+      - namespaces
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+      - taskruns
+  - verbs:
+      - "*"
+    apiGroups:
+      - ci.openshift.org
+    resources:
+      - testplatformclusters


### PR DESCRIPTION
### **User description**
The cluster role didn't have the required rules in it, which are required by the service account the build service use to run the build pipeline.


___

### **PR Type**
Enhancement


___

### **Description**
- Add RBAC rules to `appstudio-pipelines-runner` cluster role

- Enable access to secrets, security context constraints, and policies

- Grant permissions for Tekton pipeline runs and task runs

- Allow management of test platform clusters and namespaces


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["appstudio-pipelines-runner<br/>ClusterRole"] -->|"Add rules"| B["Secrets access<br/>get, list"]
  A -->|"Add rules"| C["SCC permissions<br/>use appstudio-pipelines-scc"]
  A -->|"Add rules"| D["Enterprise Contract<br/>Policies access"]
  A -->|"Add rules"| E["Tekton resources<br/>PipelineRuns, TaskRuns"]
  A -->|"Add rules"| F["Test Platform<br/>Clusters management"]
  A -->|"Add rules"| G["EaaS Namespaces<br/>CRUD operations"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifests.yaml</strong><dd><code>Add RBAC rules to appstudio-pipelines-runner cluster role</code></dd></summary>
<hr>

operator/pkg/manifests/build-service/manifests.yaml

<ul><li>Replace empty <code>rules: null</code> with comprehensive RBAC rules<br> <li> Add permissions for secrets, security context constraints, and <br>enterprise contract policies<br> <li> Grant access to Tekton pipeline runs and task runs<br> <li> Enable management of test platform clusters and EaaS namespaces</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4397/files#diff-b6ebcb551aa02f1fff746c1340fab93b39d5639f2bc158fa522af5f96cd3205e">+47/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>appstudio-pipelines-runner.yaml</strong><dd><code>Populate RBAC rules in appstudio-pipelines-runner definition</code></dd></summary>
<hr>

operator/upstream-kustomizations/build-service/core/appstudio-pipelines-runner.yaml

<ul><li>Reorder apiVersion and kind fields for consistency<br> <li> Populate empty rules with seven RBAC permission rules<br> <li> Add permissions for secrets, SCC, enterprise contract policies, Tekton <br>resources, and test platform clusters<br> <li> Enable namespace management operations in EaaS API group</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4397/files#diff-702656fbb3f863874aaae2957579ec679c86d2d7df81cb3dc4fd65c36f283cc3">+47/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

