### PR TITLE
fix(5303): detect container tool

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -60,10 +60,9 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # CONTAINER_TOOL defines the container tool to be used for building images.
-# Be aware that the target commands are only tested with Docker which is
-# scaffolded by default. However, you might want to replace it to use other
-# tools. (i.e. podman)
-CONTAINER_TOOL ?= docker
+# If not set, try docker then podman so podman-only systems work without a docker alias.
+# Override with: make docker-build CONTAINER_TOOL=podman
+CONTAINER_TOOL ?= $(shell (command -v docker >/dev/null 2>&1 && echo docker) || (command -v podman >/dev/null 2>&1 && echo podman) || echo docker)
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.


### PR DESCRIPTION
### **User description**
Detect the container tool available for the user. This prevents failures (e.g. in deploy-local.sh) if the user only has podman installed without docker alias.

Assisted-by: Cursor


___

### **PR Type**
Bug fix


___

### **Description**
- Auto-detect container tool (docker or podman) availability

- Prevents failures when only podman installed without docker alias

- Falls back to docker if neither tool found

- Allows manual override via CONTAINER_TOOL parameter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check docker availability"] -- "found" --> B["Use docker"]
  A -- "not found" --> C["Check podman availability"]
  C -- "found" --> D["Use podman"]
  C -- "not found" --> E["Default to docker"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Dynamic container tool detection in Makefile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/Makefile

<ul><li>Replaced hardcoded <code>CONTAINER_TOOL ?= docker</code> with dynamic detection <br>logic<br> <li> Added shell command to check for docker, then podman availability<br> <li> Updated comments to document fallback behavior and override <br>instructions<br> <li> Maintains backward compatibility with default docker fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5305/files#diff-6973a61c21dd57b26f0452d3716fe9213974883a2fe1b216504bf63532cd1187">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

