### PR TITLE
chore(KFLUXVNGD-666): hard code releases to be drafts

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -118,10 +118,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # TODO: Revert to use input when repository_dispatch events support draft flag
+          # Change "true" back to "${{ inputs.draft }}" to restore manual control
           .github/scripts/create-release.sh \
             "${{ steps.version.outputs.version }}" \
             "${{ steps.payload.outputs.git_ref }}" \
             /tmp/release-notes.md \
             operator/dist \
-            "${{ inputs.draft }}" \
+            "true" \
             "${{ inputs.generate_notes }}"


### PR DESCRIPTION
For testing, we'd like to make all releases drafts, but when testing from an event, it's not as clean to set the draft flag defaults, so for now, we hard code it to true to keep things simple.