### PR TITLE
feat(KFLUXVNGD-755): release rc tags as pre-release

### DIFF
--- a/.github/scripts/create-release.sh
+++ b/.github/scripts/create-release.sh
@@ -19,6 +19,10 @@ set -euo pipefail
 #   create-release.sh v0.2025.01 c5683934bbdf40fc5517d9cf491b381c4a2f049d /tmp/release-notes.md operator/dist true false
 #   create-release.sh v0.2025.01 main /tmp/release-notes.md operator/dist true false
 
+# Version substring that marks a release as prerelease (e.g. candidate).
+# If VERSION contains this, --prerelease is used.
+PRERELEASE_VERSION_SUBSTRING="rc"
+
 if [ $# -ne 6 ]; then
   echo "Error: Invalid number of arguments"
   echo "Usage: $0 <version> <git_ref> <notes_file> <artifact_dir> <draft> <generate_notes>"
@@ -46,6 +50,12 @@ if [ "$GENERATE_NOTES" == "true" ]; then
   echo "Auto-generating commit history"
 else
   echo "Skipping auto-generated commit history (use generate_notes=true for future releases)"
+fi
+
+PRERELEASE_FLAG=""
+if [[ "$VERSION" == *"${PRERELEASE_VERSION_SUBSTRING}"* ]]; then
+  PRERELEASE_FLAG="--prerelease"
+  echo "Version contains '${PRERELEASE_VERSION_SUBSTRING}'; creating as prerelease"
 fi
 
 # Verify files exist
@@ -79,6 +89,7 @@ gh release create "$VERSION" \
   --notes-file "$NOTES_FILE" \
   $GENERATE_NOTES_FLAG \
   $DRAFT_FLAG \
+  $PRERELEASE_FLAG \
   "${ARTIFACTS[@]}" \
   --target "$(git rev-parse "$GIT_REF^{commit}")"
 


### PR DESCRIPTION
We plan to move to have most of our releases as pre-releases. Those should not be released in the same way both to GitHub and to the operator catalog.

This change mark releases for such tags as pre-releases in GitHub, which will cause them to be skipped, at least for now, from being released to the operator catalog.

Assisted-by: Cursor