### PR TITLE
feat(KFLUXVNGD-605): make version available to the operator

### DIFF
--- a/.tekton/konflux-operator-push.yaml
+++ b/.tekton/konflux-operator-push.yaml
@@ -31,6 +31,9 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
+  - name: build-args
+    value:
+      - "GIT_COMMIT={{revision}}"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/konflux-operator-tag.yaml
+++ b/.tekton/konflux-operator-tag.yaml
@@ -34,6 +34,10 @@ spec:
     - linux/arm64
   - name: rebuild
     value: "true"
+  - name: build-args
+    value:
+      - "VERSION={{git_tag}}"
+      - "GIT_COMMIT={{revision}}"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/operator/Containerfile
+++ b/operator/Containerfile
@@ -2,6 +2,8 @@
 FROM registry.access.redhat.com/ubi10/go-toolset@sha256:947962f92cc541358a90d54b8da4a4a313522c7b3f602bd934c559f0cc2d2b19 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION
+ARG GIT_COMMIT
 
 ENV GOTOOLCHAIN=auto
 WORKDIR /workspace
@@ -16,7 +18,16 @@ COPY --chmod=755 api/ api/
 COPY --chmod=755 internal/ internal/
 COPY --chmod=755 pkg/ pkg/
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /opt/app-root/manager cmd/main.go
+# Extract version info from build args or git if not provided, then build with
+# all version info embedded via ldflags
+RUN VERSION_VALUE="${VERSION:-$(git describe --tags --exact-match HEAD 2>/dev/null || echo 'unknown')}" && \
+    GIT_COMMIT_VALUE="${GIT_COMMIT:-$(git rev-parse HEAD 2>/dev/null || echo 'unknown')}" && \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build -a \
+    -ldflags \
+    "-X github.com/konflux-ci/konflux-ci/operator/pkg/version.Version=$${VERSION_VALUE} \
+    -X github.com/konflux-ci/konflux-ci/operator/pkg/version.GitCommit=$${GIT_COMMIT_VALUE}" \
+    -o /opt/app-root/manager cmd/main.go
 
 # Use UBI minimal as base image
 FROM registry.access.redhat.com/ubi10/ubi-minimal@sha256:67aafc6c9c44374e1baf340110d4c835457d59a0444c068ba9ac6431a6d9e7ac

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -59,6 +59,7 @@ import (
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/ui"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/version"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -137,6 +138,12 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	setupLog.Info(
+		"Konflux Operator",
+		"version", version.Version,
+		"gitCommit", version.GitCommit,
+	)
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will

--- a/operator/pkg/version/version.go
+++ b/operator/pkg/version/version.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+// These variables are set at build time via ldflags.
+// Default values are "unknown" and will be replaced during the build process.
+var (
+	// Version is the version of the operator (e.g., "v0.0.1")
+	Version = "unknown"
+	// GitCommit is the git commit SHA used to build the binary
+	GitCommit = "unknown"
+)

--- a/operator/pkg/version/version_test.go
+++ b/operator/pkg/version/version_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"testing"
+)
+
+func TestVersionVariables(t *testing.T) {
+	// Contract test: verify variables are accessible
+	// Values are initialized to "unknown" but can be overridden at build time via ldflags
+	// We don't assert specific values since they depend on build configuration
+	_ = Version
+	_ = GitCommit
+	// If we get here without compilation errors, the variables exist and are accessible
+}


### PR DESCRIPTION
### **User description**
The build process now embeds version information into the Konflux CI operator binary. When build was triggered by a Git tag, that tag is used as the version.

Assisted-by: Cursor


___

### **PR Type**
Enhancement


___

### **Description**
- Embed version information into operator binary at build time

- Create version package with Version, GitCommit, BuildDate variables

- Log version details on operator startup

- Pass VERSION build argument from Git tags in Tekton pipeline


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Git Tag"] -->|"VERSION={{git_tag}}"| B["Tekton Pipeline"]
  B -->|"build-args"| C["Containerfile"]
  C -->|"ldflags"| D["Go Build"]
  D -->|"embeds"| E["version Package"]
  E -->|"logs"| F["Operator Startup"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version.go</strong><dd><code>Create version package with build-time variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/pkg/version/version.go

<ul><li>New package created to expose version-related variables<br> <li> Three variables defined: <code>Version</code>, <code>GitCommit</code>, <code>BuildDate</code><br> <li> Variables initialized to "unknown" as defaults<br> <li> Designed to be overridden at build time via ldflags</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4503/files#diff-fa70d429187e273964c3e5d1236fbaec2a5b914c92a0f12fe3f227cb701f1ef0">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Log version info on operator startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/cmd/main.go

<ul><li>Import new <code>version</code> package<br> <li> Log version information on operator startup<br> <li> Display Version, GitCommit, and BuildDate in logs</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4503/files#diff-6951a7b3b8a59603497b68b62013a806397c640ce0a42a3862f6a4ffad4fda89">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version_test.go</strong><dd><code>Add version package accessibility test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/pkg/version/version_test.go

<ul><li>Contract test verifying version variables are accessible<br> <li> Tests that variables exist and can be compiled without errors<br> <li> No assertions on specific values due to build-time configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4503/files#diff-2da19d67e56cd47fcde6a6cb7ac43c3701a3488e70ef3f9dd402ad2f339fdc24">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Containerfile</strong><dd><code>Embed version info via ldflags in build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/Containerfile

<ul><li>Add <code>VERSION</code> build argument to builder stage<br> <li> Extract version from Git tags or use provided VERSION argument<br> <li> Embed version info via ldflags during build<br> <li> Calculate GitCommit and BuildDate at build time</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4503/files#diff-83d60bedb0fb35caedaaeeb7135a499ae3f041c51f28abfb9da3ad864e601070">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>konflux-operator-tag.yaml</strong><dd><code>Pass Git tag as VERSION build argument</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.tekton/konflux-operator-tag.yaml

<ul><li>Add <code>build-args</code> parameter to pass VERSION from Git tags<br> <li> VERSION set to <code>{{git_tag}}</code> template variable<br> <li> Enables automatic version injection from Git tags</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4503/files#diff-c3911c48e5ebbb5e722ff29b361c5ac6a7baca323e2c1a4253b4f0ff2785fa1a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

