### PR TITLE
fix: Change wait condition for cert-manager deployment

### DIFF
--- a/deploy-deps.sh
+++ b/deploy-deps.sh
@@ -126,7 +126,7 @@ deploy_tekton() {
 deploy_cert_manager() {
     kubectl apply -k "${script_path}/dependencies/cert-manager"
     sleep 5
-    retry "kubectl wait --for=condition=Ready --timeout=120s -l app.kubernetes.io/instance=cert-manager -n cert-manager pod" \
+    retry "kubectl wait --for=condition=Available --timeout=120s deployment -l app.kubernetes.io/instance=cert-manager -n cert-manager" \
           "Cert manager did not become available within the allocated time"
 }
 


### PR DESCRIPTION
### **User description**
This might be related to the changes made after vendoring cert-manager (and upgrading to the latest version): A job created when deploying cert-manager might be reaching completed state, which is causing the wait command to wait indefinitely.

Changing the script to wait only on deployments instead.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix cert-manager deployment wait condition to prevent indefinite hangs

- Changed from waiting on pods to waiting on deployments

- Updated condition from Ready to Available for proper deployment status


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["kubectl wait on pods<br/>condition=Ready"] -->|Issue: Job reaches<br/>completed state| B["Indefinite wait"]
  C["kubectl wait on deployments<br/>condition=Available"] -->|Fix: Proper deployment<br/>status check| D["Timely completion"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-deps.sh</strong><dd><code>Update cert-manager wait condition to deployments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deploy-deps.sh

<ul><li>Modified <code>deploy_cert_manager()</code> function to wait on deployments instead <br>of pods<br> <li> Changed wait condition from <code>Ready</code> to <code>Available</code><br> <li> Removed pod selector filter and replaced with deployment resource type<br> <li> Maintains same timeout duration of 120 seconds</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5139/files#diff-1aed564d8d4084314771feef8103355be3d8150b3f5979a1eea66d939a9fe670">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

