### PR TITLE
chore(KFLUXVNGD-693): add ta repo token to e2e workflows

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -287,6 +287,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           QUAY_DOCKERCONFIGJSON: ${{ secrets.QUAY_DOCKERCONFIGJSON }}
           RELEASE_SERVICE_CATALOG_REVISION: ${{ secrets.RELEASE_SERVICE_CATALOG_REVISION }}
+          RELEASE_CATALOG_TA_QUAY_TOKEN: ${{ secrets.RELEASE_CATALOG_TA_QUAY_TOKEN }}
         run: |
           ./test/e2e/run-e2e.sh
 

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -153,6 +153,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           QUAY_DOCKERCONFIGJSON: ${{ secrets.QUAY_DOCKERCONFIGJSON }}
           RELEASE_SERVICE_CATALOG_REVISION: ${{ secrets.RELEASE_SERVICE_CATALOG_REVISION }}
+          RELEASE_CATALOG_TA_QUAY_TOKEN: ${{ secrets.RELEASE_CATALOG_TA_QUAY_TOKEN }}
         run: |
           ./test/e2e/run-e2e.sh
 


### PR DESCRIPTION
We're going to move the e2e tests to use the development branch of release-service-catalog, which requires a token for writing to a trusted artifact repository.

This change will allow testing this in the next PR.