### PR TITLE
fix: remove notifications from konflux-info CR

### DIFF
--- a/operator/config/samples/konflux_v1alpha1_konflux.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konflux.yaml
@@ -91,22 +91,6 @@ spec:
       publicInfo:
         environment: development
         visibility: public
-        integrations:
-          image_controller:
-            enabled: true
-            notifications:
-              # Example webhook notification
-              - title: "Build Notification"
-                event: "build_complete"
-                method: "webhook"
-                config:
-                  url: "https://webhook.example.com/build"
-              # Example email notification
-              - title: "Email Notification"
-                event: "repo_push"
-                method: "email"
-                config:
-                  email: "team@example.com"
       banner:
         items:
           - summary: "Welcome to Konflux-CI! This is a development environment for testing and development purposes."


### PR DESCRIPTION
The konflux-info part of the main top-level PR includes notifications, which caused onboarding of applications to fail. This commit removes this bit.

Assisted-by: Cursor