### PR TITLE
fix: auto-detect image-controller requirement in deploy-local.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ scripts/*.env
 my-konflux.yaml
 konflux-local.yaml
 scripts/smee-channel-id.yaml
+
+# Git worktrees
+.worktrees/


### PR DESCRIPTION
When QUAY_TOKEN and QUAY_ORGANIZATION are configured but no CR is explicitly specified, auto-select konflux-e2e.yaml which enables image-controller. This eliminates the confusing "namespace not created" warning users encounter when expecting Quay integration to work.

Users can still override by setting KONFLUX_CR or passing a CR argument.

Fixes: https://github.com/konflux-ci/konflux-ci/issues/5278

Assisted-by: Claude Code (Sonnet 4.5)