### PR TITLE
fix(namespace-lister): simplify NetworkPolicy for cross-platform API server access

### DIFF
--- a/operator/pkg/manifests/namespace-lister/manifests.yaml
+++ b/operator/pkg/manifests/namespace-lister/manifests.yaml
@@ -227,19 +227,6 @@ spec:
       protocol: TCP
     - port: 443
       protocol: TCP
-    to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-      podSelector:
-        matchLabels:
-          component: kube-apiserver
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: openshift-kube-apiserver
-      podSelector:
-        matchLabels:
-          app: openshift-kube-apiserver
   podSelector:
     matchLabels:
       apps: namespace-lister

--- a/operator/upstream-kustomizations/namespace-lister/network_policy_allow_to_apiserver.yaml
+++ b/operator/upstream-kustomizations/namespace-lister/network_policy_allow_to_apiserver.yaml
@@ -15,16 +15,3 @@ spec:
       protocol: TCP
     - port: 443
       protocol: TCP
-    to:
-    - podSelector:
-        matchLabels:
-          component: kube-apiserver
-      namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-    - podSelector:
-        matchLabels:
-          app: openshift-kube-apiserver
-      namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: openshift-kube-apiserver


### PR DESCRIPTION
Simplify the NetworkPolicy to allow egress on ports 443 and 6443 TCP to any destination, removing the restrictive pod/namespace selectors and ipBlock rules.

Problem:
The previous NetworkPolicy attempted to restrict egress traffic to specific API server pods using label selectors. This approach failed on HyperShift clusters where the kubernetes service endpoint (e.g., 172.20.0.1) is not translated to a pod IP that NetworkPolicy selectors can match.

In HyperShift, the control plane runs on a management cluster and communication happens via Konnectivity proxy. When pods connect to the kubernetes service, traffic routes to an endpoint IP that isn't a pod within the hosted cluster, so pod/namespace selectors don't apply.

Alternatives considered:

1. Pod selectors for API server pods:
   - `component: kube-apiserver` in kube-system (standard K8s)
   - `app: openshift-kube-apiserver` in openshift-kube-apiserver (OpenShift)
   - `app: konnectivity-agent` in kube-system (HyperShift)
   - `k8s-app: kube-apiserver-proxy` in kube-system (HyperShift) Result: Failed on HyperShift because the kubernetes service endpoint is not translated to a pod IP - NetworkPolicy cannot match it.

2. ipBlock with specific CIDR (e.g., 172.20.0.0/16): Result: Not portable - HyperShift hosted control plane endpoint CIDRs vary per deployment and cannot be hardcoded.

3. ipBlock with service CIDR: Result: Service CIDRs are configurable per cluster, making this approach non-portable.

4. ipBlock with all RFC 1918 private ranges: Result: Overly broad and still may not cover all deployments.

Chosen solution:
Allow egress to any destination but restrict to ports 443 (HTTPS) and 6443 (Kubernetes API) only. This is the safest portable option because:
- Works across all platforms (Kubernetes, OpenShift, HyperShift)
- No environment-specific configuration required
- Still provides port-level restriction
- The namespace-lister application only communicates with the API server, so the broader network access is acceptable for this workload

Assisted-By: Cursor