### PR TITLE
fix: unbound variable when running deploy-local.sh

### DIFF
--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -93,7 +93,7 @@ export INCREASE_PODMAN_PIDS_LIMIT
 export GITHUB_PRIVATE_KEY GITHUB_APP_ID WEBHOOK_SECRET QUAY_TOKEN QUAY_ORGANIZATION
 
 # Get Konflux CR file path (precedence, high->low: command-line arg, env var, default)
-KONFLUX_CR="${1:-$KONFLUX_CR}"
+KONFLUX_CR="${1:-${KONFLUX_CR:-}}"
 
 # Auto-select e2e CR when Quay credentials are configured but no explicit CR specified
 if [ -n "${QUAY_TOKEN:-}" ] && [ -n "${QUAY_ORGANIZATION:-}" ] && [ -z "${KONFLUX_CR}" ]; then


### PR DESCRIPTION
When running deploy-local without any arguments, we got an unbound variable.

```bash
$ ./scripts/deploy-local.sh
Loading configuration from <...>/konflux-ci/scripts/deploy-local.env
./scripts/deploy-local.sh: line 96: KONFLUX_CR: unbound variable
```

If nothing is set, use an empty string as the CR will be overridden to one of the defaults.