### PR TITLE
feat(KFLUXVNGD-723): Add OpenShift version to public info

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"fmt"
@@ -40,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 
@@ -73,6 +75,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	utilruntime.Must(certmanagerv1.AddToScheme(scheme))
+	utilruntime.Must(configv1.Install(scheme))
 	utilruntime.Must(consolev1.AddToScheme(scheme))
 	utilruntime.Must(securityv1.Install(scheme))
 
@@ -273,14 +276,25 @@ func main() {
 		setupLog.Error(err, "unable to detect cluster info")
 		os.Exit(1)
 	}
-	k8sVer := "unknown"
+	k8sVer := clusterinfo.UnknownVersion
 	if v, err := clusterInfo.K8sVersion(); err == nil && v != nil {
 		k8sVer = v.GitVersion
 	}
-	setupLog.Info("Detected cluster info",
+	logFields := []any{
 		"platform", clusterInfo.Platform(),
 		"k8sVersion", k8sVer,
-	)
+	}
+
+	if clusterInfo.IsOpenShift() {
+		osVersion, err := clusterinfo.GetOpenShiftVersion(context.Background(), mgr.GetClient())
+		if err != nil {
+			setupLog.V(1).Info("Could not retrieve OpenShift version", "error", err.Error())
+
+		}
+		logFields = append(logFields, "openShiftVersion", osVersion)
+
+	}
+	setupLog.Info("Detected cluster info", logFields...)
 
 	if err := (&konflux.KonfluxReconciler{
 		Client:      mgr.GetClient(),

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -158,6 +158,14 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - ingresses
   verbs:
   - get

--- a/operator/internal/controller/info/konfluxinfo_controller_test.go
+++ b/operator/internal/controller/info/konfluxinfo_controller_test.go
@@ -19,7 +19,7 @@ package info
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -42,7 +42,7 @@ var _ = Describe("KonfluxInfo Controller", func() {
 		BeforeEach(func() {
 			By("creating the custom resource for the Kind KonfluxInfo")
 			err := k8sClient.Get(ctx, typeNamespacedName, konfluxinfo)
-			if err != nil && errors.IsNotFound(err) {
+			if err != nil && apierrors.IsNotFound(err) {
 				resource := &konfluxv1alpha1.KonfluxInfo{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: CRName,


### PR DESCRIPTION
### **User description**
- Add OpenShift version to public info
- Add tests for the OpenShift version
- Use watcher to detect OpenShift version
- Update existing tests

Logic:

- Returns empty string if not running on OpenShift (no-op)
- Iterate over history[].version to pick the first entry with Completed status -> the current openshift version
- Error handling:
  - If we could not fetch the ClusterVersion resource -> version: unknown and an error will be returned
  - If no entry with Completed state found -> version: unknown and an error will be returned
  - If a Completed entry was found but the version is empty -> version: unknown and an error will be returned

Assited-By: Cursor and Claude-4.5-sonnet


___

### **PR Type**
Enhancement


___

### **Description**
- Add OpenShift version detection to cluster info package

- Expose OpenShift version in public info JSON output

- Watch ClusterVersion resource for version changes on OpenShift

- Update RBAC permissions to access ClusterVersion resource


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ClusterVersion Resource"] -->|Get/Watch| B["GetOpenShiftVersion Function"]
  B -->|Returns Version| C["KonfluxInfo Reconciler"]
  C -->|Includes in JSON| D["Public Info Output"]
  E["Main Setup"] -->|Calls GetOpenShiftVersion| F["Logs OpenShift Version"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Add OpenShift version detection to main setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/cmd/main.go

<ul><li>Import <code>context</code> package and OpenShift <code>configv1</code> API<br> <li> Register <code>configv1</code> scheme for OpenShift API types<br> <li> Call <code>GetOpenShiftVersion()</code> when running on OpenShift<br> <li> Include OpenShift version in cluster info logging</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5307/files#diff-6951a7b3b8a59603497b68b62013a806397c640ce0a42a3862f6a4ffad4fda89">+17/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>konfluxinfo_controller.go</strong><dd><code>Integrate OpenShift version into info reconciliation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/info/konfluxinfo_controller.go

<ul><li>Import OpenShift <code>configv1</code> API and controller predicates<br> <li> Add RBAC rule for <code>clusterversions</code> resource access<br> <li> Conditionally watch <code>ClusterVersion</code> resource on OpenShift clusters<br> <li> Retrieve and include OpenShift version in generated info JSON<br> <li> Update <code>generateInfoJSON()</code> and <code>applyInfoDefaults()</code> to accept OpenShift <br>version parameter<br> <li> Add <code>OpenShiftVersion</code> field to <code>infoJSON</code> struct</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5307/files#diff-632df3e422d02f42ebc3adf96fe1683930511f632b57b7d58fdcd60f75e46b2a">+31/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>clusterinfo.go</strong><dd><code>Implement OpenShift version retrieval logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/pkg/clusterinfo/clusterinfo.go

<ul><li>Add <code>UnknownVersion</code> constant for version retrieval failures<br> <li> Define <code>ErrNoCompletedVersion</code> sentinel error<br> <li> Implement <code>GetOpenShiftVersion()</code> function to fetch version from <br>ClusterVersion resource<br> <li> Search through status history for first Completed entry to get actual <br>running version<br> <li> Reorder struct fields in <code>Info</code> type for consistency<br> <li> Rename parameter from <code>client</code> to <code>discoveryClient</code> for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5307/files#diff-8dbe40b2ffa3cb0a7d90ca101480b244d5fa464c5267025e11b93168835dbabe">+50/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>konfluxinfo_controller_test.go</strong><dd><code>Fix import alias naming in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/internal/controller/info/konfluxinfo_controller_test.go

<ul><li>Rename import alias from <code>errors</code> to <code>apierrors</code> for clarity<br> <li> Update error checking to use renamed import alias</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5307/files#diff-b2a1fd18688e1e3a919f2db0ce749c556e3f385fe12085aa15536271729b25cf">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clusterinfo_test.go</strong><dd><code>Add extensive tests for OpenShift version retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/pkg/clusterinfo/clusterinfo_test.go

<ul><li>Add comprehensive test suite for <code>GetOpenShiftVersion()</code> function<br> <li> Test stable cluster with completed version<br> <li> Test upgrade scenarios with partial and completed states<br> <li> Test error cases: missing resource, no completed version, empty <br>version field<br> <li> Use fake Kubernetes client for testing<br> <li> Verify correct version selection from history entries</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5307/files#diff-17874adbcd1520db0142705d7e883daa6aee3ff7cd10e66221c146ab9ac0cfcb">+176/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>role.yaml</strong><dd><code>Add RBAC permissions for ClusterVersion access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/config/rbac/role.yaml

<ul><li>Add RBAC rule for <code>config.openshift.io</code> API group<br> <li> Grant permissions to get, list, and watch <code>clusterversions</code> resource</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5307/files#diff-bf75d41206005954349fa60826c9cc3bd1a976c9e5c8884de0cb59ee68a13fa8">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

