### PR TITLE
fix: remove duplicate wait on cr

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -235,15 +235,6 @@ jobs:
           kubectl version
           kind version
 
-      - name: Wait for Konflux CR to be Ready
-        run: |
-          # Wait for the Konflux CR to be ready
-          # If the operator deployment is ready and the CR is ready, the operator should have
-          # ensured all underlying services (webhooks, CRDs, etc.) are ready
-          echo "Waiting for Konflux CR to be ready..."
-          kubectl wait --for=condition=Ready=True konflux konflux --timeout=15m
-          echo "Konflux CR is ready!"
-
       - name: List namespaces
         run: |
           kubectl get namespace


### PR DESCRIPTION
### **User description**
We were waiting on the Konflux CR twice, once in the script and once in the workflow. Keeping only the script wait.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove duplicate wait on Konflux CR in workflow

- Keep only the script-based wait implementation

- Eliminate redundant CR readiness check


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["operator-test-e2e.yaml"] -- "removes duplicate wait step" --> B["Streamlined workflow"]
  C["deploy-local.sh script"] -- "contains primary wait logic" --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator-test-e2e.yaml</strong><dd><code>Remove duplicate Konflux CR readiness wait step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/operator-test-e2e.yaml

<ul><li>Removed duplicate "Wait for Konflux CR to be Ready" workflow step<br> <li> Eliminated redundant kubectl wait command for CR readiness<br> <li> Kept the wait logic in deploy-local.sh script as single source of <br>truth</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5323/files#diff-4608c9a6806d47acb069a4d5586ed2091dc1e10d5f40a21f1d229f3053ff79a4">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

