### PR TITLE
chore(KFLUXVNGD-605): use tag in output image

### DIFF
--- a/.tekton/konflux-operator-push.yaml
+++ b/.tekton/konflux-operator-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/konflux-vanguard-tenant/konflux-operator:{{revision}}
+    value: quay.io/redhat-user-workloads/konflux-vanguard-tenant/konflux-operator:{{revision}}{{git_tag}}
   - name: dockerfile
     value: Containerfile
   - name: path-context


### PR DESCRIPTION
### **User description**
To distinguish between builds made for push events and tag events. The added tag variable will be empty for push events.


___

### **PR Type**
Enhancement


___

### **Description**
- Add git tag variable to container image output tag

- Distinguish builds from push events vs tag events

- Tag variable remains empty for push events


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build Event"] --> B{"Event Type"}
  B -->|"Push Event"| C["Image Tag: revision"]
  B -->|"Tag Event"| D["Image Tag: revision + git_tag"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>konflux-operator-push.yaml</strong><dd><code>Add git tag to image output tag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.tekton/konflux-operator-push.yaml

<ul><li>Modified output-image parameter to include git_tag variable<br> <li> Image tag now uses format <code>{{revision}}{{git_tag}}</code><br> <li> Allows differentiation between push and tag event builds</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4495/files#diff-1137526f4d30c00c780c215d4a541867b2ba0aa4ec564f7f5a7c011a9cea48a1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

