### PR TITLE
fix: enabled tekton updates in renovate

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,0 @@
-[tools]
-kind = "0.22.0"
-kubectl = "1.30.0"
-go = "1.21.9"
-"go:golang.org/x/tools/cmd/stringer" = "0.22.0"
-"go:github.com/onsi/ginkgo/v2/ginkgo" = "2.19.0"

--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -30,10 +30,6 @@ spec:
       name: dockerfile
       type: string
     - default: "false"
-      description: Force rebuild image
-      name: rebuild
-      type: string
-    - default: "false"
       description: Skip checks against built image
       name: skip-checks
       type: string
@@ -102,12 +98,6 @@ spec:
   tasks:
     - name: init
       params:
-        - name: image-url
-          value: $(params.output-image)
-        - name: rebuild
-          value: $(params.rebuild)
-        - name: skip-checks
-          value: $(params.skip-checks)
         - name: enable-cache-proxy
           value: $(params.enable-cache-proxy)
       taskRef:
@@ -115,7 +105,7 @@ spec:
           - name: name
             value: init
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:b349d24cb896573695802d6913d311640b44675ec082b3ad167721946a6a0a71
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.3@sha256:aa6f8632cc23d605c5942505ff1d00280db16a6fda5c4c56c4ed9ae936b5fbc6
           - name: kind
             value: task
         resolver: bundles
@@ -136,15 +126,10 @@ spec:
           - name: name
             value: git-clone-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:0a89e1a6304076525e9766f63a4cd006763d21d5aca6863281fc427537a23c6f
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:306b69e6db435ad4a7cf258b6219d9b998eb37da44f5e9ac882ac86a08109154
           - name: kind
             value: task
         resolver: bundles
-      when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
       workspaces:
         - name: basic-auth
           workspace: git-auth
@@ -229,11 +214,6 @@ spec:
           - name: kind
             value: task
         resolver: bundles
-      when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
     - name: build-image-index
       params:
         - name: IMAGE
@@ -256,15 +236,10 @@ spec:
           - name: name
             value: build-image-index
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:39561ac43e325159497c10c0284cf61dfddf39e39100ca5e3df6b73c5d96db8b
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:8c422a5380a3d877257003dee153190322af84fe6f4f25e9eee7d8bf61a62577
           - name: kind
             value: task
         resolver: bundles
-      when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
     - name: build-source-image
       params:
         - name: BINARY_IMAGE
@@ -287,10 +262,6 @@ spec:
             value: task
         resolver: bundles
       when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
         - input: $(params.build-source-image)
           operator: in
           values:
@@ -308,7 +279,7 @@ spec:
           - name: name
             value: deprecated-image-check
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:462baed733dfc38aca5395499e92f19b6f13a74c2e88fe5d86c3cffa2f899b57
+            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:e3a55ccdf1091b4a35507f9ee2d1918d8e89a5f96babcb5486b491226da03d6f
           - name: kind
             value: task
         resolver: bundles
@@ -335,7 +306,7 @@ spec:
           - name: name
             value: clair-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:a5fa66ed5b8c107e7bc29cb084edcc07e394f818cc59ef2db2f9dcb0cd1fa3dc
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:3ff4d1c3c503454c6b7f072e225df43656fb415a5d2a658ab6ce279c0dc128aa
           - name: kind
             value: task
         resolver: bundles
@@ -553,7 +524,7 @@ spec:
           - name: name
             value: apply-tags
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.2@sha256:e4017ec351a0891ef95989f35bd20b8c3f091fa1a3da364c4d4e975e99f3063c
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:510b6d2a3b188adeb716e49566b57d611ab36bd69a2794b5ddfc11dbf014c2ca
           - name: kind
             value: task
         resolver: bundles
@@ -576,7 +547,7 @@ spec:
           - name: name
             value: push-dockerfile-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:08bba4a659ecd48f871bef00b80af58954e5a09fcbb28a1783ddd640c4f6535e
+            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:6fb61bec5ef161225a850005233db68cfdc03ad54e1a54cc49cc98d98ea3d259
           - name: kind
             value: task
         resolver: bundles
@@ -593,7 +564,7 @@ spec:
           - name: name
             value: rpms-signature-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:0b10508c82ccb0f5a06a66ce7af56e9bfd40651ddefdf0f499988e897771ee28
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:a99d8fd4c9027356b18e5d2910cc44dbc2fcb53c384ba34696645d9e7faa9084
           - name: kind
             value: task
         resolver: bundles

--- a/renovate.json
+++ b/renovate.json
@@ -36,7 +36,9 @@
       "registryUrls": ["https://charts.jetstack.io"]
     }
   ],
-  "enabledManagers": ["regex", "kustomize", "github-actions", "gomod", "dockerfile"],
+  "tekton": {
+    "fileMatch": ["^\\.tekton/.*\\.ya?ml$"]
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
### **User description**
When onboarding to Konflux, tekton updates were not enabled in renovate. The references are now outdated and fail Conforma.

This change enabled all default managers, manually update the reference that fails Conforma, and removes mise as it's unused and we don't want to get renovate updates for it now that everything is enabled.

Assisted-by: Cursor


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Enable Tekton task updates in Renovate configuration

- Update outdated Tekton task SHA256 hash reference

- Remove unused mise tool configuration file

- Configure Tekton-specific file matching pattern


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Renovate Config"] -->|"Add Tekton manager"| B["Enable Tekton Updates"]
  C["Tekton Pipeline YAML"] -->|"Update SHA256"| D["Fix Conforma Validation"]
  E["mise.toml"] -->|"Remove unused"| F["Cleanup Config"]
  B --> G["Coordinated Updates"]
  D --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Enable Tekton manager with file pattern matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renovate.json

<ul><li>Replace <code>enabledManagers</code> array with explicit Tekton manager <br>configuration<br> <li> Add <code>tekton</code> manager with file pattern matching for <code>.tekton/*.yaml</code> and <br><code>.tekton/*.yml</code> files<br> <li> Maintain existing custom managers and grouping rules</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5056/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-pipeline.yaml</strong><dd><code>Update clair-scan task SHA256 hash reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.tekton/build-pipeline.yaml

<ul><li>Update <code>task-clair-scan</code> bundle SHA256 hash from outdated value<br> <li> Fix reference to pass Conforma validation requirements</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5056/files#diff-824ab9f3a9936597ea406f3d5fe782805cae27855afac62f92f68d917e5bf61e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.mise.toml</strong><dd><code>Remove unused mise tool configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.mise.toml

<ul><li>Remove entire file containing unused tool version definitions<br> <li> Eliminate unnecessary Renovate update triggers for mise tools</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5056/files#diff-1bac9641068b68e6b60d0166663560d45b271c427fd863f8d56ed36964f99ee2">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

