### PR TITLE
chore: use comment instead of environment for triggering ci

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -5,91 +5,79 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
+  repository_dispatch:
+    types: [e2e]
 
 jobs:
+  # Gate: bots, repo collaborators (write+), or repository_dispatch/merge_group. Others need /run from a maintainer.
   check-prerequisites:
     runs-on: ubuntu-latest
     steps:
-    - name: Check prerequisites for running Operator tests
+    - name: Check prerequisites
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       run: |
-        if [ "${{ github.event_name }}" != 'pull_request_target' ]; then
-          echo "The workflow is not triggered from PR, but ${{ github.event_name }} - skipping further checks."
+        # 1. Allow Manual Dispatch or Merge Queue
+        if [[ "${{ github.event_name }}" == 'repository_dispatch' || "${{ github.event_name }}" == 'merge_group' ]]; then
+          echo "✅ Trigger is ${{ github.event_name }} (Trusted Context). Allowed."
           exit 0
         fi
 
-        WHITELISTED_BOT_NAMES=(
+        # 2. Check Bot Whitelist
+        declare -a WHITELISTED_BOTS=(
           "renovate[bot]"
           "red-hat-konflux[bot]"
           "github-actions[bot]"
           "konflux-ci-update-bot[bot]"
         )
-        REQUIRED_LABEL_NAME="ok-to-test"
 
-        ORG="${{ github.repository_owner }}"
-        PR_AUTHOR=$(jq --raw-output .pull_request.user.login $GITHUB_EVENT_PATH)
-        echo "PR author: $PR_AUTHOR"
-        PR_LABELS=$(jq --raw-output .pull_request.labels[].name $GITHUB_EVENT_PATH)
-
-        # Check if PR author is in the whitelisted bots list
-        BOT_WHITELISTED=false
-        for BOT_NAME in "${WHITELISTED_BOT_NAMES[@]}"; do
-          if [ "$PR_AUTHOR" == "$BOT_NAME" ]; then
-            BOT_WHITELISTED=true
-            echo "PR author is $BOT_NAME, skipping further checks."
-            break
+        for BOT in "${WHITELISTED_BOTS[@]}"; do
+          if [[ "$PR_AUTHOR" == "$BOT" ]]; then
+            echo "✅ Author is whitelisted bot ($BOT). Allowed."
+            exit 0
           fi
         done
 
-        if [ "$BOT_WHITELISTED" == "true" ]; then
+        # 3. Check Repository Permissions (works with private org membership)
+        USER_PERM=$(gh api "/repos/${{ github.repository }}/collaborators/$PR_AUTHOR/permission" --jq .permission 2>/dev/null || echo "none")
+
+        if [[ "$USER_PERM" =~ ^(admin|write|maintain)$ ]]; then
+          echo "✅ Author ($PR_AUTHOR) has '$USER_PERM' access. Allowed."
           exit 0
         fi
 
-        if [[ "$PR_LABELS" == *$REQUIRED_LABEL_NAME* ]]; then
-          echo "PR has '$REQUIRED_LABEL_NAME' label, skipping further checks."
-          exit 0
-        fi
+        # 4. Fail and Instruct
+        echo "❌ Blocked: Untrusted author ($PR_AUTHOR) with permission '$USER_PERM'."
 
-        if gh api "/orgs/$ORG/members/$PR_AUTHOR"; then
-          echo "PR author is a member of $ORG GitHub organization, skipping further checks"
-          exit 0
-        fi
-
-        # Create comma-separated list for error message
-        BOT_LIST=$(IFS=','; echo "${WHITELISTED_BOT_NAMES[*]}")
-
-        ERROR_SUMMARY=$(cat <<EOF
-
-        ### ❌ Cannot run Operator tests - at least one of the following conditions must be met:
-        * PR author is one of: $BOT_LIST
-        * PR has label '$REQUIRED_LABEL_NAME'
-        * PR author is a public member of '$ORG' GitHub organization
+        cat <<EOF >> $GITHUB_STEP_SUMMARY
+        ### 🛑 CI Approval Required
+        The PR author is not a maintainer or whitelisted bot.
+        **Action Required:** A maintainer must comment \`/run\` on this PR to trigger tests.
         EOF
-        )
-        echo "$ERROR_SUMMARY" >> $GITHUB_STEP_SUMMARY
-        echo "$ERROR_SUMMARY"
 
         exit 1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
   check-changes:
     name: Check for relevant changes
     runs-on: ubuntu-slim
     needs: [check-prerequisites]
-    # Use e2e-tests environment (Required reviewers) only for human PRs; bots and
-    # merge_group use no env so they run without approval.
-    environment: >-
-      ${{ github.event_name == 'pull_request_target' &&
-      !contains(',renovate[bot],red-hat-konflux[bot],github-actions[bot],konflux-ci-update-bot[bot],',
-      format(',{0},', github.event.pull_request.user.login)) &&
-      'e2e-tests' || '' }}
     outputs:
       operator: ${{ steps.changed-files.outputs.any_changed }}
     steps:
+      - name: Set checkout ref
+        id: set-ref
+        run: |
+          case "${{ github.event_name }}" in
+            repository_dispatch) ref=$(jq -r '.client_payload.head_sha' $GITHUB_EVENT_PATH) ;;
+            merge_group)        ref=$(jq -r '.merge_group.head_sha' $GITHUB_EVENT_PATH) ;;
+            *)                  ref=$(jq -r '.pull_request.head.sha' $GITHUB_EVENT_PATH) ;;
+          esac
+          echo "ref=$ref" >> $GITHUB_OUTPUT
       - name: Checkout PR branch
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ steps.set-ref.outputs.ref }}
           fetch-depth: 0
       - name: Check for changes
         uses: tj-actions/changed-files@v47
@@ -170,6 +158,15 @@ jobs:
       run:
         working-directory: operator
     steps:
+      - name: Set checkout ref
+        id: set-ref
+        run: |
+          case "${{ github.event_name }}" in
+            repository_dispatch) ref=$(jq -r '.client_payload.head_sha' $GITHUB_EVENT_PATH) ;;
+            merge_group)        ref=$(jq -r '.merge_group.head_sha' $GITHUB_EVENT_PATH) ;;
+            *)                  ref=$(jq -r '.pull_request.head.sha' $GITHUB_EVENT_PATH) ;;
+          esac
+          echo "ref=$ref" >> $GITHUB_OUTPUT
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
@@ -179,7 +176,7 @@ jobs:
       - name: Clone the code
         uses: actions/checkout@v6
         with:
-          ref: "${{ github.event.pull_request.head.sha }}"
+          ref: ${{ steps.set-ref.outputs.ref }}
 
       - name: Disable AppArmor
         # works around a change in ubuntu 24.04 that restricts Linux namespace access

--- a/.github/workflows/pr-comment-commands.yml
+++ b/.github/workflows/pr-comment-commands.yml
@@ -1,0 +1,70 @@
+# Org members can trigger E2E runs on any PR by commenting /run.
+# One comment = one run of both Operator E2E and Sanity workflows.
+#
+# How it works:
+# - Bot or org member pushes to a PR branch → workflow runs on pull_request_target.
+#   check-prerequisites runs, sees PR author is bot/org member → exits 0 → rest of
+#   workflow runs (check-changes, then test or test-skip). No comment needed.
+# - Non-member pushes → same trigger, but check-prerequisites runs, sees PR author
+#   is not bot and not org member → exits 1 → workflow fails there. No later jobs
+#   run. To run CI, an org member must comment /run → pr-comment-commands dispatches
+#   "e2e" → both workflows run via repository_dispatch (they skip the PR gate).
+
+name: PR Comment Commands
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  handle-command:
+    name: Handle /run
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/run') &&
+      contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    steps:
+      - name: Get PR details
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('number', pr.data.number);
+            core.setOutput('head_sha', pr.data.head.sha);
+
+      - name: Trigger E2E workflows
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          TRIGGERED_BY: ${{ github.event.comment.user.login }}
+        with:
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'e2e',
+              client_payload: {
+                pr_number: parseInt(process.env.PR_NUMBER),
+                head_sha: process.env.HEAD_SHA,
+                triggered_by: process.env.TRIGGERED_BY
+              }
+            });
+
+      # Add rocket emoji to the /run comment as feedback that the command was accepted
+      - name: React to comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -5,83 +5,72 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
+  repository_dispatch:
+    types: [e2e]
+
 jobs:
+  # Gate: bots, repo collaborators (write+), or repository_dispatch/merge_group. Others need /run from a maintainer.
   check-prerequisites:
     runs-on: ubuntu-latest
     steps:
-    - name: Check prerequisites for running Sanity test
+    - name: Check prerequisites
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       run: |
-        if [ "${{ github.event_name }}" != 'pull_request_target' ]; then
-          echo "The workflow is not triggered from PR, but ${{ github.event_name }} - skipping further checks."
+        # 1. Allow Manual Dispatch or Merge Queue
+        if [[ "${{ github.event_name }}" == 'repository_dispatch' || "${{ github.event_name }}" == 'merge_group' ]]; then
+          echo "✅ Trigger is ${{ github.event_name }} (Trusted Context). Allowed."
           exit 0
         fi
 
-        WHITELISTED_BOT_NAMES=(
+        # 2. Check Bot Whitelist
+        declare -a WHITELISTED_BOTS=(
           "renovate[bot]"
           "red-hat-konflux[bot]"
           "github-actions[bot]"
           "konflux-ci-update-bot[bot]"
         )
-        REQUIRED_LABEL_NAME="ok-to-test"
 
-        ORG="${{ github.repository_owner }}"
-        PR_AUTHOR=$(jq --raw-output .pull_request.user.login $GITHUB_EVENT_PATH)
-        echo "PR author: $PR_AUTHOR"
-        PR_LABELS=$(jq --raw-output .pull_request.labels[].name $GITHUB_EVENT_PATH)
-
-        # Check if PR author is in the whitelisted bots list
-        BOT_WHITELISTED=false
-        for BOT_NAME in "${WHITELISTED_BOT_NAMES[@]}"; do
-          if [ "$PR_AUTHOR" == "$BOT_NAME" ]; then
-            BOT_WHITELISTED=true
-            echo "PR author is $BOT_NAME, skipping further checks."
-            break
+        for BOT in "${WHITELISTED_BOTS[@]}"; do
+          if [[ "$PR_AUTHOR" == "$BOT" ]]; then
+            echo "✅ Author is whitelisted bot ($BOT). Allowed."
+            exit 0
           fi
         done
 
-        if [ "$BOT_WHITELISTED" == "true" ]; then
+        # 3. Check Repository Permissions (works with private org membership)
+        USER_PERM=$(gh api "/repos/${{ github.repository }}/collaborators/$PR_AUTHOR/permission" --jq .permission 2>/dev/null || echo "none")
+
+        if [[ "$USER_PERM" =~ ^(admin|write|maintain)$ ]]; then
+          echo "✅ Author ($PR_AUTHOR) has '$USER_PERM' access. Allowed."
           exit 0
         fi
 
-        if [[ "$PR_LABELS" == *$REQUIRED_LABEL_NAME* ]]; then
-          echo "PR has '$REQUIRED_LABEL_NAME' label, skipping further checks."
-          exit 0
-        fi
+        # 4. Fail and Instruct
+        echo "❌ Blocked: Untrusted author ($PR_AUTHOR) with permission '$USER_PERM'."
 
-        if gh api "/orgs/$ORG/members/$PR_AUTHOR"; then
-          echo "PR author is a member of $ORG GitHub organization, skipping further checks"
-          exit 0
-        fi
-
-        # Create comma-separated list for error message
-        BOT_LIST=$(IFS=','; echo "${WHITELISTED_BOT_NAMES[*]}")
-
-        ERROR_SUMMARY=$(cat <<EOF
-
-        ### ❌ Cannot run Sanity test - at least one of the following conditions must be met:
-        * PR author is one of: $BOT_LIST
-        * PR has label '$REQUIRED_LABEL_NAME'
-        * PR author is a public member of '$ORG' GitHub organization
+        cat <<EOF >> $GITHUB_STEP_SUMMARY
+        ### 🛑 CI Approval Required
+        The PR author is not a maintainer or whitelisted bot.
+        **Action Required:** A maintainer must comment \`/run\` on this PR to trigger tests.
         EOF
-        )
-        echo "$ERROR_SUMMARY" >> $GITHUB_STEP_SUMMARY
-        echo "$ERROR_SUMMARY"
 
         exit 1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
   sanity-test:
     needs: check-prerequisites
     runs-on: ubuntu-latest
-    # Use e2e-tests environment (Required reviewers) only for human PRs; bots and
-    # merge_group use no env so they run without approval
-    environment: >-
-      ${{ github.event_name == 'pull_request_target' &&
-      !contains(',renovate[bot],red-hat-konflux[bot],github-actions[bot],konflux-ci-update-bot[bot],',
-      format(',{0},', github.event.pull_request.user.login)) &&
-      'e2e-tests' || '' }}
     steps:
+      - name: Set checkout ref
+        id: set-ref
+        run: |
+          case "${{ github.event_name }}" in
+            repository_dispatch) ref=$(jq -r '.client_payload.head_sha' $GITHUB_EVENT_PATH) ;;
+            merge_group)        ref=$(jq -r '.merge_group.head_sha' $GITHUB_EVENT_PATH) ;;
+            *)                  ref=$(jq -r '.pull_request.head.sha' $GITHUB_EVENT_PATH) ;;
+          esac
+          echo "ref=$ref" >> $GITHUB_OUTPUT
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
@@ -93,7 +82,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
-          ref: "${{ github.event.pull_request.head.sha }}"
+          ref: ${{ steps.set-ref.outputs.ref }}
 
       - name: Disable AppArmor
         # works around a change in ubuntu 24.04 that restricts Linux namespace access


### PR DESCRIPTION
### **User description**
Trying an alternative for using environments for gating CI. With this approach, org members will not need approvals, while external contributors will need an org member to comment /run to trigger CI.

Assisted-by: Cursor


___

### **PR Type**
Enhancement


___

### **Description**
- Replace environment-based CI gating with comment-triggered dispatch

- Implement `/run` command for maintainers to approve external contributor PRs

- Refactor prerequisite checks to use repository permissions instead of labels

- Add support for `repository_dispatch` and `merge_group` trigger events


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PR["Pull Request<br/>from External User"]
  GATE["check-prerequisites<br/>Gate Job"]
  DISPATCH["repository_dispatch<br/>Event"]
  COMMENT["Maintainer<br/>Comments /run"]
  ALLOWED["✅ Run E2E &<br/>Sanity Tests"]
  BLOCKED["❌ Blocked<br/>Awaiting /run"]
  
  PR -->|pull_request_target| GATE
  GATE -->|Bot or Collaborator| ALLOWED
  GATE -->|External User| BLOCKED
  COMMENT -->|Triggers| DISPATCH
  DISPATCH -->|Skips Gate| ALLOWED
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator-test-e2e.yaml</strong><dd><code>Replace environment gating with permission-based checks</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/operator-test-e2e.yaml

<ul><li>Added <code>repository_dispatch</code> trigger with <code>e2e</code> event type<br> <li> Refactored <code>check-prerequisites</code> to check repository collaborator <br>permissions instead of org membership and labels<br> <li> Removed environment-based gating from <code>check-changes</code> and test jobs<br> <li> Added dynamic checkout ref resolution for <code>repository_dispatch</code>, <br><code>merge_group</code>, and <code>pull_request_target</code> events<br> <li> Improved error messaging with clear instructions for maintainer <br>approval</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4981/files#diff-4608c9a6806d47acb069a4d5586ed2091dc1e10d5f40a21f1d229f3053ff79a4">+47/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pr-comment-commands.yml</strong><dd><code>New workflow for maintainer-triggered CI approval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-comment-commands.yml

<ul><li>New workflow to handle <code>/run</code> comments from maintainers on PRs<br> <li> Validates comment author is owner, member, or collaborator<br> <li> Extracts PR details and triggers <code>repository_dispatch</code> event with <code>e2e</code> <br>type<br> <li> Passes PR number and head SHA in client payload for workflow <br>consumption<br> <li> Adds rocket emoji reaction to approved comments</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4981/files#diff-3958ec6e5d475f1858dd89a71f4aea87c66734672ae8491b3b0f94a1c6c95768">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sanity-test.yml</strong><dd><code>Replace environment gating with permission-based checks</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/sanity-test.yml

<ul><li>Added <code>repository_dispatch</code> trigger with <code>e2e</code> event type<br> <li> Refactored <code>check-prerequisites</code> to check repository collaborator <br>permissions instead of org membership and labels<br> <li> Removed environment-based gating from <code>sanity-test</code> job<br> <li> Added dynamic checkout ref resolution for <code>repository_dispatch</code>, <br><code>merge_group</code>, and <code>pull_request_target</code> events<br> <li> Improved error messaging with clear instructions for maintainer <br>approval</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4981/files#diff-c68f5ef87662968636741c0c819fd08d5c7f2a1c020a572d10356b72e63f742f">+38/-49</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

