### PR TITLE
chore: change comment to run ci

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -9,7 +9,7 @@ on:
     types: [e2e]
 
 jobs:
-  # Gate: bots, repo collaborators (write+), or repository_dispatch/merge_group. Others need /run from a maintainer.
+  # Gate: bots, repo collaborators (write+), or repository_dispatch/merge_group. Others need /allow from a maintainer.
   check-prerequisites:
     runs-on: ubuntu-latest
     steps:
@@ -53,7 +53,7 @@ jobs:
         cat <<EOF >> $GITHUB_STEP_SUMMARY
         ### 🛑 CI Approval Required
         The PR author is not a maintainer or whitelisted bot.
-        **Action Required:** A maintainer must comment \`/run\` on this PR to trigger tests.
+        **Action Required:** A maintainer must comment \`/allow\` on this PR to trigger tests.
         EOF
 
         exit 1

--- a/.github/workflows/pr-comment-commands.yml
+++ b/.github/workflows/pr-comment-commands.yml
@@ -1,4 +1,4 @@
-# Org members can trigger E2E runs on any PR by commenting /run.
+# Org members can trigger E2E runs on any PR by commenting /allow.
 # One comment = one run of both Operator E2E and Sanity workflows.
 #
 # How it works:
@@ -7,7 +7,7 @@
 #   workflow runs (check-changes, then test or test-skip). No comment needed.
 # - Non-member pushes → same trigger, but check-prerequisites runs, sees PR author
 #   is not bot and not org member → exits 1 → workflow fails there. No later jobs
-#   run. To run CI, an org member must comment /run → pr-comment-commands dispatches
+#   run. To run CI, an org member must comment /allow → pr-comment-commands dispatches
 #   "e2e" → both workflows run via repository_dispatch (they skip the PR gate).
 
 name: PR Comment Commands
@@ -18,7 +18,7 @@ on:
 
 jobs:
   handle-command:
-    name: Handle /run
+    name: Handle /allow
     runs-on: ubuntu-latest
     permissions:
       contents: write   # required for repos.createDispatchEvent
@@ -26,7 +26,7 @@ jobs:
       issues: write    # for reactions.createForIssueComment
     if: |
       github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/run') &&
+      startsWith(github.event.comment.body, '/allow') &&
       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     steps:
       - name: Get PR details

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -9,7 +9,7 @@ on:
     types: [e2e]
 
 jobs:
-  # Gate: bots, repo collaborators (write+), or repository_dispatch/merge_group. Others need /run from a maintainer.
+  # Gate: bots, repo collaborators (write+), or repository_dispatch/merge_group. Others need /allow from a maintainer.
   check-prerequisites:
     runs-on: ubuntu-latest
     steps:
@@ -53,7 +53,7 @@ jobs:
         cat <<EOF >> $GITHUB_STEP_SUMMARY
         ### 🛑 CI Approval Required
         The PR author is not a maintainer or whitelisted bot.
-        **Action Required:** A maintainer must comment \`/run\` on this PR to trigger tests.
+        **Action Required:** A maintainer must comment \`/allow\` on this PR to trigger tests.
         EOF
 
         exit 1


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Update CI command from `/run` to `/allow` across workflows

- Standardize command reference in comments and job names

- Clarify maintainer approval process documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Workflows"] -- "Update command reference" --> B["/allow instead of /run"]
  B -- "Applied to" --> C["operator-test-e2e.yaml"]
  B -- "Applied to" --> D["pr-comment-commands.yml"]
  B -- "Applied to" --> E["sanity-test.yml"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator-test-e2e.yaml</strong><dd><code>Update CI approval command reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/operator-test-e2e.yaml

<ul><li>Updated gate comment to reference <code>/allow</code> instead of <code>/run</code><br> <li> Changed CI approval instruction message to use <code>/allow</code> command</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4986/files#diff-4608c9a6806d47acb069a4d5586ed2091dc1e10d5f40a21f1d229f3053ff79a4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pr-comment-commands.yml</strong><dd><code>Rename command handler and update references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-comment-commands.yml

<ul><li>Updated workflow header comment to reference <code>/allow</code> command<br> <li> Changed job name from "Handle /run" to "Handle /allow"<br> <li> Updated workflow trigger condition to check for <code>/allow</code> prefix<br> <li> Updated internal documentation to reflect new command name</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4986/files#diff-3958ec6e5d475f1858dd89a71f4aea87c66734672ae8491b3b0f94a1c6c95768">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sanity-test.yml</strong><dd><code>Update CI approval command reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/sanity-test.yml

<ul><li>Updated gate comment to reference <code>/allow</code> instead of <code>/run</code><br> <li> Changed CI approval instruction message to use <code>/allow</code> command</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4986/files#diff-c68f5ef87662968636741c0c819fd08d5c7f2a1c020a572d10356b72e63f742f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

