### PR TITLE
fix: honor explicit ingress host even when ingress is disabled

### DIFF
--- a/operator/api/v1alpha1/konfluxui_types.go
+++ b/operator/api/v1alpha1/konfluxui_types.go
@@ -45,7 +45,10 @@ type IngressSpec struct {
 	// IngressClassName specifies which IngressClass to use for the ingress.
 	// +optional
 	IngressClassName *string `json:"ingressClassName,omitempty"`
-	// Host is the hostname to use for the ingress.
+	// Host is the hostname used as the endpoint for configuring oauth2-proxy, dex, and related components.
+	// When set, this hostname is always used regardless of whether ingress is enabled,
+	// allowing users who manage their own external routing (e.g., Gateway API, hardware LB)
+	// to configure the endpoint without the operator managing an Ingress resource.
 	// On OpenShift, if empty, the default ingress domain and naming convention will be used.
 	// +optional
 	Host string `json:"host,omitempty"`

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
@@ -1774,7 +1774,10 @@ spec:
                             type: boolean
                           host:
                             description: |-
-                              Host is the hostname to use for the ingress.
+                              Host is the hostname used as the endpoint for configuring oauth2-proxy, dex, and related components.
+                              When set, this hostname is always used regardless of whether ingress is enabled,
+                              allowing users who manage their own external routing (e.g., Gateway API, hardware LB)
+                              to configure the endpoint without the operator managing an Ingress resource.
                               On OpenShift, if empty, the default ingress domain and naming convention will be used.
                             type: string
                           ingressClassName:

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxuis.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxuis.yaml
@@ -451,7 +451,10 @@ spec:
                     type: boolean
                   host:
                     description: |-
-                      Host is the hostname to use for the ingress.
+                      Host is the hostname used as the endpoint for configuring oauth2-proxy, dex, and related components.
+                      When set, this hostname is always used regardless of whether ingress is enabled,
+                      allowing users who manage their own external routing (e.g., Gateway API, hardware LB)
+                      to configure the endpoint without the operator managing an Ingress resource.
                       On OpenShift, if empty, the default ingress domain and naming convention will be used.
                     type: string
                   ingressClassName:

--- a/operator/docs/content/docs/guides/_index.md
+++ b/operator/docs/content/docs/guides/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Guides"
+linkTitle: "Guides"
+weight: 1
+description: "How-to guides for configuring and deploying Konflux."
+---
+
+This section contains guides for common configuration scenarios.

--- a/operator/docs/content/docs/guides/custom-url.md
+++ b/operator/docs/content/docs/guides/custom-url.md
@@ -1,0 +1,138 @@
+---
+title: "Custom URL without Operator-Managed Ingress"
+linkTitle: "Custom URL"
+weight: 1
+description: "How to configure a custom URL for Konflux UI when managing your own ingress or external routing."
+---
+
+The Konflux operator can manage an Ingress resource for the UI automatically.
+When ingress is enabled (the default on OpenShift), the operator creates and
+maintains the Ingress. When ingress is disabled (the default on plain
+Kubernetes), the UI is accessible via port-forwarding on `localhost:9443`.
+
+In both environments, you may want to manage your own routing — for example,
+using a standard Kubernetes Ingress with your own ingress controller, a hardware
+load balancer, or any other external routing mechanism.
+
+This guide shows how to configure the operator so that all internal components
+(oauth2-proxy, dex, etc.) use your custom hostname, **without** the operator
+creating or managing an Ingress resource.
+
+## Configuration
+
+Set `ingress.enabled: false` and `ingress.host` to your desired hostname in the
+Konflux CR:
+
+```yaml
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  ui:
+    spec:
+      ingress:
+        enabled: false
+        host: konflux.example.com
+```
+
+With this configuration:
+
+- **`ingress.enabled: false`** — the operator will **not** create an Ingress
+  resource. You are responsible for routing traffic to the `proxy` service in the
+  `konflux-ui` namespace.
+- **`ingress.host`** — the operator configures oauth2-proxy, dex, and all
+  related components to use this hostname for OIDC redirect URLs, issuer URLs,
+  and allowed redirect domains. This ensures authentication flows work correctly
+  with your custom URL.
+
+## Routing to the Backend
+
+Regardless of which routing method you choose, traffic must reach the **`proxy`**
+service in the `konflux-ui` namespace on port **`web-tls`** (port 9443). The
+proxy service terminates TLS using a certificate signed by the `ui-ca` CA
+(managed by cert-manager).
+
+### Kubernetes Ingress
+
+On plain Kubernetes, create an Ingress resource with your ingress controller. The
+exact annotations depend on your ingress controller (nginx, traefik, etc.):
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: konflux-ui
+  namespace: konflux-ui
+  annotations:
+    # Add annotations specific to your ingress controller here.
+    # The backend (proxy service) uses TLS, so you may need to configure
+    # your ingress controller for backend TLS / SSL passthrough.
+spec:
+  ingressClassName: nginx  # Adjust to your ingress controller
+  rules:
+    - host: konflux.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: proxy
+                port:
+                  name: web-tls
+  tls:
+    - hosts:
+        - konflux.example.com
+      secretName: my-tls-secret  # Your TLS certificate for the edge
+```
+
+> **Note:** Since the backend proxy service uses TLS (port `web-tls` / 9443),
+> you may need to configure your ingress controller to trust the backend CA
+> certificate. The CA certificate is stored in the `ui-ca` Secret in the
+> `konflux-ui` namespace.
+
+### OpenShift Ingress (Route)
+
+On OpenShift, the Ingress-to-Route controller automatically converts Ingress
+resources into Routes. Use the OpenShift-specific annotations for TLS
+re-encryption:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: konflux-ui
+  namespace: konflux-ui
+  annotations:
+    route.openshift.io/destination-ca-certificate-secret: ui-ca
+    route.openshift.io/termination: reencrypt
+spec:
+  rules:
+    - host: konflux.apps.my-cluster.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: proxy
+                port:
+                  name: web-tls
+```
+
+Key points:
+
+- **`route.openshift.io/termination: reencrypt`** — the router terminates the
+  external TLS connection and creates a new TLS connection to the backend.
+- **`route.openshift.io/destination-ca-certificate-secret: ui-ca`** — tells the
+  router to trust the CA certificate from the `ui-ca` Secret when connecting to
+  the backend proxy service.
+
+### Other Routing Methods
+
+The same approach works with any routing mechanism (Gateway API, hardware load
+balancer, service mesh, etc.) as long as traffic reaches the `proxy` service on
+port 9443 with TLS re-encryption. The backend proxy serves TLS using a
+certificate signed by the `ui-ca` CA — your routing layer must be configured to
+trust this CA for the backend connection.

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -195,7 +195,9 @@ func GetOpenShiftIngressDomain(ctx context.Context, c client.Client) (string, er
 }
 
 // DetermineEndpointURL determines the endpoint URL for the UI based on ingress configuration.
-// If ingress is enabled and host is specified, use that host.
+// If host is explicitly specified, use that host regardless of whether ingress is enabled.
+// This allows users who manage their own external routing (e.g., Gateway API, hardware LB)
+// to configure the endpoint without the operator managing an Ingress resource.
 // If ingress is enabled on OpenShift without a host, use the default OpenShift ingress domain.
 // Otherwise, use the default localhost configuration.
 // The namespace parameter is used for generating the OpenShift hostname convention.
@@ -209,6 +211,16 @@ func DetermineEndpointURL(
 ) (*url.URL, error) {
 	ingressSpec := ui.Spec.GetIngress()
 
+	// If host is explicitly specified, always use it (no port for TLS on 443).
+	// This takes priority over the ingress-enabled check so that users who manage
+	// their own routing can set a hostname without the operator creating an Ingress.
+	if ingressSpec.Host != "" {
+		return &url.URL{
+			Scheme: "https",
+			Host:   ingressSpec.Host,
+		}, nil
+	}
+
 	// Determine if ingress is effectively enabled:
 	// - Explicitly enabled (true), OR
 	// - Unset (nil) AND on OpenShift (defaults to true on OpenShift)
@@ -220,14 +232,6 @@ func DetermineEndpointURL(
 		return &url.URL{
 			Scheme: "https",
 			Host:   fmt.Sprintf("%s:%s", DefaultProxyHostname, DefaultProxyPort),
-		}, nil
-	}
-
-	// If host is explicitly specified, use it (no port for ingress, TLS on 443)
-	if ingressSpec.Host != "" {
-		return &url.URL{
-			Scheme: "https",
-			Host:   ingressSpec.Host,
 		}, nil
 	}
 

--- a/operator/pkg/ingress/ingress_test.go
+++ b/operator/pkg/ingress/ingress_test.go
@@ -391,6 +391,29 @@ func TestDetermineEndpointURL(t *testing.T) {
 		g.Expect(endpoint.Port()).To(gomega.Equal(DefaultProxyPort))
 	})
 
+	t.Run("returns explicit host when ingress is disabled but host is specified", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		ui := &konfluxv1alpha1.KonfluxUI{
+			Spec: konfluxv1alpha1.KonfluxUISpec{
+				Ingress: &konfluxv1alpha1.IngressSpec{
+					Enabled: ptr.To(false),
+					Host:    "my-custom-host.example.com",
+				},
+			},
+		}
+
+		// Even with ingress disabled, explicit host should be honored
+		// (e.g., user managing their own Gateway API or external routing)
+		endpoint, err := DetermineEndpointURL(
+			context.Background(), nil, ui, "konflux-ui", nil)
+
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(endpoint.Hostname()).To(gomega.Equal("my-custom-host.example.com"))
+		g.Expect(endpoint.Port()).To(gomega.Equal("")) // No port for standard TLS
+		g.Expect(endpoint.String()).To(gomega.Equal("https://my-custom-host.example.com"))
+	})
+
 	t.Run("returns explicit host when ingress is enabled with host specified", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
@@ -409,6 +432,30 @@ func TestDetermineEndpointURL(t *testing.T) {
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(endpoint.Hostname()).To(gomega.Equal("my-custom-host.example.com"))
 		g.Expect(endpoint.Port()).To(gomega.Equal("")) // No port for standard ingress TLS
+		g.Expect(endpoint.String()).To(gomega.Equal("https://my-custom-host.example.com"))
+	})
+
+	t.Run("returns explicit host on OpenShift instead of generating hostname", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		ui := &konfluxv1alpha1.KonfluxUI{
+			Spec: konfluxv1alpha1.KonfluxUISpec{
+				Ingress: &konfluxv1alpha1.IngressSpec{
+					Enabled: ptr.To(true),
+					Host:    "my-custom-host.example.com",
+				},
+			},
+		}
+
+		openShiftClusterInfo := createOpenShiftClusterInfo()
+
+		// Even on OpenShift, explicit host should take priority over auto-generated hostname
+		endpoint, err := DetermineEndpointURL(
+			context.Background(), nil, ui, "konflux-ui", openShiftClusterInfo)
+
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(endpoint.Hostname()).To(gomega.Equal("my-custom-host.example.com"))
+		g.Expect(endpoint.Port()).To(gomega.Equal(""))
 		g.Expect(endpoint.String()).To(gomega.Equal("https://my-custom-host.example.com"))
 	})
 


### PR DESCRIPTION
Previously, DetermineEndpointURL checked whether ingress was enabled before checking for an explicit host. This meant users who set ingress.enabled=false with ingress.host (e.g., managing their own Gateway API or external routing) would always get localhost:9443 as the endpoint, making oauth2-proxy and dex redirect to the wrong URL.

Swap the check order so an explicit host always takes priority, regardless of whether the operator manages the Ingress resource.

fixes: https://github.com/konflux-ci/konflux-ci/issues/5086
Assisted-By: Cursor