### PR TITLE
fix(KFLUXVNGD-674): parse gitref

### DIFF
--- a/.github/scripts/create-release.sh
+++ b/.github/scripts/create-release.sh
@@ -81,6 +81,6 @@ gh release create "$VERSION" \
   $GENERATE_NOTES_FLAG \
   $DRAFT_FLAG \
   "${ARTIFACTS[@]}" \
-  --target "$GIT_REF"
+  --target "$(git rev-parse "$GIT_REF")"
 
 echo "Release created successfully: $VERSION"


### PR DESCRIPTION
parse gitref from event payload

This PR is for adding git rev-parse to our gitref, so that whatever git reference is provided (branch name, tag, short SHA, etc.), it will be resolved to the full commit SHA before being passed to the --target flag of the GitHub release command.