### PR TITLE
fix(KFLUXVNGD-705): report cert-manager missing and requeue

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -279,8 +279,9 @@ func main() {
 	)
 
 	if err := (&konflux.KonfluxReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ClusterInfo: clusterInfo,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Konflux")
 		os.Exit(1)

--- a/operator/internal/condition/constants.go
+++ b/operator/internal/condition/constants.go
@@ -67,4 +67,13 @@ const (
 
 	// ReasonSubCRStatusFailed indicates that fetching sub-CR status failed.
 	ReasonSubCRStatusFailed = "SubCRStatusFailed"
+
+	// ReasonCertManagerNotInstalled indicates that cert-manager CRDs are not installed.
+	ReasonCertManagerNotInstalled = "CertManagerNotInstalled"
+
+	// ReasonCertManagerInstallationCheckFailed indicates that checking cert-manager availability failed.
+	ReasonCertManagerInstallationCheckFailed = "CertManagerInstallationCheckFailed"
+
+	// ReasonCertManagerInstalled indicates that cert-manager CRDs are installed.
+	ReasonCertManagerInstalled = "CertManagerInstalled"
 )

--- a/operator/internal/constant/constant.go
+++ b/operator/internal/constant/constant.go
@@ -24,6 +24,8 @@ const (
 	KonfluxComponentLabel = "konflux.konflux-ci.dev/component"
 	// ConditionTypeReady is the condition type for overall readiness
 	ConditionTypeReady = "Ready"
+	// ConditionTypeCertManagerAvailable is the condition type for cert-manager availability
+	ConditionTypeCertManagerAvailable = "CertManagerAvailable"
 	// CertManagerGroup is the API group for cert-manager resources
 	CertManagerGroup = "cert-manager.io"
 	// KyvernoGroup is the API group for Kyverno resources

--- a/operator/internal/controller/applicationapi/konfluxapplicationapi_controller.go
+++ b/operator/internal/controller/applicationapi/konfluxapplicationapi_controller.go
@@ -116,8 +116,6 @@ func (r *KonfluxApplicationAPIReconciler) Reconcile(ctx context.Context, req ctr
 // applyManifests loads and applies all embedded manifests to the cluster using the tracking client.
 // Manifests are parsed once and cached; deep copies are used during reconciliation.
 func (r *KonfluxApplicationAPIReconciler) applyManifests(ctx context.Context, tc *tracking.Client) error {
-	log := logf.FromContext(ctx)
-
 	objects, err := r.ObjectStore.GetForComponent(manifests.ApplicationAPI)
 	if err != nil {
 		return fmt.Errorf("failed to get parsed manifests for ApplicationAPI: %w", err)
@@ -126,18 +124,6 @@ func (r *KonfluxApplicationAPIReconciler) applyManifests(ctx context.Context, tc
 	for _, obj := range objects {
 		// Apply with ownership using the tracking client
 		if err := tc.ApplyOwned(ctx, obj); err != nil {
-			gvk := obj.GetObjectKind().GroupVersionKind()
-			if gvk.Group == constant.CertManagerGroup || gvk.Group == constant.KyvernoGroup {
-				// TODO: Remove this once we decide how to install cert-manager crds in envtest
-				// TODO: Remove this once we decide if we want to have a dependency on Kyverno
-				log.Info("Skipping resource: CRD not installed",
-					"kind", gvk.Kind,
-					"apiVersion", gvk.GroupVersion().String(),
-					"namespace", obj.GetNamespace(),
-					"name", obj.GetName(),
-				)
-				continue
-			}
 			return fmt.Errorf("failed to apply object %s/%s (%s) from %s: %w",
 				obj.GetNamespace(), obj.GetName(), tracking.GetKind(obj), manifests.ApplicationAPI, err)
 		}

--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
@@ -185,18 +185,6 @@ func (r *KonfluxBuildServiceReconciler) applyManifests(ctx context.Context, tc *
 
 		// Apply with ownership using the tracking client
 		if err := tc.ApplyOwned(ctx, obj); err != nil {
-			gvk := obj.GetObjectKind().GroupVersionKind()
-			if gvk.Group == constant.CertManagerGroup || gvk.Group == constant.KyvernoGroup {
-				// TODO: Remove this once we decide how to install cert-manager crds in envtest
-				// TODO: Remove this once we decide if we want to have a dependency on Kyverno
-				log.Info("Skipping resource: CRD not installed",
-					"kind", gvk.Kind,
-					"apiVersion", gvk.GroupVersion().String(),
-					"namespace", obj.GetNamespace(),
-					"name", obj.GetName(),
-				)
-				continue
-			}
 			return fmt.Errorf("failed to apply object %s/%s (%s) from %s: %w",
 				obj.GetNamespace(), obj.GetName(), tracking.GetKind(obj), manifests.BuildService, err)
 		}

--- a/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller.go
+++ b/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller.go
@@ -141,8 +141,6 @@ func (r *KonfluxEnterpriseContractReconciler) Reconcile(ctx context.Context, req
 // applyManifests loads and applies all embedded manifests to the cluster using the tracking client.
 // Manifests are parsed once and cached; deep copies are used during reconciliation.
 func (r *KonfluxEnterpriseContractReconciler) applyManifests(ctx context.Context, tc *tracking.Client) error {
-	log := logf.FromContext(ctx)
-
 	objects, err := r.ObjectStore.GetForComponent(manifests.EnterpriseContract)
 	if err != nil {
 		return fmt.Errorf("failed to get parsed manifests for EnterpriseContract: %w", err)
@@ -151,18 +149,6 @@ func (r *KonfluxEnterpriseContractReconciler) applyManifests(ctx context.Context
 	for _, obj := range objects {
 		// Apply with ownership using the tracking client
 		if err := tc.ApplyOwned(ctx, obj); err != nil {
-			gvk := obj.GetObjectKind().GroupVersionKind()
-			if gvk.Group == constant.CertManagerGroup || gvk.Group == constant.KyvernoGroup {
-				// TODO: Remove this once we decide how to install cert-manager crds in envtest
-				// TODO: Remove this once we decide if we want to have a dependency on Kyverno
-				log.Info("Skipping resource: CRD not installed",
-					"kind", gvk.Kind,
-					"apiVersion", gvk.GroupVersion().String(),
-					"namespace", obj.GetNamespace(),
-					"name", obj.GetName(),
-				)
-				continue
-			}
 			return fmt.Errorf("failed to apply object %s/%s (%s) from %s: %w",
 				obj.GetNamespace(), obj.GetName(), tracking.GetKind(obj), manifests.EnterpriseContract, err)
 		}

--- a/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
+++ b/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
@@ -138,8 +138,6 @@ func (r *KonfluxImageControllerReconciler) Reconcile(ctx context.Context, req ct
 // applyManifests loads and applies all embedded manifests to the cluster using the tracking client.
 // Manifests are parsed once and cached; deep copies are used during reconciliation.
 func (r *KonfluxImageControllerReconciler) applyManifests(ctx context.Context, tc *tracking.Client) error {
-	log := logf.FromContext(ctx)
-
 	objects, err := r.ObjectStore.GetForComponent(manifests.ImageController)
 	if err != nil {
 		return fmt.Errorf("failed to get parsed manifests for ImageController: %w", err)
@@ -148,18 +146,6 @@ func (r *KonfluxImageControllerReconciler) applyManifests(ctx context.Context, t
 	for _, obj := range objects {
 		// Apply with ownership using the tracking client
 		if err := tc.ApplyOwned(ctx, obj); err != nil {
-			gvk := obj.GetObjectKind().GroupVersionKind()
-			if gvk.Group == constant.CertManagerGroup || gvk.Group == constant.KyvernoGroup {
-				// TODO: Remove this once we decide how to install cert-manager crds in envtest
-				// TODO: Remove this once we decide if we want to have a dependency on Kyverno
-				log.Info("Skipping resource: CRD not installed",
-					"kind", gvk.Kind,
-					"apiVersion", gvk.GroupVersion().String(),
-					"namespace", obj.GetNamespace(),
-					"name", obj.GetName(),
-				)
-				continue
-			}
 			return fmt.Errorf("failed to apply object %s/%s (%s) from %s: %w",
 				obj.GetNamespace(), obj.GetName(), tracking.GetKind(obj), manifests.ImageController, err)
 		}

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
@@ -182,9 +182,8 @@ func (r *KonfluxIntegrationServiceReconciler) applyManifests(ctx context.Context
 		// Apply with ownership using the tracking client
 		if err := tc.ApplyOwned(ctx, obj); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
-			if gvk.Group == constant.CertManagerGroup || gvk.Group == constant.KyvernoGroup {
-				// TODO: Remove this once we decide how to install cert-manager crds in envtest
-				// TODO: Remove this once we decide if we want to have a dependency on Kyverno
+			// TODO: Remove this once we decide if we want to have a dependency on Kyverno
+			if gvk.Group == constant.KyvernoGroup {
 				log.Info("Skipping resource: CRD not installed",
 					"kind", gvk.Kind,
 					"apiVersion", gvk.GroupVersion().String(),

--- a/operator/internal/controller/konflux/konflux_controller_certmanager_test.go
+++ b/operator/internal/controller/konflux/konflux_controller_certmanager_test.go
@@ -1,0 +1,345 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package konflux
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/version"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
+)
+
+var _ = Describe("Konflux Controller - Cert-Manager Dependency", func() {
+	Context("When cert-manager CRDs are not installed", func() {
+		var (
+			ctx                context.Context
+			reconciler         *KonfluxReconciler
+			fakeClient         client.Client
+			konflux            *konfluxv1alpha1.Konflux
+			typeNamespacedName types.NamespacedName
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			scheme := runtime.NewScheme()
+			_ = konfluxv1alpha1.AddToScheme(scheme)
+
+			// Create a fake client WITHOUT cert-manager resources
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&konfluxv1alpha1.Konflux{}).
+				Build()
+
+			// Create clusterInfo without cert-manager resources
+			mockDiscoveryClient := &certManagerMockDiscoveryClient{
+				hasCertManager: false,
+			}
+			clusterInfo, _ := clusterinfo.DetectWithClient(mockDiscoveryClient)
+
+			reconciler = &KonfluxReconciler{
+				Client:      fakeClient,
+				Scheme:      scheme,
+				ClusterInfo: clusterInfo,
+			}
+
+			konflux = &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: CRName,
+				},
+			}
+
+			typeNamespacedName = types.NamespacedName{
+				Name: CRName,
+			}
+
+			// Create the Konflux CR
+			Expect(fakeClient.Create(ctx, konflux)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			// Cleanup
+			_ = fakeClient.Delete(ctx, konflux)
+		})
+
+		It("should set CertManagerAvailable and Ready conditions to False when cert-manager is missing", func() {
+			By("Reconciling the Konflux CR")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Fetching the updated Konflux CR")
+			updatedKonflux := &konfluxv1alpha1.Konflux{}
+			Expect(fakeClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+
+			By("Verifying CertManagerAvailable condition is False")
+			cond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeCertManagerAvailable)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(condition.ReasonCertManagerNotInstalled))
+			Expect(cond.Message).To(ContainSubstring("cert-manager CRDs are not installed"))
+
+			By("Verifying Ready condition is False")
+			readyCond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeReady)
+			Expect(readyCond).NotTo(BeNil())
+			Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(readyCond.Reason).To(Equal(condition.ReasonCertManagerNotInstalled))
+			Expect(readyCond.Message).To(ContainSubstring("cert-manager CRDs are not installed"))
+		})
+	})
+
+	Context("When cert-manager CRDs are installed", func() {
+		var (
+			ctx                context.Context
+			reconciler         *KonfluxReconciler
+			fakeClient         client.Client
+			konflux            *konfluxv1alpha1.Konflux
+			typeNamespacedName types.NamespacedName
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			scheme := runtime.NewScheme()
+			_ = konfluxv1alpha1.AddToScheme(scheme)
+
+			// Create a fake client WITH cert-manager resources
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&konfluxv1alpha1.Konflux{}).
+				Build()
+
+			// Create clusterInfo with cert-manager resources
+			mockDiscoveryClient := &certManagerMockDiscoveryClient{
+				hasCertManager: true,
+			}
+			clusterInfo, _ := clusterinfo.DetectWithClient(mockDiscoveryClient)
+
+			reconciler = &KonfluxReconciler{
+				Client:      fakeClient,
+				Scheme:      scheme,
+				ClusterInfo: clusterInfo,
+			}
+
+			konflux = &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: CRName,
+				},
+			}
+
+			typeNamespacedName = types.NamespacedName{
+				Name: CRName,
+			}
+
+			// Create the Konflux CR
+			Expect(fakeClient.Create(ctx, konflux)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			// Cleanup
+			_ = fakeClient.Delete(ctx, konflux)
+		})
+
+		It("should set CertManagerAvailable condition to True", func() {
+			By("Reconciling the Konflux CR")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Fetching the updated Konflux CR")
+			updatedKonflux := &konfluxv1alpha1.Konflux{}
+			Expect(fakeClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+
+			By("Verifying CertManagerAvailable condition is True")
+			cond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeCertManagerAvailable)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal("CertManagerInstalled"))
+			Expect(cond.Message).To(ContainSubstring("cert-manager CRDs are installed"))
+		})
+
+		It("should not override Ready condition when cert-manager is available", func() {
+			By("Reconciling the Konflux CR")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Fetching the updated Konflux CR")
+			updatedKonflux := &konfluxv1alpha1.Konflux{}
+			Expect(fakeClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+
+			By("Verifying Ready condition is not overridden by cert-manager check")
+			readyCond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeReady)
+			// Ready condition should be set based on sub-CR statuses, not cert-manager
+			// If cert-manager is available, it shouldn't force Ready to False
+			if readyCond != nil {
+				Expect(readyCond.Reason).NotTo(Equal(condition.ReasonCertManagerNotInstalled))
+			}
+		})
+	})
+
+	Context("When cert-manager check fails with an error", func() {
+		var (
+			ctx                context.Context
+			reconciler         *KonfluxReconciler
+			fakeClient         client.Client
+			konflux            *konfluxv1alpha1.Konflux
+			typeNamespacedName types.NamespacedName
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			scheme := runtime.NewScheme()
+			_ = konfluxv1alpha1.AddToScheme(scheme)
+
+			// Create a fake client
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&konfluxv1alpha1.Konflux{}).
+				Build()
+
+			// Create clusterInfo that returns an error when checking cert-manager
+			// This simulates RBAC issues or network problems
+			mockDiscoveryClient := &certManagerMockDiscoveryClient{
+				hasCertManager: false,
+				returnError:    true,
+			}
+			clusterInfo, _ := clusterinfo.DetectWithClient(mockDiscoveryClient)
+
+			reconciler = &KonfluxReconciler{
+				Client:      fakeClient,
+				Scheme:      scheme,
+				ClusterInfo: clusterInfo,
+			}
+
+			konflux = &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: CRName,
+				},
+			}
+
+			typeNamespacedName = types.NamespacedName{
+				Name: CRName,
+			}
+
+			// Create the Konflux CR
+			Expect(fakeClient.Create(ctx, konflux)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			// Cleanup
+			_ = fakeClient.Delete(ctx, konflux)
+		})
+
+		It("should continue reconciliation and set CertManagerAvailable to Unknown", func() {
+			By("Reconciling the Konflux CR")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			// Reconciliation should continue even if cert-manager check fails
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Fetching the updated Konflux CR")
+			updatedKonflux := &konfluxv1alpha1.Konflux{}
+			Expect(fakeClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+
+			By("Verifying that CertManagerAvailable condition is set to Unknown")
+			cond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeCertManagerAvailable)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(cond.Reason).To(Equal(condition.ReasonCertManagerInstallationCheckFailed))
+			Expect(cond.Message).To(ContainSubstring("simulated RBAC or network error"))
+		})
+
+		It("should allow Ready to be True when CertManagerAvailable is Unknown", func() {
+			By("Reconciling the Konflux CR")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Fetching the updated Konflux CR")
+			updatedKonflux := &konfluxv1alpha1.Konflux{}
+			Expect(fakeClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+
+			By("Verifying CertManagerAvailable is Unknown")
+			certManagerCond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeCertManagerAvailable)
+			Expect(certManagerCond).NotTo(BeNil())
+			Expect(certManagerCond.Status).To(Equal(metav1.ConditionUnknown))
+
+			By("Verifying Ready condition is not overridden by Unknown CertManagerAvailable")
+			// Ready should be based on sub-CR statuses, not blocked by Unknown cert-manager status
+			readyCond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeReady)
+			// Ready condition should exist (set by SetAggregatedReadyCondition)
+			// It should NOT be False with CertManagerNotInstalled reason since cert-manager is Unknown, not False
+			if readyCond != nil {
+				Expect(readyCond.Reason).NotTo(Equal(condition.ReasonCertManagerNotInstalled))
+			}
+		})
+	})
+})
+
+// certManagerMockDiscoveryClient implements clusterinfo.DiscoveryClient for testing cert-manager scenarios
+type certManagerMockDiscoveryClient struct {
+	hasCertManager bool
+	returnError    bool
+}
+
+func (m *certManagerMockDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	if m.returnError && groupVersion == "cert-manager.io/v1" {
+		return nil, apierrors.NewInternalError(errors.New("simulated RBAC or network error"))
+	}
+
+	if groupVersion == "cert-manager.io/v1" && m.hasCertManager {
+		return &metav1.APIResourceList{
+			GroupVersion: "cert-manager.io/v1",
+			APIResources: []metav1.APIResource{
+				{Kind: "Certificate"},
+				{Kind: "Issuer"},
+				{Kind: "ClusterIssuer"},
+			},
+		}, nil
+	}
+
+	if groupVersion == "config.openshift.io/v1" {
+		// Return empty to indicate not OpenShift
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: groupVersion}, "")
+	}
+
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: groupVersion}, "")
+}
+
+func (m *certManagerMockDiscoveryClient) ServerVersion() (*version.Info, error) {
+	return &version.Info{GitVersion: "v1.30.0"}, nil
+}

--- a/operator/internal/controller/konflux/konflux_controller_test.go
+++ b/operator/internal/controller/konflux/konflux_controller_test.go
@@ -23,7 +23,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +33,7 @@ import (
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/defaulttenant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/internalregistry"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 )
 
 var _ = Describe("Konflux Controller", func() {
@@ -68,9 +71,11 @@ var _ = Describe("Konflux Controller", func() {
 		})
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
+			clusterInfo := createTestClusterInfo()
 			controllerReconciler := &KonfluxReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:      k8sClient,
+				Scheme:      k8sClient.Scheme(),
+				ClusterInfo: clusterInfo,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -198,9 +203,11 @@ var _ = Describe("Konflux Controller", func() {
 			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
 
 			By("reconciling the Konflux CR")
+			clusterInfo := createTestClusterInfo()
 			reconciler := &KonfluxReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:      k8sClient,
+				Scheme:      k8sClient.Scheme(),
+				ClusterInfo: clusterInfo,
 			}
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -229,9 +236,11 @@ var _ = Describe("Konflux Controller", func() {
 			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
 
 			By("reconciling the Konflux CR")
+			clusterInfo := createTestClusterInfo()
 			reconciler := &KonfluxReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:      k8sClient,
+				Scheme:      k8sClient.Scheme(),
+				ClusterInfo: clusterInfo,
 			}
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -260,9 +269,11 @@ var _ = Describe("Konflux Controller", func() {
 			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
 
 			By("reconciling the Konflux CR")
+			clusterInfo := createTestClusterInfo()
 			reconciler := &KonfluxReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:      k8sClient,
+				Scheme:      k8sClient.Scheme(),
+				ClusterInfo: clusterInfo,
 			}
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -292,9 +303,11 @@ var _ = Describe("Konflux Controller", func() {
 			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
 
 			By("reconciling to create the InternalRegistry CR")
+			clusterInfo := createTestClusterInfo()
 			reconciler := &KonfluxReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:      k8sClient,
+				Scheme:      k8sClient.Scheme(),
+				ClusterInfo: clusterInfo,
 			}
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -365,9 +378,11 @@ var _ = Describe("Konflux Controller", func() {
 			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
 
 			By("reconciling the Konflux CR")
+			clusterInfo := createTestClusterInfo()
 			reconciler := &KonfluxReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:      k8sClient,
+				Scheme:      k8sClient.Scheme(),
+				ClusterInfo: clusterInfo,
 			}
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -397,9 +412,11 @@ var _ = Describe("Konflux Controller", func() {
 			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
 
 			By("reconciling the Konflux CR")
+			clusterInfo := createTestClusterInfo()
 			reconciler := &KonfluxReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:      k8sClient,
+				Scheme:      k8sClient.Scheme(),
+				ClusterInfo: clusterInfo,
 			}
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -428,9 +445,11 @@ var _ = Describe("Konflux Controller", func() {
 			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
 
 			By("reconciling the Konflux CR")
+			clusterInfo := createTestClusterInfo()
 			reconciler := &KonfluxReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:      k8sClient,
+				Scheme:      k8sClient.Scheme(),
+				ClusterInfo: clusterInfo,
 			}
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -459,9 +478,11 @@ var _ = Describe("Konflux Controller", func() {
 			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
 
 			By("reconciling to create the DefaultTenant CR")
+			clusterInfo := createTestClusterInfo()
 			reconciler := &KonfluxReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:      k8sClient,
+				Scheme:      k8sClient.Scheme(),
+				ClusterInfo: clusterInfo,
 			}
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -494,3 +515,30 @@ var _ = Describe("Konflux Controller", func() {
 		})
 	})
 })
+
+// createTestClusterInfo creates a minimal ClusterInfo for testing
+func createTestClusterInfo() *clusterinfo.Info {
+	mockClient := &testMockDiscoveryClient{
+		resources:     map[string]*metav1.APIResourceList{},
+		serverVersion: &version.Info{GitVersion: "v1.30.0"},
+	}
+	info, _ := clusterinfo.DetectWithClient(mockClient)
+	return info
+}
+
+// testMockDiscoveryClient implements clusterinfo.DiscoveryClient for general testing
+type testMockDiscoveryClient struct {
+	resources     map[string]*metav1.APIResourceList
+	serverVersion *version.Info
+}
+
+func (m *testMockDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	if r, ok := m.resources[groupVersion]; ok {
+		return r, nil
+	}
+	return nil, errors.NewNotFound(schema.GroupResource{Group: groupVersion}, "")
+}
+
+func (m *testMockDiscoveryClient) ServerVersion() (*version.Info, error) {
+	return m.serverVersion, nil
+}

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
@@ -163,9 +163,8 @@ func (r *KonfluxNamespaceListerReconciler) applyManifests(ctx context.Context, t
 		// Apply with ownership using the tracking client
 		if err := tc.ApplyOwned(ctx, obj); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
-			if gvk.Group == constant.CertManagerGroup || gvk.Group == constant.KyvernoGroup {
-				// TODO: Remove this once we decide how to install cert-manager crds in envtest
-				// TODO: Remove this once we decide if we want to have a dependency on Kyverno
+			// TODO: Remove this once we decide if we want to have a dependency on Kyverno
+			if gvk.Group == constant.KyvernoGroup {
 				log.Info("Skipping resource: CRD not installed",
 					"kind", gvk.Kind,
 					"apiVersion", gvk.GroupVersion().String(),

--- a/operator/internal/controller/rbac/konfluxrbac_controller.go
+++ b/operator/internal/controller/rbac/konfluxrbac_controller.go
@@ -134,8 +134,6 @@ func (r *KonfluxRBACReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 // applyManifests loads and applies all embedded manifests to the cluster using the tracking client.
 func (r *KonfluxRBACReconciler) applyManifests(ctx context.Context, tc *tracking.Client) error {
-	log := logf.FromContext(ctx)
-
 	objects, err := r.ObjectStore.GetForComponent(manifests.RBAC)
 	if err != nil {
 		return fmt.Errorf("failed to get manifests for RBAC: %w", err)
@@ -144,18 +142,6 @@ func (r *KonfluxRBACReconciler) applyManifests(ctx context.Context, tc *tracking
 	for _, obj := range objects {
 		// Apply with ownership using the tracking client
 		if err := tc.ApplyOwned(ctx, obj); err != nil {
-			gvk := obj.GetObjectKind().GroupVersionKind()
-			// TODO: Remove this once we decide how to install cert-manager crds in envtest
-			// TODO: Remove this once we decide if we want to have a dependency on Kyverno
-			if gvk.Group == constant.CertManagerGroup || gvk.Group == constant.KyvernoGroup {
-				log.Info("Skipping resource: CRD not installed",
-					"kind", gvk.Kind,
-					"apiVersion", gvk.GroupVersion().String(),
-					"namespace", obj.GetNamespace(),
-					"name", obj.GetName(),
-				)
-				continue
-			}
 			return fmt.Errorf("failed to apply object %s/%s (%s) from %s: %w",
 				obj.GetNamespace(), obj.GetName(), tracking.GetKind(obj), manifests.RBAC, err)
 		}

--- a/operator/internal/controller/testutil/testutil.go
+++ b/operator/internal/controller/testutil/testutil.go
@@ -86,6 +86,7 @@ func SetupTestEnv(basePath string) *TestEnv {
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join(basePath, "config", "crd", "bases"),
+			filepath.Join(basePath, "test", "crds", "cert-manager"),
 			filepath.Join(GetGoModuleDir("github.com/openshift/api"), "console", "v1", "zz_generated.crd-manifests"),
 			filepath.Join(GetGoModuleDir("github.com/openshift/api"), "security", "v1", "zz_generated.crd-manifests"),
 		},

--- a/operator/internal/controller/ui/konfluxui_controller.go
+++ b/operator/internal/controller/ui/konfluxui_controller.go
@@ -269,8 +269,6 @@ func (r *KonfluxUIReconciler) ensureNamespaceExists(ctx context.Context, tc *tra
 // dexConfigMapName is the name of the Dex ConfigMap to use (empty if not configured).
 // endpoint is the base URL used to configure oauth2-proxy.
 func (r *KonfluxUIReconciler) applyManifests(ctx context.Context, tc *tracking.Client, ui *konfluxv1alpha1.KonfluxUI, dexConfigMapName string, endpoint *url.URL) error {
-	log := logf.FromContext(ctx)
-
 	objects, err := r.ObjectStore.GetForComponent(manifests.UI)
 	if err != nil {
 		return fmt.Errorf("failed to get parsed manifests for UI: %w", err)
@@ -290,18 +288,6 @@ func (r *KonfluxUIReconciler) applyManifests(ctx context.Context, tc *tracking.C
 		}
 
 		if err := tc.ApplyOwned(ctx, obj); err != nil {
-			gvk := obj.GetObjectKind().GroupVersionKind()
-			if gvk.Group == constant.CertManagerGroup || gvk.Group == constant.KyvernoGroup {
-				// TODO: Remove this once we decide how to install cert-manager crds in envtest
-				// TODO: Remove this once we decide if we want to have a dependency on Kyverno
-				log.Info("Skipping resource: CRD not installed",
-					"kind", gvk.Kind,
-					"apiVersion", gvk.GroupVersion().String(),
-					"namespace", obj.GetNamespace(),
-					"name", obj.GetName(),
-				)
-				continue
-			}
 			return fmt.Errorf("failed to apply object %s/%s (%s): %w",
 				obj.GetNamespace(), obj.GetName(), tracking.GetKind(obj), err)
 		}

--- a/operator/pkg/clusterinfo/clusterinfo.go
+++ b/operator/pkg/clusterinfo/clusterinfo.go
@@ -21,6 +21,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
@@ -108,25 +109,64 @@ func (i *Info) K8sVersion() *version.Info {
 }
 
 // HasResource checks if a specific resource kind exists in the given API group version.
+// Returns true if the resource exists, false if it doesn't exist.
+// If an error occurs (e.g., RBAC, network issues), it returns false with the error
+// to allow callers to distinguish between "not found" and "check failed".
 func (i *Info) HasResource(groupVersion, kind string) (bool, error) {
+	has, err := i.HasAllResources(groupVersion, []string{kind})
+	if err != nil {
+		return false, err
+	}
+	return has, nil
+}
+
+// HasAllResources checks if all specified resource kinds exist in the given API group version.
+// Returns true only if ALL specified kinds exist, false if any are missing.
+// If an error occurs (e.g., RBAC, network issues), it returns false with the error
+// to allow callers to distinguish between "not found" and "check failed".
+// This method makes a single API call, making it more efficient than calling HasResource
+// multiple times for resources in the same group version.
+func (i *Info) HasAllResources(groupVersion string, kinds []string) (bool, error) {
 	resourceList, err := i.client.ServerResourcesForGroupVersion(groupVersion)
 	if err != nil {
-		// If the group doesn't exist, the resource doesn't exist
-		return false, nil
+		// If NotFound, the resources don't exist
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		// Other errors (RBAC, network) should be propagated
+		return false, fmt.Errorf("failed to check %s resources: %w", groupVersion, err)
 	}
 
+	// Build a set of available resource kinds
+	availableKinds := sets.New[string]()
 	for _, resource := range resourceList.APIResources {
-		if resource.Kind == kind {
-			return true, nil
+		availableKinds.Insert(resource.Kind)
+	}
+
+	// Check if all required kinds exist
+	for _, kind := range kinds {
+		if !availableKinds.Has(kind) {
+			return false, nil
 		}
 	}
 
-	return false, nil
+	return true, nil
 }
 
 // HasTekton checks if Tekton Pipelines is installed.
 func (i *Info) HasTekton() (bool, error) {
 	return i.HasResource("tekton.dev/v1", "Pipeline")
+}
+
+// HasCertManager checks if cert-manager is installed by verifying that all required
+// cert-manager resources exist. Returns true only if ALL required resources are present:
+// - Certificate (cert-manager.io/v1)
+// - Issuer (cert-manager.io/v1)
+// - ClusterIssuer (cert-manager.io/v1)
+//
+// This function uses HasAllResources to check all required resources in a single API call.
+func (i *Info) HasCertManager() (bool, error) {
+	return i.HasAllResources("cert-manager.io/v1", []string{"Certificate", "Issuer", "ClusterIssuer"})
 }
 
 // detectOpenShift checks if the operator is running on OpenShift by


### PR DESCRIPTION
### **User description**
If cert-manager is not installed at reconciliation time, some CRs will not be able to reconcile. As we don't track cert-manager in the operator logic, nothing will requeue reconciliation.

This commit adds a status condition for cert-manager and also requeues reconciliation if cert-manager CRDs are not found.

Assisted-by: Cursor


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add cert-manager availability checking with status conditions
  - Detects if cert-manager CRDs are installed before reconciliation
  - Sets CertManagerAvailable condition (True/False/Unknown)
  - Requeues reconciliation when cert-manager is missing or check fails

- Implement dependency override mechanism for Ready status
  - New OverrideReadyIfDependencyFalse function allows dependencies to block Ready
  - Only False conditions override Ready, Unknown conditions are allowed
  - Enables proper status reporting when required components are missing

- Remove cert-manager CRD skip logic from component controllers
  - Eliminates workarounds that silently skipped cert-manager resources
  - Centralizes cert-manager dependency handling in main Konflux controller
  - Ensures cert-manager namespace is created before applying resources

- Add comprehensive test coverage for cert-manager scenarios
  - Tests for missing, installed, and error cases
  - Validates condition override behavior with various dependency states


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Konflux Reconciler"] -->|checks| B["ClusterInfo.HasCertManager"]
  B -->|queries| C["API Discovery"]
  C -->|returns| D{CertManager CRDs?}
  D -->|found| E["Set CertManagerAvailable=True"]
  D -->|missing| F["Set CertManagerAvailable=False"]
  D -->|error| G["Set CertManagerAvailable=Unknown"]
  E --> H["OverrideReadyIfDependencyFalse"]
  F --> H
  G --> H
  H -->|False only| I["Override Ready=False"]
  H -->|True/Unknown| J["Keep Ready as-is"]
  I --> K["Requeue Reconciliation"]
  J --> L["Continue Reconciliation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>main.go</strong><dd><code>Pass ClusterInfo to KonfluxReconciler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-6951a7b3b8a59603497b68b62013a806397c640ce0a42a3862f6a4ffad4fda89">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>condition.go</strong><dd><code>Add dependency override mechanism for Ready status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-ef151b8fb9d8b69fd9e95bad70eca15a491e3ccd04d2cf98ffe1d77efb79dfdb">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>constants.go</strong><dd><code>Add cert-manager related condition reason constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-14bd65ef321cb84f099887f790fbe1aa7b4d24b88c9f76e4400a0bccbc6cb632">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>constant.go</strong><dd><code>Add CertManagerAvailable condition type constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-87894aecf0f7273b1ba13f9b68012e8330024c0048125dc30232c00c5ae70cf7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxcertmanager_controller.go</strong><dd><code>Add namespace creation and remove CRD skip logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-bc15110b14183241956f51a2e7147b54875a977ae44959fe9b62f0015917b140">+23/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>konflux_controller.go</strong><dd><code>Add cert-manager availability checking and requeue logic</code>&nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-cf5a332f0b87d850769b080f9c8208e9446d2af3456f8e328572bc072b4c9294">+75/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>clusterinfo.go</strong><dd><code>Add HasAllResources and HasCertManager detection methods</code>&nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-8dbe40b2ffa3cb0a7d90ca101480b244d5fa464c5267025e11b93168835dbabe">+44/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>condition_test.go</strong><dd><code>Add comprehensive tests for dependency override logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-3ac613729ccc686614ef9f22d34a4ab1fe6c62756d818d678163ed0d05bc0fdb">+249/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>konflux_controller_certmanager_test.go</strong><dd><code>Add comprehensive cert-manager dependency tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-9492f79078a33122d1d9ff4a5720f83def3c4b291fc1a71b44ac0603b7a3b499">+345/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>konflux_controller_test.go</strong><dd><code>Update tests to use ClusterInfo in reconciler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-611e5fe29f8957c796f325a65cc4501da208e0cf1f1c0d01633e18e40cda41dd">+66/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>testutil.go</strong><dd><code>Add cert-manager CRDs to test environment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-755f23c20824a8973cd74a175db7a22f794df6df8a6fe8da19ab1afd7d13820b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>clusterinfo_test.go</strong><dd><code>Add tests for HasAllResources and HasCertManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-17874adbcd1520db0142705d7e883daa6aee3ff7cd10e66221c146ab9ac0cfcb">+221/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>konfluxapplicationapi_controller.go</strong><dd><code>Remove cert-manager CRD skip workaround logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-a26d909023f4db43ed66f8358f2c04eb71cb4b5397d0d7e73001335bc375f2bc">+0/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxbuildservice_controller.go</strong><dd><code>Remove cert-manager CRD skip workaround logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-a9eb32fdeac8e9df38f775bd7c7bc7810435b45a98261a1ec289debb08ecaa4b">+0/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxenterprisecontract_controller.go</strong><dd><code>Remove cert-manager CRD skip workaround logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-1ed52ee73b3c2525d3c33a29ca46e0b68fc4e5e4eaefdb9c5a395cd211f818f0">+0/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluximagecontroller_controller.go</strong><dd><code>Remove cert-manager CRD skip workaround logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-6c763c167279b0ad5d7272ca04ced07e667537e7f202d723e1a9ce41517e5b4b">+0/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxinfo_controller.go</strong><dd><code>Remove cert-manager CRD skip workaround logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-632df3e422d02f42ebc3adf96fe1683930511f632b57b7d58fdcd60f75e46b2a">+0/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxintegrationservice_controller.go</strong><dd><code>Update to only skip Kyverno CRD errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-d0b6239196f48e8128517c03b341f09ade5066982ccb496f4a8b801668ac582e">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxinternalregistry_controller.go</strong><dd><code>Refine CRD skip logic to only trust-manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-f678954c718ca7623e3eeb74f0b75dc6b2eb4b6da7f998f612ca4bcef6cd372a">+12/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxnamespacelister_controller.go</strong><dd><code>Update to only skip Kyverno CRD errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-9b30ab1991bf2cfb0dc610075f32e1481c532adf137a67afda314a6f8584b6b2">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxrbac_controller.go</strong><dd><code>Remove cert-manager CRD skip workaround logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-94d40166ce83e790ce9fe3fc19a6bb54999db3387551ad1d30989c722bcc965f">+0/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxreleaseservice_controller.go</strong><dd><code>Remove cert-manager CRD skip workaround logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-854d2c3b514dba7f5e74c56b6a2cc9b24308a6a17be5bfad5b996580d4823575">+0/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxui_controller.go</strong><dd><code>Remove cert-manager CRD skip workaround logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-24d972a47782a65c4bb0528b6a7352cac3a33aa318ccd2d11584881d688124be">+0/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>role.yaml</strong><dd><code>Add list and watch permissions for CRDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4729/files#diff-bf75d41206005954349fa60826c9cc3bd1a976c9e5c8884de0cb59ee68a13fa8">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

