### PR TITLE
chore(KONFLUX-11977): add CI environment

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -75,6 +75,14 @@ jobs:
   check-changes:
     name: Check for relevant changes
     runs-on: ubuntu-slim
+    needs: [check-prerequisites]
+    # Use e2e-tests environment (Required reviewers) only for human PRs; bots and
+    # merge_group use no env so they run without approval.
+    environment: >-
+      ${{ github.event_name == 'pull_request_target' &&
+      !contains(',renovate[bot],red-hat-konflux[bot],github-actions[bot],konflux-ci-update-bot[bot],',
+      format(',{0},', github.event.pull_request.user.login)) &&
+      'e2e-tests' || '' }}
     outputs:
       operator: ${{ steps.changed-files.outputs.any_changed }}
     steps:
@@ -101,6 +109,11 @@ jobs:
     name: ${{ matrix.job_name }}
     runs-on: ubuntu-slim
     needs: [check-prerequisites, check-changes]
+    environment: >-
+      ${{ github.event_name == 'pull_request_target' &&
+      !contains(',renovate[bot],red-hat-konflux[bot],github-actions[bot],konflux-ci-update-bot[bot],',
+      format(',{0},', github.event.pull_request.user.login)) &&
+      'e2e-tests' || '' }}
     if: needs.check-changes.outputs.operator != 'true'
     strategy:
       matrix:
@@ -131,6 +144,11 @@ jobs:
     name: ${{ matrix.job_name }}
     runs-on: ${{ matrix.runner }}
     needs: [check-prerequisites, check-changes]
+    environment: >-
+      ${{ github.event_name == 'pull_request_target' &&
+      !contains(',renovate[bot],red-hat-konflux[bot],github-actions[bot],konflux-ci-update-bot[bot],',
+      format(',{0},', github.event.pull_request.user.login)) &&
+      'e2e-tests' || '' }}
     if: needs.check-changes.outputs.operator == 'true'
     strategy:
       matrix:

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -74,6 +74,13 @@ jobs:
   sanity-test:
     needs: check-prerequisites
     runs-on: ubuntu-latest
+    # Use e2e-tests environment (Required reviewers) only for human PRs; bots and
+    # merge_group use no env so they run without approval
+    environment: >-
+      ${{ github.event_name == 'pull_request_target' &&
+      !contains(',renovate[bot],red-hat-konflux[bot],github-actions[bot],konflux-ci-update-bot[bot],',
+      format(',{0},', github.event.pull_request.user.login)) &&
+      'e2e-tests' || '' }}
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main


### PR DESCRIPTION
### **User description**
Use environment in CI workflows.

Assisted-by: Cursor


___

### **PR Type**
Enhancement


___

### **Description**
- Add conditional environment configuration to CI workflows

- Restrict e2e-tests environment to authorized users only

- Exclude bot accounts and external contributors from environment access

- Apply environment rules to check-changes, test-skip, and test jobs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  WF["CI Workflows<br/>operator-test-e2e.yaml<br/>sanity-test.yml"]
  ENV["Environment Configuration<br/>e2e-tests"]
  COND["Conditional Logic<br/>PR Target + Auth Check"]
  JOBS["Jobs<br/>check-changes<br/>test-skip<br/>test<br/>sanity-test"]
  WF --> COND
  COND --> ENV
  ENV --> JOBS
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator-test-e2e.yaml</strong><dd><code>Add conditional e2e-tests environment to test jobs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/operator-test-e2e.yaml

<ul><li>Add environment configuration to check-changes job with conditional <br>logic<br> <li> Add environment configuration to test-skip job with bot/user filtering<br> <li> Add environment configuration to test job with authorization checks<br> <li> Environment set to 'e2e-tests' only for authorized pull_request_target <br>events</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4950/files#diff-4608c9a6806d47acb069a4d5586ed2091dc1e10d5f40a21f1d229f3053ff79a4">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sanity-test.yml</strong><dd><code>Add conditional e2e-tests environment to sanity-test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/sanity-test.yml

<ul><li>Add environment configuration to sanity-test job<br> <li> Implement conditional logic to restrict access to authorized users<br> <li> Exclude renovate[bot], red-hat-konflux[bot], github-actions[bot], and <br>konflux-ci-update-bot[bot]<br> <li> Environment activated only for pull_request_target events from non-bot <br>users</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4950/files#diff-c68f5ef87662968636741c0c819fd08d5c7f2a1c020a572d10356b72e63f742f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

