### PR TITLE
Add place holder script for deploying konflux on OCP

### DIFF
--- a/deploy-konflux-on-ocp.sh
+++ b/deploy-konflux-on-ocp.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+main() {
+    echo "Deploying Konflux" >&2
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
This script will be called by the openshift CI jobs. Adding it now, so we can merge the new jobs and iterate on the implementation of the script in the konflux-ci repository.