### PR TITLE
chore: report ci for amd and arm

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -68,6 +68,7 @@ jobs:
     outputs:
       operator: ${{ steps.changed-files.outputs.any_changed }}
       check_run_id: ${{ steps.create-check.outputs.check_run_id }}
+      check_run_id_arm64: ${{ steps.create-check.outputs.check_run_id_arm64 }}
     steps:
       - name: Set checkout ref
         id: set-ref
@@ -86,14 +87,22 @@ jobs:
         with:
           script: |
             const head_sha = '${{ steps.set-ref.outputs.ref }}';
-            const { data } = await github.rest.checks.create({
+            const { data: e2e } = await github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               name: 'Run Operator E2E Tests',
               head_sha,
               status: 'in_progress'
             });
-            core.setOutput('check_run_id', data.id);
+            const { data: arm64 } = await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Run Operator Integration Tests (ARM64)',
+              head_sha,
+              status: 'in_progress'
+            });
+            core.setOutput('check_run_id', e2e.id);
+            core.setOutput('check_run_id_arm64', arm64.id);
       - name: Checkout PR branch
         uses: actions/checkout@v6
         with:
@@ -341,24 +350,22 @@ jobs:
     permissions:
       checks: write
     steps:
-      - name: Update check run
+      - name: Update check runs
         uses: actions/github-script@v7
         with:
           script: |
             const checkRunId = parseInt(process.env.CHECK_RUN_ID);
+            const checkRunIdArm64 = parseInt(process.env.CHECK_RUN_ID_ARM64);
             const testResult = process.env.TEST_RESULT;
             const testSkipResult = process.env.TEST_SKIP_RESULT;
             let conclusion = 'failure';
             if (testResult === 'success' || testSkipResult === 'success') conclusion = 'success';
             else if (testResult === 'cancelled' || testSkipResult === 'cancelled') conclusion = 'cancelled';
-            await github.rest.checks.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              check_run_id: checkRunId,
-              status: 'completed',
-              conclusion
-            });
+            const update = { owner: context.repo.owner, repo: context.repo.repo, status: 'completed', conclusion };
+            await github.rest.checks.update({ ...update, check_run_id: checkRunId });
+            await github.rest.checks.update({ ...update, check_run_id: checkRunIdArm64 });
         env:
           CHECK_RUN_ID: ${{ needs.check-changes.outputs.check_run_id }}
+          CHECK_RUN_ID_ARM64: ${{ needs.check-changes.outputs.check_run_id_arm64 }}
           TEST_RESULT: ${{ needs.test.result }}
           TEST_SKIP_RESULT: ${{ needs.test-skip.result }}


### PR DESCRIPTION
### **User description**
Assisted-by: Cursor


___

### **PR Type**
Enhancement


___

### **Description**
- Add ARM64 check run reporting to CI workflow

- Create separate check run for ARM64 integration tests

- Update both AMD and ARM check runs with test results

- Refactor check update logic for code reusability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Create Check Runs"] -->|AMD x86_64| B["E2E Tests Check"]
  A -->|ARM64| C["Integration Tests Check"]
  D["Test Results"] -->|Update Both| E["Report Status to PR"]
  B --> E
  C --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator-test-e2e.yaml</strong><dd><code>Dual check run reporting for AMD and ARM64</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/operator-test-e2e.yaml

<ul><li>Added <code>check_run_id_arm64</code> output to capture ARM64 check run ID<br> <li> Created separate check run for ARM64 integration tests alongside AMD <br>E2E tests<br> <li> Updated <code>report-operator-e2e-status</code> job to update both AMD and ARM64 <br>check runs<br> <li> Refactored check update logic using object spread operator for DRY <br>principle<br> <li> Added <code>CHECK_RUN_ID_ARM64</code> environment variable to report job</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/4989/files#diff-4608c9a6806d47acb069a4d5586ed2091dc1e10d5f40a21f1d229f3053ff79a4">+17/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

