### PR TITLE
feat(e2e): add e2e test for arm64

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -57,14 +57,14 @@ jobs:
             const { data: e2e } = await github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: 'Run Operator E2E Tests',
+              name: 'Run Operator E2E Tests (AMD64)',
               head_sha,
               status: 'in_progress'
             });
             const { data: arm64 } = await github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: 'Run Operator Integration Tests (ARM64)',
+              name: 'Run Operator E2E Tests (ARM64)',
               head_sha,
               status: 'in_progress'
             });
@@ -105,16 +105,16 @@ jobs:
             cluster_suffix: ""
             test_scope: "integration+e2e"
             konflux_cr: "operator/config/samples/konflux-e2e.yaml"
-            job_name: "Run Operator E2E Tests"
+            job_name: "Run Operator E2E Tests (AMD64)"
           - arch: arm64
             runner: ubuntu-24.04-arm
             kind_binary: kind-linux-arm64
             kubectl_arch: arm64
             image_suffix: "-arm64"
             cluster_suffix: "-arm"
-            test_scope: "integration"
+            test_scope: "integration+e2e"
             konflux_cr: "operator/config/samples/konflux-e2e.yaml"
-            job_name: "Run Operator Integration Tests (ARM64)"
+            job_name: "Run Operator E2E Tests (ARM64)"
     steps:
       - name: Skip test - no operator changes
         run: |
@@ -137,16 +137,16 @@ jobs:
             cluster_suffix: ""
             test_scope: "integration+e2e"
             konflux_cr: "operator/config/samples/konflux-e2e.yaml"
-            job_name: "Run Operator E2E Tests"
+            job_name: "Run Operator E2E Tests (AMD64)"
           - arch: arm64
             runner: ubuntu-24.04-arm
             kind_binary: kind-linux-arm64
             kubectl_arch: arm64
             image_suffix: "-arm64"
             cluster_suffix: "-arm"
-            test_scope: "integration"
+            test_scope: "integration+e2e"
             konflux_cr: "operator/config/samples/konflux-e2e.yaml"
-            job_name: "Run Operator Integration Tests (ARM64)"
+            job_name: "Run Operator E2E Tests (ARM64)"
     env:
       # renovate: datasource=github-releases depName=kubernetes-sigs/kind
       KIND_VERSION: "0.31.0"


### PR DESCRIPTION
### **User description**
Add e2e test for arm64


___

### **PR Type**
Enhancement


___

### **Description**
- Update ARM64 test configuration to run E2E tests instead of integration tests

- Rename ARM64 job from "Integration Tests" to "E2E Tests" for clarity

- Change test_scope from "integration" to "integration+e2e" for ARM64 architecture


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ARM64 Test Config"] -- "Update test_scope" --> B["integration+e2e"]
  A -- "Rename job" --> C["E2E Tests ARM64"]
  A -- "Update check name" --> D["Run Operator E2E Tests ARM64"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator-test-e2e.yaml</strong><dd><code>Configure ARM64 to run E2E tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/operator-test-e2e.yaml

<ul><li>Updated ARM64 check run name from "Integration Tests" to "E2E Tests"<br> <li> Changed test_scope for ARM64 from "integration" to "integration+e2e" <br>in two job matrices<br> <li> Updated job_name for ARM64 from "Integration Tests" to "E2E Tests" in <br>both matrices<br> <li> Ensures ARM64 architecture runs full E2E test suite alongside <br>integration tests</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5312/files#diff-4608c9a6806d47acb069a4d5586ed2091dc1e10d5f40a21f1d229f3053ff79a4">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

