### PR TITLE
Revert "fix(KFLUXVNGD-694): Publish operator workflow isn't triggerred"

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -116,10 +116,22 @@ jobs:
             /tmp/release-notes.md
           echo "notes_file=/tmp/release-notes.md" >> $GITHUB_OUTPUT
 
+      # Use a GitHub App token so that:
+      # 1) The release event triggers other workflows (GITHUB_TOKEN would not).
+      # 2) The token has workflow scope, required when the release target commit touches workflow files.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-workflows: write
+
       - name: Create GitHub Release
         working-directory: ${{ github.workspace }}
         env:
-          GH_TOKEN: ${{ secrets.KONFLUX_CI_BOT_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           .github/scripts/create-release.sh \
             "${{ steps.version.outputs.version }}" \


### PR DESCRIPTION
### **User description**
Reverts konflux-ci/konflux-ci#4776


___

### **PR Type**
Bug fix


___

### **Description**
- Reverts commit f86b1e4b931ac6ee638f3e32ebd00b44d2fa2511

- Changes GH_TOKEN from KONFLUX_CI_BOT_PAT to GITHUB_TOKEN

- Restores previous GitHub release creation workflow behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Revert Commit f86b1e4"] --> B["Update GH_TOKEN"]
  B --> C["Use GITHUB_TOKEN instead of KONFLUX_CI_BOT_PAT"]
  C --> D["Restore Previous Workflow"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-release.yaml</strong><dd><code>Revert GH_TOKEN to GITHUB_TOKEN in release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/create-release.yaml

<ul><li>Reverted GH_TOKEN environment variable from <code>secrets.KONFLUX_CI_BOT_PAT</code> <br>to <code>secrets.GITHUB_TOKEN</code><br> <li> Restores the GitHub release creation step to use the default GitHub <br>token<br> <li> Part of reverting commit f86b1e4b931ac6ee638f3e32ebd00b44d2fa2511</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4834/files#diff-a318819fb0ec8889018cbef8e6dd222e317757d95ddd93b62b714ac7c49f04f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

