### PR TITLE
fix: ec crd not ready in time during tests

### DIFF
--- a/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
+++ b/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
@@ -18,6 +18,7 @@ package enterprisecontract
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -73,10 +74,13 @@ var _ = Describe("KonfluxEnterpriseContract Controller", func() {
 				ObjectStore: objectStore,
 			}
 
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			By("Waiting for reconciliation to succeed (CRD may need to establish first)")
+			Eventually(func() error {
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				return err
+			}).WithTimeout(15 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
 		})


### PR DESCRIPTION
### **User description**
The EC controller is applying both the EC CRD and CRs, but sometimes the CRD is not ready by the time the CRs are applied, which causes the tests to fail.

Adding retries so it eventually passes.

Assisted-by: Cursor


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add retry logic to EC controller reconciliation test

- Wrap reconciliation call in Eventually block with timeout

- Allow CRD to establish before applying CRs

- Import time package for timeout configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Reconciliation"] -->|Previously Direct Call| B["Immediate Failure"]
  A -->|Now with Eventually| C["Retry Loop"]
  C -->|Timeout 15s| D["CRD Established"]
  D -->|Polling 500ms| E["Reconciliation Success"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>konfluxenterprisecontract_controller_test.go</strong><dd><code>Add retry logic to reconciliation test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go

<ul><li>Import <code>time</code> package for timeout and polling configuration<br> <li> Wrap <code>Reconcile</code> call in <code>Eventually</code> block with 15 second timeout<br> <li> Add 500 millisecond polling interval for retry attempts<br> <li> Add descriptive "By" statement explaining CRD establishment wait</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5070/files#diff-36db2d53df98c5992a1c044d47c059715ce1ec2cf90ba65da23080b67fe4b2a9">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

