### PR TITLE
fix(KFLUXVNGD-665): wrong check before event sending

### DIFF
--- a/tasks/send-github-release-event/README.md
+++ b/tasks/send-github-release-event/README.md
@@ -46,7 +46,8 @@ the task falls back to PAT. If neither is available, the task will fail.
 
 ## Behavior
 
-1. **Checks release status**: Only proceeds if release status is "True"
+1. **Checks release status**: Only proceeds if `ManagedPipelineProcessed` condition has
+reason "Succeeded".
 2. **Checks if tag-based**: Only proceeds if `source-branch` starts with `refs/tags/`
 3. **Extracts data from Release CR**:
    - Version: Extracted from `source-branch` annotation (removes `refs/tags/` prefix)

--- a/tasks/send-github-release-event/send-github-release-event.yaml
+++ b/tasks/send-github-release-event/send-github-release-event.yaml
@@ -200,9 +200,12 @@ spec:
         RELEASE=$(kubectl get release "$RELEASE_NAME" -n "$RELEASE_NAMESPACE" -o json)
 
         # Check if release succeeded
-        RELEASE_STATUS=$(jq -r '.status.conditions[] | select(.type=="Released") | .status' <<< "$RELEASE")
-        if [ "$RELEASE_STATUS" != "True" ]; then
-          echo "Release not successful (status: $RELEASE_STATUS), skipping GitHub event"
+        RELEASECONDITIONS=$(kubectl get release "$RELEASE_NAME" -n "$RELEASE_NAMESPACE" \
+          -o jsonpath='{.status.conditions}' | jq '.[] | select(.type == "ManagedPipelineProcessed")')
+        RELEASESTATUS=$(jq -r '.reason' <<< "$RELEASECONDITIONS")
+
+        if [[ "$RELEASESTATUS" != *"Succeeded"* ]]; then
+          echo "Release managed pipeline not successful (reason: $RELEASESTATUS), skipping GitHub event"
           exit 0
         fi
 


### PR DESCRIPTION
Wrong status was used before sending event to GitHub. Aligned the check with what we're doing for slack notifications.

Assisted-by: Cursor