### PR TITLE
fix: report CI status when triggered by comment

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -64,6 +64,7 @@ jobs:
     needs: [check-prerequisites]
     outputs:
       operator: ${{ steps.changed-files.outputs.any_changed }}
+      check_run_id: ${{ steps.create-check.outputs.check_run_id }}
     steps:
       - name: Set checkout ref
         id: set-ref
@@ -75,6 +76,21 @@ jobs:
           esac
           echo "ref=$ref" >> $GITHUB_OUTPUT
           echo "Trigger: ${{ github.event_name }} → checkout ref: $ref"
+      - name: Create check run (comment-triggered)
+        if: github.event_name == 'repository_dispatch'
+        id: create-check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const head_sha = '${{ steps.set-ref.outputs.ref }}';
+            const { data } = await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Run Operator E2E Tests',
+              head_sha,
+              status: 'in_progress'
+            });
+            core.setOutput('check_run_id', data.id);
       - name: Checkout PR branch
         uses: actions/checkout@v6
         with:
@@ -313,3 +329,31 @@ jobs:
         with:
           name: logs-${{ matrix.arch }}
           path: logs
+
+  # Report check result to PR when triggered by /allow (so the run appears on the PR and can gate it)
+  report-operator-e2e-status:
+    if: always() && needs.check-changes.outputs.check_run_id != ''
+    needs: [check-changes, test-skip, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update check run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const checkRunId = parseInt(process.env.CHECK_RUN_ID);
+            const testResult = process.env.TEST_RESULT;
+            const testSkipResult = process.env.TEST_SKIP_RESULT;
+            let conclusion = 'failure';
+            if (testResult === 'success' || testSkipResult === 'success') conclusion = 'success';
+            else if (testResult === 'cancelled' || testSkipResult === 'cancelled') conclusion = 'cancelled';
+            await github.rest.checks.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: checkRunId,
+              status: 'completed',
+              conclusion
+            });
+        env:
+          CHECK_RUN_ID: ${{ needs.check-changes.outputs.check_run_id }}
+          TEST_RESULT: ${{ needs.test.result }}
+          TEST_SKIP_RESULT: ${{ needs.test-skip.result }}

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -61,6 +61,8 @@ jobs:
   sanity-test:
     needs: check-prerequisites
     runs-on: ubuntu-latest
+    outputs:
+      check_run_id: ${{ steps.create-check.outputs.check_run_id }}
     steps:
       - name: Set checkout ref
         id: set-ref
@@ -72,6 +74,21 @@ jobs:
           esac
           echo "ref=$ref" >> $GITHUB_OUTPUT
           echo "Trigger: ${{ github.event_name }} → checkout ref: $ref"
+      - name: Create check run (comment-triggered)
+        if: github.event_name == 'repository_dispatch'
+        id: create-check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const head_sha = '${{ steps.set-ref.outputs.ref }}';
+            const { data } = await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Sanity Test',
+              head_sha,
+              status: 'in_progress'
+            });
+            core.setOutput('check_run_id', data.id);
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
@@ -164,3 +181,29 @@ jobs:
         with:
           name: logs
           path: logs
+
+  # Report check result to PR when triggered by /allow (so the run appears on the PR and can gate it)
+  report-sanity-status:
+    if: always() && needs.sanity-test.outputs.check_run_id != ''
+    needs: [sanity-test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update check run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const checkRunId = parseInt(process.env.CHECK_RUN_ID);
+            const result = process.env.SANITY_RESULT;
+            let conclusion = 'failure';
+            if (result === 'success') conclusion = 'success';
+            else if (result === 'cancelled') conclusion = 'cancelled';
+            await github.rest.checks.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: checkRunId,
+              status: 'completed',
+              conclusion
+            });
+        env:
+          CHECK_RUN_ID: ${{ needs.sanity-test.outputs.check_run_id }}
+          SANITY_RESULT: ${{ needs.sanity-test.result }}


### PR DESCRIPTION
### **User description**
Assisted-by: Cursor


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Create GitHub check runs when workflows triggered by comment

- Report final test status back to PR via check run updates

- Enable comment-triggered runs to appear and gate PRs

- Applied to both operator E2E and sanity test workflows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Comment Trigger<br/>repository_dispatch"] -->|"Create check run"| B["Check Run<br/>in_progress"]
  C["Test Job"] -->|"Completes"| D["Report Status Job"]
  D -->|"Update check run"| E["Check Run<br/>completed"]
  E -->|"Appears on PR"| F["PR Gate/Status"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator-test-e2e.yaml</strong><dd><code>Add check run creation and status reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/operator-test-e2e.yaml

<ul><li>Added <code>check_run_id</code> output to <code>check-changes</code> job<br> <li> Created check run when workflow triggered by comment <br>(<code>repository_dispatch</code>)<br> <li> Added new <code>report-operator-e2e-status</code> job to update check run with <br>final test results<br> <li> Determines conclusion based on test and test-skip job results</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4987/files#diff-4608c9a6806d47acb069a4d5586ed2091dc1e10d5f40a21f1d229f3053ff79a4">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sanity-test.yml</strong><dd><code>Add check run creation and status reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/sanity-test.yml

<ul><li>Added <code>check_run_id</code> output to <code>sanity-test</code> job<br> <li> Created check run when workflow triggered by comment <br>(<code>repository_dispatch</code>)<br> <li> Added new <code>report-sanity-status</code> job to update check run with final test <br>results<br> <li> Determines conclusion based on sanity test job result</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4987/files#diff-c68f5ef87662968636741c0c819fd08d5c7f2a1c020a572d10356b72e63f742f">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

