### PR TITLE
chore(KFLUXVNGD-713): update operator to use updated Dex images

### DIFF
--- a/operator/pkg/manifests/ui/manifests.yaml
+++ b/operator/pkg/manifests/ui/manifests.yaml
@@ -357,7 +357,7 @@ spec:
             secretKeyRef:
               key: client-secret
               name: oauth2-proxy-client-secret
-        image: ghcr.io/dexidp/dex:v2.44.0
+        image: quay.io/redhat-user-workloads/konflux-vanguard-tenant/dex:on-pr-7c4d79d392626bfebd6d5e65aacb23d74a6d21bb
         name: dex
         ports:
         - containerPort: 9443
@@ -369,6 +369,8 @@ spec:
           httpGet:
             path: /healthz/ready
             port: telemetry
+          initialDelaySeconds: 10
+          periodSeconds: 10
         resources:
           limits:
             cpu: 50m

--- a/operator/upstream-kustomizations/ui/dex/dex.yaml
+++ b/operator/upstream-kustomizations/ui/dex/dex.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       serviceAccountName: dex # This is created below
       containers:
-      - image: ghcr.io/dexidp/dex:latest
+      - image: quay.io/konflux-ci/dex:latest
         name: dex
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
         securityContext:

--- a/operator/upstream-kustomizations/ui/dex/kustomization.yml
+++ b/operator/upstream-kustomizations/ui/dex/kustomization.yml
@@ -5,6 +5,6 @@ resources:
   - dex.yaml
 
 images:
-  - name: ghcr.io/dexidp/dex
-    newName: ghcr.io/dexidp/dex
-    newTag: v2.44.0
+  - name: quay.io/konflux-ci/dex
+    newName: quay.io/konflux-ci/dex
+    newTag: af0f83bb04f8b92e5234d6cd4c853cbc0658033be7a8fc7516ed18c37d0d8383


### PR DESCRIPTION
Update the operator to use the konflux-ci rebuild images of Dex