### PR TITLE
fix(KFLUXVNGD-655): Add Dex CA certificate to oauth2-proxy container

### DIFF
--- a/operator/pkg/manifests/ui/manifests.yaml
+++ b/operator/pkg/manifests/ui/manifests.yaml
@@ -628,6 +628,7 @@ spec:
   dnsNames:
   - localhost
   - dex.konflux-ui
+  - dex.konflux-ui.svc.cluster.local
   isCA: true
   issuerRef:
     kind: ClusterIssuer

--- a/operator/upstream-kustomizations/ui/README.md
+++ b/operator/upstream-kustomizations/ui/README.md
@@ -2,11 +2,80 @@
 
 ## Overview
 
-This component will deploy the UI.
+This component deploys the Konflux UI with the following key components:
 
-`proxy` - Forwards requests to the kube api, and redirects the user to perform
-authentication if the user doesn't have a valid cookie.
+- **proxy** - An nginx + oauth2-proxy deployment that handles authentication and proxies requests to the Kubernetes API
+- **dex** - An OpenID Connect (OIDC) identity provider for authentication
+
+## Certificate Infrastructure
+
+### TLS Certificate for Dex
+
+The `dex` service uses a self-signed TLS certificate for secure communication. This certificate is automatically managed by cert-manager:
+
+1. **Certificate Resource** (`upstream-kustomizations/ui/certmanager/certificate.yaml`)
+   - Defines a Certificate CR named `serving-cert` in the `konflux-ui` namespace
+   - Uses `self-signed-cluster-issuer` (ClusterIssuer) to generate the certificate
+   - cert-manager automatically creates and maintains the `dex-cert` secret with:
+     - `tls.crt` - Dex's TLS certificate
+     - `tls.key` - Dex's private key (kept secure in this secret)
+     - `ca.crt` - The CA certificate (same as tls.crt for self-signed certs)
+
+2. **Certificate Lifecycle**
+   - cert-manager automatically renews the certificate before expiration
+   - When renewed, cert-manager updates the `dex-cert` secret in-place
+   - The dex pod automatically reloads the updated certificate
+
+### CA Bundle Synchronization for oauth2-proxy
+
+The `oauth2-proxy` needs to trust Dex's TLS certificate. This is achieved through a controller-managed CA bundle:
+
+1. **Controller Sync Process** (implemented in `konfluxui_controller.go`)
+   - The `reconcileDexCABundle()` function watches the `dex-cert` secret
+   - When the secret is created or updated (e.g., during cert renewal), the controller:
+     - Extracts `ca.crt` from the `dex-cert` secret
+     - Syncs it to the `dex-ca-bundle` ConfigMap in the `konflux-ui` namespace
+   - The ConfigMap is updated **in-place** (no content-based hashing)
+
+2. **oauth2-proxy Integration**
+   - The `dex-ca-bundle` ConfigMap is mounted into the oauth2-proxy container
+   - The `SSL_CERT_FILE` environment variable points to the mounted CA certificate
+   - This allows oauth2-proxy to verify Dex's TLS certificate during HTTPS connections
+
+3. **Update Behavior**
+   - When cert-manager renews the Dex certificate:
+     - The controller detects the secret change (via watcher)
+     - Updates the `dex-ca-bundle` ConfigMap with the new CA
+     - Kubernetes eventually propagates the ConfigMap update to mounted volumes
+     - oauth2-proxy pods pick up the new CA on their next natural restart/redeploy
+   - **Note**: ConfigMap updates do not trigger automatic pod restarts. For most use cases, this is acceptable as certificate rotations are infrequent and pods are regularly redeployed. If immediate propagation is critical, consider using a tool like [Reloader](https://github.com/stakater/Reloader) to watch ConfigMaps and restart pods automatically.
+
+### Security Considerations
+
+- **Credential Isolation**: The `dex-cert` secret (containing the private key) is only mounted by the dex pod. The oauth2-proxy pod only accesses the public CA certificate via the ConfigMap.
+- **Public CA Data**: Using a ConfigMap (not a Secret) for the CA bundle is appropriate because CA certificates are public data used only for verification, not authentication.
+- **No Intermediate Certificate Creation**: The controller directly syncs the CA bytes from the existing secret, eliminating the risk of creating additional certificates with minting capabilities.
 
 ## Dependencies
 
-`Dex` is required to be present for `oauth2-proxy` to be deployed.
+- **cert-manager** - Required for TLS certificate management
+- **Dex** - Required as the OIDC provider for oauth2-proxy
+
+## Verification
+
+To verify the certificate infrastructure is working:
+
+```bash
+# Check that cert-manager created the dex-cert secret
+kubectl get secret dex-cert -n konflux-ui
+
+# Check that the controller synced the CA to the ConfigMap
+kubectl get configmap dex-ca-bundle -n konflux-ui
+
+# Verify the CA certificate content matches
+kubectl get secret dex-cert -n konflux-ui -o jsonpath='{.data.ca\.crt}' | base64 -d
+kubectl get configmap dex-ca-bundle -n konflux-ui -o jsonpath='{.data.ca\.crt}'
+
+# Check that oauth2-proxy pods have the volume mounted
+kubectl get deployment proxy -n konflux-ui -o yaml | grep -A 5 oauth2-proxy-ca
+```

--- a/operator/upstream-kustomizations/ui/dex/dex.yaml
+++ b/operator/upstream-kustomizations/ui/dex/dex.yaml
@@ -12,6 +12,7 @@ spec:
   dnsNames:
   - localhost
   - dex.konflux-ui
+  - dex.konflux-ui.svc.cluster.local
   issuerRef:
     kind: ClusterIssuer
     name: self-signed-cluster-issuer


### PR DESCRIPTION
### **User description**
- Create a new Issuer that uses dex-cert as the Certificate Authority.
- Create a new Certificate that uses the new Issuer.
- Add the new certificate to the oauth2-proxy container.
- Update dex-cert dnsNames to include svc.cluster.local
- Remove skip verify from oauth2-proxy container
- Use SSL_CERT_FILE environment variable to point to the new certificate
- Update tests to include the certificate

Assisted-By: Cursor


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replace insecure TLS skip-verify with proper CA certificate verification

- Add oauth2-proxy-ca-cert issued by dex-ca-issuer for mutual TLS trust

- Mount CA certificate volume and set SSL_CERT_FILE environment variable

- Update dex-cert dnsNames to include svc.cluster.local for cluster DNS resolution

- Add comprehensive certificate infrastructure documentation and troubleshooting guide


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["self-signed-cluster-issuer"] -->|issues| B["dex-cert<br/>isCA: true"]
  B -->|used as CA by| C["dex-ca-issuer"]
  C -->|issues| D["oauth2-proxy-ca-cert"]
  D -->|mounted as| E["oauth2-proxy container"]
  E -->|verifies Dex TLS via| F["SSL_CERT_FILE<br/>environment variable"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>konfluxui_controller.go</strong><dd><code>Add CA certificate volume and remove skip-verify</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/ui/konfluxui_controller.go

<ul><li>Add <code>oauth2ProxyCACertSecretName</code> constant for the CA certificate secret<br> <li> Create <code>buildOAuth2ProxyCAVolume()</code> function to define volume from <br>oauth2-proxy-ca-cert secret<br> <li> Refactor <code>buildProxyOverlay()</code> to apply CA volume to both nil and <br>non-nil spec cases<br> <li> Replace <code>WithTLSSkipVerify()</code> with <code>WithOAuth2ProxyCA()</code> in oauth2-proxy <br>options</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4850/files#diff-24d972a47782a65c4bb0528b6a7352cac3a33aa318ccd2d11584881d688124be">+55/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Replace skip-verify with CA certificate configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/pkg/oauth2proxy/config.go

<ul><li>Add three constants for CA volume configuration: <br><code>OAuth2ProxyCAVolumeName</code>, <code>OAuth2ProxyCAMountPath</code>, <br><code>OAuth2ProxyCACertFileName</code><br> <li> Replace <code>WithTLSSkipVerify()</code> function with <code>WithOAuth2ProxyCA()</code> that <br>sets <code>SSL_CERT_FILE</code> env var and mounts CA certificate<br> <li> Add detailed comments explaining the CA certificate trust model and <br>credential isolation</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4850/files#diff-30d5b502efaacbdb8c3b86628bde99c3a8340db9b7d1659fb20f902047df562e">+40/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>konfluxui_customization_test.go</strong><dd><code>Update tests for CA certificate configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/ui/konfluxui_customization_test.go

<ul><li>Add import for <code>gstruct</code> matcher from gomega<br> <li> Import <code>oauth2proxy</code> package for constants<br> <li> Remove <code>OAUTH2_PROXY_SSL_INSECURE_SKIP_VERIFY</code> from required env vars <br>list<br> <li> Add test case "adds dex-ca volume to deployment" verifying volume and <br>mount configuration<br> <li> Update <code>TestBuildOAuth2ProxyOptions</code> to verify <code>SSL_CERT_FILE</code> env var and <br>CA volume mount</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4850/files#diff-f1eae7a16e055233d023d08cdd96d38daf24a39090e9cc74758d63fda37a087e">+47/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config_test.go</strong><dd><code>Refactor tests for container-level assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/pkg/oauth2proxy/config_test.go

<ul><li>Refactor <code>applyOption()</code> helper to return full container instead of just <br>env vars<br> <li> Update all test functions to use refactored helper and access <br>container properties<br> <li> Replace <code>TestWithTLSSkipVerify()</code> with <code>TestWithOAuth2ProxyCA()</code> verifying <br>env var and volume mount<br> <li> Update test assertions to work with container object instead of env <br>var slice</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4850/files#diff-2f28cef9c5027003c84f686b01282e15b3cd08e52cc4c73f096067a82567cec6">+33/-22</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifests.yaml</strong><dd><code>Add dex-ca-issuer and oauth2-proxy-ca-cert resources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/pkg/manifests/ui/manifests.yaml

<ul><li>Add <code>dex.konflux-ui.svc.cluster.local</code> to dex-cert dnsNames<br> <li> Add new <code>dex-ca-issuer</code> Issuer resource using dex-cert as CA<br> <li> Add new <code>oauth2-proxy-ca-cert</code> Certificate issued by dex-ca-issuer</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4850/files#diff-b4087adab82021e5f589128ca400b3542479df861a6ecc3c5cb018510a5faeca">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>certificate.yaml</strong><dd><code>Add dex-ca-issuer and oauth2-proxy-ca-cert certificates</code>&nbsp; &nbsp; </dd></summary>
<hr>

operator/upstream-kustomizations/ui/certmanager/certificate.yaml

<ul><li>Add <code>dex-ca-issuer</code> Issuer resource using dex-cert secret as CA<br> <li> Add <code>oauth2-proxy-ca-cert</code> Certificate resource with dnsNames and <br>issuerRef pointing to dex-ca-issuer<br> <li> Include detailed comments explaining the certificate purpose and <br>security model</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4850/files#diff-76eada907b15d2a3965f85d9b2a58903497f791e5ebbf351241d9b48aafa1bd8">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dex.yaml</strong><dd><code>Add cluster DNS name to dex certificate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/upstream-kustomizations/ui/dex/dex.yaml

<ul><li>Add <code>dex.konflux-ui.svc.cluster.local</code> to dex-cert dnsNames for cluster <br>DNS resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4850/files#diff-26018efeec51730936e29c4b5f775b2ea37d63cc60a5c6060659b9aded2e3753">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add certificate infrastructure documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/upstream-kustomizations/ui/README.md

<ul><li>Add comprehensive "Certificate Infrastructure" section documenting the <br>trust chain architecture<br> <li> Document four certificate components and their roles in the TLS setup<br> <li> Explain resource creation order and automatic renewal behavior<br> <li> Provide TLS configuration details with YAML examples<br> <li> Document security model with credential isolation explanation<br> <li> Add troubleshooting section with verification commands and common <br>issues</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4850/files#diff-dc60b72ac467bde30cca8afd14fffe7b504fd02934a72bb8f3aa595db3955272">+135/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

