### PR TITLE
fix(KFLUXVNGD-736): track CRDs created by the operator

### DIFF
--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -81,7 +81,9 @@ rules:
   verbs:
   - create
   - get
+  - list
   - patch
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/operator/internal/controller/handler/handler.go
+++ b/operator/internal/controller/handler/handler.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package handler provides shared controller-runtime handler helpers (e.g. map
+// functions for watches) used by reconcilers.
+package handler
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlhandler "sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
+)
+
+// MapCRDToRequest returns a handler that enqueues a reconcile request for the
+// given CR when a CRD managed by the component is updated or deleted. Use it
+// with Watches(..., handler.EnqueueRequestsFromMapFunc(...)) so that
+// out-of-band CRD deletion triggers reconciliation and re-apply.
+// It returns an error if the store fails or the component has no CRD names.
+//
+//	store is the ObjectStore (e.g. r.ObjectStore).
+//	component is the manifests component that deploys the CRDs (e.g. manifests.ApplicationAPI).
+//	crName is the name of the singleton CR to enqueue (e.g. applicationapi.CRName).
+func MapCRDToRequest(
+	store *manifests.ObjectStore,
+	component manifests.Component,
+	crName string,
+) (ctrlhandler.MapFunc, error) {
+	names, err := store.GetCRDNamesForComponent(component)
+	if err != nil {
+		return func(context.Context, client.Object) []reconcile.Request { return nil }, err
+	}
+	if len(names) == 0 {
+		return func(
+			context.Context, client.Object) []reconcile.Request {
+			return nil
+		}, fmt.Errorf("no CRD names for component %s", component)
+	}
+	managedNames := sets.New(names...)
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		if managedNames.Has(obj.GetName()) {
+			return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: crName}}}
+		}
+		return nil
+	}, nil
+}

--- a/operator/internal/controller/handler/handler_test.go
+++ b/operator/internal/controller/handler/handler_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	return scheme
+}
+
+func TestMapCRDToRequest_EnqueuesWhenCRDNameIsManaged(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	scheme := testScheme(t)
+	store, err := manifests.NewObjectStore(scheme)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	names, err := store.GetCRDNamesForComponent(manifests.ApplicationAPI)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(names).NotTo(gomega.BeEmpty(), "ApplicationAPI component should have CRDs in manifests")
+
+	managedCRDName := names[0]
+	mapFunc, err := MapCRDToRequest(store, manifests.ApplicationAPI, "konflux-application-api")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: managedCRDName},
+	}
+
+	reqs := mapFunc(ctx, crd)
+	g.Expect(reqs).To(gomega.HaveLen(1))
+	g.Expect(reqs[0].Name).To(gomega.Equal("konflux-application-api"))
+}
+
+func TestMapCRDToRequest_ReturnsNilWhenCRDNameNotManaged(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	scheme := testScheme(t)
+	store, err := manifests.NewObjectStore(scheme)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	mapFunc, err := MapCRDToRequest(store, manifests.ApplicationAPI, "konflux-application-api")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "some.other.crd.not.in.manifest"},
+	}
+
+	reqs := mapFunc(ctx, crd)
+	g.Expect(reqs).To(gomega.BeNil())
+}
+
+func TestMapCRDToRequest_ReturnsErrorWhenComponentHasNoCRDs(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	scheme := testScheme(t)
+	store, err := manifests.NewObjectStore(scheme)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	mapFunc, err := MapCRDToRequest(store, manifests.Registry, "konflux-internal-registry")
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("no CRD names"))
+
+	// Returned mapFunc is a no-op and returns nil
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "any.crd"},
+	}
+	reqs := mapFunc(ctx, crd)
+	g.Expect(reqs).To(gomega.BeNil())
+}
+
+func TestMapCRDToRequest_ReturnsErrorWhenStoreErrorsForUnknownComponent(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	scheme := testScheme(t)
+	store, err := manifests.NewObjectStore(scheme)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	mapFunc, err := MapCRDToRequest(store, manifests.Component("unknown-component"), "some-cr")
+	g.Expect(err).To(gomega.HaveOccurred())
+
+	// Returned mapFunc is a no-op and returns nil
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "any.crd"},
+	}
+	reqs := mapFunc(ctx, crd)
+	g.Expect(reqs).To(gomega.BeNil())
+}

--- a/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
+++ b/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
@@ -23,16 +23,19 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
+	crdhandler "github.com/konflux-ci/konflux-ci/operator/internal/controller/handler"
 	"github.com/konflux-ci/konflux-ci/operator/internal/predicate"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
@@ -79,7 +82,7 @@ type KonfluxImageControllerReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,resourceNames=image-controller-manager-rolebinding;image-controller-metrics-auth-rolebinding,verbs=bind
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;patch
-// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;create;patch
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -155,6 +158,10 @@ func (r *KonfluxImageControllerReconciler) applyManifests(ctx context.Context, t
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KonfluxImageControllerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	crdMapFunc, err := crdhandler.MapCRDToRequest(r.ObjectStore, manifests.ImageController, CRName)
+	if err != nil {
+		return err
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&konfluxv1alpha1.KonfluxImageController{}).
 		Named("konfluximagecontroller").
@@ -169,5 +176,8 @@ func (r *KonfluxImageControllerReconciler) SetupWithManager(mgr ctrl.Manager) er
 		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
 		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
 		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
+		// Watch CRDs so that out-of-band deletion triggers reconcile and re-apply.
+		Watches(&apiextensionsv1.CustomResourceDefinition{},
+			handler.EnqueueRequestsFromMapFunc(crdMapFunc)).
 		Complete(r)
 }

--- a/operator/internal/controller/releaseservice/konfluxreleaseservice_controller.go
+++ b/operator/internal/controller/releaseservice/konfluxreleaseservice_controller.go
@@ -23,16 +23,19 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
+	crdhandler "github.com/konflux-ci/konflux-ci/operator/internal/controller/handler"
 	"github.com/konflux-ci/konflux-ci/operator/internal/predicate"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/customization"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
@@ -87,7 +90,7 @@ type KonfluxReleaseServiceReconciler struct {
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates;issuers,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=appstudio.redhat.com,resources=releaseserviceconfigs,verbs=get;list;watch;create;patch
-// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;create;patch
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -201,6 +204,10 @@ func buildReleaseControllerManagerOverlay(spec *konfluxv1alpha1.ControllerManage
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KonfluxReleaseServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	crdMapFunc, err := crdhandler.MapCRDToRequest(r.ObjectStore, manifests.Release, CRName)
+	if err != nil {
+		return err
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&konfluxv1alpha1.KonfluxReleaseService{}).
 		Named("konfluxreleaseservice").
@@ -215,5 +222,8 @@ func (r *KonfluxReleaseServiceReconciler) SetupWithManager(mgr ctrl.Manager) err
 		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
 		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
 		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
+		// Watch CRDs so that out-of-band deletion triggers reconcile and re-apply.
+		Watches(&apiextensionsv1.CustomResourceDefinition{},
+			handler.EnqueueRequestsFromMapFunc(crdMapFunc)).
 		Complete(r)
 }

--- a/operator/pkg/kubernetes/crd.go
+++ b/operator/pkg/kubernetes/crd.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kubernetes provides shared helpers for working with Kubernetes API objects.
+package kubernetes
+
+import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IsCustomResourceDefinition returns true if obj is a CustomResourceDefinition.
+// It is used by pkg/manifests (GetCRDNamesForComponent) and pkg/tracking (SetOwnership
+// skips controller reference on CRDs so they are not cascade-deleted when the CR is removed).
+func IsCustomResourceDefinition(obj client.Object) bool {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if !gvk.Empty() {
+		return gvk.Group == "apiextensions.k8s.io" && gvk.Kind == "CustomResourceDefinition"
+	}
+	// Fallback for typed CRD when GVK is not set (e.g. struct literal).
+	_, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	return ok
+}

--- a/operator/pkg/kubernetes/crd_test.go
+++ b/operator/pkg/kubernetes/crd_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsCustomResourceDefinition(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	t.Run("returns true for CustomResourceDefinition", func(t *testing.T) {
+		crd := &apiextensionsv1.CustomResourceDefinition{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "apiextensions.k8s.io/v1",
+				Kind:       "CustomResourceDefinition",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "applications.appstudio.redhat.com"},
+		}
+		g.Expect(IsCustomResourceDefinition(crd)).To(gomega.BeTrue())
+	})
+
+	t.Run("returns false for ConfigMap", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		}
+		g.Expect(IsCustomResourceDefinition(cm)).To(gomega.BeFalse())
+	})
+
+	t.Run("returns true for CustomResourceDefinition with empty GVK (type assertion fallback)",
+		func(t *testing.T) {
+			crd := &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "applications.appstudio.redhat.com"},
+			}
+			crd.APIVersion = ""
+			crd.Kind = ""
+			g.Expect(IsCustomResourceDefinition(crd)).To(gomega.BeTrue())
+		})
+
+	t.Run("returns false for empty GVK", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		}
+		cm.APIVersion = ""
+		cm.Kind = ""
+		g.Expect(IsCustomResourceDefinition(cm)).To(gomega.BeFalse())
+	})
+}

--- a/operator/pkg/manifests/manifests_test.go
+++ b/operator/pkg/manifests/manifests_test.go
@@ -3,6 +3,11 @@ package manifests
 import (
 	"strings"
 	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 func TestAllComponents(t *testing.T) {
@@ -73,5 +78,67 @@ func TestManifestContent(t *testing.T) {
 
 	if !strings.Contains(string(content), "apiVersion:") {
 		t.Error("application-api manifest doesn't contain 'apiVersion:'")
+	}
+}
+
+// testScheme returns a scheme that can decode core and CRD resources (used for GetCRDNamesForComponent).
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	return scheme
+}
+
+func TestGetCRDNamesForComponent(t *testing.T) {
+	scheme := testScheme(t)
+	store, err := NewObjectStore(scheme)
+	if err != nil {
+		t.Fatalf("NewObjectStore() error = %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		component Component
+		wantEmpty bool
+		wantErr   bool
+	}{
+		{
+			name:      "ApplicationAPI has CRDs",
+			component: ApplicationAPI,
+			wantEmpty: false,
+			wantErr:   false,
+		},
+		{
+			name:      "Registry has no CRDs",
+			component: Registry,
+			wantEmpty: true,
+			wantErr:   false,
+		},
+		{
+			name:      "unknown component returns error",
+			component: Component("unknown"),
+			wantEmpty: true,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			names, err := store.GetCRDNamesForComponent(tt.component)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetCRDNamesForComponent(%s) error = %v, wantErr %v", tt.component, err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if tt.wantEmpty && len(names) != 0 {
+				t.Errorf("GetCRDNamesForComponent(%s) expected empty names, got %v", tt.component, names)
+			}
+			if !tt.wantEmpty && len(names) == 0 {
+				t.Errorf("GetCRDNamesForComponent(%s) expected non-empty names", tt.component)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### **User description**
Make the operator track the CRDs it creates, so that reconciliation is triggered if they are modified out of band.

Also, make the operator not delete CRD it creates on CR removal.

Assisted-by: Cursor


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Track CRDs created by operator to trigger reconciliation on out-of-band modifications

- Prevent cascade deletion of CRDs when CR is removed by skipping controller reference

- Add CRD watch handlers to all component reconcilers for automatic re-apply

- Implement helper functions to identify and map CRDs to reconciliation requests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CRD Modified/Deleted"] -->|"Watch Trigger"| B["MapCRDToRequest Handler"]
  B -->|"Enqueue Request"| C["Component Reconciler"]
  C -->|"Re-apply"| A
  D["SetOwnership"] -->|"Skip Controller Ref"| E["CRD Not Cascade-Deleted"]
  E -->|"Survives CR Removal"| F["Manual Cleanup Required"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>handler.go</strong><dd><code>New CRD-to-request mapping handler function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5304/files#diff-20576f31ddcd9edb54abe4b7b263d74b7f5d47f7b50979f26b144fdbc50835aa">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxapplicationapi_controller.go</strong><dd><code>Add CRD watch and update RBAC permissions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5304/files#diff-a26d909023f4db43ed66f8358f2c04eb71cb4b5397d0d7e73001335bc375f2bc">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxenterprisecontract_controller.go</strong><dd><code>Add CRD watch and update RBAC permissions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5304/files#diff-1ed52ee73b3c2525d3c33a29ca46e0b68fc4e5e4eaefdb9c5a395cd211f818f0">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluximagecontroller_controller.go</strong><dd><code>Add CRD watch and update RBAC permissions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5304/files#diff-6c763c167279b0ad5d7272ca04ced07e667537e7f202d723e1a9ce41517e5b4b">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxintegrationservice_controller.go</strong><dd><code>Add CRD watch and update RBAC permissions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5304/files#diff-d0b6239196f48e8128517c03b341f09ade5066982ccb496f4a8b801668ac582e">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>konfluxreleaseservice_controller.go</strong><dd><code>Add CRD watch and update RBAC permissions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5304/files#diff-854d2c3b514dba7f5e74c56b6a2cc9b24308a6a17be5bfad5b996580d4823575">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>crd.go</strong><dd><code>New helper to identify CustomResourceDefinition objects</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5304/files#diff-73e6f8839d0be5b3dcf47a91ccffef2bf0491a943e98c85913e969a22e274e67">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>manifests.go</strong><dd><code>Add method to retrieve CRD names for components</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5304/files#diff-dee1ad7111a51cbc90c800d207a74499cec80ec08a577cf4ac5daeb48b24af78">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>handler_test.go</strong><dd><code>Tests for CRD mapping handler functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5304/files#diff-d37ad890f41d4f9f26fb5c1eccf5f50d39970a5d00965fb4f839ce89806a8d06">+122/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>crd_test.go</strong><dd><code>Tests for CRD identification helper function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5304/files#diff-42c1333f93fc90e828e90ed0cb04f19bd61f8959bca3ce5fb231e987f541426b">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>manifests_test.go</strong><dd><code>Tests for GetCRDNamesForComponent method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5304/files#diff-5d617718a42e2f8aa3a5d7709ae60a9938584c73b0b95ec34ffd9e4c6c1c47d7">+67/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tracking_test.go</strong><dd><code>Tests for CRD ownership handling without controller reference</code></dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5304/files#diff-23708af2dee5b32591e69af440bf058812607ceb230317ae3c04fd2db61e6430">+93/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>tracking.go</strong><dd><code>Skip controller reference on CRDs to prevent cascade deletion</code></dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5304/files#diff-b17c4fd99cc067eaa572457a96eaeaf8d0d226c083933b4368fc82e8f9139f7e">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>role.yaml</strong><dd><code>Update CRD permissions to include list and watch verbs</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5304/files#diff-bf75d41206005954349fa60826c9cc3bd1a976c9e5c8884de0cb59ee68a13fa8">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

