### PR TITLE
feat(KFLUXVNGD-723): Add OpenShift version to public info

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"fmt"
@@ -40,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 
@@ -73,6 +75,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	utilruntime.Must(certmanagerv1.AddToScheme(scheme))
+	utilruntime.Must(configv1.Install(scheme))
 	utilruntime.Must(consolev1.AddToScheme(scheme))
 	utilruntime.Must(securityv1.Install(scheme))
 
@@ -273,14 +276,25 @@ func main() {
 		setupLog.Error(err, "unable to detect cluster info")
 		os.Exit(1)
 	}
-	k8sVer := "unknown"
+	k8sVer := clusterinfo.UnknownVersion
 	if v, err := clusterInfo.K8sVersion(); err == nil && v != nil {
 		k8sVer = v.GitVersion
 	}
-	setupLog.Info("Detected cluster info",
+	logFields := []any{
 		"platform", clusterInfo.Platform(),
 		"k8sVersion", k8sVer,
-	)
+	}
+
+	if clusterInfo.IsOpenShift() {
+		osVersion, err := clusterinfo.GetOpenShiftVersion(context.Background(), mgr.GetClient())
+		if err != nil {
+			setupLog.V(1).Info("Could not retrieve OpenShift version", "error", err.Error())
+
+		}
+		logFields = append(logFields, "openShiftVersion", osVersion)
+
+	}
+	setupLog.Info("Detected cluster info", logFields...)
 
 	if err := (&konflux.KonfluxReconciler{
 		Client:      mgr.GetClient(),

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -158,6 +158,14 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - ingresses
   verbs:
   - get

--- a/operator/internal/controller/info/konfluxinfo_controller_test.go
+++ b/operator/internal/controller/info/konfluxinfo_controller_test.go
@@ -19,7 +19,7 @@ package info
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -42,7 +42,7 @@ var _ = Describe("KonfluxInfo Controller", func() {
 		BeforeEach(func() {
 			By("creating the custom resource for the Kind KonfluxInfo")
 			err := k8sClient.Get(ctx, typeNamespacedName, konfluxinfo)
-			if err != nil && errors.IsNotFound(err) {
+			if err != nil && apierrors.IsNotFound(err) {
 				resource := &konfluxv1alpha1.KonfluxInfo{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: CRName,


### PR DESCRIPTION
### **User description**
- Add OpenShift version to public info
- Add tests for the OpenShift version
- Use conditional watcher to detect OpenShift version
- Update existing tests

Logic:
- Returns empty string if not running on OpenShift (no-op)
- Iterate over history[].version to pick the first entry with `Completed` status -> the current openshift version
- Error handling:
   - If we could not fetch the `ClusterVersion` resource  -> `version: unknown` and an error will be returned
   - If no entry with `Completed` state found -> `version: unknown` and an error will be returned
   - If a `Completed` entry was found but the version is empty -> `version: unknown` and an error will be returned
     
Assited-By: Cursor and Claude-4.5-sonnet


___

### **PR Type**
Enhancement


___

### **Description**
- Add OpenShift version detection and expose in public info

- Implement conditional watcher for ClusterVersion resource

- Update cluster info detection to fetch OpenShift version via runtime client

- Add RBAC permissions for clusterversions resource access


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cluster Detection"] -->|"Detect OpenShift"| B["Platform Info"]
  B -->|"IsOpenShift"| C["Fetch ClusterVersion"]
  C -->|"Runtime Client"| D["OpenShift Version"]
  D -->|"Include in"| E["Public Info JSON"]
  E -->|"Watch Changes"| F["Conditional Watcher"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>main.go</strong><dd><code>Pass runtime client to cluster detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5233/files#diff-6951a7b3b8a59603497b68b62013a806397c640ce0a42a3862f6a4ffad4fda89">+16/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxinfo_controller.go</strong><dd><code>Add OpenShift version to public info JSON</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5233/files#diff-632df3e422d02f42ebc3adf96fe1683930511f632b57b7d58fdcd60f75e46b2a">+33/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>clusterinfo.go</strong><dd><code>Implement OpenShift version retrieval from ClusterVersion</code></dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5233/files#diff-8dbe40b2ffa3cb0a7d90ca101480b244d5fa464c5267025e11b93168835dbabe">+49/-11</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>poller_test.go</strong><dd><code>Update test calls with runtime client parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5233/files#diff-d74f00efba4fa547868262de26255c2c604e360e674c184f18e48fad3ee26e52">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxbuildservice_controller_test.go</strong><dd><code>Update cluster detection test calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5233/files#diff-e0a6883567d9ea32a4a0e43482b3dfff86b7c02eef719a4ddee1bd01b2137b1b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konflux_controller_certmanager_test.go</strong><dd><code>Update cluster detection test calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5233/files#diff-9492f79078a33122d1d9ff4a5720f83def3c4b291fc1a71b44ac0603b7a3b499">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konflux_controller_test.go</strong><dd><code>Update cluster detection test calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5233/files#diff-611e5fe29f8957c796f325a65cc4501da208e0cf1f1c0d01633e18e40cda41dd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxui_controller_test.go</strong><dd><code>Update cluster detection test calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5233/files#diff-0d78f62808074a69d9de536e539001124db90d682eaf78dc8ba6d8ef62720a86">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>clusterinfo_test.go</strong><dd><code>Add comprehensive tests for OpenShift version detection</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5233/files#diff-17874adbcd1520db0142705d7e883daa6aee3ff7cd10e66221c146ab9ac0cfcb">+147/-15</a></td>

</tr>

<tr>
  <td><strong>ingress_test.go</strong><dd><code>Update cluster detection test calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5233/files#diff-c5e8120f8a6a52a6f71668c505a64061e57c2b9f9a631411e3a4c643f2301af0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>role.yaml</strong><dd><code>Add RBAC permissions for clusterversions resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5233/files#diff-bf75d41206005954349fa60826c9cc3bd1a976c9e5c8884de0cb59ee68a13fa8">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

