### PR TITLE
fix: resolve staticcheck SA1019 warnings and update golangci-lint to v2.8.0

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -290,7 +290,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.18.0
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries
 ENVTEST_K8S_VERSION ?= 1.33.0
-GOLANGCI_LINT_VERSION ?= v2.1.0
+GOLANGCI_LINT_VERSION ?= v2.8.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/operator/internal/condition/reconcile_error_test.go
+++ b/operator/internal/condition/reconcile_error_test.go
@@ -114,7 +114,6 @@ var _ = Describe("ReconcileErrorHandler", func() {
 		It("should return empty result and original error", func() {
 			result, returnedErr := handler.Handle(ctx, testErr, "TestReason", "test operation")
 
-			Expect(result.Requeue).To(BeFalse())
 			Expect(result.RequeueAfter).To(BeZero())
 			Expect(returnedErr).To(Equal(testErr))
 		})
@@ -126,7 +125,7 @@ var _ = Describe("ReconcileErrorHandler", func() {
 
 			// Should still return the original error, not the update error
 			Expect(returnedErr).To(Equal(testErr))
-			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeZero())
 		})
 
 		It("should include operation in error message", func() {


### PR DESCRIPTION
- Replace deprecated result.Requeue with result.RequeueAfter in reconcile_error_test.go
- Update golangci-lint from previous version to v2.8.0