### PR TITLE
fix(KFLUXVNGD-693): use latest release pipelines

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -90,6 +90,7 @@ jobs:
           files: |
             operator/**
             dependencies/**
+            test/e2e/**
             .github/workflows/operator-test-e2e.yaml
 
   # Lightweight jobs that create status checks when tests are skipped
@@ -286,7 +287,6 @@ jobs:
           GH_ORG: ${{ secrets.GH_ORG }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           QUAY_DOCKERCONFIGJSON: ${{ secrets.QUAY_DOCKERCONFIGJSON }}
-          RELEASE_SERVICE_CATALOG_REVISION: ${{ secrets.RELEASE_SERVICE_CATALOG_REVISION }}
           RELEASE_CATALOG_TA_QUAY_TOKEN: ${{ secrets.RELEASE_CATALOG_TA_QUAY_TOKEN }}
         run: |
           ./test/e2e/run-e2e.sh

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -152,7 +152,6 @@ jobs:
           GH_ORG: ${{ secrets.GH_ORG }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           QUAY_DOCKERCONFIGJSON: ${{ secrets.QUAY_DOCKERCONFIGJSON }}
-          RELEASE_SERVICE_CATALOG_REVISION: ${{ secrets.RELEASE_SERVICE_CATALOG_REVISION }}
           RELEASE_CATALOG_TA_QUAY_TOKEN: ${{ secrets.RELEASE_CATALOG_TA_QUAY_TOKEN }}
         run: |
           ./test/e2e/run-e2e.sh

--- a/renovate.json
+++ b/renovate.json
@@ -202,6 +202,20 @@
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "kubernetes/kubernetes",
       "extractVersionTemplate": "^v?(?<version>.*)$"
+    },
+    {
+      "description": "Track release-service-catalog development branch SHA in test/e2e/vars.sh",
+      "customType": "regex",
+      "matchStringsStrategy": "combination",
+      "fileMatch": ["test/e2e/vars.sh"],
+      "matchStrings": [
+        "# renovate: datasource=git-refs depName=https://github.com/konflux-ci/release-service-catalog",
+        "RELEASE_SERVICE_CATALOG_REVISION=\"(?<currentDigest>[a-f0-9]{40})\""
+      ],
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "https://github.com/konflux-ci/release-service-catalog",
+      "currentValueTemplate": "development",
+      "autoReplaceStringTemplate": "RELEASE_SERVICE_CATALOG_REVISION=\"{{newDigest}}\""
     }
   ]
 }

--- a/test/e2e/run-e2e.sh
+++ b/test/e2e/run-e2e.sh
@@ -6,10 +6,12 @@ main() {
     echo "Running E2E tests" >&2
     # shellcheck disable=SC1091
     source "${script_path}/vars.sh"
+
     local github_org="${GH_ORG:?A GitHub org where the https://github.com/redhat-appstudio-qe/konflux-ci-sample repo is present/forked should be provided}"
     local github_token="${GH_TOKEN:?A GitHub token should be provided}"
     local quay_dockerconfig="${QUAY_DOCKERCONFIGJSON:?quay.io credentials in .dockerconfig format should be provided}"
-    local catalog_revision="${RELEASE_SERVICE_CATALOG_REVISION:-development}"
+    local catalog_revision="${RELEASE_SERVICE_CATALOG_REVISION:?RELEASE_SERVICE_CATALOG_REVISION must be set in vars.sh or env}"
+    local release_catalog_ta_quay_token="${RELEASE_CATALOG_TA_QUAY_TOKEN:-}"
 
     docker run \
         --network=host \
@@ -21,6 +23,7 @@ main() {
         -e E2E_APPLICATIONS_NAMESPACE=user-ns2 \
         -e TEST_ENVIRONMENT=upstream \
         -e RELEASE_SERVICE_CATALOG_REVISION="$catalog_revision" \
+        -e RELEASE_CATALOG_TA_QUAY_TOKEN="$release_catalog_ta_quay_token" \
         "$E2E_TEST_IMAGE" \
         /bin/bash -c "ginkgo -v --label-filter=upstream-konflux --focus=\"Test local\" /konflux-e2e/konflux-e2e.test"
 }

--- a/test/e2e/vars.sh
+++ b/test/e2e/vars.sh
@@ -1,4 +1,8 @@
 #!/bin/bash -e
 export E2E_TEST_IMAGE
 # https://github.com/konflux-ci/e2e-tests/commit/<COMMIT>
-E2E_TEST_IMAGE=quay.io/redhat-user-workloads/konflux-qe-team-tenant/konflux-e2e/konflux-e2e-tests@sha256:57db18d1495078be0fee03bff16332118926aea44908693f687bd03cdc4eb70c
+E2E_TEST_IMAGE=quay.io/redhat-user-workloads/konflux-qe-team-tenant/konflux-e2e/konflux-e2e-tests@sha256:e164b4d85eb6999720a3ff1b267cc504b12fd4b29c73b4f0c324e60fe022713e
+
+export RELEASE_SERVICE_CATALOG_REVISION
+# renovate: datasource=git-refs depName=https://github.com/konflux-ci/release-service-catalog
+RELEASE_SERVICE_CATALOG_REVISION="1025ec2df85e045adec718e205a43f1262e40857"


### PR DESCRIPTION
Use the latest release-service-catalog revision, providing a token to use the trusted artifacts repo it requires for running pipelines.

Assisted-by: Cursor