### PR TITLE
fix(KFLUXVNGD-605): version embedding in operator image

### DIFF
--- a/.tekton/konflux-operator-pull-request.yaml
+++ b/.tekton/konflux-operator-pull-request.yaml
@@ -36,6 +36,10 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
+  - name: build-args
+    value:
+    - "OPERATOR_VERSION={{revision}}"
+    - "GIT_COMMIT={{revision}}"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/konflux-operator-push.yaml
+++ b/.tekton/konflux-operator-push.yaml
@@ -33,7 +33,8 @@ spec:
     - linux/arm64
   - name: build-args
     value:
-      - "GIT_COMMIT={{revision}}"
+    - "OPERATOR_VERSION={{revision}}"
+    - "GIT_COMMIT={{revision}}"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/konflux-operator-tag.yaml
+++ b/.tekton/konflux-operator-tag.yaml
@@ -36,8 +36,8 @@ spec:
     value: "true"
   - name: build-args
     value:
-      - "VERSION={{git_tag}}"
-      - "GIT_COMMIT={{revision}}"
+    - "OPERATOR_VERSION={{git_tag}}"
+    - "GIT_COMMIT={{revision}}"
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/operator/Containerfile
+++ b/operator/Containerfile
@@ -2,7 +2,7 @@
 FROM registry.access.redhat.com/ubi10/go-toolset@sha256:947962f92cc541358a90d54b8da4a4a313522c7b3f602bd934c559f0cc2d2b19 AS builder
 ARG TARGETOS
 ARG TARGETARCH
-ARG VERSION
+ARG OPERATOR_VERSION
 ARG GIT_COMMIT
 
 ENV GOTOOLCHAIN=auto
@@ -18,19 +18,17 @@ COPY --chmod=755 api/ api/
 COPY --chmod=755 internal/ internal/
 COPY --chmod=755 pkg/ pkg/
 
-# Extract version info from build args or git if not provided, then build with
-# all version info embedded via ldflags
-RUN VERSION_VALUE="${VERSION:-$(git describe --tags --exact-match HEAD 2>/dev/null || echo 'unknown')}" && \
-    GIT_COMMIT_VALUE="${GIT_COMMIT:-$(git rev-parse HEAD 2>/dev/null || echo 'unknown')}" && \
-    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+# Build with version info embedded via ldflags
+# ARG values are expected to be passed from the build pipeline, defaulting to "unknown" if not set
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
     go build -a \
-    -ldflags \
-    "-X github.com/konflux-ci/konflux-ci/operator/pkg/version.Version=$${VERSION_VALUE} \
-    -X github.com/konflux-ci/konflux-ci/operator/pkg/version.GitCommit=$${GIT_COMMIT_VALUE}" \
+    -ldflags "-X github.com/konflux-ci/konflux-ci/operator/pkg/version.Version=${OPERATOR_VERSION:-unknown} \
+              -X github.com/konflux-ci/konflux-ci/operator/pkg/version.GitCommit=${GIT_COMMIT:-unknown}" \
     -o /opt/app-root/manager cmd/main.go
 
 # Use UBI minimal as base image
 FROM registry.access.redhat.com/ubi10/ubi-minimal@sha256:67aafc6c9c44374e1baf340110d4c835457d59a0444c068ba9ac6431a6d9e7ac
+ARG OPERATOR_VERSION
 WORKDIR /
 
 COPY --from=builder /opt/app-root/manager .
@@ -42,7 +40,7 @@ LABEL description="Kubernetes operator for managing Konflux installations"
 LABEL summary="Kubernetes operator for managing Konflux installations"
 LABEL io.k8s.description="Kubernetes operator for managing Konflux installations"
 LABEL io.k8s.display-name="konflux-operator"
-LABEL version="0.1"
+LABEL version="${OPERATOR_VERSION#v}"
 LABEL release="1"
 LABEL vendor="Red Hat, Inc."
 # vendor label should be solved in conforma

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -201,7 +201,12 @@ run: manifests generate fmt vet install-user-rbac ## Run a controller from your 
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -f Containerfile -t ${IMG} .
+	$(CONTAINER_TOOL) build \
+		-f Containerfile \
+		-t ${IMG} \
+		$(if $(VERSION),--build-arg OPERATOR_VERSION=$(VERSION)) \
+		$(if $(GIT_COMMIT),--build-arg GIT_COMMIT=$(GIT_COMMIT)) \
+		.
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
### **User description**
The Containerfile code for embedding the version was wrong. This should now be fixed.

Assisted-by: Cursor


___

### **PR Type**
Bug fix


___

### **Description**
- Rename VERSION build arg to OPERATOR_VERSION for consistency

- Simplify version embedding logic in Containerfile

- Use ARG values directly with fallback defaults

- Update Makefile docker-build to pass version args conditionally

- Fix YAML indentation in Tekton pipeline files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build Args<br/>OPERATOR_VERSION<br/>GIT_COMMIT"] -->|"Pass to<br/>Containerfile"| B["Containerfile<br/>Embed via ldflags"]
  B -->|"Build<br/>operator binary"| C["Container Image<br/>with version info"]
  D["Makefile<br/>docker-build"] -->|"Pass VERSION<br/>and GIT_COMMIT"| A
  E["Tekton Pipeline<br/>konflux-operator-tag"] -->|"Set build args"| A
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Containerfile</strong><dd><code>Simplify version embedding with renamed ARG</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/Containerfile

<ul><li>Rename ARG VERSION to ARG OPERATOR_VERSION for consistency<br> <li> Simplify version embedding by using ARG values directly with fallback <br>defaults<br> <li> Remove complex shell variable extraction logic<br> <li> Use cleaner ldflags syntax with inline variable substitution</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4517/files#diff-83d60bedb0fb35caedaaeeb7135a499ae3f041c51f28abfb9da3ad864e601070">+6/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>konflux-operator-tag.yaml</strong><dd><code>Rename VERSION to OPERATOR_VERSION arg</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.tekton/konflux-operator-tag.yaml

<ul><li>Rename VERSION build arg to OPERATOR_VERSION for consistency<br> <li> Fix YAML indentation in build-args section</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4517/files#diff-c3911c48e5ebbb5e722ff29b361c5ac6a7baca323e2c1a4253b4f0ff2785fa1a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Add conditional build args to docker-build target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/Makefile

<ul><li>Update docker-build target to pass OPERATOR_VERSION and GIT_COMMIT as <br>build args<br> <li> Use conditional syntax to only pass args when VERSION or GIT_COMMIT <br>are defined<br> <li> Improve formatting with multi-line command structure</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4517/files#diff-6973a61c21dd57b26f0452d3716fe9213974883a2fe1b216504bf63532cd1187">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>konflux-operator-push.yaml</strong><dd><code>Fix YAML indentation in build-args</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.tekton/konflux-operator-push.yaml

- Fix YAML indentation in build-args section for consistency


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4517/files#diff-1137526f4d30c00c780c215d4a541867b2ba0aa4ec564f7f5a7c011a9cea48a1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

