### PR TITLE
fix: ci permissions

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -62,6 +62,9 @@ jobs:
     name: Check for relevant changes
     runs-on: ubuntu-slim
     needs: [check-prerequisites]
+    permissions:
+      contents: read
+      checks: write
     outputs:
       operator: ${{ steps.changed-files.outputs.any_changed }}
       check_run_id: ${{ steps.create-check.outputs.check_run_id }}
@@ -335,6 +338,8 @@ jobs:
     if: always() && needs.check-changes.outputs.check_run_id != ''
     needs: [check-changes, test-skip, test]
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     steps:
       - name: Update check run
         uses: actions/github-script@v7

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -61,6 +61,9 @@ jobs:
   sanity-test:
     needs: check-prerequisites
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     outputs:
       check_run_id: ${{ steps.create-check.outputs.check_run_id }}
     steps:
@@ -187,6 +190,8 @@ jobs:
     if: always() && needs.sanity-test.outputs.check_run_id != ''
     needs: [sanity-test]
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     steps:
       - name: Update check run
         uses: actions/github-script@v7


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add explicit permissions to GitHub Actions workflows

- Grant `contents: read` to jobs requiring repository access

- Grant `checks: write` to jobs updating check run status

- Improve security posture by following least privilege principle


___

### Diagram Walkthrough


```mermaid
flowchart LR
  WF["Workflows<br/>operator-test-e2e.yaml<br/>sanity-test.yml"]
  PERMS["Add Permissions<br/>contents: read<br/>checks: write"]
  JOBS["Jobs<br/>check-changes<br/>sanity-test<br/>report-status"]
  WF --> PERMS
  PERMS --> JOBS
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator-test-e2e.yaml</strong><dd><code>Add permissions to operator test e2e workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/operator-test-e2e.yaml

<ul><li>Add <code>permissions</code> block to <code>check-changes</code> job with <code>contents: read</code> and <br><code>checks: write</code><br> <li> Add <code>permissions</code> block to <code>report-operator-e2e-status</code> job with <code>checks: </code><br><code>write</code><br> <li> Enables jobs to read repository contents and update check run status <br>securely</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4988/files#diff-4608c9a6806d47acb069a4d5586ed2091dc1e10d5f40a21f1d229f3053ff79a4">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sanity-test.yml</strong><dd><code>Add permissions to sanity test workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/sanity-test.yml

<ul><li>Add <code>permissions</code> block to <code>sanity-test</code> job with <code>contents: read</code> and <br><code>checks: write</code><br> <li> Add <code>permissions</code> block to <code>report-sanity-status</code> job with <code>checks: write</code><br> <li> Restricts job access to only required GitHub API scopes</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4988/files#diff-c68f5ef87662968636741c0c819fd08d5c7f2a1c020a572d10356b72e63f742f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

