### PR TITLE
fix: rename sanity test job in CI

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -93,7 +93,7 @@ jobs:
             const { data } = await github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: 'Sanity Test',
+              name: 'sanity-test',
               head_sha,
               status: 'in_progress'
             });


### PR DESCRIPTION
### **User description**
The sanity test job name when triggered by comment was misaligned with the name which branch protection is expecting. Hopefully aligning this will allow PRs from forks to be merged.

Assisted-by: Cursor


___

### **PR Type**
Bug fix


___

### **Description**
- Align sanity test job name with branch protection requirements

- Change check run name from 'Sanity Test' to 'sanity-test'

- Enable PR merging from forks by matching expected job name


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Workflow"] -- "creates check run" --> B["Check Name"]
  B -- "was: 'Sanity Test'" --> C["Mismatch"]
  C -- "fix to: 'sanity-test'" --> D["Aligned with Branch Protection"]
  D --> E["Forks Can Merge"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sanity-test.yml</strong><dd><code>Rename check run to match branch protection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/sanity-test.yml

<ul><li>Updated check run name from 'Sanity Test' to 'sanity-test'<br> <li> Aligns with branch protection rule expectations<br> <li> Enables proper status checks for PRs from forks</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5306/files#diff-c68f5ef87662968636741c0c819fd08d5c7f2a1c020a572d10356b72e63f742f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

