### PR TITLE
refactor(operator): centralize condition handling and reduce code dup…

### DIFF
--- a/operator/internal/condition/condition_test.go
+++ b/operator/internal/condition/condition_test.go
@@ -50,9 +50,9 @@ var _ = Describe("Conditions Helper Functions", func() {
 					NotReadyNames: []string{},
 				}
 
-				SetOverallReadyCondition(testObject, "Ready", summary)
+				SetOverallReadyCondition(testObject, summary)
 
-				condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+				condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
 				Expect(condition).NotTo(BeNil())
 				Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 				Expect(condition.Reason).To(Equal("AllComponentsReady"))
@@ -67,9 +67,9 @@ var _ = Describe("Conditions Helper Functions", func() {
 					NotReadyNames: []string{},
 				}
 
-				SetOverallReadyCondition(testObject, "Ready", summary)
+				SetOverallReadyCondition(testObject, summary)
 
-				condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+				condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
 				Expect(condition).NotTo(BeNil())
 				Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 				Expect(condition.Message).To(Equal("All 5 deployments are ready"))
@@ -82,9 +82,9 @@ var _ = Describe("Conditions Helper Functions", func() {
 					NotReadyNames: []string{"deployment-1", "deployment-2"},
 				}
 
-				SetOverallReadyCondition(testObject, "Ready", summary)
+				SetOverallReadyCondition(testObject, summary)
 
-				condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+				condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
 				Expect(condition).NotTo(BeNil())
 				Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 				Expect(condition.Reason).To(Equal("ComponentsNotReady"))
@@ -100,9 +100,9 @@ var _ = Describe("Conditions Helper Functions", func() {
 					NotReadyNames: []string{},
 				}
 
-				SetOverallReadyCondition(testObject, "Ready", summary)
+				SetOverallReadyCondition(testObject, summary)
 
-				condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+				condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
 				Expect(condition).NotTo(BeNil())
 				Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 				Expect(condition.Reason).To(Equal("AllComponentsReady"))
@@ -116,28 +116,12 @@ var _ = Describe("Conditions Helper Functions", func() {
 					TotalCount: 0,
 				}
 
-				SetOverallReadyCondition(testObject, "Ready", summary)
+				SetOverallReadyCondition(testObject, summary)
 
-				condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+				condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
 				Expect(condition).NotTo(BeNil())
 				Expect(condition.Message).NotTo(Equal("All 0 deployments are ready"))
 				Expect(condition.Message).To(Equal("Component ready (no deployments to track)"))
-			})
-		})
-
-		Context("when using custom condition types", func() {
-			It("should respect the custom ready condition type", func() {
-				summary := DeploymentStatusSummary{
-					AllReady:   true,
-					TotalCount: 0,
-				}
-
-				SetOverallReadyCondition(testObject, "CustomReady", summary)
-
-				condition := apimeta.FindStatusCondition(testObject.GetConditions(), "CustomReady")
-				Expect(condition).NotTo(BeNil())
-				Expect(condition.Type).To(Equal("CustomReady"))
-				Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 			})
 		})
 	})
@@ -292,9 +276,9 @@ var _ = Describe("Conditions Helper Functions", func() {
 				{Name: "component-2", Ready: true},
 			}
 
-			SetAggregatedReadyCondition(testObject, "Ready", subCRStatuses)
+			SetAggregatedReadyCondition(testObject, subCRStatuses)
 
-			condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+			condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
 			Expect(condition).NotTo(BeNil())
 			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 			Expect(condition.Reason).To(Equal("AllComponentsReady"))
@@ -307,9 +291,9 @@ var _ = Describe("Conditions Helper Functions", func() {
 				{Name: "component-2", Ready: false},
 			}
 
-			SetAggregatedReadyCondition(testObject, "Ready", subCRStatuses)
+			SetAggregatedReadyCondition(testObject, subCRStatuses)
 
-			condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+			condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
 			Expect(condition).NotTo(BeNil())
 			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 			Expect(condition.Reason).To(Equal("ComponentsNotReady"))
@@ -333,9 +317,9 @@ var _ = Describe("Conditions Helper Functions", func() {
 		It("should set a failed condition with error message", func() {
 			testErr := fmt.Errorf("something went wrong")
 
-			SetFailedCondition(testObject, "Ready", "ReconciliationFailed", testErr)
+			SetFailedCondition(testObject, TypeReady, "ReconciliationFailed", testErr)
 
-			condition := apimeta.FindStatusCondition(testObject.GetConditions(), "Ready")
+			condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
 			Expect(condition).NotTo(BeNil())
 			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 			Expect(condition.Reason).To(Equal("ReconciliationFailed"))

--- a/operator/internal/condition/constants.go
+++ b/operator/internal/condition/constants.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package condition
+
+// Condition type constants.
+// These are the standard condition types used across all Konflux CRs.
+const (
+	// TypeReady indicates the overall readiness of a resource.
+	TypeReady = "Ready"
+)
+
+// Condition reason constants.
+// These reasons provide standardized explanations for condition states.
+const (
+	// ReasonAllComponentsReady indicates all components are ready.
+	ReasonAllComponentsReady = "AllComponentsReady"
+
+	// ReasonComponentsNotReady indicates one or more components are not ready.
+	ReasonComponentsNotReady = "ComponentsNotReady"
+
+	// ReasonDeploymentReady indicates a deployment is ready.
+	ReasonDeploymentReady = "DeploymentReady"
+
+	// ReasonDeploymentNotReady indicates a deployment is not ready.
+	ReasonDeploymentNotReady = "DeploymentNotReady"
+
+	// ReasonApplyFailed indicates that applying resources failed.
+	ReasonApplyFailed = "ApplyFailed"
+
+	// ReasonCleanupFailed indicates that cleanup of orphaned resources failed.
+	ReasonCleanupFailed = "CleanupFailed"
+
+	// ReasonStatusUpdateFailed indicates that fetching deployment status failed.
+	ReasonStatusUpdateFailed = "StatusUpdateFailed"
+
+	// ReasonNamespaceCreationFailed indicates that namespace creation failed.
+	ReasonNamespaceCreationFailed = "NamespaceCreationFailed"
+
+	// ReasonEndpointDeterminationFailed indicates that endpoint URL determination failed.
+	ReasonEndpointDeterminationFailed = "EndpointDeterminationFailed"
+
+	// ReasonConfigMapFailed indicates that ConfigMap reconciliation failed.
+	ReasonConfigMapFailed = "ConfigMapFailed"
+
+	// ReasonIngressReconcileFailed indicates that Ingress reconciliation failed.
+	ReasonIngressReconcileFailed = "IngressReconcileFailed"
+
+	// ReasonSecretCreationFailed indicates that secret creation failed.
+	ReasonSecretCreationFailed = "SecretCreationFailed"
+
+	// ReasonOAuthFailed indicates that OAuth resource reconciliation failed.
+	ReasonOAuthFailed = "OAuthFailed"
+
+	// ReasonSubCRStatusFailed indicates that fetching sub-CR status failed.
+	ReasonSubCRStatusFailed = "SubCRStatusFailed"
+)

--- a/operator/internal/condition/reconcile_error.go
+++ b/operator/internal/condition/reconcile_error.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package condition
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+)
+
+// ReconcileErrorHandler handles error reporting for reconcilers.
+// It provides a consistent way to set failed conditions, update status,
+// and log errors with proper context.
+type ReconcileErrorHandler struct {
+	log          logr.Logger
+	statusClient client.StatusWriter
+	cr           konfluxv1alpha1.ConditionAccessor
+	crKind       string
+}
+
+// NewReconcileErrorHandler creates a new ReconcileErrorHandler for a specific CR.
+// crKind is used in error messages to identify which CR type failed (e.g., "KonfluxBuildService").
+func NewReconcileErrorHandler(
+	log logr.Logger,
+	statusClient client.StatusWriter,
+	cr konfluxv1alpha1.ConditionAccessor,
+	crKind string,
+) *ReconcileErrorHandler {
+	return &ReconcileErrorHandler{
+		log:          log,
+		statusClient: statusClient,
+		cr:           cr,
+		crKind:       crKind,
+	}
+}
+
+// Handle sets a failed condition on the CR, updates the status, and returns the error.
+// The operation parameter provides context about what operation failed (e.g., "apply manifests", "cleanup orphans").
+// Returns a ctrl.Result and the original error, suitable for returning from a Reconcile function.
+func (h *ReconcileErrorHandler) Handle(
+	ctx context.Context,
+	err error,
+	reason string,
+	operation string,
+) (ctrl.Result, error) {
+	h.log.Error(err, fmt.Sprintf("Failed to %s", operation))
+
+	// Set the failed condition with a descriptive message
+	SetFailedCondition(h.cr, TypeReady, reason, fmt.Errorf("%s: %w", operation, err))
+
+	// Update the status
+	if updateErr := h.statusClient.Update(ctx, h.cr); updateErr != nil {
+		h.log.Error(updateErr, fmt.Sprintf("Failed to update %s status after %s failure", h.crKind, operation))
+	}
+
+	return ctrl.Result{}, err
+}
+
+// HandleApplyError handles errors that occur when applying manifests.
+func (h *ReconcileErrorHandler) HandleApplyError(ctx context.Context, err error) (ctrl.Result, error) {
+	return h.Handle(ctx, err, ReasonApplyFailed, "apply manifests")
+}
+
+// HandleCleanupError handles errors that occur when cleaning up orphaned resources.
+func (h *ReconcileErrorHandler) HandleCleanupError(ctx context.Context, err error) (ctrl.Result, error) {
+	return h.Handle(ctx, err, ReasonCleanupFailed, "cleanup orphaned resources")
+}
+
+// HandleStatusUpdateError handles errors that occur when updating component statuses.
+func (h *ReconcileErrorHandler) HandleStatusUpdateError(ctx context.Context, err error) (ctrl.Result, error) {
+	return h.Handle(ctx, err, ReasonStatusUpdateFailed, "update component statuses")
+}
+
+// HandleWithReason handles errors with a custom reason and operation description.
+// This is useful for component-specific error handling that doesn't fit the standard patterns.
+func (h *ReconcileErrorHandler) HandleWithReason(ctx context.Context, err error, reason string, operation string) (ctrl.Result, error) {
+	return h.Handle(ctx, err, reason, operation)
+}

--- a/operator/internal/condition/reconcile_error_test.go
+++ b/operator/internal/condition/reconcile_error_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package condition
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+)
+
+// mockStatusWriter is a mock implementation of client.StatusWriter for testing
+type mockStatusWriter struct {
+	updateCalled bool
+	updateErr    error
+	lastObject   client.Object
+}
+
+func (m *mockStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	m.updateCalled = true
+	m.lastObject = obj
+	return m.updateErr
+}
+
+func (m *mockStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	return nil
+}
+
+func (m *mockStatusWriter) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	return nil
+}
+
+var _ = Describe("ReconcileErrorHandler", func() {
+	var (
+		ctx        context.Context
+		testObject *konfluxv1alpha1.KonfluxRBAC
+		mockStatus *mockStatusWriter
+		handler    *ReconcileErrorHandler
+		testErr    error
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		testErr = errors.New("test error")
+
+		testObject = &konfluxv1alpha1.KonfluxRBAC{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-rbac",
+				Namespace:  "default",
+				Generation: 1,
+			},
+		}
+
+		mockStatus = &mockStatusWriter{}
+		handler = NewReconcileErrorHandler(
+			logr.Discard(), // Use a discarding logger for tests
+			mockStatus,
+			testObject,
+			"KonfluxRBAC",
+		)
+	})
+
+	Describe("NewReconcileErrorHandler", func() {
+		It("should create a handler with the correct fields", func() {
+			Expect(handler).NotTo(BeNil())
+			Expect(handler.cr).To(Equal(testObject))
+			Expect(handler.crKind).To(Equal("KonfluxRBAC"))
+			Expect(handler.statusClient).To(Equal(mockStatus))
+		})
+	})
+
+	Describe("Handle", func() {
+		It("should set a failed condition on the CR", func() {
+			_, returnedErr := handler.Handle(ctx, testErr, "TestReason", "test operation")
+
+			Expect(returnedErr).To(Equal(testErr))
+
+			condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal("TestReason"))
+			Expect(condition.Message).To(ContainSubstring("test operation"))
+			Expect(condition.Message).To(ContainSubstring("test error"))
+		})
+
+		It("should call status update", func() {
+			_, _ = handler.Handle(ctx, testErr, "TestReason", "test operation")
+
+			Expect(mockStatus.updateCalled).To(BeTrue())
+			Expect(mockStatus.lastObject).To(Equal(testObject))
+		})
+
+		It("should return empty result and original error", func() {
+			result, returnedErr := handler.Handle(ctx, testErr, "TestReason", "test operation")
+
+			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeZero())
+			Expect(returnedErr).To(Equal(testErr))
+		})
+
+		It("should not fail if status update fails", func() {
+			mockStatus.updateErr = errors.New("update failed")
+
+			result, returnedErr := handler.Handle(ctx, testErr, "TestReason", "test operation")
+
+			// Should still return the original error, not the update error
+			Expect(returnedErr).To(Equal(testErr))
+			Expect(result.Requeue).To(BeFalse())
+		})
+
+		It("should include operation in error message", func() {
+			_, _ = handler.Handle(ctx, testErr, "TestReason", "apply custom resources")
+
+			condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Message).To(Equal("apply custom resources: test error"))
+		})
+	})
+
+	Describe("HandleApplyError", func() {
+		It("should use ReasonApplyFailed and apply manifests operation", func() {
+			_, returnedErr := handler.HandleApplyError(ctx, testErr)
+
+			Expect(returnedErr).To(Equal(testErr))
+
+			condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Reason).To(Equal(ReasonApplyFailed))
+			Expect(condition.Message).To(ContainSubstring("apply manifests"))
+		})
+	})
+
+	Describe("HandleCleanupError", func() {
+		It("should use ReasonCleanupFailed and cleanup operation", func() {
+			_, returnedErr := handler.HandleCleanupError(ctx, testErr)
+
+			Expect(returnedErr).To(Equal(testErr))
+
+			condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Reason).To(Equal(ReasonCleanupFailed))
+			Expect(condition.Message).To(ContainSubstring("cleanup orphaned resources"))
+		})
+	})
+
+	Describe("HandleStatusUpdateError", func() {
+		It("should use ReasonStatusUpdateFailed and status update operation", func() {
+			_, returnedErr := handler.HandleStatusUpdateError(ctx, testErr)
+
+			Expect(returnedErr).To(Equal(testErr))
+
+			condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Reason).To(Equal(ReasonStatusUpdateFailed))
+			Expect(condition.Message).To(ContainSubstring("update component statuses"))
+		})
+	})
+
+	Describe("HandleWithReason", func() {
+		It("should use custom reason and operation", func() {
+			_, returnedErr := handler.HandleWithReason(ctx, testErr, "CustomReason", "custom operation")
+
+			Expect(returnedErr).To(Equal(testErr))
+
+			condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Reason).To(Equal("CustomReason"))
+			Expect(condition.Message).To(ContainSubstring("custom operation"))
+		})
+	})
+
+	Describe("error message formatting", func() {
+		It("should wrap the original error with operation context", func() {
+			originalErr := errors.New("connection refused")
+			_, _ = handler.Handle(ctx, originalErr, "NetworkError", "connect to API server")
+
+			condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Message).To(Equal("connect to API server: connection refused"))
+		})
+
+		It("should handle wrapped errors correctly", func() {
+			innerErr := errors.New("inner error")
+			wrappedErr := errors.New("outer error: " + innerErr.Error())
+			_, _ = handler.Handle(ctx, wrappedErr, "WrappedError", "process request")
+
+			condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Message).To(Equal("process request: outer error: inner error"))
+		})
+	})
+
+	Describe("observed generation", func() {
+		It("should set observed generation from CR", func() {
+			testObject.Generation = 5
+			_, _ = handler.Handle(ctx, testErr, "TestReason", "test operation")
+
+			condition := apimeta.FindStatusCondition(testObject.GetConditions(), TypeReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.ObservedGeneration).To(Equal(int64(5)))
+		})
+	})
+})

--- a/operator/internal/controller/certmanager/konfluxcertmanager_controller_test.go
+++ b/operator/internal/controller/certmanager/konfluxcertmanager_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
 )
 
@@ -110,7 +111,7 @@ var _ = Describe("KonfluxCertManager Controller", func() {
 
 			var readyCondition *metav1.Condition
 			for i := range conditions {
-				if conditions[i].Type == CertManagerConditionTypeReady {
+				if conditions[i].Type == condition.TypeReady {
 					readyCondition = &conditions[i]
 					break
 				}
@@ -148,7 +149,7 @@ var _ = Describe("KonfluxCertManager Controller", func() {
 
 			var readyCondition *metav1.Condition
 			for i := range conditions {
-				if conditions[i].Type == CertManagerConditionTypeReady {
+				if conditions[i].Type == condition.TypeReady {
 					readyCondition = &conditions[i]
 					break
 				}
@@ -185,7 +186,7 @@ var _ = Describe("KonfluxCertManager Controller", func() {
 
 			var readyCondition *metav1.Condition
 			for i := range conditions {
-				if conditions[i].Type == CertManagerConditionTypeReady {
+				if conditions[i].Type == condition.TypeReady {
 					readyCondition = &conditions[i]
 					break
 				}

--- a/operator/internal/controller/info/konfluxinfo_customization_test.go
+++ b/operator/internal/controller/info/konfluxinfo_customization_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
 )
 
 func TestKonfluxInfoReconciliation(t *testing.T) {
@@ -211,7 +212,7 @@ func TestKonfluxInfoReconciliation(t *testing.T) {
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		conditions := updatedInfo.GetConditions()
-		readyCondition := findCondition(conditions, InfoConditionTypeReady)
+		readyCondition := findCondition(conditions, condition.TypeReady)
 		g.Expect(readyCondition).NotTo(gomega.BeNil())
 		g.Expect(readyCondition.Status).To(gomega.Equal(metav1.ConditionTrue))
 	})

--- a/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
+++ b/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
 )
@@ -111,7 +112,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 
 			var readyCondition *metav1.Condition
 			for i := range conditions {
-				if conditions[i].Type == InternalRegistryConditionTypeReady {
+				if conditions[i].Type == condition.TypeReady {
 					readyCondition = &conditions[i]
 					break
 				}


### PR DESCRIPTION
### **User description**
…lication

Optimize status reporting across all reconcilers by:

- Extract common condition logic into the `condition` package
- Add `ReconcileErrorHandler` to standardize error handling in reconcilers, reducing boilerplate for setting failed conditions and updating status
- Introduce constants for condition types (`TypeReady`) and reasons (`ReasonApplyFailed`, `ReasonCleanupFailed`, etc.) to avoid hardcoding
- Simplify `UpdateComponentStatuses`, `SetOverallReadyCondition`, and `SetAggregatedReadyCondition` by using `TypeReady` internally instead of requiring it as a parameter
- Improve error messages to include operation context (e.g., "apply manifests: <error>" instead of generic "<error>")
- Add test coverage for ReconcileErrorHandler

This change ensures consistent Ready condition handling across all reconcilers while making the code more maintainable and error messages more descriptive.

Assisted-By: Cursor


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Centralize condition handling with new `constants.go` defining standardized condition types and reasons

- Introduce `ReconcileErrorHandler` to standardize error handling across all reconcilers

- Simplify function signatures by removing `readyConditionType` parameter, using `TypeReady` constant instead

- Replace hardcoded condition strings with constants (`ReasonApplyFailed`, `ReasonCleanupFailed`, etc.)

- Reduce boilerplate error handling code across 11 reconciler controllers

- Add comprehensive test coverage for `ReconcileErrorHandler` with 8 test cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New Constants<br/>TypeReady<br/>ReasonApplyFailed<br/>etc."] --> B["ReconcileErrorHandler"]
  B --> C["Simplified<br/>Reconcilers"]
  D["UpdateComponentStatuses<br/>SetOverallReadyCondition<br/>SetAggregatedReadyCondition"] --> E["Remove readyConditionType<br/>parameter"]
  E --> C
  F["11 Controllers"] --> C
  C --> G["Consistent error<br/>reporting"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td><strong>constants.go</strong><dd><code>New file with standardized condition constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-14bd65ef321cb84f099887f790fbe1aa7b4d24b88c9f76e4400a0bccbc6cb632">+70/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reconcile_error.go</strong><dd><code>New ReconcileErrorHandler for standardized error handling</code></dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-7eca41353f80172e1a04ec3bb33ba753a5093e75cbc37de866b1d1ba66534168">+97/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>condition.go</strong><dd><code>Replace hardcoded strings with constants, remove readyConditionType </code><br><code>parameter</code></dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-ef151b8fb9d8b69fd9e95bad70eca15a491e3ccd04d2cf98ffe1d77efb79dfdb">+14/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxapplicationapi_controller.go</strong><dd><code>Use ReconcileErrorHandler, simplify error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-a26d909023f4db43ed66f8358f2c04eb71cb4b5397d0d7e73001335bc375f2bc">+9/-22</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxbuildservice_controller.go</strong><dd><code>Use ReconcileErrorHandler, simplify error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-a9eb32fdeac8e9df38f775bd7c7bc7810435b45a98261a1ec289debb08ecaa4b">+9/-22</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxcertmanager_controller.go</strong><dd><code>Use ReconcileErrorHandler, simplify error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-bc15110b14183241956f51a2e7147b54875a977ae44959fe9b62f0015917b140">+9/-22</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxenterprisecontract_controller.go</strong><dd><code>Use ReconcileErrorHandler, simplify error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-1ed52ee73b3c2525d3c33a29ca46e0b68fc4e5e4eaefdb9c5a395cd211f818f0">+9/-22</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluximagecontroller_controller.go</strong><dd><code>Use ReconcileErrorHandler, simplify error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-6c763c167279b0ad5d7272ca04ced07e667537e7f202d723e1a9ce41517e5b4b">+9/-22</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxinfo_controller.go</strong><dd><code>Use ReconcileErrorHandler with custom reasons for component-specific </code><br><code>errors</code></dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-632df3e422d02f42ebc3adf96fe1683930511f632b57b7d58fdcd60f75e46b2a">+12/-40</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxintegrationservice_controller.go</strong><dd><code>Use ReconcileErrorHandler, simplify error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-d0b6239196f48e8128517c03b341f09ade5066982ccb496f4a8b801668ac582e">+9/-22</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxinternalregistry_controller.go</strong><dd><code>Use ReconcileErrorHandler, simplify error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-f678954c718ca7623e3eeb74f0b75dc6b2eb4b6da7f998f612ca4bcef6cd372a">+9/-22</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konflux_controller.go</strong><dd><code>Use ReconcileErrorHandler, simplify error handling across 15+ error </code><br><code>cases</code></dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-cf5a332f0b87d850769b080f9c8208e9446d2af3456f8e328572bc072b4c9294">+31/-153</a></td>

</tr>

<tr>
  <td><strong>konfluxnamespacelister_controller.go</strong><dd><code>Use ReconcileErrorHandler, simplify error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-9b30ab1991bf2cfb0dc610075f32e1481c532adf137a67afda314a6f8584b6b2">+9/-22</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxrbac_controller.go</strong><dd><code>Use ReconcileErrorHandler, simplify error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-94d40166ce83e790ce9fe3fc19a6bb54999db3387551ad1d30989c722bcc965f">+9/-22</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxreleaseservice_controller.go</strong><dd><code>Use ReconcileErrorHandler, simplify error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-854d2c3b514dba7f5e74c56b6a2cc9b24308a6a17be5bfad5b996580d4823575">+9/-22</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxui_controller.go</strong><dd><code>Use ReconcileErrorHandler with custom reasons for UI-specific errors</code></dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-24d972a47782a65c4bb0528b6a7352cac3a33aa318ccd2d11584881d688124be">+15/-58</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>reconcile_error_test.go</strong><dd><code>Comprehensive test coverage for ReconcileErrorHandler</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-28f5ba0f40b2a4f727d457c27b091b43a5a97499665a905c05cb5de7369a1967">+224/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>condition_test.go</strong><dd><code>Update tests to use TypeReady constant and remove custom type tests</code></dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-3ac613729ccc686614ef9f22d34a4ab1fe6c62756d818d678163ed0d05bc0fdb">+16/-32</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxcertmanager_controller_test.go</strong><dd><code>Update tests to use TypeReady constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-d2c37d5fb3772e2e58bf24517d5360d01f55e086c7c7f0a3dee77646e3df8c8d">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxinfo_customization_test.go</strong><dd><code>Update tests to use TypeReady constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-18a304ca14c8587ffae77de02bd3f1bc89b0aa27f00167c211bff5282b9a775d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxinternalregistry_controller_test.go</strong><dd><code>Update tests to use TypeReady constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4499/files#diff-4e822bd5a42992c8a93a31a43c0c726cbd2d900065ff4082835886499b38186c">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

