### PR TITLE
fix(KFLUXVNGD-638): Remove trusted-ca ConfigMap from default-tenant namespace

### DIFF
--- a/operator/hack/create-tenant.sh
+++ b/operator/hack/create-tenant.sh
@@ -63,18 +63,6 @@ metadata:
     konflux-ci.dev/type: tenant
 EOF
 
-# Create the trusted-ca ConfigMap
-echo "🔐 Creating trusted-ca ConfigMap..."
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: trusted-ca
-  namespace: ${NAMESPACE}
-  labels:
-    config.openshift.io/inject-trusted-cabundle: "true"
-EOF
-
 # Create the konflux-integration-runner ServiceAccount
 echo "👤 Creating konflux-integration-runner ServiceAccount..."
 kubectl apply -f - <<EOF
@@ -125,7 +113,6 @@ echo "✅ Tenant namespace '${NAMESPACE}' created successfully!"
 echo ""
 echo "Resources created:"
 echo "  - Namespace: ${NAMESPACE} (with label konflux-ci.dev/type: tenant)"
-echo "  - ConfigMap: trusted-ca"
 echo "  - ServiceAccount: konflux-integration-runner"
 echo "  - RoleBinding: konflux-integration-runner -> ClusterRole/konflux-integration-runner"
 echo "  - RoleBinding: ${ADMIN_USER%%@*}-konflux-admin -> ClusterRole/konflux-admin-user-actions"

--- a/operator/internal/controller/defaulttenant/konfluxdefaulttenant_controller_test.go
+++ b/operator/internal/controller/defaulttenant/konfluxdefaulttenant_controller_test.go
@@ -144,28 +144,6 @@ var _ = Describe("KonfluxDefaultTenant Controller", func() {
 			Expect(ns.Labels).To(HaveKeyWithValue("konflux-ci.dev/type", "tenant"))
 		})
 
-		It("should create the trusted-ca ConfigMap", func() {
-			By("creating the custom resource")
-			resource := &konfluxv1alpha1.KonfluxDefaultTenant{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the trusted-ca ConfigMap was created")
-			cm := &corev1.ConfigMap{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: "trusted-ca", Namespace: "default-tenant"}, cm)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(cm.Labels).To(HaveKeyWithValue("config.openshift.io/inject-trusted-cabundle", "true"))
-		})
-
 		It("should create the konflux-integration-runner ServiceAccount", func() {
 			By("creating the custom resource")
 			resource := &konfluxv1alpha1.KonfluxDefaultTenant{

--- a/operator/pkg/manifests/default-tenant/manifests.yaml
+++ b/operator/pkg/manifests/default-tenant/manifests.yaml
@@ -38,11 +38,3 @@ subjects:
 - kind: ServiceAccount
   name: konflux-integration-runner
   namespace: default-tenant
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    config.openshift.io/inject-trusted-cabundle: "true"
-  name: trusted-ca
-  namespace: default-tenant

--- a/operator/upstream-kustomizations/default-tenant/default-tenant.yaml
+++ b/operator/upstream-kustomizations/default-tenant/default-tenant.yaml
@@ -7,14 +7,6 @@ metadata:
     konflux-ci.dev/type: tenant
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: trusted-ca
-  namespace: default-tenant
-  labels:
-    config.openshift.io/inject-trusted-cabundle: "true"
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: konflux-integration-runner


### PR DESCRIPTION
### **User description**
Since buildah task was fixed and updated in version 0.8 we don't need to create the `trusted-ca` ConfigMap in `default-tenant` namespace anymore.

This PR commit removes the creation of the ConfigMap.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove trusted-ca ConfigMap creation from default-tenant namespace

- Update controller test to remove ConfigMap verification test

- Remove ConfigMap from manifest and kustomization files

- Update tenant creation script to exclude ConfigMap


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["trusted-ca ConfigMap<br/>creation code"] -->|removed| B["Controller test"]
  A -->|removed| C["Manifest files"]
  A -->|removed| D["Kustomization files"]
  A -->|removed| E["Tenant creation script"]
  B --> F["Buildah task v0.8<br/>no longer needs ConfigMap"]
  C --> F
  D --> F
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>konfluxdefaulttenant_controller_test.go</strong><dd><code>Remove trusted-ca ConfigMap test case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/defaulttenant/konfluxdefaulttenant_controller_test.go

<ul><li>Removed test case "should create the trusted-ca ConfigMap"<br> <li> Removed verification logic for ConfigMap creation and labels<br> <li> Simplified test suite by eliminating ConfigMap-related assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5063/files#diff-bb04d256e928446a81f235cda3f6789544f9f42e10d28cd7f41c4e22914f8514">+0/-22</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-tenant.sh</strong><dd><code>Remove ConfigMap creation from tenant script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/hack/create-tenant.sh

<ul><li>Removed kubectl apply command that created trusted-ca ConfigMap<br> <li> Removed ConfigMap metadata with inject-trusted-cabundle label<br> <li> Updated resource creation summary to exclude ConfigMap reference</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5063/files#diff-c60d4436208eb486fa4febcdf19cd4362fd84da0a80ac0ab4c55661cd6830dc2">+0/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>manifests.yaml</strong><dd><code>Remove ConfigMap from manifest file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/pkg/manifests/default-tenant/manifests.yaml

<ul><li>Removed ConfigMap resource definition from manifest<br> <li> Removed metadata labels for trusted-ca ConfigMap<br> <li> Kept ServiceAccount and RoleBinding resources intact</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5063/files#diff-9d6850f4f64545f694df516aa726f4f6ec47d8ff33f8bd13ce3370b0e619182f">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>default-tenant.yaml</strong><dd><code>Remove ConfigMap from kustomization file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/upstream-kustomizations/default-tenant/default-tenant.yaml

<ul><li>Removed ConfigMap resource definition from kustomization<br> <li> Removed ConfigMap metadata and labels configuration<br> <li> Preserved Namespace and ServiceAccount resources</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5063/files#diff-b6935ac1f8a185248e617b8361db68d7c49e9f282997216c984bc37cd9db3814">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

