### PR TITLE
feat(KFLUXVNGD-605): add final pipeline and task

### DIFF
--- a/pipelines/notify-and-trigger-github-release/README.md
+++ b/pipelines/notify-and-trigger-github-release/README.md
@@ -1,0 +1,94 @@
+# notify-and-trigger-github-release Pipeline
+
+Pipeline that sends Slack notifications and triggers GitHub release workflow.
+
+## Description
+
+This pipeline combines:
+1. **Slack notification**: Uses the `notify-slack-on-failure` task from community-catalog
+2. **GitHub repository_dispatch event**: Uses the `send-github-release-event` task
+(only for tag-based releases)
+3. **Failure notification**: Uses the `notify-slack-github-event-failure` task in the
+`finally` block to notify if the GitHub event fails
+
+The GitHub event task only runs for tag-based releases and gracefully exits for
+branch-based releases. The failure notification task runs in the `finally` block,
+ensuring it executes even if other tasks fail.
+
+## Authentication
+
+The pipeline supports two authentication methods for GitHub:
+
+1. **GitHub App** (preferred): Provide a single secret (`githubAppSecretName`, default:
+  `github-app-credentials`) with three keys:
+   - `githubAppIdKey` (default: `app-id`) - contains the GitHub App ID
+   - `githubInstallationIdKey` (default: `installation-id`) - contains the Installation ID
+   - `githubPrivateKeyKey` (default: `private-key`) - contains the App's private key
+
+2. **Personal Access Token (PAT)** (fallback): Provide `githubTokenSecretName` (default:
+  `github-token`) and `githubTokenSecretKey`
+
+**Priority**: GitHub App is checked first. If GitHub App credentials are not available,
+the pipeline falls back to PAT. If neither is available, the task will fail.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| release | Namespaced name of release (format: "namespace/name") | No | - |
+| secretName | Name of secret which contains Slack webhook URL | No | - |
+| secretKeyName | Name of key within secret which contains Slack webhook URL | No | - |
+| slackHandles | Comma-separated list of Slack member IDs or group IDs to be tagged on failures | Yes | "" |
+| notifySuccess | If "true", sends Slack notification on success | Yes | "false" |
+| tagSuccess | If "true", tags users in success notifications | Yes | "false" |
+| githubTokenSecretName | Name of secret which contains GitHub token (PAT). Used as fallback if GitHub App authentication is not available. | Yes | "github-token" |
+| githubTokenSecretKey | Name of key within secret which contains GitHub token | Yes | token |
+| githubAppSecretName | Name of secret which contains GitHub App credentials (app-id, installation-id, private-key). Preferred authentication method. | Yes | github-app-credentials |
+| githubAppIdKey | Name of key within GitHub App secret which contains the App ID | Yes | app-id |
+| githubInstallationIdKey | Name of key within GitHub App secret which contains the Installation ID | Yes | installation-id |
+| githubPrivateKeyKey | Name of key within GitHub App secret which contains the private key | Yes | private-key |
+| githubRepo | GitHub repository in format "owner/repo" | Yes | "konflux-ci/konflux-ci" |
+| slackTaskGitUrl | URL to git repo where the Slack notification task is stored (community-catalog) | Yes | https://github.com/konflux-ci/community-catalog.git |
+| slackTaskGitRevision | Revision in the Slack task git repo to be used | Yes | development |
+
+## Task Execution Order
+
+1. **notify-slack**: Always runs first
+2. **send-github-event**: Runs after Slack notification succeeds (only for tag-based
+  releases)
+3. **notify-slack-github-event-failure** (in `finally` block): Runs if send-github-event
+  task fails, regardless of overall pipeline status
+
+## Usage in ReleasePlan
+
+```yaml
+spec:
+  finalPipeline:
+    params:
+      - name: secretName
+        value: vanguard-ci-notifier-webhook
+      - name: secretKeyName
+        value: url
+      - name: slackHandles
+        value: "Smygroup"
+      # Option 1: Use GitHub App (preferred, uses defaults)
+      # No params needed - uses default secret name "github-app-credentials"
+      # with default keys: app-id, installation-id, private-key
+      # Option 2: Use PAT token (fallback)
+      # - name: githubTokenSecretName
+      #   value: github-release-token
+      # - name: githubTokenSecretKey
+      #   value: token
+      - name: githubRepo
+        value: konflux-ci/konflux-ci
+    pipelineRef:
+      params:
+        - name: url
+          value: "https://github.com/konflux-ci/konflux-ci.git"
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: "pipelines/notify-and-trigger-github-release/notify-and-trigger-github-release.yaml"
+      resolver: git
+    serviceAccountName: build-pipeline-konflux-operator
+```

--- a/pipelines/notify-and-trigger-github-release/notify-and-trigger-github-release.yaml
+++ b/pipelines/notify-and-trigger-github-release/notify-and-trigger-github-release.yaml
@@ -1,0 +1,161 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: notify-and-trigger-github-release
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.14.0" # Required for .status in finally
+    tekton.dev/tags: release
+spec:
+  description: |-
+    Pipeline that sends Slack notifications and triggers GitHub release workflow.
+
+    This pipeline combines:
+    1. Slack notification (using the community-catalog task)
+    2. GitHub repository_dispatch event (for tag-based releases only)
+
+    The GitHub event task only runs for tag-based releases and gracefully exits
+    for branch-based releases.
+  params:
+    - name: release
+      type: string
+      description: Namespaced name of release - should be in format "namespace/name"
+    - name: secretName
+      type: string
+      description: Name of secret which contains Slack webhook URL
+    - name: secretKeyName
+      type: string
+      description: Name of key within secret which contains Slack webhook URL
+    - name: slackHandles
+      type: string
+      description: Comma-separated list of Slack member IDs or group IDs to be tagged on failures
+      default: ""
+    - name: notifySuccess
+      type: string
+      description: If set to "true", it will also send Slack notification on success
+      default: "false"
+    - name: tagSuccess
+      type: string
+      description: |-
+        If set to "true", will tag users in success notifications as well
+        (only applies when notifySuccess is true)
+      default: "false"
+    - name: githubTokenSecretName
+      type: string
+      description: |-
+        Name of secret which contains GitHub token (PAT).
+        Used as fallback if GitHub App authentication is not available.
+      default: "github-token"
+    - name: githubTokenSecretKey
+      type: string
+      description: Name of key within secret which contains GitHub token
+      default: token
+    - name: githubAppSecretName
+      type: string
+      description: |-
+        Name of secret which contains GitHub App credentials (app-id, installation-id, private-key).
+        Used when githubTokenSecretName is not provided.
+      default: github-app-credentials
+    - name: githubAppIdKey
+      type: string
+      description: Name of key within GitHub App secret which contains the App ID
+      default: app-id
+    - name: githubInstallationIdKey
+      type: string
+      description: Name of key within GitHub App secret which contains the Installation ID
+      default: installation-id
+    - name: githubPrivateKeyKey
+      type: string
+      description: Name of key within GitHub App secret which contains the private key
+      default: private-key
+    - name: githubRepo
+      type: string
+      description: GitHub repository in format "owner/repo" (e.g., "konflux-ci/konflux-ci")
+      default: "konflux-ci/konflux-ci"
+    - name: slackTaskGitUrl
+      type: string
+      description: The url to the git repo where the Slack notification task is stored (community-catalog)
+      default: https://github.com/konflux-ci/community-catalog.git
+    - name: slackTaskGitRevision
+      type: string
+      description: The revision in the Slack task git repo to be used
+      default: development
+  tasks:
+    - name: notify-slack
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.slackTaskGitUrl)
+          - name: revision
+            value: $(params.slackTaskGitRevision)
+          - name: pathInRepo
+            value: tasks/notify-slack-on-failure/notify-slack-on-failure.yaml
+      params:
+        - name: secretName
+          value: $(params.secretName)
+        - name: secretKeyName
+          value: $(params.secretKeyName)
+        - name: release
+          value: $(params.release)
+        - name: notifySuccess
+          value: $(params.notifySuccess)
+        - name: slackHandles
+          value: $(params.slackHandles)
+        - name: tagSuccess
+          value: $(params.tagSuccess)
+
+    - name: send-github-event
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/konflux-ci.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/send-github-release-event/send-github-release-event.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: githubTokenSecretName
+          value: $(params.githubTokenSecretName)
+        - name: githubTokenSecretKey
+          value: $(params.githubTokenSecretKey)
+        - name: githubAppSecretName
+          value: $(params.githubAppSecretName)
+        - name: githubAppIdKey
+          value: $(params.githubAppIdKey)
+        - name: githubInstallationIdKey
+          value: $(params.githubInstallationIdKey)
+        - name: githubPrivateKeyKey
+          value: $(params.githubPrivateKeyKey)
+        - name: githubRepo
+          value: $(params.githubRepo)
+      runAfter:
+        - notify-slack
+
+  finally:
+    - name: notify-slack-github-event-failure
+      when:
+        - input: $(tasks.send-github-event.status)
+          operator: in
+          values: ["Failed"]
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/konflux-ci.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/notify-slack-github-event-failure/notify-slack-github-event-failure.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: secretName
+          value: $(params.secretName)
+        - name: secretKeyName
+          value: $(params.secretKeyName)
+        - name: slackHandles
+          value: $(params.slackHandles)

--- a/tasks/notify-slack-github-event-failure/notify-slack-github-event-failure.yaml
+++ b/tasks/notify-slack-github-event-failure/notify-slack-github-event-failure.yaml
@@ -1,0 +1,124 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: notify-slack-github-event-failure
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "release, tenant"
+spec:
+  description: |-
+    Tekton task to send a Slack notification when the GitHub release event task fails.
+
+    This task sends a failure notification to Slack when the send-github-release-event
+    task fails, alerting the team that the GitHub release workflow was not triggered.
+  params:
+    - name: release
+      type: string
+      description: Namespaced name of release - should be in format "namespace/name"
+    - name: secretName
+      type: string
+      description: Name of secret which contains Slack webhook URL
+    - name: secretKeyName
+      type: string
+      description: Name of key within secret which contains Slack webhook URL
+    - name: slackHandles
+      type: string
+      description: Comma-separated list of Slack member IDs or group IDs to be tagged on failures
+      default: ""
+  volumes:
+    - name: slack-token
+      secret:
+        secretName: $(params.secretName)
+        optional: true
+  steps:
+    - name: notify-failure
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      volumeMounts:
+        - name: slack-token
+          mountPath: "/etc/secrets"
+          readOnly: true
+      env:
+        - name: KEYNAME
+          value: $(params.secretKeyName)
+        - name: SLACK_HANDLES
+          value: $(params.slackHandles)
+      script: |
+        #!/usr/bin/env bash
+        set -euxo pipefail
+
+        # Read Slack webhook URL from secret
+        if [ -z "${KEYNAME}" ]; then
+          echo "Error: Slack secret key name not provided"
+          exit 1
+        fi
+
+        if [ -f "/etc/secrets/${KEYNAME}" ]; then
+          set +x
+          WEBHOOK_URL=$(cat "/etc/secrets/${KEYNAME}")
+          set -x
+        else
+          echo "Error: Slack secret not found at /etc/secrets/${KEYNAME}"
+          exit 1
+        fi
+
+        # Parse release namespace and name
+        IFS='/' read -r RELEASE_NAMESPACE RELEASE_NAME <<< "$(params.release)"
+
+        # Build mentions string if handles are provided
+        MENTIONS_PREFIX=""
+        if [ -n "${SLACK_HANDLES}" ]; then
+          # Save original IFS
+          OLD_IFS=$IFS
+          # Split by comma
+          IFS=',' read -ra HANDLES <<< "$SLACK_HANDLES"
+          MENTIONS=""
+          for handle in "${HANDLES[@]}"; do
+            # Trim whitespace from each handle
+            handle=$(echo "$handle" | xargs)
+            if [ -n "$handle" ]; then
+              if [[ "$handle" == S* ]]; then
+                # Group IDs start with S, use <!subteam^GROUP_ID> format
+                MENTION="<!subteam^$handle>"
+              else
+                # Assume it's a user ID and use <@USER_ID> format
+                MENTION="<@$handle>"
+              fi
+              MENTIONS="$MENTIONS $MENTION"
+            fi
+          done
+          # Trim leading/trailing whitespace from the final string
+          MENTIONS=$(echo "$MENTIONS" | xargs)
+          # Set prefix with mentions
+          MENTIONS_PREFIX=$(printf "%s\n\n" "$MENTIONS")
+          # Restore IFS
+          IFS=$OLD_IFS
+        fi
+
+        # Construct failure message
+        MESSAGE=$(printf "%sRelease: %s/%s\n\nGitHub release event task failed. The GitHub release workflow was not triggered." \
+          "$MENTIONS_PREFIX" "$RELEASE_NAMESPACE" "$RELEASE_NAME")
+
+        # Send message to Slack
+        cat > /tmp/payload.json << EOF
+        {"text": $(echo -n "$MESSAGE" | jq -Rsa .)}
+        EOF
+
+        set +x
+        RESPONSE=$(curl -s -w "\n%{http_code}" \
+          -X POST \
+          -H "Content-Type: application/json" \
+          "${WEBHOOK_URL}" \
+          -d @/tmp/payload.json)
+        set -x
+
+        HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+        BODY=$(echo "$RESPONSE" | sed '$d')
+
+        if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+          echo "Successfully sent Slack notification (HTTP $HTTP_CODE)"
+        else
+          echo "Warning: Failed to send Slack notification (HTTP $HTTP_CODE): $BODY"
+          # Don't fail the task if Slack notification fails
+          exit 0
+        fi

--- a/tasks/send-github-release-event/README.md
+++ b/tasks/send-github-release-event/README.md
@@ -1,0 +1,63 @@
+# send-github-release-event
+
+Tekton task to send a `repository_dispatch` event to GitHub after a successful tag-based
+release.
+
+## Description
+
+This task extracts version, image tag, and git ref from the Release CR and sends a
+`repository_dispatch` event to trigger the GitHub release workflow.
+
+The task only runs for tag-based releases (when `source-branch` starts with
+`refs/tags/`). It gracefully exits if the release is not tag-based or if the release was
+not successful.
+
+## Authentication
+
+The task supports two authentication methods:
+
+1. **GitHub App** (preferred): Provide a single secret (`githubAppSecretName`, default:
+   `github-app-credentials`) with three keys:
+   - `githubAppIdKey` (default: `app-id`) - contains the GitHub App ID
+   - `githubInstallationIdKey` (default: `installation-id`) - contains the Installation ID
+   - `githubPrivateKeyKey` (default: `private-key`) - contains the App's private key
+
+   The task will generate a JWT, exchange it for an installation token, and use that token.
+
+2. **Personal Access Token (PAT)** (fallback): Provide `githubTokenSecretName`
+   (default: `github-token`) and `githubTokenSecretKey`. The token is read directly
+   from the secret.
+
+**Priority**: GitHub App is checked first. If GitHub App credentials are not available,
+the task falls back to PAT. If neither is available, the task will fail.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| release | The namespaced name of the Release (format: "namespace/name") | No | - |
+| githubTokenSecretName | Name of secret which contains GitHub token (PAT). Used as fallback if GitHub App authentication is not available. | Yes | "github-token" |
+| githubTokenSecretKey | Name of key within secret which contains GitHub token | Yes | token |
+| githubAppSecretName | Name of secret which contains GitHub App credentials (app-id, installation-id, private-key). Preferred authentication method. | Yes | github-app-credentials |
+| githubAppIdKey | Name of key within GitHub App secret which contains the App ID | Yes | app-id |
+| githubInstallationIdKey | Name of key within GitHub App secret which contains the Installation ID | Yes | installation-id |
+| githubPrivateKeyKey | Name of key within GitHub App secret which contains the private key | Yes | private-key |
+| githubRepo | GitHub repository in format "owner/repo" (e.g., "konflux-ci/konflux-ci") | No | - |
+
+## Behavior
+
+1. **Checks release status**: Only proceeds if release status is "True"
+2. **Checks if tag-based**: Only proceeds if `source-branch` starts with `refs/tags/`
+3. **Extracts data from Release CR**:
+   - Version: Extracted from `source-branch` annotation (removes `refs/tags/` prefix)
+   - Git SHA: From `metadata.labels.pac.test.appstudio.openshift.io/sha`
+   - Image tag: From `status.artifacts.images[0].urls[]` (finds `release-sha-*` format)
+4. **Sends GitHub event**: Sends `repository_dispatch` with event type `konflux-build-complete`
+
+## Exit Codes
+
+- **0 (success)**: Event sent successfully, or release was not tag-based (graceful exit)
+- **1 (failure)**: Missing required parameters or secrets
+
+The task is designed to not fail the pipeline if the GitHub event cannot be sent (e.g.,
+network issues). It logs a warning and exits successfully.

--- a/tasks/send-github-release-event/send-github-release-event.yaml
+++ b/tasks/send-github-release-event/send-github-release-event.yaml
@@ -1,0 +1,270 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: send-github-release-event
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "release, tenant"
+spec:
+  description: |-
+    Tekton task to send a repository_dispatch event to GitHub after a successful tag-based release.
+
+    This task extracts version, image tag, and git ref from the Release CR and sends a
+    repository_dispatch event to trigger the GitHub release workflow.
+
+    The task only runs for tag-based releases (when source-branch starts with "refs/tags/").
+    It gracefully exits if the release is not tag-based or if the release was not successful.
+  params:
+    - name: release
+      type: string
+      description: Namespaced name of release - should be in format "namespace/name"
+    - name: githubTokenSecretName
+      type: string
+      description: |-
+        Name of secret which contains GitHub token (PAT).
+        Used as fallback if GitHub App authentication is not available.
+      default: "github-token"
+    - name: githubTokenSecretKey
+      type: string
+      description: Name of key within secret which contains GitHub token
+      default: token
+    - name: githubAppSecretName
+      type: string
+      description: |-
+        Name of secret which contains GitHub App credentials (app-id, installation-id, private-key).
+        Used when githubTokenSecretName is not provided.
+      default: github-app-credentials
+    - name: githubAppIdKey
+      type: string
+      description: Name of key within GitHub App secret which contains the App ID
+      default: app-id
+    - name: githubInstallationIdKey
+      type: string
+      description: Name of key within GitHub App secret which contains the Installation ID
+      default: installation-id
+    - name: githubPrivateKeyKey
+      type: string
+      description: Name of key within GitHub App secret which contains the private key
+      default: private-key
+    - name: githubRepo
+      type: string
+      description: GitHub repository in format "owner/repo" (e.g., "konflux-ci/konflux-ci")
+  volumes:
+    - name: github-token
+      secret:
+        secretName: $(params.githubTokenSecretName)
+        optional: true
+    - name: github-app-credentials
+      secret:
+        secretName: $(params.githubAppSecretName)
+        optional: true
+  steps:
+    - name: send-github-event
+      image: quay.io/konflux-ci/release-service-utils:9b99072bc14c25be6924a6338af166211ea069a8
+      volumeMounts:
+        - name: github-token
+          mountPath: "/etc/secrets/token"
+          readOnly: true
+        - name: github-app-credentials
+          mountPath: "/etc/secrets/app"
+          readOnly: true
+      env:
+        - name: GITHUB_TOKEN_KEY
+          value: $(params.githubTokenSecretKey)
+        - name: GITHUB_REPO
+          value: $(params.githubRepo)
+        - name: GITHUB_APP_ID_KEY
+          value: $(params.githubAppIdKey)
+        - name: GITHUB_INSTALLATION_ID_KEY
+          value: $(params.githubInstallationIdKey)
+        - name: GITHUB_PRIVATE_KEY_KEY
+          value: $(params.githubPrivateKeyKey)
+      script: |
+        #!/usr/bin/env bash
+        # We explicitly avoid 'x' here to prevent logging variable values.
+        # We will use 'set -x' only on non-sensitive blocks.
+        set -euo pipefail
+
+        # Temporary file to store the token securely (outside of logs)
+        TOKEN_FILE="/tmp/gh_token_env.sh"
+        touch "$TOKEN_FILE"
+        chmod 600 "$TOKEN_FILE"
+
+        # Determine authentication method: GitHub App (preferred) or PAT (fallback)
+        if [ -n "${GITHUB_APP_ID_KEY}" ] && [ -f "/etc/secrets/app/${GITHUB_APP_ID_KEY}" ]; then
+          echo "Using GitHub App authentication"
+
+          # 1. Prepare credentials
+          APP_ID=$(cat "/etc/secrets/app/${GITHUB_APP_ID_KEY}")
+          INSTALLATION_ID=$(cat "/etc/secrets/app/${GITHUB_INSTALLATION_ID_KEY}")
+          PRIVATE_KEY_PATH="/tmp/private_key.pem"
+          cat "/etc/secrets/app/${GITHUB_PRIVATE_KEY_KEY}" > "$PRIVATE_KEY_PATH"
+          chmod 600 "$PRIVATE_KEY_PATH"
+
+          # 2. Generate token using Python (Writing directly to the TOKEN_FILE)
+          export APP_ID INSTALLATION_ID PRIVATE_KEY_PATH TOKEN_FILE
+          if ! python3 - << 'PYTHON_EOF'; then
+        import time, json, base64, requests, sys, os
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import padding
+
+        try:
+            app_id = os.environ['APP_ID']
+            inst_id = os.environ['INSTALLATION_ID']
+            key_path = os.environ['PRIVATE_KEY_PATH']
+            output_file = os.environ['TOKEN_FILE']
+
+            def b64_encode(data):
+                return base64.urlsafe_b64encode(data).decode('utf-8').replace('=', '')
+
+            header = b64_encode(json.dumps({'alg': 'RS256', 'typ': 'JWT'}).encode())
+            payload = b64_encode(
+              json.dumps(
+                {'iat': int(time.time()), 'exp': int(time.time()) + 600, 'iss': app_id}
+              ).encode())
+
+            with open(key_path, 'rb') as f:
+                key = serialization.load_pem_private_key(f.read(), password=None)
+
+            signature = b64_encode(
+              key.sign(f'{header}.{payload}'.encode(), padding.PKCS1v15(), hashes.SHA256()))
+            jwt_token = f'{header}.{payload}.{signature}'
+
+            url = f'https://api.github.com/app/installations/{inst_id}/access_tokens'
+            resp = requests.post(
+              url, headers={
+                'Authorization': f'Bearer {jwt_token}',
+                'Accept': 'application/vnd.github+json'
+              })
+            resp.raise_for_status()
+
+            # CRITICAL: Write to file instead of printing to stdout
+            token = resp.json()['token']
+            with open(output_file, 'w') as f:
+                f.write(f'export GITHUB_TOKEN="{token}"\n')
+            os.chmod(output_file, 0o600)  # rw------- permissions
+
+        except Exception as e:
+            print(f"Python Auth Error: {e}", file=sys.stderr)
+            sys.exit(1)
+        PYTHON_EOF
+            echo "Error: Failed to generate GitHub App installation token" >&2
+            rm -f "$PRIVATE_KEY_PATH"
+            exit 1
+          fi
+
+          # Clean up private key immediately
+          rm -f "$PRIVATE_KEY_PATH"
+
+        elif [ -n "${GITHUB_TOKEN_KEY}" ] && [ -f "/etc/secrets/token/${GITHUB_TOKEN_KEY}" ]; then
+          echo "GitHub App credentials not found, using PAT token for authentication"
+          # Write to file instead of variable to avoid accidental 'set -x' leakage
+          echo "export GITHUB_TOKEN=\"$(cat "/etc/secrets/token/${GITHUB_TOKEN_KEY}")\"" > "$TOKEN_FILE"
+        else
+          echo "Error: Neither GitHub App credentials nor PAT token found"
+          echo "Either provide githubAppSecretName or githubTokenSecretName"
+          exit 1
+        fi
+
+        # 3. Source the token into the shell environment
+        if [ -s "$TOKEN_FILE" ]; then
+          source "$TOKEN_FILE"
+          rm -f "$TOKEN_FILE"
+        else
+          echo "Error: Failed to generate GitHub token file"
+          exit 1
+        fi
+
+        # Verify token was loaded (check before enabling set -x to avoid logging token value)
+        # Use a pattern that doesn't expand the variable value in logs
+        TOKEN_SET=0
+        [ -n "${GITHUB_TOKEN:-}" ] && TOKEN_SET=1
+        if [ "$TOKEN_SET" -eq 0 ]; then
+          echo "Error: Failed to obtain GitHub token"
+          exit 1
+        fi
+
+        if [ -z "${GITHUB_REPO}" ]; then
+          echo "Error: GitHub repository not provided"
+          exit 1
+        fi
+
+        set -x
+        echo "Authentication successful for repository: ${GITHUB_REPO}"
+
+        # Parse release namespace and name
+        IFS='/' read -r RELEASE_NAMESPACE RELEASE_NAME <<< "$(params.release)"
+
+        # Get Release CR
+        RELEASE=$(kubectl get release "$RELEASE_NAME" -n "$RELEASE_NAMESPACE" -o json)
+
+        # Check if release succeeded
+        RELEASE_STATUS=$(jq -r '.status.conditions[] | select(.type=="Released") | .status' <<< "$RELEASE")
+        if [ "$RELEASE_STATUS" != "True" ]; then
+          echo "Release not successful (status: $RELEASE_STATUS), skipping GitHub event"
+          exit 0
+        fi
+
+        # Extract source branch to determine if it's tag-based
+        SOURCE_BRANCH=$(jq -r '.metadata.annotations."pac.test.appstudio.openshift.io/source-branch"' <<< "$RELEASE")
+
+        # Check if this is a tag-based release
+        if [[ ! "$SOURCE_BRANCH" =~ ^refs/tags/ ]]; then
+          echo "Not a tag-based release (source-branch: $SOURCE_BRANCH), skipping GitHub event"
+          exit 0
+        fi
+
+        # Extract version directly from source-branch (remove "refs/tags/" prefix)
+        VERSION="${SOURCE_BRANCH#refs/tags/}"
+
+        # Extract git SHA
+        GIT_SHA=$(jq -r '.metadata.labels."pac.test.appstudio.openshift.io/sha"' <<< "$RELEASE")
+        if [ -z "$GIT_SHA" ] || [ "$GIT_SHA" == "null" ]; then
+          echo "Warning: git sha not found in Release labels, skipping GitHub event"
+          exit 0
+        fi
+
+        # Extract image tag (find the release-sha-* format)
+        IMAGE_TAG=$(jq -r '.status.artifacts.images[0].urls[] | select(contains("release-sha-"))' <<< "$RELEASE" | head -1)
+        if [ -z "$IMAGE_TAG" ] || [ "$IMAGE_TAG" == "null" ]; then
+          echo "Warning: image tag not found in Release artifacts, skipping GitHub event"
+          exit 0
+        fi
+
+        # Extract just the tag part: release-sha-80669c7
+        IMAGE_TAG_VALUE=$(echo "$IMAGE_TAG" | sed 's/.*:\(release-sha-[^@]*\).*/\1/')
+
+        echo "Sending GitHub repository_dispatch event:"
+        echo "  version: $VERSION"
+        echo "  image_tag: $IMAGE_TAG_VALUE"
+        echo "  git_ref: $GIT_SHA"
+
+        # Prepare payload
+        PAYLOAD=$(jq -n \
+          --arg version "$VERSION" \
+          --arg image_tag "$IMAGE_TAG_VALUE" \
+          --arg git_ref "$GIT_SHA" \
+          '{version: $version, image_tag: $image_tag, git_ref: $git_ref}')
+
+        # Send repository_dispatch event
+        set +x
+        RESPONSE=$(curl -s -w "\n%{http_code}" \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/repos/${GITHUB_REPO}/dispatches" \
+          -d "{\"event_type\":\"konflux-build-complete\",\"client_payload\":${PAYLOAD}}")
+        set -x
+
+        HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+        BODY=$(echo "$RESPONSE" | sed '$d')
+
+        if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+          echo "Successfully sent GitHub repository_dispatch event (HTTP $HTTP_CODE)"
+        else
+          echo "Warning: Failed to send GitHub event (HTTP $HTTP_CODE): $BODY"
+          # Don't fail the pipeline, just log the warning
+          exit 0
+        fi


### PR DESCRIPTION
Implement final pipeline to notify and trigger GitHub release. This pipeline will replace the one currently referenced in the operator releaseplan, and will notify Slack both on release failures (as before) and on failures for sending the GitHub release event.

Assisted-by: Cursor