### PR TITLE
Add workflow to create community-operators-prod PRs

### DIFF
--- a/.github/scripts/create-community-operator-pr.sh
+++ b/.github/scripts/create-community-operator-pr.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+set -euo pipefail
+
+# Create Community Operator PR Script
+# This script creates a PR to the community-operators-prod repository
+# with a new bundle version for the Konflux operator.
+#
+# Usage:
+#   create-community-operator-pr.sh <release_tag>
+#
+# Arguments:
+#   release_tag - GitHub release tag (e.g., v0.0.4)
+#
+# Environment Variables (required):
+#   GITHUB_TOKEN - GitHub token for downloading release assets from source repo
+#   FORK_TOKEN   - GitHub token with write access to the fork (for push and PR creation)
+#
+# Example:
+#   GITHUB_TOKEN=ghp_xxx FORK_TOKEN=ghp_yyy create-community-operator-pr.sh v0.0.4
+
+# Configuration
+UPSTREAM_REPO="redhat-openshift-ecosystem/community-operators-prod"
+FORK_REPO="konflux-ci/community-operators-prod"
+SOURCE_REPO="konflux-ci/konflux-ci"
+OPERATOR_NAME="konflux"
+
+if [ $# -ne 1 ]; then
+  echo "Error: Invalid number of arguments"
+  echo "Usage: $0 <release_tag>"
+  exit 1
+fi
+
+RELEASE_TAG="$1"
+
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "Error: GITHUB_TOKEN environment variable is required"
+  exit 1
+fi
+
+if [ -z "${FORK_TOKEN:-}" ]; then
+  echo "Error: FORK_TOKEN environment variable is required"
+  exit 1
+fi
+
+echo "=== Creating Community Operator PR ==="
+echo "Release tag: ${RELEASE_TAG}"
+echo "Source repo: ${SOURCE_REPO}"
+echo "Fork repo: ${FORK_REPO}"
+echo "Upstream repo: ${UPSTREAM_REPO}"
+
+# Create temporary directory for work
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "${WORK_DIR}"' EXIT
+echo "Working directory: ${WORK_DIR}"
+
+# Download release assets
+echo ""
+echo "=== Downloading release assets ==="
+ASSETS_DIR="${WORK_DIR}/assets"
+mkdir -p "${ASSETS_DIR}"
+
+# Download version file (use GITHUB_TOKEN for source repo access)
+echo "Downloading version file..."
+GH_TOKEN="${GITHUB_TOKEN}" gh release download "${RELEASE_TAG}" \
+  --repo "${SOURCE_REPO}" \
+  --pattern "version" \
+  --dir "${ASSETS_DIR}"
+
+# Download bundle tarball
+echo "Downloading bundle.tar.gz..."
+GH_TOKEN="${GITHUB_TOKEN}" gh release download "${RELEASE_TAG}" \
+  --repo "${SOURCE_REPO}" \
+  --pattern "bundle.tar.gz" \
+  --dir "${ASSETS_DIR}"
+
+# Read and process version
+VERSION_WITH_V=$(cat "${ASSETS_DIR}/version")
+VERSION="${VERSION_WITH_V#v}"  # Strip leading 'v'
+echo "Version (with v): ${VERSION_WITH_V}"
+echo "Version (without v): ${VERSION}"
+
+# Extract bundle
+echo ""
+echo "=== Extracting bundle ==="
+BUNDLE_DIR="${WORK_DIR}/bundle"
+mkdir -p "${BUNDLE_DIR}"
+tar xzf "${ASSETS_DIR}/bundle.tar.gz" -C "${BUNDLE_DIR}"
+echo "Bundle contents:"
+ls -la "${BUNDLE_DIR}"
+
+# Clone the fork (use FORK_TOKEN for fork repo access)
+echo ""
+echo "=== Cloning fork repository ==="
+REPO_DIR="${WORK_DIR}/community-operators-prod"
+git clone --depth 1 "https://x-access-token:${FORK_TOKEN}@github.com/${FORK_REPO}.git" "${REPO_DIR}"
+cd "${REPO_DIR}"
+
+# Configure git
+git config user.name "konflux-ci-bot"
+git config user.email "konflux-ci-bot@redhat.com"
+
+# Add upstream remote
+git remote add upstream "https://github.com/${UPSTREAM_REPO}.git"
+git fetch upstream main --depth 1
+
+# Create branch from upstream main
+BRANCH_NAME="${OPERATOR_NAME}-${VERSION}"
+echo ""
+echo "=== Creating branch: ${BRANCH_NAME} ==="
+git checkout -b "${BRANCH_NAME}" upstream/main
+
+# Create operator version directory
+OPERATOR_DIR="operators/${OPERATOR_NAME}/${VERSION}"
+echo ""
+echo "=== Creating operator directory: ${OPERATOR_DIR} ==="
+mkdir -p "${OPERATOR_DIR}"
+
+# Copy all bundle contents (manifests, metadata, tests, Dockerfile, release-config.yaml, etc.)
+cp -r "${BUNDLE_DIR}"/* "${OPERATOR_DIR}/"
+echo "✅ Copied all bundle contents"
+
+echo ""
+echo "Operator directory contents:"
+find "${OPERATOR_DIR}" -type f | head -20
+
+# Prepare commit/PR message
+COMMIT_TITLE="operator ${OPERATOR_NAME} (${VERSION})"
+COMMIT_BODY="## New Operator Bundle
+
+**Operator:** ${OPERATOR_NAME}
+**Version:** ${VERSION}
+**Source Release:** https://github.com/${SOURCE_REPO}/releases/tag/${RELEASE_TAG}
+
+This PR adds a new bundle version for the Konflux operator.
+
+### Changes
+- Added bundle for version ${VERSION}
+"
+
+# Stage and commit changes
+echo ""
+echo "=== Committing changes ==="
+git add "${OPERATOR_DIR}"
+git commit -m "${COMMIT_TITLE}" -m "${COMMIT_BODY}"
+echo "Commit title: ${COMMIT_TITLE}"
+
+# Push to fork
+echo ""
+echo "=== Pushing to fork ==="
+git push origin "${BRANCH_NAME}"
+
+# Create PR to upstream
+echo ""
+echo "=== Creating Pull Request ==="
+
+# Use FORK_TOKEN for PR creation (needs write access to create PR from fork)
+PR_URL=$(GH_TOKEN="${FORK_TOKEN}" gh pr create \
+  --repo "${UPSTREAM_REPO}" \
+  --head "${FORK_REPO%%/*}:${BRANCH_NAME}" \
+  --base main \
+  --title "${COMMIT_TITLE}" \
+  --body "${COMMIT_BODY}")
+
+echo ""
+echo "=== PR Created Successfully ==="
+echo "PR URL: ${PR_URL}"
+echo ""
+echo "Done!"

--- a/.github/workflows/community-operator-pr.yaml
+++ b/.github/workflows/community-operator-pr.yaml
@@ -1,0 +1,48 @@
+name: Community Operator PR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'GitHub release tag (e.g., v0.0.4)'
+        required: true
+        type: string
+
+jobs:
+  create-pr:
+    name: Create Community Operator PR
+    runs-on: ubuntu-latest
+    # Skip pre-releases for automatic triggers
+    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
+    steps:
+      - name: Generate GitHub App token for fork repository
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.UPDATE_BOT_APP_ID }}
+          private-key: ${{ secrets.UPDATE_BOT_PRIVATE_KEY }}
+          owner: konflux-ci
+          repositories: community-operators-prod
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Determine release tag
+        id: release
+        run: |
+          if [ "${{ github.event_name }}" == "release" ]; then
+            RELEASE_TAG="${{ github.event.release.tag_name }}"
+          else
+            RELEASE_TAG="${{ inputs.release_tag }}"
+          fi
+          echo "tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
+          echo "Using release tag: ${RELEASE_TAG}"
+
+      - name: Create Community Operator PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORK_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          .github/scripts/create-community-operator-pr.sh "${{ steps.release.outputs.tag }}"


### PR DESCRIPTION
This adds automation to create PRs to the community-operators-prod repository when a new release is published.

Components:
- .github/scripts/create-community-operator-pr.sh: Script that downloads the bundle from a release, pushes it to the fork, and creates a PR
- .github/workflows/community-operator-pr.yaml: Workflow that triggers on release publish or manual dispatch

The workflow:
- Downloads bundle.tar.gz and version from the release
- Extracts bundle to operators/konflux/<version>/ (version without 'v')
- Pushes to konflux-ci/community-operators-prod fork
- Creates PR to redhat-openshift-ecosystem/community-operators-prod

Tokens used:
- GITHUB_TOKEN: Download release assets from source repo
- GitHub App (UPDATE_BOT): Push to fork repository

Assisted-By: Cursor