### PR TITLE
fix(): configure hugo baseurl for github pages

### DIFF
--- a/.github/scripts/configure-hugo-baseurl.sh
+++ b/.github/scripts/configure-hugo-baseurl.sh
@@ -43,8 +43,8 @@ if [ ! -f "$CONFIG_FILE" ]; then
 fi
 
 # Calculate baseURL and URL
-# baseURL includes repository name: /${REPO_NAME}/operator
-# This matches the actual GitHub Pages serving path
+# baseURL is /${REPO_NAME} (where GitHub Pages actually serves the files)
+# The content structure determines the paths within the site
 if [ -n "${GITHUB_PAGES_DOMAIN:-}" ]; then
   # Custom domain
   URL="https://${GITHUB_PAGES_DOMAIN}"
@@ -53,7 +53,7 @@ else
   URL="https://${GITHUB_OWNER}.github.io"
 fi
 
-BASEURL="/${REPO_NAME}/operator"
+BASEURL="/${REPO_NAME}"
 
 FULL_BASEURL="${URL}${BASEURL}"
 

--- a/operator/config/samples/konflux_v1alpha1_konflux.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konflux.yaml
@@ -1,5 +1,5 @@
 # Title: Konflux Configuration
-# Description: Complete Konflux configuration with all components
+# Description: Complete Konflux configuration with all components (UI, Build Service, Integration Service, Release Service, etc.)
 apiVersion: konflux.konflux-ci.dev/v1alpha1
 kind: Konflux
 metadata:


### PR DESCRIPTION
### **User description**
Configure hugo baseurl for github pages to use the custom domain konflux-ci.dev.


___

### **PR Type**
Bug fix


___

### **Description**
- Corrects Hugo baseURL configuration for GitHub Pages deployment

- Changes baseURL from `/${REPO_NAME}/operator` to `/${REPO_NAME}`

- Updates comments to clarify baseURL structure and content routing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hugo Config"] -->|Previous baseURL| B["/${REPO_NAME}/operator"]
  A -->|Updated baseURL| C["/${REPO_NAME}"]
  C -->|Matches| D["GitHub Pages serving path"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configure-hugo-baseurl.sh</strong><dd><code>Correct baseURL path for GitHub Pages deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/scripts/configure-hugo-baseurl.sh

<ul><li>Changed baseURL from <code>/${REPO_NAME}/operator</code> to <code>/${REPO_NAME}</code> to match <br>actual GitHub Pages serving path<br> <li> Updated comments to clarify that baseURL is the repository name path <br>and content structure determines internal site paths<br> <li> Removed misleading reference to <code>/operator</code> suffix in configuration <br>logic</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4523/files#diff-d8d917e55b886dfc5711bf7e6d89a0a53cc6e00897b77c71e89069876b5c29a9">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

