### PR TITLE
feat(build-service): conditionally apply SCC on OpenShift only

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -41,6 +41,7 @@ import (
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	consolev1 "github.com/openshift/api/console/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller"
@@ -59,6 +60,7 @@ func init() {
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	utilruntime.Must(certmanagerv1.AddToScheme(scheme))
 	utilruntime.Must(consolev1.AddToScheme(scheme))
+	utilruntime.Must(securityv1.Install(scheme))
 
 	utilruntime.Must(konfluxv1alpha1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
@@ -267,6 +269,7 @@ func main() {
 		Client:      mgr.GetClient(),
 		Scheme:      mgr.GetScheme(),
 		ObjectStore: objectStore,
+		ClusterInfo: clusterInfo,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KonfluxBuildService")
 		os.Exit(1)

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -578,6 +578,16 @@ rules:
   - bind
   - escalate
 - apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - trust.cert-manager.io
   resources:
   - bundles

--- a/operator/internal/controller/konfluxbuildservice_controller_test.go
+++ b/operator/internal/controller/konfluxbuildservice_controller_test.go
@@ -21,13 +21,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	securityv1 "github.com/openshift/api/security/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 )
 
 var _ = Describe("KonfluxBuildService Controller", func() {
@@ -81,4 +84,149 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
 		})
 	})
+
+	Context("OpenShift SecurityContextConstraints", func() {
+		const sccName = "appstudio-pipelines-scc"
+
+		var (
+			ctx                  context.Context
+			buildService         *konfluxv1alpha1.KonfluxBuildService
+			reconciler           *KonfluxBuildServiceReconciler
+			openShiftClusterInfo *clusterinfo.Info
+			defaultClusterInfo   *clusterinfo.Info
+			typeNamespacedName   types.NamespacedName
+		)
+
+		sccExists := func(ctx context.Context) bool {
+			scc := &securityv1.SecurityContextConstraints{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: sccName}, scc)
+			return err == nil
+		}
+
+		reconcileBuildService := func(ctx context.Context) {
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		}
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			typeNamespacedName = types.NamespacedName{
+				Name:      KonfluxBuildServiceCRName,
+				Namespace: "default",
+			}
+
+			By("cleaning up any existing SCC from previous tests")
+			existingSCC := &securityv1.SecurityContextConstraints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: sccName,
+				},
+			}
+			_ = k8sClient.Delete(ctx, existingSCC)
+
+			By("creating mock cluster info for OpenShift and non-OpenShift platforms")
+			var err error
+			openShiftClusterInfo, err = clusterinfo.DetectWithClient(&buildServiceMockDiscoveryClient{
+				resources: map[string]*metav1.APIResourceList{
+					"config.openshift.io/v1": {
+						APIResources: []metav1.APIResource{
+							{Kind: "ClusterVersion"},
+						},
+					},
+				},
+				serverVersion: &version.Info{GitVersion: "v1.29.0"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			defaultClusterInfo, err = clusterinfo.DetectWithClient(&buildServiceMockDiscoveryClient{
+				resources:     map[string]*metav1.APIResourceList{},
+				serverVersion: &version.Info{GitVersion: "v1.29.0"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating the KonfluxBuildService resource")
+			buildService = &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      KonfluxBuildServiceCRName,
+					Namespace: "default",
+				},
+				Spec: konfluxv1alpha1.KonfluxBuildServiceSpec{},
+			}
+			err = k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxBuildService{})
+			if errors.IsNotFound(err) {
+				Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+			}
+
+			reconciler = &KonfluxBuildServiceReconciler{
+				Client:      k8sClient,
+				Scheme:      k8sClient.Scheme(),
+				ObjectStore: objectStore,
+				ClusterInfo: nil, // Will be set in individual tests
+			}
+		})
+
+		AfterEach(func() {
+			By("cleaning up the SCC")
+			existingSCC := &securityv1.SecurityContextConstraints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: sccName,
+				},
+			}
+			_ = k8sClient.Delete(ctx, existingSCC)
+
+			By("cleaning up KonfluxBuildService resource")
+			_ = k8sClient.Delete(ctx, buildService)
+		})
+
+		It("Should create SCC when running on OpenShift", func() {
+			By("setting ClusterInfo to OpenShift")
+			reconciler.ClusterInfo = openShiftClusterInfo
+
+			By("reconciling the resource")
+			reconcileBuildService(ctx)
+
+			By("verifying the SCC was created")
+			Expect(sccExists(ctx)).To(BeTrue())
+		})
+
+		It("Should NOT create SCC when NOT running on OpenShift", func() {
+			By("setting ClusterInfo to non-OpenShift")
+			reconciler.ClusterInfo = defaultClusterInfo
+
+			By("reconciling the resource")
+			reconcileBuildService(ctx)
+
+			By("verifying the SCC was NOT created")
+			Expect(sccExists(ctx)).To(BeFalse())
+		})
+
+		It("Should NOT create SCC when ClusterInfo is nil", func() {
+			By("keeping ClusterInfo as nil")
+			reconciler.ClusterInfo = nil
+
+			By("reconciling the resource")
+			reconcileBuildService(ctx)
+
+			By("verifying the SCC was NOT created")
+			Expect(sccExists(ctx)).To(BeFalse())
+		})
+	})
 })
+
+// buildServiceMockDiscoveryClient implements clusterinfo.DiscoveryClient for testing.
+type buildServiceMockDiscoveryClient struct {
+	resources     map[string]*metav1.APIResourceList
+	serverVersion *version.Info
+}
+
+func (m *buildServiceMockDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	if r, ok := m.resources[groupVersion]; ok {
+		return r, nil
+	}
+	return nil, errors.NewNotFound(schema.GroupResource{Group: groupVersion}, "")
+}
+
+func (m *buildServiceMockDiscoveryClient) ServerVersion() (*version.Info, error) {
+	return m.serverVersion, nil
+}

--- a/operator/internal/controller/suite_test.go
+++ b/operator/internal/controller/suite_test.go
@@ -37,8 +37,9 @@ import (
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 
-	// Import openshift/api for ConsoleLink types and CRDs
+	// Import openshift/api for ConsoleLink and SecurityContextConstraints types and CRDs
 	consolev1 "github.com/openshift/api/console/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -72,6 +73,9 @@ var _ = BeforeSuite(func() {
 	err = consolev1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = securityv1.Install(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
 	// +kubebuilder:scaffold:scheme
 
 	// Parse all embedded manifests into an ObjectStore
@@ -83,6 +87,7 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "config", "crd", "bases"),
 			filepath.Join(getGoModuleDir("github.com/openshift/api"), "console", "v1", "zz_generated.crd-manifests"),
+			filepath.Join(getGoModuleDir("github.com/openshift/api"), "security", "v1", "zz_generated.crd-manifests"),
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/operator/pkg/manifests/build-service/manifests.yaml
+++ b/operator/pkg/manifests/build-service/manifests.yaml
@@ -458,3 +458,44 @@ spec:
           name: trusted-ca
           optional: true
         name: trusted-ca
+---
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- SETFCAP
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+- system:cluster-admins
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: appstudio-pipelines-scc
+  namespace: build-service
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/operator/upstream-kustomizations/build-service/core/appstudio-pipeline-scc.yaml
+++ b/operator/upstream-kustomizations/build-service/core/appstudio-pipeline-scc.yaml
@@ -1,0 +1,39 @@
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- SETFCAP
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+- system:cluster-admins
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: appstudio-pipelines-scc
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/operator/upstream-kustomizations/build-service/core/kustomization.yaml
+++ b/operator/upstream-kustomizations/build-service/core/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - build-config-rolebinding.yaml
   - appstudio-pipelines-runner.yaml
   - build-pipeline-runner-rolebinding.yaml
+  - appstudio-pipeline-scc.yaml
 
 namespace: build-service
 


### PR DESCRIPTION
### **User description**
Add OpenShift detection to the KonfluxBuildService controller to conditionally create SecurityContextConstraints (SCC) only when running on OpenShift clusters.

On Openshift, the SCC is required for the build-pipeline, without it some of its task won't be able to execute.

Changes:
- Add ClusterInfo field to KonfluxBuildServiceReconciler
- Skip SCC application on non-OpenShift clusters using type assertion
- Add RBAC permissions for securitycontextconstraints
- Register OpenShift security/v1 types in scheme (main.go and test suite)
- Add envtest coverage for SCC conditional logic

Assisted-By: Cursor


___

### **PR Type**
Enhancement


___

### **Description**
- Add OpenShift detection to conditionally apply SecurityContextConstraints

- Register OpenShift security/v1 API types in scheme

- Add RBAC permissions for securitycontextconstraints resource

- Include comprehensive test coverage for SCC conditional logic

- Add SCC manifest to build-service deployment configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["KonfluxBuildService Controller"] -->|"Add ClusterInfo field"| B["Cluster Detection"]
  B -->|"Check IsOpenShift"| C{"Running on OpenShift?"}
  C -->|"Yes"| D["Create SCC"]
  C -->|"No"| E["Skip SCC"]
  F["Register security/v1 Types"] -->|"Update Scheme"| G["API Types Available"]
  H["Add RBAC Rules"] -->|"Grant Permissions"| I["SCC Management"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Register OpenShift security API and inject ClusterInfo</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/cmd/main.go

<ul><li>Import OpenShift security/v1 API types<br> <li> Register security/v1 types in the scheme using <code>securityv1.Install()</code><br> <li> Pass <code>ClusterInfo</code> to <code>KonfluxBuildServiceReconciler</code> during <br>initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4407/files#diff-6951a7b3b8a59603497b68b62013a806397c640ce0a42a3862f6a4ffad4fda89">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>role.yaml</strong><dd><code>Add RBAC permissions for SecurityContextConstraints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/config/rbac/role.yaml

<ul><li>Add new RBAC rule for <code>security.openshift.io</code> group<br> <li> Grant permissions for <code>securitycontextconstraints</code> resource<br> <li> Allow create, get, list, patch, and watch verbs</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4407/files#diff-bf75d41206005954349fa60826c9cc3bd1a976c9e5c8884de0cb59ee68a13fa8">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>manifests.yaml</strong><dd><code>Add SecurityContextConstraints manifest to build-service</code>&nbsp; </dd></summary>
<hr>

operator/pkg/manifests/build-service/manifests.yaml

<ul><li>Add complete SecurityContextConstraints manifest for <br><code>appstudio-pipelines-scc</code><br> <li> Configure SCC with appropriate security policies and volume types<br> <li> Set priority to 10 and restrict to cluster-admins group</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4407/files#diff-b6ebcb551aa02f1fff746c1340fab93b39d5639f2bc158fa522af5f96cd3205e">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>appstudio-pipeline-scc.yaml</strong><dd><code>Create standalone SCC manifest file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/upstream-kustomizations/build-service/core/appstudio-pipeline-scc.yaml

<ul><li>Create new SCC manifest file for build-service deployment<br> <li> Define security policies including capability restrictions and volume <br>types<br> <li> Configure fsGroup, seLinuxContext, and runAsUser constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4407/files#diff-49bd27d8c66e3d82bc0db7293ec92b2aba9020f339999b2d9785315961c0f30c">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Include SCC in kustomization resources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/upstream-kustomizations/build-service/core/kustomization.yaml

- Add `appstudio-pipeline-scc.yaml` to kustomization resources list


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4407/files#diff-49e27336969e85fd630ea5a21f9a26990cd666d2bd3474231529ceaa91ae3c8c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>konfluxbuildservice_controller.go</strong><dd><code>Add OpenShift detection and SCC conditional application</code>&nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/konfluxbuildservice_controller.go

<ul><li>Import <code>securityv1</code> and <code>clusterinfo</code> packages<br> <li> Add <code>ClusterInfo</code> field to <code>KonfluxBuildServiceReconciler</code> struct<br> <li> Add RBAC annotation for <code>securitycontextconstraints</code> resource <br>permissions<br> <li> Implement conditional logic to skip SCC creation on non-OpenShift <br>clusters</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4407/files#diff-65fb49be09e9389255ffa6d0b5425da83af3e6040b4be2813ebd70cfcd80f205">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>konfluxbuildservice_controller_test.go</strong><dd><code>Add test coverage for SCC conditional logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/konfluxbuildservice_controller_test.go

<ul><li>Import security/v1 and clusterinfo packages<br> <li> Add comprehensive test suite for SCC conditional logic<br> <li> Create mock discovery client for testing cluster detection<br> <li> Test three scenarios: SCC creation on OpenShift, skipping on <br>non-OpenShift, and nil ClusterInfo</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4407/files#diff-ed2d7d52a9fb47fdb0b393ef53f81a1ade47e2361b47e12cfffb7c318cb83d06">+150/-2</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>suite_test.go</strong><dd><code>Register OpenShift security API in test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/suite_test.go

<ul><li>Import OpenShift security/v1 API types<br> <li> Register security/v1 types in test scheme using <code>securityv1.Install()</code><br> <li> Update comment to reflect SecurityContextConstraints support</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4407/files#diff-157288df70e66f14c013764a4b7d4372a2e447c9161c7bfb4611be5a70c139c3">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

