### PR TITLE
fix: run e2e only for same-repo PRs

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -9,54 +9,21 @@ on:
     types: [e2e]
 
 jobs:
-  # Gate: bots, repo collaborators (write+), or repository_dispatch/merge_group. Others need /allow from a maintainer.
+  # Gate: only same-repo PRs run heavy jobs on push. Fork PRs need /allow. Trusted contexts (dispatch, merge_group) always run.
   check-prerequisites:
     runs-on: ubuntu-latest
     steps:
     - name: Check prerequisites
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       run: |
-        # 1. Allow Manual Dispatch or Merge Queue
-        if [[ "${{ github.event_name }}" == 'repository_dispatch' || "${{ github.event_name }}" == 'merge_group' ]]; then
-          echo "✅ Trigger is ${{ github.event_name }} (Trusted Context). Allowed."
-          exit 0
+        # Fork PRs: fail so heavy jobs do not run on push (no secrets). Only /allow can trigger them.
+        if [[ "${{ github.event_name }}" == 'pull_request' && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]]; then
+          echo "❌ Fork PR: heavy jobs do not run on push (no secrets). Comment /allow to trigger tests."
+          echo "### Fork PR" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Tests are not run automatically from forks." >> $GITHUB_STEP_SUMMARY
+          echo "**Action Required:** A maintainer must comment \`/allow\` on this PR to trigger tests." >> $GITHUB_STEP_SUMMARY
+          exit 1
         fi
-
-        # 2. Check Bot Whitelist
-        declare -a WHITELISTED_BOTS=(
-          "renovate[bot]"
-          "red-hat-konflux[bot]"
-          "github-actions[bot]"
-          "konflux-ci-update-bot[bot]"
-        )
-
-        for BOT in "${WHITELISTED_BOTS[@]}"; do
-          if [[ "$PR_AUTHOR" == "$BOT" ]]; then
-            echo "✅ Author is whitelisted bot ($BOT). Allowed."
-            exit 0
-          fi
-        done
-
-        # 3. Check Repository Permissions (works with private org membership)
-        USER_PERM=$(gh api "/repos/${{ github.repository }}/collaborators/$PR_AUTHOR/permission" --jq .permission 2>/dev/null || echo "none")
-
-        if [[ "$USER_PERM" =~ ^(admin|write|maintain)$ ]]; then
-          echo "✅ Author ($PR_AUTHOR) has '$USER_PERM' access. Allowed."
-          exit 0
-        fi
-
-        # 4. Fail and Instruct
-        echo "❌ Blocked: Untrusted author ($PR_AUTHOR) with permission '$USER_PERM'."
-
-        cat <<EOF >> $GITHUB_STEP_SUMMARY
-        ### 🛑 CI Approval Required
-        The PR author is not a maintainer or whitelisted bot.
-        **Action Required:** A maintainer must comment \`/allow\` on this PR to trigger tests.
-        EOF
-
-        exit 1
 
   check-changes:
     name: Check for relevant changes

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -15,54 +15,21 @@ on:
     types: [e2e]
 
 jobs:
-  # Gate: bots, repo collaborators (write+), or repository_dispatch/merge_group. Others need /allow from a maintainer.
+  # Gate: only same-repo PRs run heavy jobs on push. Fork PRs need /allow. Trusted contexts (dispatch, merge_group) always run.
   check-prerequisites:
     runs-on: ubuntu-latest
     steps:
     - name: Check prerequisites
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       run: |
-        # 1. Allow Manual Dispatch or Merge Queue
-        if [[ "${{ github.event_name }}" == 'repository_dispatch' || "${{ github.event_name }}" == 'merge_group' ]]; then
-          echo "✅ Trigger is ${{ github.event_name }} (Trusted Context). Allowed."
-          exit 0
+        # Fork PRs: fail so heavy jobs do not run on push (no secrets). Only /allow can trigger them.
+        if [[ "${{ github.event_name }}" == 'pull_request' && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]]; then
+          echo "❌ Fork PR: heavy jobs do not run on push (no secrets). Comment /allow to trigger tests."
+          echo "### Fork PR" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Tests are not run automatically from forks." >> $GITHUB_STEP_SUMMARY
+          echo "**Action Required:** A maintainer must comment \`/allow\` on this PR to trigger tests." >> $GITHUB_STEP_SUMMARY
+          exit 1
         fi
-
-        # 2. Check Bot Whitelist
-        declare -a WHITELISTED_BOTS=(
-          "renovate[bot]"
-          "red-hat-konflux[bot]"
-          "github-actions[bot]"
-          "konflux-ci-update-bot[bot]"
-        )
-
-        for BOT in "${WHITELISTED_BOTS[@]}"; do
-          if [[ "$PR_AUTHOR" == "$BOT" ]]; then
-            echo "✅ Author is whitelisted bot ($BOT). Allowed."
-            exit 0
-          fi
-        done
-
-        # 3. Check Repository Permissions (works with private org membership)
-        USER_PERM=$(gh api "/repos/${{ github.repository }}/collaborators/$PR_AUTHOR/permission" --jq .permission 2>/dev/null || echo "none")
-
-        if [[ "$USER_PERM" =~ ^(admin|write|maintain)$ ]]; then
-          echo "✅ Author ($PR_AUTHOR) has '$USER_PERM' access. Allowed."
-          exit 0
-        fi
-
-        # 4. Fail and Instruct
-        echo "❌ Blocked: Untrusted author ($PR_AUTHOR) with permission '$USER_PERM'."
-
-        cat <<EOF >> $GITHUB_STEP_SUMMARY
-        ### 🛑 CI Approval Required
-        The PR author is not a maintainer or whitelisted bot.
-        **Action Required:** A maintainer must comment \`/allow\` on this PR to trigger tests.
-        EOF
-
-        exit 1
 
   sanity-test:
     needs: check-prerequisites


### PR DESCRIPTION
### **User description**
PRs from forks do not have access to secrets regardless of who opens them, and PRs opened from the same repo should mean a trusted entity created it, so we can rely on that instead of checking for the author.

Assisted-by: Cursor


___

### **PR Type**
Bug fix


___

### **Description**
- Simplify E2E gating logic to check repository source instead of author permissions

- Remove bot whitelist and permission checks that required GitHub API calls

- Only block fork PRs from running heavy jobs; same-repo PRs always proceed

- Reduce workflow complexity and eliminate GITHUB_TOKEN dependency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR Trigger"] --> B{"Pull Request?"}
  B -->|No| C["Allow<br/>dispatch/merge_group"]
  B -->|Yes| D{"Same Repo?"}
  D -->|Yes| C
  D -->|No| E["Block Fork PR<br/>Require /allow"]
  C --> F["Run Heavy Jobs"]
  E --> G["Skip Heavy Jobs"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator-test-e2e.yaml</strong><dd><code>Simplify E2E gate to fork detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/operator-test-e2e.yaml

<ul><li>Replaced complex author permission checks with simple fork detection <br>logic<br> <li> Removed bot whitelist array and GitHub API permission queries<br> <li> Removed GITHUB_TOKEN and PR_AUTHOR environment variables<br> <li> Updated gate comment to reflect new same-repo vs fork-based strategy</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5308/files#diff-4608c9a6806d47acb069a4d5586ed2091dc1e10d5f40a21f1d229f3053ff79a4">+10/-42</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sanity-test.yml</strong><dd><code>Simplify sanity test gate to fork detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/sanity-test.yml

<ul><li>Replaced complex author permission checks with simple fork detection <br>logic<br> <li> Removed bot whitelist array and GitHub API permission queries<br> <li> Removed GITHUB_TOKEN and PR_AUTHOR environment variables<br> <li> Updated gate comment to reflect new same-repo vs fork-based strategy</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5308/files#diff-c68f5ef87662968636741c0c819fd08d5c7f2a1c020a572d10356b72e63f742f">+10/-42</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

