### PR TITLE
fix(KFLUXVNGD-694): Publish operator workflow isn't triggerred

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -119,7 +119,7 @@ jobs:
       - name: Create GitHub Release
         working-directory: ${{ github.workspace }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.KONFLUX_CI_BOT_PAT }}
         run: |
           .github/scripts/create-release.sh \
             "${{ steps.version.outputs.version }}" \


### PR DESCRIPTION
The `create-release.yaml` workflow was using the default `GITHUB_TOKEN` to create releases.
GitHub Actions prevents events triggered by `GITHUB_TOKEN` from triggering other workflows to avoid infinite loops. 
This prevented the `community-operator-pr.yaml` workflow (which listens for `release` events) from running automatically. 

This commit updates the workflow to use `KONFLUX_CI_BOT_PAT`, which will enable triggering the downstream community operator PR workflow.

Assisted-By: Cursor