### PR TITLE
fix: release token secret name

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -123,8 +123,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.UPDATE_BOT_APP_ID }}
+          private-key: ${{ secrets.UPDATE_BOT_PRIVATE_KEY }}
           permission-contents: write
           permission-workflows: write
 


### PR DESCRIPTION
### **User description**
The name of the secret used for the release token was incorrect.


___

### **PR Type**
Bug fix


___

### **Description**
- Corrects GitHub App token secret names in release workflow

- Changes from RELEASE_BOT to UPDATE_BOT secret references

- Ensures release workflow uses correct authentication credentials


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release Workflow"] -- "uses incorrect secrets" --> B["RELEASE_BOT_APP_ID<br/>RELEASE_BOT_PRIVATE_KEY"]
  A -- "corrected to" --> C["UPDATE_BOT_APP_ID<br/>UPDATE_BOT_PRIVATE_KEY"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-release.yaml</strong><dd><code>Correct GitHub App token secret names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/create-release.yaml

<ul><li>Updated <code>app-id</code> secret reference from <code>RELEASE_BOT_APP_ID</code> to <br><code>UPDATE_BOT_APP_ID</code><br> <li> Updated <code>private-key</code> secret reference from <code>RELEASE_BOT_PRIVATE_KEY</code> to <br><code>UPDATE_BOT_PRIVATE_KEY</code><br> <li> Fixes GitHub App token authentication in the release workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4836/files#diff-a318819fb0ec8889018cbef8e6dd222e317757d95ddd93b62b714ac7c49f04f6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

