### PR TITLE
feat(KFLUXVNGD-605): detect git commit from quay image

### DIFF
--- a/.github/scripts/create-release.sh
+++ b/.github/scripts/create-release.sh
@@ -5,11 +5,11 @@ set -euo pipefail
 # This script creates a GitHub release using the GitHub CLI
 #
 # Usage:
-#   create-release.sh <version> <commit_sha> <notes_file> <artifact_dir> <draft> <generate_notes>
+#   create-release.sh <version> <git_ref> <notes_file> <artifact_dir> <draft> <generate_notes>
 #
 # Arguments:
 #   version        - Release version (e.g., v0.2025.01)
-#   commit_sha     - Full commit SHA to release
+#   git_ref        - Git ref to release (commit SHA, branch, or tag)
 #   notes_file     - Path to release notes markdown file
 #   artifact_dir   - Directory containing artifact files to upload
 #   draft          - "true" to create as draft, "false" otherwise
@@ -17,16 +17,17 @@ set -euo pipefail
 #
 # Example:
 #   create-release.sh v0.2025.01 c5683934bbdf40fc5517d9cf491b381c4a2f049d /tmp/release-notes.md operator/dist true false
+#   create-release.sh v0.2025.01 main /tmp/release-notes.md operator/dist true false
 
 if [ $# -ne 6 ]; then
   echo "Error: Invalid number of arguments"
-  echo "Usage: $0 <version> <commit_sha> <notes_file> <artifact_dir> <draft> <generate_notes>"
+  echo "Usage: $0 <version> <git_ref> <notes_file> <artifact_dir> <draft> <generate_notes>"
   echo "  draft and generate_notes should be 'true' or 'false'"
   exit 1
 fi
 
 VERSION="$1"
-COMMIT_SHA="$2"
+GIT_REF="$2"
 NOTES_FILE="$3"
 ARTIFACT_DIR="$4"
 DRAFT="$5"
@@ -80,6 +81,6 @@ gh release create "$VERSION" \
   $GENERATE_NOTES_FLAG \
   $DRAFT_FLAG \
   "${ARTIFACTS[@]}" \
-  --target "$COMMIT_SHA"
+  --target "$GIT_REF"
 
 echo "Release created successfully: $VERSION"

--- a/.github/scripts/detect-sha-from-quay.sh
+++ b/.github/scripts/detect-sha-from-quay.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+set -euo pipefail
+
+# Detect SHA from Quay Script
+# This script detects the latest image tag from Quay and maps the short SHA to full commit SHA.
+# If image_tag or commit_sha (git ref) are provided, they are used (with validation).
+# Otherwise, values are auto-detected from Quay.
+#
+# Usage:
+#   detect-sha-from-quay.sh [repository_root] [image_tag] [commit_sha]
+#
+# Arguments:
+#   repository_root - Optional path to repository root (default: current directory)
+#   image_tag       - Optional image tag (e.g., release-sha-abc1234). If not provided, will detect from Quay
+#   commit_sha      - Optional git ref (commit SHA, branch, or tag). If not provided, will detect from Quay
+#
+# Outputs (to stdout, key=value format):
+#   image_tag=value
+#   git_ref=value
+#
+# Example:
+#   detect-sha-from-quay.sh
+#   detect-sha-from-quay.sh . release-sha-abc1234
+#   detect-sha-from-quay.sh . "" c32df7f1234567890abcdef1234567890abcdef12
+
+REPO_ROOT="${1:-.}"
+PROVIDED_IMAGE_TAG="${2:-}"
+PROVIDED_GIT_REF="${3:-}"
+REPO_NAMESPACE="konflux-ci"
+REPO_NAME="konflux-operator"
+QUAY_API_URL="https://quay.io/api/v1"
+
+cd "${REPO_ROOT}"
+
+# If both are provided, validate and use them
+if [ -n "${PROVIDED_IMAGE_TAG}" ] && [ -n "${PROVIDED_GIT_REF}" ]; then
+    echo "Using provided values" >&2
+
+    # Validate git ref exists (can be SHA, branch, or tag)
+    if ! git rev-parse --verify "${PROVIDED_GIT_REF}" >/dev/null 2>&1; then
+        echo "Error: Provided git ref not found: ${PROVIDED_GIT_REF}" >&2
+        exit 1
+    fi
+
+    echo "image_tag=${PROVIDED_IMAGE_TAG}"
+    echo "git_ref=${PROVIDED_GIT_REF}"
+    exit 0
+fi
+
+# Determine image_tag: use provided or detect from Quay
+if [ -n "${PROVIDED_IMAGE_TAG}" ]; then
+    IMAGE_TAG="${PROVIDED_IMAGE_TAG}"
+    echo "Using provided image_tag: ${IMAGE_TAG}" >&2
+else
+    # Need to detect image tag from Quay
+    echo "Detecting latest image from Quay..." >&2
+
+    # Query Quay API for tags matching release-sha-* pattern
+    # Get tags, filter for release-sha-*, sort by timestamp (latest first), get the first one
+    latest_tag=$(curl -s "${QUAY_API_URL}/repository/${REPO_NAMESPACE}/${REPO_NAME}/tag/?limit=100&onlyActiveTags=true" \
+        | jq -r '[.tags[] | select(.name | startswith("release-sha-"))] | sort_by(.start_ts) | reverse | .[0].name // empty' 2>/dev/null || echo "")
+
+    if [ -z "${latest_tag}" ]; then
+        echo "Error: No release-sha-* tags found in Quay repository ${REPO_NAMESPACE}/${REPO_NAME}" >&2
+        exit 1
+    fi
+
+    IMAGE_TAG="${latest_tag}"
+    echo "Using detected image_tag: ${IMAGE_TAG}" >&2
+fi
+
+# If git ref is provided, validate it
+if [ -n "${PROVIDED_GIT_REF}" ]; then
+    GIT_REF="${PROVIDED_GIT_REF}"
+    echo "Using provided git ref: ${GIT_REF}" >&2
+
+    # Validate git ref exists (can be SHA, branch, or tag)
+    if ! git rev-parse --verify "${GIT_REF}" >/dev/null 2>&1; then
+        echo "Error: Provided git ref not found: ${GIT_REF}" >&2
+        exit 1
+    fi
+else
+    # Need to extract short SHA from image tag to map to full commit SHA
+    # Extract short SHA from image tag (e.g., release-sha-c32df7f -> c32df7f)
+    short_sha="${IMAGE_TAG#release-sha-}"
+
+    if [ -z "${short_sha}" ]; then
+        echo "Error: Could not extract SHA from image tag: ${IMAGE_TAG}" >&2
+        exit 1
+    fi
+
+    echo "Extracted short SHA: ${short_sha}" >&2
+
+    # Map short SHA to full commit SHA using git rev-parse
+    full_sha=$(git rev-parse "${short_sha}" 2>/dev/null || echo "")
+
+    if [ -z "${full_sha}" ]; then
+        # If rev-parse fails, try to fetch and search
+        echo "Short SHA not found locally, attempting to fetch..." >&2
+        git fetch origin --depth=100 2>/dev/null || true
+
+        # Try again after fetch
+        full_sha=$(git rev-parse "${short_sha}" 2>/dev/null || echo "")
+    fi
+
+    if [ -z "${full_sha}" ]; then
+        echo "Error: Could not resolve short SHA ${short_sha} to full commit SHA" >&2
+        echo "Make sure the repository is checked out and the commit exists" >&2
+        exit 1
+    fi
+
+    # Verify it's a valid full SHA (40 characters for SHA-1)
+    # This validation is needed here because we're extracting from release-sha-* tags
+    if [ ${#full_sha} -ne 40 ]; then
+        echo "Error: Resolved SHA is not a full commit SHA: ${full_sha}" >&2
+        exit 1
+    fi
+
+    GIT_REF="${full_sha}"
+    echo "Mapped to full SHA: ${GIT_REF}" >&2
+fi
+
+# Output in key=value format for easy parsing
+echo "image_tag=${IMAGE_TAG}"
+echo "git_ref=${GIT_REF}"

--- a/.github/scripts/prepare-release-notes.sh
+++ b/.github/scripts/prepare-release-notes.sh
@@ -5,20 +5,27 @@ set -euo pipefail
 # This script generates release notes in markdown format for GitHub releases
 #
 # Usage:
-#   prepare-release-notes.sh <version> <image_tag> <commit_sha> <output_file>
+#   prepare-release-notes.sh <version> <image_tag> <git_ref> <output_file>
+#
+# Arguments:
+#   version     - Release version (e.g., v0.2025.03)
+#   image_tag   - Image tag (e.g., release-sha-abc1234)
+#   git_ref     - Git ref (commit SHA, branch, or tag)
+#   output_file - Path to output file
 #
 # Example:
 #   prepare-release-notes.sh v0.2025.03 release-sha-abc1234 c515b60f474cb00a11176e5b400205a679b68aac /tmp/release-notes.md
+#   prepare-release-notes.sh v0.2025.03 release-sha-abc1234 main /tmp/release-notes.md
 
 if [ $# -ne 4 ]; then
   echo "Error: Invalid number of arguments"
-  echo "Usage: $0 <version> <image_tag> <commit_sha> <output_file>"
+  echo "Usage: $0 <version> <image_tag> <git_ref> <output_file>"
   exit 1
 fi
 
 VERSION="$1"
 IMAGE_TAG="$2"
-COMMIT_SHA="$3"
+GIT_REF="$3"
 OUTPUT_FILE="$4"
 
 # Generate release notes
@@ -33,7 +40,7 @@ kubectl apply -f https://github.com/konflux-ci/konflux-ci/releases/download/${VE
 ### Image
 - **Repository**: quay.io/konflux-ci/konflux-operator
 - **Tag**: ${IMAGE_TAG}
-- **Commit SHA**: ${COMMIT_SHA}
+- **Git Ref**: ${GIT_REF}
 - **Pull command**: \`podman pull quay.io/konflux-ci/konflux-operator:${IMAGE_TAG}\`
 
 ### Artifacts

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -7,13 +7,13 @@ on:
         description: 'Release version (e.g., v0.0.1). If not provided, will auto-calculate from latest release'
         required: false
         type: string
-      commit_sha:
-        description: 'Full commit SHA to release'
-        required: true
+      git_ref:
+        description: 'Git ref to release (commit SHA, branch, or tag). If not provided, will auto-detect from latest Quay image'
+        required: false
         type: string
       image_tag:
-        description: 'Image tag (e.g., release-sha-abc1234)'
-        required: true
+        description: 'Image tag (e.g., release-sha-abc1234). If not provided, will auto-detect from latest Quay image'
+        required: false
         type: string
       draft:
         description: 'Create as draft release (for testing - no notifications)'
@@ -39,8 +39,31 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.commit_sha }}
           fetch-depth: 0
+
+      - name: Detect SHA and image tag from Quay
+        id: detect-sha
+        working-directory: ${{ github.workspace }}
+        run: |
+          result=$(.github/scripts/detect-sha-from-quay.sh \
+            "${{ github.workspace }}" \
+            "${{ inputs.image_tag }}" \
+            "${{ inputs.git_ref }}")
+          echo "${result}" | grep "^image_tag=" >> $GITHUB_OUTPUT
+          echo "${result}" | grep "^git_ref=" >> $GITHUB_OUTPUT
+
+      - name: Checkout target commit
+        working-directory: ${{ github.workspace }}
+        run: |
+          TARGET_REF="${{ inputs.git_ref || steps.detect-sha.outputs.git_ref }}"
+          CURRENT_SHA=$(git rev-parse HEAD)
+          TARGET_SHA=$(git rev-parse "${TARGET_REF}")
+          if [ "${TARGET_SHA}" != "${CURRENT_SHA}" ]; then
+            echo "Checking out target ref: ${TARGET_REF}"
+            git checkout "${TARGET_REF}"
+          else
+            echo "Already on target ref: ${TARGET_REF}"
+          fi
 
       - name: Calculate or use provided version
         id: version
@@ -59,7 +82,8 @@ jobs:
 
       - name: Generate release artifacts
         run: |
-          bash ${{ github.workspace }}/.github/scripts/generate-release-artifacts.sh "${{ inputs.image_tag }}"
+          .github/scripts/generate-release-artifacts.sh \
+            "${{ inputs.image_tag || steps.detect-sha.outputs.image_tag }}"
 
       - name: Prepare release notes
         id: release-notes
@@ -67,8 +91,8 @@ jobs:
         run: |
           .github/scripts/prepare-release-notes.sh \
             "${{ steps.version.outputs.version }}" \
-            "${{ inputs.image_tag }}" \
-            "${{ inputs.commit_sha }}" \
+            "${{ inputs.image_tag || steps.detect-sha.outputs.image_tag }}" \
+            "${{ inputs.git_ref || steps.detect-sha.outputs.git_ref }}" \
             /tmp/release-notes.md
           echo "notes_file=/tmp/release-notes.md" >> $GITHUB_OUTPUT
 
@@ -79,7 +103,7 @@ jobs:
         run: |
           .github/scripts/create-release.sh \
             "${{ steps.version.outputs.version }}" \
-            "${{ inputs.commit_sha }}" \
+            "${{ inputs.git_ref || steps.detect-sha.outputs.git_ref }}" \
             /tmp/release-notes.md \
             operator/dist \
             "${{ inputs.draft }}" \


### PR DESCRIPTION
### **User description**
Our release process will take the latest image in the registry and create a release based on this image and the commit that triggered it.

This commit adds a script that detects the git sha from the quay image.

Assisted-by: Curosr


___

### **PR Type**
Enhancement


___

### **Description**
- Add auto-detection of git commit SHA from Quay image tags

- Make git_ref and image_tag optional workflow inputs with auto-detection

- Refactor scripts to support flexible git references (SHA, branch, tag)

- Implement Quay API integration to fetch latest release-sha-* image tags


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow Input<br/>git_ref, image_tag"] --> B["detect-sha-from-quay.sh"]
  C["Quay API"] --> B
  D["Git Repository"] --> B
  B --> E["Resolved Values<br/>git_ref, image_tag"]
  E --> F["Checkout Target Commit"]
  E --> G["Generate Release Notes"]
  E --> H["Create GitHub Release"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>detect-sha-from-quay.sh</strong><dd><code>New script to detect SHA from Quay images</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/scripts/detect-sha-from-quay.sh

<ul><li>New script that detects latest image tag from Quay API with <br>release-sha-* pattern<br> <li> Maps short SHA from image tag to full commit SHA using git rev-parse<br> <li> Supports optional parameters for image_tag and git_ref with validation<br> <li> Handles git fetch fallback when short SHA not found locally<br> <li> Outputs key=value format for easy parsing in workflows</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4456/files#diff-754e0e94d2497e84b17f8a68e92f69e7c7e9f8709e1755e260ba43933861994a">+125/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create-release.sh</strong><dd><code>Refactor to support flexible git references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/scripts/create-release.sh

<ul><li>Rename parameter from commit_sha to git_ref for flexibility<br> <li> Update documentation to reflect support for commit SHA, branch, or tag<br> <li> Update usage examples to show branch reference usage<br> <li> Update gh release create command to use git_ref variable</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4456/files#diff-9080a746afd84bf19a232e917724b9112a336a9e62c472df01b14bbe942612c2">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>prepare-release-notes.sh</strong><dd><code>Update to use flexible git references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/scripts/prepare-release-notes.sh

<ul><li>Rename parameter from commit_sha to git_ref<br> <li> Update documentation with argument descriptions and examples<br> <li> Update release notes template to display git_ref instead of commit SHA<br> <li> Add example showing branch reference usage</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4456/files#diff-6b3805b09ff7047976073026dd5afe2ab59d640ffe03849be54632483ab4c44d">+11/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create-release.yaml</strong><dd><code>Implement auto-detection workflow with optional inputs</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/create-release.yaml

<ul><li>Make git_ref and image_tag workflow inputs optional with <br>auto-detection<br> <li> Add new detect-sha-from-quay step to auto-detect values from Quay<br> <li> Add checkout target commit step to handle dynamic ref resolution<br> <li> Remove hardcoded ref from initial checkout action<br> <li> Update subsequent steps to use detected or provided values with <br>fallback<br> <li> Update generate-release-artifacts call to use detected image_tag</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4456/files#diff-a318819fb0ec8889018cbef8e6dd222e317757d95ddd93b62b714ac7c49f04f6">+34/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

