### PR TITLE
fix(KFLUXVNGD-648): enable renovate for upstream manifests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,17 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "ignorePaths": [
-    "operator/upstream-kustomizations/application-api/**",
-    "operator/upstream-kustomizations/build-service/monitoring/**",
-    "operator/upstream-kustomizations/build-service/core/kustomization.yaml",
-    "operator/upstream-kustomizations/build-service/kustomization.yaml",
-    "operator/upstream-kustomizations/enterprise-contract/core/**",
-    "operator/upstream-kustomizations/image-controller/**",
-    "operator/upstream-kustomizations/integration/**",
-    "operator/upstream-kustomizations/namespace-lister/**",
-    "operator/upstream-kustomizations/rbac/**",
-    "operator/upstream-kustomizations/release/**",
-    "operator/upstream-kustomizations/ui/**",
     "operator/pkg/manifests/**"
   ],
   "packageRules": [
@@ -70,7 +59,10 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["konflux-ci/enterprise-contract/core/kustomization.yaml"],
+      "fileMatch": [
+        "konflux-ci/enterprise-contract/core/kustomization.yaml",
+        "operator/upstream-kustomizations/enterprise-contract/core/kustomization.yaml"
+      ],
       "matchStrings": [
         "- verify_ec_task_bundle=(?<depName>quay\\.io/enterprise-contract/ec-task-bundle)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
@@ -81,7 +73,10 @@
     {
       "customType": "regex",
       "matchStringsStrategy": "combination",
-      "fileMatch": ["konflux-ci/enterprise-contract/core/kustomization.yaml"],
+      "fileMatch": [
+        "konflux-ci/enterprise-contract/core/kustomization.yaml",
+        "operator/upstream-kustomizations/enterprise-contract/core/kustomization.yaml"
+      ],
       "matchStrings": [
         "- verify_ec_task_git_url=(?<packageName>https:\/\/github\\.com\/enterprise-contract\/ec-cli)\\.git",
         "- verify_ec_task_git_revision=(?<currentDigest>[a-f0-9]{40})"


### PR DESCRIPTION
### **User description**
The automation we have for keeping the upstream manifests up to date are based on the assumption that each upstream manifest that needs to be tracked has a git repo reference, according to which we can also track its image. However, some of the upstream manifests we have are image-only.

To cover these cases, we are enabling renovate for tracking the upstream manifests. It might be that in the future we will disable the part of the automation that tracks the git repos and only have it run kustomize build to vendor the operator baseline manifests.

Assisted-by: Cursor


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Enable Renovate to track image-only upstream manifests

- Remove upstream-kustomizations paths from ignorePaths

- Add enterprise-contract core kustomization to Renovate rules

- Support automated dependency updates for previously untracked manifests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Renovate Configuration"] -->|Remove ignorePaths| B["Upstream Kustomizations"]
  A -->|Add fileMatch rules| C["Enterprise Contract Core"]
  B -->|Enable tracking| D["Image-only Manifests"]
  C -->|Track dependencies| E["Docker Images & Git Refs"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Enable Renovate tracking for upstream manifests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renovate.json

<ul><li>Removed 13 upstream-kustomizations paths from ignorePaths array to <br>enable Renovate tracking<br> <li> Added <br>operator/upstream-kustomizations/enterprise-contract/core/kustomization.yaml <br>to two existing package rules for docker and git-refs datasources<br> <li> Reformatted fileMatch arrays for better readability with multi-line <br>formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4400/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+8/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

