### PR TITLE
fix: Remove OpenShift-specific TLS annotations

### DIFF
--- a/operator/pkg/manifests/integration/manifests.yaml
+++ b/operator/pkg/manifests/integration/manifests.yaml
@@ -279,7 +279,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: integration-service/serving-cert
     controller-gen.kubebuilder.io/version: v0.17.2
-    service.beta.openshift.io/inject-cabundle: "true"
   name: integrationtestscenarios.appstudio.redhat.com
 spec:
   conversion:
@@ -1514,8 +1513,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: integration-service
@@ -1730,7 +1727,6 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: integration-service/serving-cert
-    service.beta.openshift.io/inject-cabundle: "true"
   name: integration-service-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -1779,7 +1775,6 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: integration-service/serving-cert
-    service.beta.openshift.io/inject-cabundle: "true"
   name: integration-service-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/operator/pkg/manifests/release/manifests.yaml
+++ b/operator/pkg/manifests/release/manifests.yaml
@@ -4709,8 +4709,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
   name: release-service-webhook-service
   namespace: release-service
 spec:
@@ -4773,7 +4771,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/konflux-ci/release-service:6b2de30f1d4431b6eac46a593a325cd15013d6e8
+        image: quay.io/konflux-ci/release-service:2dfd82ca1ce03dea893e36cb1e530a5c2b9156f6
         livenessProbe:
           httpGet:
             path: /healthz
@@ -4858,7 +4856,6 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: release-service/serving-cert
-    service.beta.openshift.io/inject-cabundle: "true"
   name: release-service-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -4945,7 +4942,6 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: release-service/serving-cert
-    service.beta.openshift.io/inject-cabundle: "true"
   name: release-service-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/operator/upstream-kustomizations/integration/kustomization.yaml
+++ b/operator/upstream-kustomizations/integration/kustomization.yaml
@@ -14,6 +14,31 @@ patches:
       - op: add
         path: /spec/progressDeadlineSeconds
         value: 2147483647
+  # Remove OpenShift-specific annotations as cert-manager is used for creating and injecting TLS secrets
+  - target:
+      kind: CustomResourceDefinition
+      name: integrationtestscenarios.appstudio.redhat.com
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/service.beta.openshift.io~1inject-cabundle
+  - target:
+      kind: ValidatingWebhookConfiguration
+      name: integration-service-validating-webhook-configuration
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/service.beta.openshift.io~1inject-cabundle
+  - target:
+      kind: MutatingWebhookConfiguration
+      name: integration-service-mutating-webhook-configuration
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/service.beta.openshift.io~1inject-cabundle
+  - target:
+      kind: Service
+      name: integration-service-webhook-service
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/service.beta.openshift.io~1serving-cert-secret-name
 
 replacements:
   - source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs

--- a/operator/upstream-kustomizations/release/kustomization.yaml
+++ b/operator/upstream-kustomizations/release/kustomization.yaml
@@ -15,6 +15,25 @@ patches:
       - op: add
         path: /spec/progressDeadlineSeconds
         value: 2147483647
+  # Remove OpenShift-specific annotations as cert-manager is used for creating and injecting TLS secrets
+  - target:
+      kind: ValidatingWebhookConfiguration
+      name: release-service-validating-webhook-configuration
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/service.beta.openshift.io~1inject-cabundle
+  - target:
+      kind: MutatingWebhookConfiguration
+      name: release-service-mutating-webhook-configuration
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/service.beta.openshift.io~1inject-cabundle
+  - target:
+      kind: Service
+      name: release-service-webhook-service
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/service.beta.openshift.io~1serving-cert-secret-name
 
 replacements:
   - source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs


### PR DESCRIPTION
Add kustomize patches to remove OpenShift service-serving-certificate annotations from upstream manifests since cert-manager is used for creating and injecting TLS secrets.

Release overlay:
- Remove service.beta.openshift.io/inject-cabundle from ValidatingWebhookConfiguration and MutatingWebhookConfiguration
- Remove service.beta.openshift.io/serving-cert-secret-name from Service

Integration overlay:
- Remove service.beta.openshift.io/inject-cabundle from CustomResourceDefinition, ValidatingWebhookConfiguration, and MutatingWebhookConfiguration
- Remove service.beta.openshift.io/serving-cert-secret-name from Service

This change also updates the references to the integration and release services since the script for generating the manifests file also updates the references.

Assisted-By: Cursor