### PR TITLE
fix(e2e): set fail-fast to false for e2e tests

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -95,6 +95,7 @@ jobs:
     needs: [check-prerequisites, check-changes]
     if: needs.check-changes.outputs.operator != 'true'
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: amd64
@@ -127,6 +128,7 @@ jobs:
     needs: [check-prerequisites, check-changes]
     if: needs.check-changes.outputs.operator == 'true'
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: amd64


### PR DESCRIPTION
### **User description**
Set fail-fast to false for e2e tests to ensure all tests are run even if some fail.


___

### **PR Type**
Bug fix


___

### **Description**
- Set fail-fast to false in e2e test workflow strategy

- Ensures all tests run even if some fail

- Applied to both test-skip and test jobs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["E2E Test Workflow"] --> B["test-skip Job"]
  A --> C["test Job"]
  B --> D["fail-fast: false"]
  C --> D
  D --> E["All tests run on failure"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator-test-e2e.yaml</strong><dd><code>Add fail-fast false to e2e test jobs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/operator-test-e2e.yaml

<ul><li>Added <code>fail-fast: false</code> to test-skip job strategy<br> <li> Added <code>fail-fast: false</code> to test job strategy<br> <li> Ensures all matrix tests execute regardless of individual failures</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5395/files#diff-4608c9a6806d47acb069a4d5586ed2091dc1e10d5f40a21f1d229f3053ff79a4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

