### PR TITLE
chore(KFLUXVNGD-605): make auto-generated notes optional

### DIFF
--- a/.github/scripts/create-release.sh
+++ b/.github/scripts/create-release.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -euo pipefail
+
+# Create Release Script
+# This script creates a GitHub release using the GitHub CLI
+#
+# Usage:
+#   create-release.sh <version> <commit_sha> <notes_file> <artifact_file> <draft> <generate_notes>
+#
+# Arguments:
+#   version        - Release version (e.g., v0.2025.01)
+#   commit_sha     - Full commit SHA to release
+#   notes_file     - Path to release notes markdown file
+#   artifact_file  - Path to artifact file to upload
+#   draft          - "true" to create as draft, "false" otherwise
+#   generate_notes - "true" to auto-generate commit history, "false" otherwise
+#
+# Example:
+#   create-release.sh v0.2025.01 c5683934bbdf40fc5517d9cf491b381c4a2f049d /tmp/release-notes.md operator/dist/install.yaml true false
+
+if [ $# -ne 6 ]; then
+  echo "Error: Invalid number of arguments"
+  echo "Usage: $0 <version> <commit_sha> <notes_file> <artifact_file> <draft> <generate_notes>"
+  echo "  draft and generate_notes should be 'true' or 'false'"
+  exit 1
+fi
+
+VERSION="$1"
+COMMIT_SHA="$2"
+NOTES_FILE="$3"
+ARTIFACT_FILE="$4"
+DRAFT="$5"
+GENERATE_NOTES="$6"
+
+# Build flags based on boolean inputs
+DRAFT_FLAG=""
+if [ "$DRAFT" == "true" ]; then
+  DRAFT_FLAG="--draft"
+  echo "Creating draft release (no notifications will be sent)"
+fi
+
+GENERATE_NOTES_FLAG=""
+if [ "$GENERATE_NOTES" == "true" ]; then
+  GENERATE_NOTES_FLAG="--generate-notes"
+  echo "Auto-generating commit history"
+else
+  echo "Skipping auto-generated commit history (use generate_notes=true for future releases)"
+fi
+
+# Verify files exist
+if [ ! -f "$NOTES_FILE" ]; then
+  echo "Error: Notes file not found: $NOTES_FILE"
+  exit 1
+fi
+
+if [ ! -f "$ARTIFACT_FILE" ]; then
+  echo "Error: Artifact file not found: $ARTIFACT_FILE"
+  exit 1
+fi
+
+# Create release using official GitHub CLI (gh)
+# Uses GITHUB_TOKEN (if permissions are insufficient, we can add GitHub App token later)
+gh release create "$VERSION" \
+  --title "Release $VERSION" \
+  --notes-file "$NOTES_FILE" \
+  $GENERATE_NOTES_FLAG \
+  $DRAFT_FLAG \
+  "$ARTIFACT_FILE" \
+  --target "$COMMIT_SHA"
+
+echo "Release created successfully: $VERSION"

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -20,6 +20,11 @@ on:
         required: false
         type: boolean
         default: true
+      generate_notes:
+        description: 'Auto-generate commit history (skip for first release with many commits)'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   create-release:
@@ -67,20 +72,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Create release using official GitHub CLI (gh)
-          # Uses GITHUB_TOKEN (if permissions are insufficient, we can add GitHub App token later)
-          # --notes prepends our custom content, --generate-notes appends commit history
-          # --draft flag creates a draft release (no notifications, hidden from main releases page)
-          DRAFT_FLAG=""
-          if [ "${{ inputs.draft }}" == "true" ]; then
-            DRAFT_FLAG="--draft"
-            echo "Creating draft release (no notifications will be sent)"
-          fi
-
-          gh release create "${{ inputs.version }}" \
-            --title "Release ${{ inputs.version }}" \
-            --notes-file /tmp/release-notes.md \
-            --generate-notes \
-            $DRAFT_FLAG \
+          .github/scripts/create-release.sh \
+            "${{ inputs.version }}" \
+            "${{ inputs.commit_sha }}" \
+            /tmp/release-notes.md \
             operator/dist/install.yaml \
-            --target "${{ inputs.commit_sha }}"
+            "${{ inputs.draft }}" \
+            "${{ inputs.generate_notes }}"


### PR DESCRIPTION
### **User description**
Since it has been a long time since the last release, the auto-generated release notes are very long and exceed the max release notes length on GitHub.

Making this optional, so we can make the first release pass. Later on, the notes will be shorted.

Assisted-by: Cursor


___

### **PR Type**
Enhancement


___

### **Description**
- Extract release creation logic into reusable shell script

- Add optional auto-generated notes parameter to workflow

- Allow skipping commit history generation for releases

- Improve release workflow flexibility and maintainability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  WF["Workflow Input<br/>generate_notes param"]
  SCRIPT["create-release.sh<br/>Script"]
  GH["GitHub CLI<br/>gh release create"]
  RELEASE["GitHub Release<br/>Created"]
  
  WF -- "passes flag" --> SCRIPT
  SCRIPT -- "conditionally adds<br/>--generate-notes" --> GH
  GH -- "creates" --> RELEASE
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-release.sh</strong><dd><code>New release creation script with optional notes generation</code></dd></summary>
<hr>

.github/scripts/create-release.sh

<ul><li>New shell script that encapsulates GitHub release creation logic<br> <li> Accepts 6 parameters including version, commit SHA, notes file, <br>artifact, draft flag, and generate_notes flag<br> <li> Conditionally applies <code>--generate-notes</code> flag based on input parameter<br> <li> Includes validation for required files and informative logging</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4439/files#diff-9080a746afd84bf19a232e917724b9112a336a9e62c472df01b14bbe942612c2">+71/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create-release.yaml</strong><dd><code>Workflow refactored to use external script with optional notes</code></dd></summary>
<hr>

.github/workflows/create-release.yaml

<ul><li>Add new <code>generate_notes</code> input parameter (boolean, default false)<br> <li> Refactor inline release creation logic to call external script<br> <li> Pass all parameters including draft and generate_notes flags to script<br> <li> Remove hardcoded <code>--generate-notes</code> flag from workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4439/files#diff-a318819fb0ec8889018cbef8e6dd222e317757d95ddd93b62b714ac7c49f04f6">+11/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

