### PR TITLE
fix: add missing proxy_pass for WebSocket endpoint and add tests

### DIFF
--- a/konflux-ci/ui/core/proxy/nginx.conf
+++ b/konflux-ci/ui/core/proxy/nginx.conf
@@ -49,7 +49,7 @@ http {
         }
 
         location = /oauth2/auth {
-            internal; 
+            internal;
             proxy_pass       http://127.0.0.1:6000;
             proxy_set_header Host             $host;
             proxy_set_header X-Real-IP        $remote_addr;
@@ -78,6 +78,7 @@ http {
         location /wss/k8s/ {
             auth_request /oauth2/auth;
 
+            proxy_pass https://kubernetes.default.svc/;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;

--- a/operator/pkg/manifests/ui/manifests.yaml
+++ b/operator/pkg/manifests/ui/manifests.yaml
@@ -108,6 +108,28 @@ subjects:
 ---
 apiVersion: v1
 data:
+  auth.conf: |
+    # Auth configuration with impersonate headers
+    auth_request_set $user  $upstream_http_x_auth_request_email;
+    proxy_set_header Impersonate-User $user;
+    proxy_set_header Impersonate-Group system:authenticated;
+    proxy_set_header Authorization "Bearer __BEARER_TOKEN__";
+  tekton-results.conf: |
+    location /api/k8s/plugins/tekton-results/ {
+        auth_request /oauth2/auth;
+
+        rewrite /api/k8s/plugins/tekton-results/(.+) /$1 break;
+        proxy_read_timeout 30m;
+        proxy_pass https://__TEKTON_RESULTS_HOSTNAME__:8080;
+        include /mnt/nginx-generated-config/auth.conf;
+    }
+kind: ConfigMap
+metadata:
+  name: proxy-nginx-templates-dt292585th
+  namespace: konflux-ui
+---
+apiVersion: v1
+data:
   nginx.conf: |
     worker_processes auto;
     error_log /var/log/nginx/error.log;
@@ -189,6 +211,7 @@ data:
             location /wss/k8s/ {
                 auth_request /oauth2/auth;
 
+                proxy_pass https://kubernetes.default.svc/;
                 proxy_http_version 1.1;
                 proxy_set_header Upgrade $http_upgrade;
                 proxy_set_header Connection $connection_upgrade;
@@ -250,29 +273,7 @@ data:
     }
 kind: ConfigMap
 metadata:
-  name: proxy-d2bh9588df
-  namespace: konflux-ui
----
-apiVersion: v1
-data:
-  auth.conf: |
-    # Auth configuration with impersonate headers
-    auth_request_set $user  $upstream_http_x_auth_request_email;
-    proxy_set_header Impersonate-User $user;
-    proxy_set_header Impersonate-Group system:authenticated;
-    proxy_set_header Authorization "Bearer __BEARER_TOKEN__";
-  tekton-results.conf: |
-    location /api/k8s/plugins/tekton-results/ {
-        auth_request /oauth2/auth;
-
-        rewrite /api/k8s/plugins/tekton-results/(.+) /$1 break;
-        proxy_read_timeout 30m;
-        proxy_pass https://__TEKTON_RESULTS_HOSTNAME__:8080;
-        include /mnt/nginx-generated-config/auth.conf;
-    }
-kind: ConfigMap
-metadata:
-  name: proxy-nginx-templates-dt292585th
+  name: proxy-t8gc9c9fbh
   namespace: konflux-ui
 ---
 apiVersion: v1
@@ -516,7 +517,7 @@ spec:
         - -R
         - /opt/app-root/src/.
         - /mnt/static-content/
-        image: quay.io/konflux-ci/konflux-ui@sha256:8a99a673ab73461ba9a29b69579aa462bd04bbc06cda46a44229612420e583aa
+        image: quay.io/konflux-ci/konflux-ui@sha256:036f2d9ba5a9e99f1485fae12662cd26714ecf832f6741f63ce97407df23c0e6
         name: copy-static-content
         resources:
           limits:
@@ -555,7 +556,7 @@ spec:
           fi
           sed "s/__TEKTON_RESULTS_HOSTNAME__/$results_hostname/" /mnt/nginx-templates/tekton-results.conf > /mnt/nginx-generated-location-config/tekton-results.conf
           chmod 640 /mnt/nginx-generated-location-config/tekton-results.conf
-        image: quay.io/konflux-ci/konflux-ui@sha256:8a99a673ab73461ba9a29b69579aa462bd04bbc06cda46a44229612420e583aa
+        image: quay.io/konflux-ci/konflux-ui@sha256:036f2d9ba5a9e99f1485fae12662cd26714ecf832f6741f63ce97407df23c0e6
         name: generate-nginx-configs
         resources:
           limits:
@@ -590,7 +591,7 @@ spec:
           items:
           - key: nginx.conf
             path: nginx.conf
-          name: proxy-d2bh9588df
+          name: proxy-t8gc9c9fbh
         name: proxy
       - configMap:
           defaultMode: 420

--- a/operator/upstream-kustomizations/ui/core/proxy/nginx.conf
+++ b/operator/upstream-kustomizations/ui/core/proxy/nginx.conf
@@ -78,6 +78,7 @@ http {
         location /wss/k8s/ {
             auth_request /oauth2/auth;
 
+            proxy_pass https://kubernetes.default.svc/;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;

--- a/test/go-tests/go.mod
+++ b/test/go-tests/go.mod
@@ -3,6 +3,7 @@ module github.com/konflux-ci/konflux-ci/test/go-tests
 go 1.24.0
 
 require (
+	github.com/coder/websocket v1.8.14
 	github.com/onsi/ginkgo/v2 v2.27.4
 	github.com/onsi/gomega v1.38.3
 	k8s.io/api v0.32.0

--- a/test/go-tests/go.sum
+++ b/test/go-tests/go.sum
@@ -1,5 +1,7 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=


### PR DESCRIPTION
### **User description**
fix: add missing proxy_pass for WebSocket endpoint and add tests

Add the missing proxy_pass directive for the /wss/k8s/ location in
nginx.conf files, which was preventing WebSocket connections from being
proxied to the Kubernetes API server.

Fixed in both:
- operator/upstream-kustomizations/ui/core/proxy/nginx.conf
- konflux-ci/ui/core/proxy/nginx.conf

Also add tests to verify WebSocket connections through the /wss/k8s/
proxy endpoint work correctly:

- Test authenticated WebSocket connections are established successfully
- Test unauthenticated WebSocket connections are rejected with 401

Key implementation details:
- Added Origin header which is required for WebSocket authentication
  through nginx/oauth2-proxy
- Used Subprotocols option for K8s base64.binary.k8s.io protocol
- Added github.com/coder/websocket dependency

This prevents regressions in WebSocket proxy functionality.

Assisted-By: Cursor


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add missing `proxy_pass` directive to `/wss/k8s/` nginx location

- Implement WebSocket connection tests for authenticated and unauthenticated scenarios

- Add `github.com/coder/websocket` dependency for WebSocket testing

- Reorganize nginx ConfigMap templates in deployment manifest


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["nginx.conf<br/>Missing proxy_pass"] -->|"Add proxy_pass<br/>directive"| B["WebSocket<br/>Proxying Fixed"]
  C["Test Suite"] -->|"Add WebSocket<br/>connection tests"| D["Authenticated<br/>& Unauthenticated<br/>Coverage"]
  E["Dependencies"] -->|"Add coder/websocket<br/>library"| F["WebSocket<br/>Testing Support"]
  B --> G["Functional<br/>WebSocket Proxy"]
  D --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nginx.conf</strong><dd><code>Add proxy_pass to WebSocket location block</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/upstream-kustomizations/ui/core/proxy/nginx.conf

<ul><li>Added missing <code>proxy_pass https://kubernetes.default.svc/;</code> directive to <br><code>/wss/k8s/</code> location block<br> <li> Directive was previously absent, preventing WebSocket connections from <br>being proxied to Kubernetes API</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4457/files#diff-2c58bc8bd7b0beb96d16d261c07e1da255acfec2707ffb3bab2dfb856d68bccc">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>manifests.yaml</strong><dd><code>Fix WebSocket proxy and reorganize ConfigMaps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/pkg/manifests/ui/manifests.yaml

<ul><li>Added missing <code>proxy_pass</code> directive to <code>/wss/k8s/</code> location in nginx.conf <br>ConfigMap<br> <li> Reorganized ConfigMap structure by moving <code>auth.conf</code> and <br><code>tekton-results.conf</code> templates to separate ConfigMap<br> <li> Updated image SHA256 hashes for <code>copy-static-content</code> and <br><code>generate-nginx-configs</code> init containers<br> <li> Updated ConfigMap name references in volume mounts to reflect new <br>structure</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4457/files#diff-b4087adab82021e5f589128ca400b3542479df861a6ecc3c5cb018510a5faeca">+27/-26</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proxy_test.go</strong><dd><code>Add WebSocket endpoint authentication tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/go-tests/proxy_test.go

<ul><li>Added WebSocket test suite with two test cases for <code>/wss/k8s/</code> endpoint<br> <li> Test authenticated WebSocket connections with Bearer token and Origin <br>header<br> <li> Test rejection of unauthenticated WebSocket connections with 401 <br>status<br> <li> Added imports for <code>time</code> package and <code>github.com/coder/websocket</code> library<br> <li> Added PipelineRuns entry to existing proxy endpoint tests</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4457/files#diff-8cd84d252048590d677a981b9945a6ab5d40058c2d44fd5017dac45f208b0c38">+59/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Add coder/websocket dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/go-tests/go.mod

<ul><li>Added <code>github.com/coder/websocket v1.8.14</code> as a new dependency for <br>WebSocket testing</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4457/files#diff-05fda3412ea1b3e76e213a92b4be459ef8844889d64f16c3de0e9a8b303d2584">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>go.sum</strong><dd><code>Update checksums for websocket dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/go-tests/go.sum

<ul><li>Added checksums for <code>github.com/coder/websocket v1.8.14</code> module and its <br>dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4457/files#diff-a6a99b0e6b3d0785ff2fcf5eb8ed944ae681a35da728064e5811337fdb3336d5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

