### PR TITLE
feat(KFLUXVNGD-605): enable basic releases

### DIFF
--- a/.github/scripts/prepare-release-notes.sh
+++ b/.github/scripts/prepare-release-notes.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+# Prepare Release Notes Script
+# This script generates release notes in markdown format for GitHub releases
+#
+# Usage:
+#   prepare-release-notes.sh <version> <image_tag> <commit_sha> <output_file>
+#
+# Example:
+#   prepare-release-notes.sh v0.2025.03 release-sha-abc1234 c515b60f474cb00a11176e5b400205a679b68aac /tmp/release-notes.md
+
+if [ $# -ne 4 ]; then
+  echo "Error: Invalid number of arguments"
+  echo "Usage: $0 <version> <image_tag> <commit_sha> <output_file>"
+  exit 1
+fi
+
+VERSION="$1"
+IMAGE_TAG="$2"
+COMMIT_SHA="$3"
+OUTPUT_FILE="$4"
+
+# Generate release notes
+cat > "${OUTPUT_FILE}" <<EOF
+## Release ${VERSION}
+
+### Installation
+\`\`\`bash
+kubectl apply -f https://github.com/konflux-ci/konflux-ci/releases/download/${VERSION}/install.yaml
+\`\`\`
+
+### Image
+- **Repository**: quay.io/konflux-ci/konflux-operator
+- **Tag**: ${IMAGE_TAG}
+- **Commit SHA**: ${COMMIT_SHA}
+- **Pull command**: \`podman pull quay.io/konflux-ci/konflux-operator:${IMAGE_TAG}\`
+
+### Artifacts
+- install.yaml - Complete installation manifest (references SHA-tagged image)
+EOF
+
+echo "Release notes generated at: ${OUTPUT_FILE}"

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,84 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., v0.2025.03)'
+        required: true
+        type: string
+      commit_sha:
+        description: 'Full commit SHA to release'
+        required: true
+        type: string
+      image_tag:
+        description: 'Image tag (e.g., release-sha-abc1234)'
+        required: true
+        type: string
+      draft:
+        description: 'Create as draft release (for testing - no notifications)'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: operator
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.commit_sha }}
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: operator/go.mod
+
+      - name: Generate install.yaml
+        env:
+          IMG: quay.io/konflux-ci/konflux-operator:${{ inputs.image_tag }}
+        run: |
+          make build-installer IMG=${IMG}
+
+          echo "Generated install.yaml at: $(pwd)/dist/install.yaml"
+          ls -lh dist/install.yaml
+
+      - name: Prepare release notes
+        id: release-notes
+        run: |
+          .github/scripts/prepare-release-notes.sh \
+            "${{ inputs.version }}" \
+            "${{ inputs.image_tag }}" \
+            "${{ inputs.commit_sha }}" \
+            /tmp/release-notes.md
+          echo "notes_file=/tmp/release-notes.md" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create release using official GitHub CLI (gh)
+          # Uses GITHUB_TOKEN (if permissions are insufficient, we can add GitHub App token later)
+          # --notes prepends our custom content, --generate-notes appends commit history
+          # --draft flag creates a draft release (no notifications, hidden from main releases page)
+          DRAFT_FLAG=""
+          if [ "${{ inputs.draft }}" == "true" ]; then
+            DRAFT_FLAG="--draft"
+            echo "Creating draft release (no notifications will be sent)"
+          fi
+
+          gh release create "${{ inputs.version }}" \
+            --title "Release ${{ inputs.version }}" \
+            --notes-file /tmp/release-notes.md \
+            --generate-notes \
+            $DRAFT_FLAG \
+            operator/dist/install.yaml \
+            --target "${{ inputs.commit_sha }}"


### PR DESCRIPTION
### **User description**
This enable very basic manual releases. The process will be augmented later on to automate the process further.

Assisted-by: Cursor


___

### **PR Type**
Enhancement


___

### **Description**
- Add manual GitHub release workflow with customizable inputs

- Create release notes generation script for standardized formatting

- Support draft releases for testing without notifications

- Include install.yaml artifact and commit history in releases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manual Trigger"] -->|version, commit_sha, image_tag| B["Create Release Workflow"]
  B -->|generates| C["install.yaml"]
  B -->|executes| D["Release Notes Script"]
  D -->|produces| E["Formatted Release Notes"]
  C -->|attached to| F["GitHub Release"]
  E -->|attached to| F
  F -->|draft or published| G["Release Published"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prepare-release-notes.sh</strong><dd><code>Release notes generation script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/scripts/prepare-release-notes.sh

<ul><li>New bash script to generate markdown-formatted release notes<br> <li> Accepts version, image tag, commit SHA, and output file as parameters<br> <li> Generates standardized release notes with installation instructions, <br>image details, and artifacts section<br> <li> Includes error handling for invalid argument count</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4428/files#diff-6b3805b09ff7047976073026dd5afe2ab59d640ffe03849be54632483ab4c44d">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create-release.yaml</strong><dd><code>Manual GitHub release creation workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/create-release.yaml

<ul><li>New GitHub Actions workflow triggered manually via workflow_dispatch<br> <li> Accepts version, commit SHA, image tag, and draft flag as inputs<br> <li> Generates install.yaml using make build-installer with specified image <br>tag<br> <li> Calls prepare-release-notes.sh to create formatted release notes<br> <li> Creates GitHub release with generated notes, commit history, and <br>install.yaml artifact<br> <li> Supports draft releases for testing without sending notifications<br> <li> Uses GitHub App token for authentication with fallback to GITHUB_TOKEN</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4428/files#diff-a318819fb0ec8889018cbef8e6dd222e317757d95ddd93b62b714ac7c49f04f6">+94/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

