### PR TITLE
fix(KFLUXVNGD-741): create issue failing to create catalog PR

### DIFF
--- a/.github/workflows/community-operator-pr.yaml
+++ b/.github/workflows/community-operator-pr.yaml
@@ -36,3 +36,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.KONFLUX_CI_BOT_PAT }}
         run: |
           .github/scripts/create-community-operator-pr.sh "${{ steps.release.outputs.tag }}"
+
+      - name: Create issue on failure
+        if: failure()
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_NAME: Community Operator PR
+          RELEASE_VERSION: ${{ steps.release.outputs.tag }}
+        run: |
+          .github/scripts/create-or-update-issue.sh \
+            "Community Operator PR Failure" \
+            "Creating the Community Operator PR failed."


### PR DESCRIPTION
### **User description**
Extend the workflow that create a catalog PR to create an issue if the PR creation fails. This will make sure failures don't go unnoticed.

Assisted-by: Cursor


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add failure handling to catalog PR creation workflow

- Create GitHub issue when Community Operator PR creation fails

- Pass relevant context variables to issue creation script

- Ensure workflow failures are tracked and visible


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Create Community Operator PR"] -->|failure| B["Create issue on failure"]
  B --> C["Call create-or-update-issue.sh"]
  C --> D["GitHub Issue Created"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>community-operator-pr.yaml</strong><dd><code>Add failure notification step to workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/community-operator-pr.yaml

<ul><li>Added new step to create GitHub issue when PR creation fails<br> <li> Configured step to run only on failure using <code>if: failure()</code> condition<br> <li> Passed environment variables including repository info, run ID, and <br>release version<br> <li> Invokes <code>create-or-update-issue.sh</code> script with failure notification <br>details</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5144/files#diff-b5f3e748ada69a888ff8c25a5b132df76b83f363a777b4145bccfe3eb05c3994">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

