### PR TITLE
fix: defaults for release repository_dispatch

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -126,8 +126,8 @@ jobs:
             "${{ steps.payload.outputs.git_ref }}" \
             /tmp/release-notes.md \
             operator/dist \
-            "${{ inputs.draft }}" \
-            "${{ inputs.generate_notes }}"
+            "${{ inputs.draft || false }}" \
+            "${{ inputs.generate_notes != false }}"
 
       - name: Create issue on release failure
         if: failure()


### PR DESCRIPTION
Defaults were not set correctly when the workflow for creating a release was triggered via repository_dispatch event.

Assisted-by: Cursor