### PR TITLE
fix: release notes not generated on repository_dispatch

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -127,7 +127,7 @@ jobs:
             /tmp/release-notes.md \
             operator/dist \
             "${{ inputs.draft || false }}" \
-            "${{ inputs.generate_notes != false }}"
+            "${{ inputs.generate_notes || 'true' }}"
 
       - name: Create issue on release failure
         if: failure()


### PR DESCRIPTION
When release is triggered from repository_dispatch event, release notes were not being generated due to incorrect boolean expression for setting the relevant input to the release script. This commit hopefully fixes the logic.

Assisted-by: Cursor