### PR TITLE
chore: change release workflow defaults

### DIFF
--- a/.github/scripts/create-release.sh
+++ b/.github/scripts/create-release.sh
@@ -73,8 +73,7 @@ if [ ${#ARTIFACTS[@]} -eq 0 ]; then
   exit 1
 fi
 
-# Create release using official GitHub CLI (gh)
-# Uses GITHUB_TOKEN (if permissions are insufficient, we can add GitHub App token later)
+# Create release using GitHub CLI
 gh release create "$VERSION" \
   --title "Release $VERSION" \
   --notes-file "$NOTES_FILE" \

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -18,15 +18,15 @@ on:
         required: false
         type: string
       draft:
-        description: 'Create as draft release (for testing - no notifications)'
-        required: false
-        type: boolean
-        default: true
-      generate_notes:
-        description: 'Auto-generate commit history (skip for first release with many commits)'
+        description: 'Create as draft release'
         required: false
         type: boolean
         default: false
+      generate_notes:
+        description: 'Include auto-generated notes with commit history'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   create-release:
@@ -121,14 +121,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # TODO: Revert to use input when repository_dispatch events support draft flag
-          # Change "true" back to "${{ inputs.draft }}" to restore manual control
           .github/scripts/create-release.sh \
             "${{ steps.version.outputs.version }}" \
             "${{ steps.payload.outputs.git_ref }}" \
             /tmp/release-notes.md \
             operator/dist \
-            "true" \
+            "${{ inputs.draft }}" \
             "${{ inputs.generate_notes }}"
 
       - name: Create issue on release failure


### PR DESCRIPTION
The release workflow was set to create drafts by default and to not generate automated release notes. This commit changes theses defaults.

It also reverts the hardwired use of the release script so it always release drafts, and do some minor cleanup.