### PR TITLE
chore(KFLUXVNGD-666): verify triggering by event

### DIFF
--- a/.github/scripts/extract-payload.sh
+++ b/.github/scripts/extract-payload.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# extract-payload.sh - Extract version, image_tag, and git_ref from workflow event
+#
+# This script extracts release information from either:
+# - repository_dispatch event (automated from Konflux): reads from github.event.client_payload
+# - workflow_dispatch event (manual): reads from workflow inputs
+#
+# Outputs to stdout in format: key=value (one per line)
+# Outputs to GITHUB_OUTPUT if GITHUB_OUTPUT is set
+
+set -euo pipefail
+
+EVENT_NAME="${1:-}"
+VERSION_INPUT="${2:-}"
+IMAGE_TAG_INPUT="${3:-}"
+GIT_REF_INPUT="${4:-}"
+VERSION_PAYLOAD="${5:-}"
+IMAGE_TAG_PAYLOAD="${6:-}"
+GIT_REF_PAYLOAD="${7:-}"
+
+if [ -z "${EVENT_NAME}" ]; then
+  echo "Usage: extract-payload.sh <event_name> [version_input] [image_tag_input] [git_ref_input] [version_payload] [image_tag_payload] [git_ref_payload]"
+  exit 1
+fi
+
+if [ "${EVENT_NAME}" == "repository_dispatch" ]; then
+  # Extract from repository_dispatch payload (automated from Konflux)
+  VERSION="${VERSION_PAYLOAD}"
+  IMAGE_TAG="${IMAGE_TAG_PAYLOAD}"
+  GIT_REF="${GIT_REF_PAYLOAD}"
+  SOURCE="repository_dispatch (Konflux)"
+else
+  # Extract from workflow_dispatch inputs (manual)
+  VERSION="${VERSION_INPUT}"
+  IMAGE_TAG="${IMAGE_TAG_INPUT}"
+  GIT_REF="${GIT_REF_INPUT}"
+  SOURCE="workflow_dispatch (manual)"
+fi
+
+# Output values
+echo "version=${VERSION}"
+echo "image_tag=${IMAGE_TAG}"
+echo "git_ref=${GIT_REF}"
+echo "source=${SOURCE}"
+
+# Also output to GITHUB_OUTPUT if set
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "version=${VERSION}"
+    echo "image_tag=${IMAGE_TAG}"
+    echo "git_ref=${GIT_REF}"
+    echo "source=${SOURCE}"
+  } >> "${GITHUB_OUTPUT}"
+fi

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,6 +1,8 @@
 name: Create Release
 
 on:
+  repository_dispatch:
+    types: [konflux-build-complete]
   workflow_dispatch:
     inputs:
       version:
@@ -36,6 +38,33 @@ jobs:
       run:
         working-directory: operator
     steps:
+      - name: Extract event payload
+        id: payload
+        working-directory: ${{ github.workspace }}
+        run: |
+          result=$(.github/scripts/extract-payload.sh \
+            "${{ github.event_name }}" \
+            "${{ inputs.version }}" \
+            "${{ inputs.image_tag }}" \
+            "${{ inputs.git_ref }}" \
+            "${{ github.event.client_payload.version }}" \
+            "${{ github.event.client_payload.image_tag }}" \
+            "${{ github.event.client_payload.git_ref }}")
+          echo "${result}" | grep "^version=" >> $GITHUB_OUTPUT
+          echo "${result}" | grep "^image_tag=" >> $GITHUB_OUTPUT
+          echo "${result}" | grep "^git_ref=" >> $GITHUB_OUTPUT
+          echo "${result}" | grep "^source=" >> $GITHUB_OUTPUT
+          echo ""
+          echo "=== Extracted Payload ==="
+          echo "${result}"
+          echo ""
+          echo "=== Full Event JSON (for debugging) ==="
+          echo '${{ toJSON(github.event) }}' | jq '.' || echo "Event data not available"
+          echo ""
+          echo "=== Exiting early for testing ==="
+          echo "Remove this exit once payload extraction is verified"
+          exit 0
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Temporarily modify the release workflow to verify it can be triggered by events. This will later be triggered from a final pipeline.

Assisted-by: Cursor