### PR TITLE
feat: add Kubernetes version to info configmap

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -273,9 +273,13 @@ func main() {
 		setupLog.Error(err, "unable to detect cluster info")
 		os.Exit(1)
 	}
+	k8sVer := "unknown"
+	if v, err := clusterInfo.K8sVersion(); err == nil && v != nil {
+		k8sVer = v.GitVersion
+	}
 	setupLog.Info("Detected cluster info",
 		"platform", clusterInfo.Platform(),
-		"k8sVersion", clusterInfo.K8sVersion().GitVersion,
+		"k8sVersion", k8sVer,
 	)
 
 	if err := (&konflux.KonfluxReconciler{
@@ -364,6 +368,7 @@ func main() {
 		Client:      mgr.GetClient(),
 		Scheme:      mgr.GetScheme(),
 		ObjectStore: objectStore,
+		ClusterInfo: clusterInfo,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KonfluxInfo")
 		os.Exit(1)

--- a/operator/internal/controller/info/mock_discovery_test.go
+++ b/operator/internal/controller/info/mock_discovery_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package info
+
+import (
+	"sync"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+
+	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
+)
+
+// MockDiscoveryClient implements clusterinfo.DiscoveryClient and allows changing
+// the reported server version during a test (e.g. to simulate a cluster upgrade).
+type MockDiscoveryClient struct {
+	lock          sync.Mutex
+	serverVersion *version.Info
+}
+
+// ServerVersion returns the currently set version. Safe for concurrent use.
+func (m *MockDiscoveryClient) ServerVersion() (*version.Info, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.serverVersion, nil
+}
+
+// SetVersion updates the reported server version. Use this during a test to
+// simulate a version change and assert the VersionPoller sends an event.
+func (m *MockDiscoveryClient) SetVersion(v string) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.serverVersion = &version.Info{GitVersion: v}
+}
+
+// ServerResourcesForGroupVersion returns NotFound for config.openshift.io/v1 so
+// clusterinfo.DetectWithClient treats the cluster as non-OpenShift and succeeds.
+func (m *MockDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: groupVersion}, "")
+}
+
+var _ clusterinfo.DiscoveryClient = (*MockDiscoveryClient)(nil)

--- a/operator/internal/controller/info/poller.go
+++ b/operator/internal/controller/info/poller.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package info
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
+)
+
+// VersionPoller is a Runnable that polls for cluster version changes and sends
+// events to a channel so the KonfluxInfo controller can refresh the info ConfigMap.
+type VersionPoller struct {
+	ClusterInfo  *clusterinfo.Info
+	Interval     time.Duration
+	EventChannel chan<- event.TypedGenericEvent[client.Object]
+}
+
+// Start runs the poll loop until ctx is cancelled. It does not cache the version;
+// each tick fetches the current version from the API server.
+func (vp *VersionPoller) Start(ctx context.Context) error {
+	log := logf.FromContext(ctx).WithName("version-poller")
+
+	if vp.ClusterInfo == nil {
+		log.Info("ClusterInfo is nil, version poller exiting")
+		<-ctx.Done()
+		return nil
+	}
+
+	ticker := time.NewTicker(vp.Interval)
+	defer ticker.Stop()
+
+	var lastVersion string
+	if v, err := vp.ClusterInfo.K8sVersion(); err == nil && v != nil {
+		lastVersion = v.GitVersion
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			v, err := vp.ClusterInfo.K8sVersion()
+			if err != nil {
+				log.V(1).Info("Failed to check cluster version", "error", err)
+				continue
+			}
+			if v == nil {
+				continue
+			}
+
+			if v.GitVersion != lastVersion {
+				log.Info("Cluster version change detected", "old", lastVersion, "new", v.GitVersion)
+				lastVersion = v.GitVersion
+				// Sentinel object only: channel requires client.Object; handler ignores it and enqueues all KonfluxInfo.
+				select {
+				case vp.EventChannel <- event.TypedGenericEvent[client.Object]{
+					Object: &metav1.PartialObjectMetadata{
+						TypeMeta:   metav1.TypeMeta{Kind: "ClusterVersion", APIVersion: "config.openshift.io/v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "cluster-upgrade"},
+					},
+				}:
+				default:
+					// Channel full or closed; skip so we don't block the poller
+					log.V(1).Info("Version change event channel full, skipping enqueue")
+				}
+			}
+		}
+	}
+}

--- a/operator/internal/controller/info/poller_test.go
+++ b/operator/internal/controller/info/poller_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package info
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
+)
+
+func TestVersionPoller_FiresEventOnVersionChange(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	mockDiscovery := &MockDiscoveryClient{}
+	mockDiscovery.SetVersion("v1.29.0")
+
+	clusterInfo, err := clusterinfo.DetectWithClient(mockDiscovery)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(clusterInfo).NotTo(gomega.BeNil())
+
+	eventCh := make(chan event.TypedGenericEvent[client.Object], 1)
+	poller := &VersionPoller{
+		ClusterInfo:  clusterInfo,
+		Interval:     10 * time.Millisecond,
+		EventChannel: eventCh,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = poller.Start(ctx)
+	}()
+
+	// No event yet (version unchanged). Consistently also gives the poller time to set lastVersion and run initial ticks.
+	g.Consistently(eventCh, 30*time.Millisecond, 10*time.Millisecond).ShouldNot(gomega.Receive())
+
+	// Simulate cluster upgrade
+	mockDiscovery.SetVersion("v1.30.0")
+
+	// Expect event within a short time (next poll)
+	var e event.TypedGenericEvent[client.Object]
+	g.Eventually(eventCh).WithTimeout(1 * time.Second).Should(gomega.Receive(&e))
+	g.Expect(e.Object).NotTo(gomega.BeNil())
+	g.Expect(e.Object.GetName()).To(gomega.Equal("cluster-upgrade"))
+}
+
+func TestVersionPoller_ExitsWhenClusterInfoNil(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	eventCh := make(chan event.TypedGenericEvent[client.Object], 1)
+	poller := &VersionPoller{
+		ClusterInfo:  nil,
+		Interval:     time.Hour,
+		EventChannel: eventCh,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- poller.Start(ctx)
+	}()
+
+	// Cancel immediately; poller should exit (it blocks on <-ctx.Done() when ClusterInfo is nil)
+	cancel()
+	g.Expect(<-done).ToNot(gomega.HaveOccurred())
+}

--- a/operator/pkg/clusterinfo/clusterinfo.go
+++ b/operator/pkg/clusterinfo/clusterinfo.go
@@ -49,11 +49,10 @@ func (p Platform) IsOpenShift() bool {
 	return p == OpenShift
 }
 
-// Info holds cluster environment information including platform, version, and capabilities.
+// Info holds cluster environment information including platform and capabilities.
 type Info struct {
-	platform   Platform
-	k8sVersion *version.Info
-	client     DiscoveryClient
+	platform Platform
+	client   DiscoveryClient
 }
 
 // Detect discovers cluster information by querying the Kubernetes API.
@@ -83,13 +82,6 @@ func DetectWithClient(client DiscoveryClient) (*Info, error) {
 		info.platform = Default
 	}
 
-	// Get K8s version
-	serverVersion, err := client.ServerVersion()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get server version: %w", err)
-	}
-	info.k8sVersion = serverVersion
-
 	return info, nil
 }
 
@@ -104,8 +96,8 @@ func (i *Info) IsOpenShift() bool {
 }
 
 // K8sVersion returns the Kubernetes version info.
-func (i *Info) K8sVersion() *version.Info {
-	return i.k8sVersion
+func (i *Info) K8sVersion() (*version.Info, error) {
+	return i.client.ServerVersion()
 }
 
 // HasResource checks if a specific resource kind exists in the given API group version.

--- a/operator/pkg/clusterinfo/clusterinfo_test.go
+++ b/operator/pkg/clusterinfo/clusterinfo_test.go
@@ -129,7 +129,9 @@ func TestDetectWithClient_ServerVersionError(t *testing.T) {
 		versionErr: errors.New("connection refused"),
 	}
 
-	_, err := DetectWithClient(mock)
+	info, err := DetectWithClient(mock)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	_, err = info.K8sVersion()
 	g.Expect(err).To(gomega.HaveOccurred())
 }
 
@@ -167,9 +169,12 @@ func TestInfo_K8sVersion(t *testing.T) {
 
 	info, err := DetectWithClient(mock)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(info.K8sVersion().GitVersion).To(gomega.Equal(expectedVersion.GitVersion))
-	g.Expect(info.K8sVersion().Major).To(gomega.Equal(expectedVersion.Major))
-	g.Expect(info.K8sVersion().Minor).To(gomega.Equal(expectedVersion.Minor))
+	v, err := info.K8sVersion()
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(v).NotTo(gomega.BeNil())
+	g.Expect(v.GitVersion).To(gomega.Equal(expectedVersion.GitVersion))
+	g.Expect(v.Major).To(gomega.Equal(expectedVersion.Major))
+	g.Expect(v.Minor).To(gomega.Equal(expectedVersion.Minor))
 }
 
 func TestInfo_HasResource(t *testing.T) {


### PR DESCRIPTION
### **User description**
Add the Kubernetes version of the cluster to the Konflux Info. Also, make it so that the version is not cached in the discovery client as the version can be changed when the cluster is upgraded.

Introduce a poller to periodically update the Kubernetes version, allowing the controller to cleanly react to version changes.

Assisted-by: Cursor


___

### **PR Type**
Enhancement


___

### **Description**
- Add Kubernetes version to info ConfigMap with non-cached retrieval

- Introduce VersionPoller to detect cluster version changes periodically

- Refactor K8sVersion() to fetch version on-demand instead of caching

- Update info.json generation to include kubernetesVersion field


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ClusterInfo"] -->|K8sVersion on-demand| B["VersionPoller"]
  B -->|detects version change| C["Event Channel"]
  C -->|triggers reconcile| D["KonfluxInfoReconciler"]
  D -->|generates info.json| E["ConfigMap with kubernetesVersion"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Pass ClusterInfo to KonfluxInfo reconciler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/cmd/main.go

<ul><li>Pass <code>ClusterInfo</code> to <code>KonfluxInfoReconciler</code> for version access<br> <li> Handle potential error when retrieving K8s version with fallback to <br>"unknown"<br> <li> Update logging to use safe version retrieval</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5094/files#diff-6951a7b3b8a59603497b68b62013a806397c640ce0a42a3862f6a4ffad4fda89">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>konfluxinfo_controller.go</strong><dd><code>Add version poller and K8s version to info ConfigMap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/info/konfluxinfo_controller.go

<ul><li>Add <code>ClusterInfo</code> field to <code>KonfluxInfoReconciler</code> struct<br> <li> Implement <code>VersionPoller</code> that checks cluster version every 10 minutes<br> <li> Add <code>enqueueKonfluxInfoForVersionChange()</code> handler to trigger reconciles <br>on version changes<br> <li> Update <code>generateInfoJSON()</code> and <code>applyInfoDefaults()</code> to accept and <br>include <code>kubernetesVersion</code> parameter<br> <li> Add <code>KubernetesVersion</code> field to <code>infoJSON</code> struct for JSON serialization<br> <li> Watch version change events via <code>WatchesRawSource()</code> in controller setup<br> <li> Retrieve current K8s version in <code>reconcileInfoConfigMap()</code> and pass to <br>JSON generation</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5094/files#diff-632df3e422d02f42ebc3adf96fe1683930511f632b57b7d58fdcd60f75e46b2a">+69/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>poller.go</strong><dd><code>Implement version poller for cluster upgrades</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/info/poller.go

<ul><li>Implement <code>VersionPoller</code> as a Runnable that polls cluster version <br>periodically<br> <li> Detect version changes by comparing current version with last known <br>version<br> <li> Send events to channel when version change is detected<br> <li> Handle nil ClusterInfo gracefully by exiting early<br> <li> Use non-blocking channel send to avoid blocking the poller</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5094/files#diff-6e5f598ee5622ccf6161fc07e1691f385cd29abd71685527482c0b133d658231">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>clusterinfo.go</strong><dd><code>Make K8s version non-cached and on-demand</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/pkg/clusterinfo/clusterinfo.go

<ul><li>Remove cached <code>k8sVersion</code> field from <code>Info</code> struct<br> <li> Change <code>K8sVersion()</code> to return <code>(*version.Info, error)</code> and fetch <br>on-demand from discovery client<br> <li> Remove version retrieval from <code>DetectWithClient()</code> initialization<br> <li> Update documentation to reflect that version is no longer cached</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5094/files#diff-8dbe40b2ffa3cb0a7d90ca101480b244d5fa464c5267025e11b93168835dbabe">+5/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mock_discovery_test.go</strong><dd><code>Add mock discovery client for testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/info/mock_discovery_test.go

<ul><li>Create new mock discovery client for testing version changes<br> <li> Implement thread-safe <code>SetVersion()</code> method to simulate cluster upgrades<br> <li> Implement <code>ServerVersion()</code> and <code>ServerResourcesForGroupVersion()</code> methods</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5094/files#diff-f707093d73ea7b700e52019a595dc959fe6bb39f10b7ca91a2a214e2b3faa4b5">+58/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>poller_test.go</strong><dd><code>Add tests for version poller</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/info/poller_test.go

<ul><li>Test that VersionPoller fires event when cluster version changes<br> <li> Test that VersionPoller exits gracefully when ClusterInfo is nil<br> <li> Use mock discovery client to simulate version upgrades</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5094/files#diff-d74f00efba4fa547868262de26255c2c604e360e674c184f18e48fad3ee26e52">+86/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>clusterinfo_test.go</strong><dd><code>Update tests for on-demand version retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/pkg/clusterinfo/clusterinfo_test.go

<ul><li>Update <code>TestDetectWithClient_ServerVersionError</code> to expect success from <br><code>DetectWithClient()</code> and error from <code>K8sVersion()</code><br> <li> Update <code>TestInfo_K8sVersion</code> to handle error return from <code>K8sVersion()</code> <br>method</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5094/files#diff-17874adbcd1520db0142705d7e883daa6aee3ff7cd10e66221c146ab9ac0cfcb">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

