### PR TITLE
fix(KFLUXVNGD-605): revert git_tag in pipeline run

### DIFF
--- a/.tekton/konflux-operator-push.yaml
+++ b/.tekton/konflux-operator-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/konflux-vanguard-tenant/konflux-operator:{{revision}}{{git_tag}}
+    value: quay.io/redhat-user-workloads/konflux-vanguard-tenant/konflux-operator:{{revision}}
   - name: dockerfile
     value: Containerfile
   - name: path-context


### PR DESCRIPTION
### **User description**
git_tag variable was not being evaluated and was used literally, which broke the pipeline.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove unevaluated `{{git_tag}}` variable from image tag

- Fix pipeline image reference to use only revision parameter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Pipeline Image Tag"] -->|"Remove {{git_tag}}"| B["Fixed Image Reference"]
  B -->|"Uses only {{revision}}"| C["Correct Tag Evaluation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>konflux-operator-push.yaml</strong><dd><code>Remove unevaluated git_tag from image tag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.tekton/konflux-operator-push.yaml

<ul><li>Removed <code>{{git_tag}}</code> variable from the output-image parameter value<br> <li> Image tag now uses only <code>{{revision}}</code> for proper variable evaluation<br> <li> Fixes broken pipeline caused by literal git_tag string in image <br>reference</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4496/files#diff-1137526f4d30c00c780c215d4a541867b2ba0aa4ec564f7f5a7c011a9cea48a1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

