### PR TITLE
chore(KFLUXVNGD-672): GitHub workflow for making sure releases are created

### DIFF
--- a/.github/scripts/verify-releases.sh
+++ b/.github/scripts/verify-releases.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+set -euo pipefail
+
+# Verify Releases Script
+# This script checks if a release was created in the past 7 days and if commits were made
+#
+# Usage:
+#   verify-releases.sh <repository>
+#
+# Arguments:
+#   repository - Repository in format owner/repo (required)
+#
+# Environment Variables:
+#   GH_TOKEN      - GitHub token for API access (required)
+#   GITHUB_ENV    - Path to GitHub Actions environment file (automatically set by GitHub Actions)
+#
+# The script sets the following environment variables (via GITHUB_ENV):
+#   COMMIT_COUNT         - Number of commits found in the past 7 days
+#   VERIFICATION_FAILED  - "true" if verification failed (no release but commits exist), unset otherwise
+#
+# Exit Codes:
+#   0 - Success (release exists OR no commits)
+#   1 - Unexpected failure: Script error (should create generic issue)
+#   2 - Expected failure: No release found but commits exist (should create verification issue)
+#
+# Example:
+#   export GH_TOKEN="your_token"
+#   verify-releases.sh owner/repo
+
+if [ $# -lt 1 ]; then
+  echo "Error: Invalid number of arguments"
+  echo "Usage: $0 <repository>"
+  echo "  repository - Repository in format owner/repo"
+  exit 1
+fi
+
+REPOSITORY="$1"
+
+# Verify GH_TOKEN is set
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "Error: GH_TOKEN environment variable is not set"
+  exit 1
+fi
+
+# Set up GitHub CLI authentication
+export GH_TOKEN
+
+# Initialize VERIFICATION_FAILED to false (will be set to true if verification fails)
+echo "VERIFICATION_FAILED=false" >> "${GITHUB_ENV}"
+
+echo "Checking for releases in the past 7 days..."
+
+# Calculate the start time ONCE (7 days ago in seconds)
+# This freezes the window so both commands (to get releases and commits) use the exact same instant
+START_TIMESTAMP=$(date -u --date='7 days ago' +%s)
+
+# Check for releases in the past 7 days using gh release list
+# Use --arg to safely pass the bash variable into the jq query
+# shellcheck disable=SC2016
+# $start is a jq variable (passed via --arg), not a bash variable, so single quotes are correct
+# Wrap in error handling to catch unexpected failures
+if ! RELEASE_COUNT=$(gh release list --repo "$REPOSITORY" --limit 100 \
+  --json publishedAt \
+  --jq --arg start "$START_TIMESTAMP" 'map(select((.publishedAt | fromdate) > ($start | tonumber))) | length' 2>&1); then
+  echo "Error: Failed to check releases - ${RELEASE_COUNT}"
+  exit 1
+fi
+
+if [ "$RELEASE_COUNT" -gt 0 ]; then
+  echo "Found $RELEASE_COUNT release(s) in the past 7 days"
+  RELEASE_EXISTS="true"
+else
+  echo "No releases found in the past 7 days"
+  RELEASE_EXISTS="false"
+fi
+
+# Get commits in the past 7 days on main branch (excluding merge commits for cleaner output)
+# Git accepts the @timestamp syntax for absolute time
+COMMITS=$(git log --since="@$START_TIMESTAMP" \
+  --oneline --no-merges main 2>/dev/null || echo "")
+
+# Count commits
+COMMIT_COUNT=$(echo "$COMMITS" | wc -l | tr -d ' ')
+
+if [ "$COMMIT_COUNT" -gt 0 ]; then
+  echo ""
+  echo "Found $COMMIT_COUNT commit(s) in the past 7 days on main branch"
+  COMMITS_EXIST="true"
+
+  # Save commits to a file for the issue creation
+  echo "$COMMITS" > /tmp/recent-commits.txt
+
+  # Show all commits in workflow logs
+  echo ""
+  echo "Recent commits:"
+  echo "$COMMITS"
+else
+  echo ""
+  echo "No commits found in the past 7 days on main branch"
+  COMMITS_EXIST="false"
+  COMMIT_COUNT=0
+fi
+
+# Set environment variable for use in workflow (persist across steps)
+echo "COMMIT_COUNT=${COMMIT_COUNT}" >> "${GITHUB_ENV}"
+
+# Fail if no release exists but commits were made (expected failure - exit code 2)
+if [ "$RELEASE_EXISTS" = "false" ] && [ "$COMMITS_EXIST" = "true" ]; then
+  echo ""
+  echo "❌ No release found in the past 7 days, but commits exist"
+  echo "Commit count: ${COMMIT_COUNT}"
+  echo ""
+  echo "This workflow verifies that a release was created when commits are made to the main branch."
+  echo "Please create a release for the recent commits."
+  
+  # Set flag to indicate this is an expected verification failure (should create issue)
+  echo "VERIFICATION_FAILED=true" >> "${GITHUB_ENV}"
+  exit 2
+fi

--- a/.github/workflows/verify-releases.yaml
+++ b/.github/workflows/verify-releases.yaml
@@ -1,0 +1,58 @@
+name: Verify Releases
+
+on:
+  # Run weekly on Tuesday at 2 AM UTC (one day after auto-tag-weekly)
+  schedule:
+    - cron: '0 2 * * 2'
+  # Allow manual triggering
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  verify-release:
+    name: Verify Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Check for releases and commits
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          .github/scripts/verify-releases.sh ${{ github.repository }}
+
+      - name: Create issue on verification failure
+        if: env.VERIFICATION_FAILED == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_NAME: Verify Releases
+        run: |
+          .github/scripts/create-or-update-issue.sh \
+            "Weekly Release Verification Failed" \
+            "No GitHub release was created in the past 7 days, but ${COMMIT_COUNT} commit(s) were made to the main branch during this period." \
+            /tmp/recent-commits.txt
+
+      - name: Create issue on unexpected failure
+        if: failure() && env.VERIFICATION_FAILED != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_NAME: Verify Releases
+        run: |
+          .github/scripts/create-or-update-issue.sh \
+            "Weekly Release Verification Workflow Failed" \
+            "The weekly release verification workflow encountered an unexpected error. Please check the workflow logs to identify and fix the issue."


### PR DESCRIPTION
This workflow verifies that a release was created during the last 7 days in case commits were made to the main branch. 
In case no release was created but commits were made, an issue is created to remind the user to create a release.

This workflow runs periodically a day after the the `create-release` is running

In any case that the workflow fails, an issue is created to remind the user to check the workflow logs and fix the issue.


Assisted-By: Cursor