### PR TITLE
doc(KFLUXVNGD-693): document the use of ocistorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,7 +726,8 @@ For more details you can examine the manifests under the
 
 To do all that, follow these steps:
 
-:gear: Edit the [release plan](./test/resources/demo-users/user/ns2/release-plan.yaml)
+:gear: Edit the `ReleasePlan` manifest at
+[test/resources/demo-users/user/ns2/release-plan.yaml](./test/resources/demo-users/user/ns2/release-plan.yaml)
 and verify that the `application` field contains the name of your application.
 
 :gear: Deploy the Release Plan under the development team namespace (`user-ns2`):
@@ -735,8 +736,8 @@ and verify that the `application` field contains the name of your application.
 kubectl create -f ./test/resources/demo-users/user/ns2/release-plan.yaml
 ```
 
-Edit the `ReleasePlanAdmission`
-[manifest](./test/resources/demo-users/user/managed-ns2/rpa.yaml):
+Edit the `ReleasePlanAdmission` manifest at
+[test/resources/demo-users/user/managed-ns2/rpa.yaml](./test/resources/demo-users/user/managed-ns2/rpa.yaml):
 
 **NOTE:** if you're using the in-cluster registry, you should not be required to make
 any of the changes to the `ReleasePlanAdmission` manifest described below before
@@ -760,6 +761,22 @@ deploying it.
         - name: test-component
           repository: quay.io/my-user/my-konflux-component-release
 ```
+
+3. :gear: The example release pipeline requires a repository into which trusted
+   artifacts will be written as a manner of passing data between tasks in the pipeline.
+
+   The **ociStorage** field tells the pipeline where to have that stored.
+
+   For example, if your release repository was
+   `quay.io/my-user/my-konflux-component-release`, you could set your TA repository
+   like this:
+
+```yaml
+    ociStorage: registry-service.kind-registry/test-component-release-ta
+```
+
+   For more details, see
+   [Trusted Artifacts (ociStorage)](./docs/quay.md#trusted-artifacts-ocistorage).
 
 :gear: Deploy the managed environment team's namespace, along with the resources
 mentioned above:

--- a/test/resources/demo-users/user/managed-ns2/rpa.yaml
+++ b/test/resources/demo-users/user/managed-ns2/rpa.yaml
@@ -19,11 +19,12 @@ spec:
   pipeline:
     pipelineRef:
       resolver: git
+      ociStorage: registry-service.kind-registry/test-component-release-ta
       params:
         - name: url
           value: "https://github.com/konflux-ci/release-service-catalog.git"
         - name: revision
-          value: 0cbe8aebf8b85763b724dc292641d2c587f13b6e
+          value: development
         - name: pathInRepo
           value: "pipelines/managed/push-to-external-registry/push-to-external-registry.yaml"
     serviceAccountName: release-pipeline


### PR DESCRIPTION
### **User description**
Updating docs to work with the ociStorage option in the release pipeline which is used for using the latest pipelines from
release-service-catalog repo.

Assisted-by: Cursor


___

### **PR Type**
Documentation


___

### **Description**
- Document ociStorage field usage in release pipeline configuration

- Add Trusted Artifacts section to Quay documentation with setup instructions

- Update ReleasePlanAdmission example to include ociStorage configuration

- Improve documentation formatting and clarity for release pipeline setup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release Pipeline<br/>Documentation"] -->|"Add ociStorage<br/>configuration"| B["Trusted Artifacts<br/>Setup Guide"]
  A -->|"Update example<br/>manifest"| C["ReleasePlanAdmission<br/>with ociStorage"]
  B -->|"Include service<br/>account details"| D["Release Pipeline<br/>Credentials"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add ociStorage documentation and improve manifest references</code></dd></summary>
<hr>

README.md

<ul><li>Improved formatting of manifest file references with proper markdown <br>links<br> <li> Added new section documenting the ociStorage field requirement for <br>release pipelines<br> <li> Included example configuration showing how to set ociStorage for <br>Trusted Artifacts<br> <li> Added reference link to detailed ociStorage documentation in <br>docs/quay.md</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4849/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+20/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>quay.md</strong><dd><code>Add Trusted Artifacts documentation and expand release pipeline setup</code></dd></summary>
<hr>

docs/quay.md

<ul><li>Added table of contents entry for Trusted Artifacts (ociStorage) <br>section<br> <li> Expanded release pipeline push secret configuration with detailed <br>step-by-step instructions<br> <li> Added new Trusted Artifacts (ociStorage) section explaining <br>configuration requirements<br> <li> Clarified service account naming and credential requirements for <br>release pipeline<br> <li> Removed outdated managed namespace examples from build pipeline <br>section</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4849/files#diff-34c39265b32debb6d9a9136761d8c4e5424239f0db664ca279405ebbed3858cf">+19/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpa.yaml</strong><dd><code>Add ociStorage field to example ReleasePlanAdmission manifest</code></dd></summary>
<hr>

test/resources/demo-users/user/managed-ns2/rpa.yaml

<ul><li>Added ociStorage field to pipelineRef configuration pointing to <br>test-component-release-ta<br> <li> Updated pipeline revision from specific commit hash to 'development' <br>branch<br> <li> Maintained all other ReleasePlanAdmission configuration unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4849/files#diff-951d30ef609263f83f9574aace6c49787ad5753ba897b3db7af2c4569564bf45">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

