### PR TITLE
fix: jetstack renovate format

### DIFF
--- a/.github/workflows/update-third-party-manifests.yaml
+++ b/.github/workflows/update-third-party-manifests.yaml
@@ -5,9 +5,9 @@ name: Update Third-Party Manifests
 
 env:
   # renovate: datasource=helm depName=jetstack/cert-manager versioning=semver
-  CERT_MANAGER_VERSION: "v1.19.1"
+  CERT_MANAGER_VERSION: "1.19.1"
   # renovate: datasource=helm depName=jetstack/trust-manager versioning=semver
-  TRUST_MANAGER_VERSION: "v0.20.2"
+  TRUST_MANAGER_VERSION: "0.20.2"
 
 on:
   schedule:
@@ -42,15 +42,15 @@ jobs:
 
       - name: Generate third-party manifests
         env:
-          CERT_MANAGER_VERSION: ${{ env.CERT_MANAGER_VERSION }}
-          TRUST_MANAGER_VERSION: ${{ env.TRUST_MANAGER_VERSION }}
+          CERT_MANAGER_VERSION: "v${{ env.CERT_MANAGER_VERSION }}"
+          TRUST_MANAGER_VERSION: "v${{ env.TRUST_MANAGER_VERSION }}"
         run: .github/scripts/update-third-party-manifests.sh
 
       - name: Create or update PR if changed
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-          CERT_MANAGER_VERSION: ${{ env.CERT_MANAGER_VERSION }}
-          TRUST_MANAGER_VERSION: ${{ env.TRUST_MANAGER_VERSION }}
+          CERT_MANAGER_VERSION: "v${{ env.CERT_MANAGER_VERSION }}"
+          TRUST_MANAGER_VERSION: "v${{ env.TRUST_MANAGER_VERSION }}"
         run: .github/scripts/create-third-party-manifests-pr.sh
 
       - name: Notify on failure


### PR DESCRIPTION
### **User description**
Renovate was removing the leading 'v' from the versions, so instead of figuring out how to fix it, we just add it back when the variables are passed.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove leading 'v' from version environment variables

- Add 'v' prefix when passing versions to scripts

- Accommodate Renovate's version format stripping behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Renovate removes 'v' prefix"] --> B["Store version without 'v'"]
  B --> C["Add 'v' prefix in script calls"]
  C --> D["Scripts receive correct format"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update-third-party-manifests.yaml</strong><dd><code>Adjust version format for Renovate compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/update-third-party-manifests.yaml

<ul><li>Removed leading 'v' from <code>CERT_MANAGER_VERSION</code> and <br><code>TRUST_MANAGER_VERSION</code> environment variables<br> <li> Added 'v' prefix when passing versions to <br><code>update-third-party-manifests.sh</code> script<br> <li> Added 'v' prefix when passing versions to <br><code>create-third-party-manifests-pr.sh</code> script<br> <li> Ensures scripts receive properly formatted version strings with 'v' <br>prefix</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4938/files#diff-427423125b2f96b12e32c28aabbd9fdc9ce63443e455dc718826b18b95bee394">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

