### PR TITLE
chore(KFLUXVNGD-713): update operator to use updated Dex images

### DIFF
--- a/operator/pkg/manifests/ui/manifests.yaml
+++ b/operator/pkg/manifests/ui/manifests.yaml
@@ -357,7 +357,7 @@ spec:
             secretKeyRef:
               key: client-secret
               name: oauth2-proxy-client-secret
-        image: ghcr.io/dexidp/dex:v2.44.0
+        image: quay.io/konflux-ci/dex:8b787ea30e1b202c61edb653f3ebc814bdd93f5d6c4f0cdf419bfd83c8173499
         name: dex
         ports:
         - containerPort: 9443

--- a/operator/upstream-kustomizations/ui/dex/dex.yaml
+++ b/operator/upstream-kustomizations/ui/dex/dex.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       serviceAccountName: dex # This is created below
       containers:
-      - image: ghcr.io/dexidp/dex:latest
+      - image: quay.io/konflux-ci/dex:latest
         name: dex
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
         securityContext:

--- a/operator/upstream-kustomizations/ui/dex/kustomization.yml
+++ b/operator/upstream-kustomizations/ui/dex/kustomization.yml
@@ -5,6 +5,6 @@ resources:
   - dex.yaml
 
 images:
-  - name: ghcr.io/dexidp/dex
-    newName: ghcr.io/dexidp/dex
-    newTag: v2.44.0
+  - name: quay.io/konflux-ci/dex
+    newName: quay.io/konflux-ci/dex
+    newTag: 8b787ea30e1b202c61edb653f3ebc814bdd93f5d6c4f0cdf419bfd83c8173499


### PR DESCRIPTION
Update the operator to use the konflux-ci rebuild images of Dex