### PR TITLE
Optimize community-operator-pr workflow and use PAT

### DIFF
--- a/.github/workflows/community-operator-pr.yaml
+++ b/.github/workflows/community-operator-pr.yaml
@@ -17,15 +17,6 @@ jobs:
     # Skip pre-releases for automatic triggers
     if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
     steps:
-      - name: Generate GitHub App token for fork repository
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.UPDATE_BOT_APP_ID }}
-          private-key: ${{ secrets.UPDATE_BOT_PRIVATE_KEY }}
-          owner: konflux-ci
-          repositories: community-operators-prod
-
       - name: Checkout repository
         uses: actions/checkout@v6
 
@@ -42,7 +33,6 @@ jobs:
 
       - name: Create Community Operator PR
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FORK_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.KONFLUX_CI_BOT_PAT }}
         run: |
           .github/scripts/create-community-operator-pr.sh "${{ steps.release.outputs.tag }}"


### PR DESCRIPTION
Script changes:
- Use treeless clone with sparse checkout for faster cloning (--filter=tree:0, sparse-checkout for operators/konflux only)
- Clone from upstream, set fork as origin for pushing
- Simplify to use single GITHUB_TOKEN instead of separate FORK_TOKEN
- Add sign-off (-s) to commits
- Force push to handle existing branches
- Update git email to konflux-ci-maintainers@redhat.com

Workflow changes:
- Remove GitHub App token generation (apps can't create cross-repo PRs)
- Use KONFLUX_CI_BOT_PAT for all operations. This is a personal access token of a bot account. This is the only method for opening PRs to repositories we don't control (can't install Github app on them).