### PR TITLE
feat(e2e): add e2e test for macos

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -34,7 +34,7 @@ jobs:
       checks: write
     outputs:
       operator: ${{ steps.changed-files.outputs.any_changed }}
-      check_run_id: ${{ steps.create-check.outputs.check_run_id }}
+      check_run_id_amd64: ${{ steps.create-check.outputs.check_run_id_amd64 }}
       check_run_id_arm64: ${{ steps.create-check.outputs.check_run_id_arm64 }}
     steps:
       - name: Set checkout ref
@@ -54,7 +54,7 @@ jobs:
         with:
           script: |
             const head_sha = '${{ steps.set-ref.outputs.ref }}';
-            const { data: e2e } = await github.rest.checks.create({
+            const { data: amd64 } = await github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               name: 'Run Operator E2E Tests (AMD64)',
@@ -68,7 +68,7 @@ jobs:
               head_sha,
               status: 'in_progress'
             });
-            core.setOutput('check_run_id', e2e.id);
+            core.setOutput('check_run_id_amd64', amd64.id);
             core.setOutput('check_run_id_arm64', arm64.id);
       - name: Checkout PR branch
         uses: actions/checkout@v6
@@ -101,8 +101,9 @@ jobs:
             runner: ubuntu-latest
             kind_binary: kind-linux-amd64
             kubectl_arch: amd64
-            image_suffix: ""
-            cluster_suffix: ""
+            kubectl_os: linux
+            image_suffix: "-amd64"
+            cluster_suffix: "-amd"
             test_scope: "integration+e2e"
             konflux_cr: "operator/config/samples/konflux-e2e.yaml"
             job_name: "Run Operator E2E Tests (AMD64)"
@@ -110,6 +111,7 @@ jobs:
             runner: ubuntu-24.04-arm
             kind_binary: kind-linux-arm64
             kubectl_arch: arm64
+            kubectl_os: linux
             image_suffix: "-arm64"
             cluster_suffix: "-arm"
             test_scope: "integration+e2e"
@@ -133,8 +135,9 @@ jobs:
             runner: ubuntu-latest
             kind_binary: kind-linux-amd64
             kubectl_arch: amd64
-            image_suffix: ""
-            cluster_suffix: ""
+            kubectl_os: linux
+            image_suffix: "-amd64"
+            cluster_suffix: "-amd"
             test_scope: "integration+e2e"
             konflux_cr: "operator/config/samples/konflux-e2e.yaml"
             job_name: "Run Operator E2E Tests (AMD64)"
@@ -142,6 +145,7 @@ jobs:
             runner: ubuntu-24.04-arm
             kind_binary: kind-linux-arm64
             kubectl_arch: arm64
+            kubectl_os: linux
             image_suffix: "-arm64"
             cluster_suffix: "-arm"
             test_scope: "integration+e2e"
@@ -170,6 +174,7 @@ jobs:
           echo "ref=$ref" >> $GITHUB_OUTPUT
           echo "Trigger: ${{ github.event_name }} → checkout ref: $ref"
       - name: Free Disk Space (Ubuntu)
+        if: runner.os == 'Linux'
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
@@ -181,6 +186,7 @@ jobs:
           ref: ${{ steps.set-ref.outputs.ref }}
 
       - name: Disable AppArmor
+        if: runner.os == 'Linux'
         # works around a change in ubuntu 24.04 that restricts Linux namespace access
         # for unprivileged users
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
@@ -199,7 +205,7 @@ jobs:
 
       - name: Install kubectl (${{ matrix.arch }})
         run: |
-          curl -LO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${{ matrix.kubectl_arch }}/kubectl"
+          curl -LO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/${{ matrix.kubectl_os }}/${{ matrix.kubectl_arch }}/kubectl"
           chmod +x kubectl
           sudo mv kubectl /usr/local/bin/kubectl
 
@@ -284,12 +290,12 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v6
         with:
-          name: logs-${{ matrix.arch }}
+          name: logs-${{ matrix.arch }}${{ matrix.cluster_suffix }}
           path: logs
 
   # Report check result to PR when triggered by /allow (so the run appears on the PR and can gate it)
   report-operator-e2e-status:
-    if: always() && needs.check-changes.outputs.check_run_id != ''
+    if: always() && needs.check-changes.outputs.check_run_id_amd64 != ''
     needs: [check-changes, test-skip, test]
     runs-on: ubuntu-latest
     permissions:
@@ -299,7 +305,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const checkRunId = parseInt(process.env.CHECK_RUN_ID);
+            const checkRunIdAmd64 = parseInt(process.env.CHECK_RUN_ID_AMD64);
             const checkRunIdArm64 = parseInt(process.env.CHECK_RUN_ID_ARM64);
             const testResult = process.env.TEST_RESULT;
             const testSkipResult = process.env.TEST_SKIP_RESULT;
@@ -307,10 +313,10 @@ jobs:
             if (testResult === 'success' || testSkipResult === 'success') conclusion = 'success';
             else if (testResult === 'cancelled' || testSkipResult === 'cancelled') conclusion = 'cancelled';
             const update = { owner: context.repo.owner, repo: context.repo.repo, status: 'completed', conclusion };
-            await github.rest.checks.update({ ...update, check_run_id: checkRunId });
+            await github.rest.checks.update({ ...update, check_run_id: checkRunIdAmd64 });
             await github.rest.checks.update({ ...update, check_run_id: checkRunIdArm64 });
         env:
-          CHECK_RUN_ID: ${{ needs.check-changes.outputs.check_run_id }}
+          CHECK_RUN_ID_AMD64: ${{ needs.check-changes.outputs.check_run_id_amd64 }}
           CHECK_RUN_ID_ARM64: ${{ needs.check-changes.outputs.check_run_id_arm64 }}
           TEST_RESULT: ${{ needs.test.result }}
           TEST_SKIP_RESULT: ${{ needs.test-skip.result }}

--- a/.github/workflows/operator-test-macos.yaml
+++ b/.github/workflows/operator-test-macos.yaml
@@ -1,0 +1,121 @@
+name: Operator macOS (Docker setup)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run Operator E2E Tests (macOS)
+    # Podman machine requires nested virtualization; Intel runners support it.
+    runs-on: macos-15-intel
+    env:
+      # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+      KIND_VERSION: "0.31.0"
+      # renovate: datasource=github-releases depName=kubernetes/kubernetes
+      KUBECTL_VERSION: "1.35.1"
+      OPERATOR_IMAGE: example.com/konflux-operator:v0.0.1-mac
+      KIND_CLUSTER: konflux-operator-test-e2e-mac
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: operator/go.mod
+          cache-dependency-path: operator/go.sum
+
+      - name: Install kind (amd64)
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-darwin-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Install kubectl (darwin amd64)
+        run: |
+          curl -LO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/darwin/amd64/kubectl"
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/kubectl
+
+      - name: Verify kind installation
+        run: kind version
+
+      - name: Install Podman
+        run: |
+          brew install podman
+          podman machine init --cpus 4 --memory 12288 --disk-size 30
+          podman machine start
+          echo "KIND_EXPERIMENTAL_PROVIDER=podman" >> $GITHUB_ENV
+
+      - name: Verify Podman
+        run: |
+          podman version
+          podman info
+
+      - name: Deploy Konflux using deploy-local.sh
+        working-directory: ${{ github.workspace }}
+        env:
+          KIND_CLUSTER: ${{ env.KIND_CLUSTER }}
+          OPERATOR_INSTALL_METHOD: "build"
+          OPERATOR_IMAGE: ${{ env.OPERATOR_IMAGE }}
+          KONFLUX_CR: operator/config/samples/konflux-e2e.yaml
+          GITHUB_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          GITHUB_APP_ID: ${{ secrets.APP_ID }}
+          WEBHOOK_SECRET: ${{ secrets.APP_WEBHOOK_SECRET }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+          QUAY_ORGANIZATION: ${{ secrets.QUAY_ORG }}
+          SMEE_CHANNEL: ${{ secrets.SMEE_CHANNEL }}
+        run: ./scripts/deploy-local.sh
+
+      - name: Show version information
+        working-directory: operator
+        run: |
+          kubectl version
+          kind version
+
+      - name: Wait for Konflux CR to be Ready
+        run: |
+          echo "Waiting for Konflux CR to be ready..."
+          kubectl wait --for=condition=Ready=True konflux konflux --timeout=15m
+          echo "Konflux CR is ready!"
+
+      - name: List namespaces
+        run: kubectl get namespace
+
+      - name: Deploy Test Resources
+        working-directory: ${{ github.workspace }}
+        env:
+          SKIP_SAMPLE_COMPONENTS: "true"
+        run: ./deploy-test-resources.sh
+
+      - name: Run Konflux Integration Tests
+        working-directory: ${{ github.workspace }}
+        run: |
+          cd test/go-tests
+          go test ./...
+
+      - name: Run E2E tests
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_ORG: ${{ secrets.GH_ORG }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          QUAY_DOCKERCONFIGJSON: ${{ secrets.QUAY_DOCKERCONFIGJSON }}
+          RELEASE_CATALOG_TA_QUAY_TOKEN: ${{ secrets.RELEASE_CATALOG_TA_QUAY_TOKEN }}
+        run: ./test/e2e/run-e2e.sh
+
+      - name: Generate error logs
+        if: ${{ !cancelled() }}
+        working-directory: ${{ github.workspace }}
+        run: |
+          echo "Konflux CR:"
+          kubectl get konflux konflux -o yaml || :
+          ./generate-err-logs.sh
+
+      - name: Archive logs
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: logs-mac
+          path: logs


### PR DESCRIPTION
### **User description**
- add e2e test for macos
- update check_run_id to check_run_id_amd64 for consistency
- update amd's cluster suffix to -amd for consistency

Assisted-By: Cursor


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add macOS e2e test support with dedicated job matrix entry

- Rename AMD64 check run ID for consistency across architectures

- Add kubectl_os variable for cross-platform binary downloads

- Standardize image and cluster suffixes for all test architectures

- Add conditional steps for Linux-only operations (AppArmor, disk space)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check Changes Job"] -->|"check_run_id_amd64"| B["Report Status Job"]
  A -->|"check_run_id_arm64"| B
  A -->|"check_run_id_macos"| B
  C["Test Job Matrix"] -->|"amd64 ubuntu-latest"| D["Run Tests"]
  C -->|"arm64 ubuntu-24.04-arm"| D
  C -->|"arm64 macos-14"| D
  D -->|"logs-amd-suffix"| E["Archive Logs"]
  D -->|"logs-arm-suffix"| E
  D -->|"logs-mac-suffix"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator-test-e2e.yaml</strong><dd><code>Add macOS e2e testing and standardize naming conventions</code>&nbsp; </dd></summary>
<hr>

.github/workflows/operator-test-e2e.yaml

<ul><li>Added macOS test matrix entry with <code>macos-14</code> runner and <br><code>kind-darwin-arm64</code> binary<br> <li> Renamed <code>check_run_id</code> output to <code>check_run_id_amd64</code> and added <br><code>check_run_id_macos</code> output<br> <li> Added <code>kubectl_os</code> matrix variable to support cross-platform kubectl <br>downloads (linux/darwin)<br> <li> Standardized image and cluster suffixes: AMD64 now uses <code>-amd64</code> and <br><code>-amd</code> instead of empty strings<br> <li> Added conditional <code>if: runner.os == 'Linux'</code> guards for AppArmor and <br>disk space cleanup steps<br> <li> Updated kubectl installation to use dynamic <code>kubectl_os</code> variable in <br>download URL<br> <li> Updated log artifact naming to include cluster suffix for better <br>organization</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5315/files#diff-4608c9a6806d47acb069a4d5586ed2091dc1e10d5f40a21f1d229f3053ff79a4">+51/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

