### PR TITLE
feat(KFLUXVNGD-781): verify releases on multiple branches

### DIFF
--- a/.github/excluded-release-branches.yaml
+++ b/.github/excluded-release-branches.yaml
@@ -1,0 +1,6 @@
+# Branches excluded from release tagging (auto-tag-weekly) and release verification.
+# Only release-x.y branches are considered; list here the ones to skip.
+# Example: add "release-0.0" to stop auto-tagging and verification for that branch.
+excluded:
+  - release-999.999
+  - release-888.888

--- a/.github/scripts/list-release-branches.sh
+++ b/.github/scripts/list-release-branches.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+# List main and release-x.y branches that are not in the excluded list.
+# Outputs a JSON array of branch names (for workflow matrix).
+# Used by auto-tag-weekly and by release verification workflow.
+#
+# Usage: .github/scripts/list-release-branches.sh
+# Expects: run from repository root; yq and jq available.
+# EXCLUDED_BRANCHES_FILE defaults to .github/excluded-release-branches.yaml
+
+if ! command -v yq &>/dev/null; then
+  echo "yq is required but not installed" >&2
+  exit 1
+fi
+
+EXCLUDED_FILE="${EXCLUDED_BRANCHES_FILE:-.github/excluded-release-branches.yaml}"
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+
+# All remote release-x.y branches (strip origin/)
+ALL_BRANCHES=$(git branch -r 2>/dev/null | sed 's/^[[:space:]]*//' | grep -E '^origin/release-[0-9]+\.[0-9]+$' | sed 's|^origin/||' | sort -V || true)
+
+# Excluded set from YAML
+EXCLUDED=""
+if [ -f "$EXCLUDED_FILE" ]; then
+  EXCLUDED=$(yq -r '.excluded[]?' "$EXCLUDED_FILE" 2>/dev/null || true)
+fi
+
+{
+  echo "main"
+  while IFS= read -r br; do
+    [ -z "$br" ] && continue
+    echo "$EXCLUDED" | grep -Fxq "$br" 2>/dev/null && continue
+    echo "$br"
+  done <<< "$ALL_BRANCHES"
+} | jq -R -s -c 'split("\n") | map(select(length>0))'

--- a/.github/workflows/verify-releases.yaml
+++ b/.github/workflows/verify-releases.yaml
@@ -12,24 +12,52 @@ permissions:
   issues: write
 
 jobs:
-  verify-release:
-    name: Verify Release
+  get-branches:
+    name: List branches to verify
     runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.set.outputs.branches }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: List branches
+        id: set
+        run: |
+          BRANCHES=$(.github/scripts/list-release-branches.sh)
+          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
+          echo "Branches to verify: $BRANCHES"
+
+  verify-release:
+    name: Verify Release (${{ matrix.branch }})
+    runs-on: ubuntu-latest
+    needs: get-branches
+    if: needs.get-branches.outputs.branches != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.get-branches.outputs.branches) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 0
           fetch-tags: true
 
-      - name: Check for releases and commits
+      - name: Verify releases
+        id: verify
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          .github/scripts/verify-releases.sh ${{ github.repository }}
+          .github/scripts/verify-releases.sh \
+            "${{ github.repository }}" \
+            "${{ matrix.branch }}"
 
       - name: Create issue on verification failure
-        if: env.VERIFICATION_FAILED == 'true'
+        if: steps.verify.outputs.verification_failed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -39,12 +67,12 @@ jobs:
           WORKFLOW_NAME: Verify Releases
         run: |
           .github/scripts/create-or-update-issue.sh \
-            "Weekly Release Verification Failed" \
-            "No GitHub release was created in the past 7 days, but ${COMMIT_COUNT} commit(s) were made to the main branch during this period." \
-            /tmp/recent-commits.txt
+            "Weekly Release Verification Failed (${{ matrix.branch }})" \
+            "Release verification failed for branch **${{ matrix.branch }}**." \
+            /tmp/verification-details.txt
 
       - name: Create issue on unexpected failure
-        if: failure() && env.VERIFICATION_FAILED != 'true'
+        if: failure() && steps.verify.outputs.verification_failed != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
### **User description**
We need to have releases on both main and any release branch that we maintain. Those could be either prereleases or stable releases, but if we had a commits tagged with stable release tag, we need to make sure a release was created for it.

The workflow and script now do that.

Assisted-by: Cursor


___

### **PR Type**
Enhancement


___

### **Description**
- Extend release verification to support multiple branches (main and release-x.y)

- Determine stream version from branch name or latest tag for proper verification

- Verify all stable tags in verification window have corresponding GitHub releases

- Add workflow matrix to check releases across all active release branches


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow Trigger"] --> B["List Release Branches"]
  B --> C["Get Branches Matrix"]
  C --> D["Verify Each Branch"]
  D --> E["Determine Stream"]
  E --> F["Check Stable Tags"]
  F --> G["Check Latest RC Tag"]
  G --> H{All Releases Exist?}
  H -->|Yes| I["✅ Pass"]
  H -->|No| J["Create Issue"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>list-release-branches.sh</strong><dd><code>List release branches for workflow matrix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/scripts/list-release-branches.sh

<ul><li>New script to list main and release-x.y branches for workflow matrix<br> <li> Filters branches against excluded list from YAML configuration<br> <li> Outputs JSON array of branch names for GitHub Actions matrix strategy<br> <li> Supports customizable excluded branches file via environment variable</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5428/files#diff-11218c070bd33ed5ec44b953be4668f153578e0ccefa489d27cbe6e064c04f0b">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>verify-releases.sh</strong><dd><code>Multi-branch release verification with stream detection</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/scripts/verify-releases.sh

<ul><li>Refactored to accept branch parameter and determine stream version<br> <li> Extracts stream from branch name (release-x.y) or latest tag (main)<br> <li> Verifies all stable tags (vX.Y.Z) in 7-day window have GitHub releases<br> <li> Checks latest RC tag also has corresponding GitHub release<br> <li> Improved output with detailed verification checks and failure reasons</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5428/files#diff-b8eb547b555348f85ea9f65667c0e4b4ee16465401436fd930ae43689d736b5b">+108/-72</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>verify-releases.yaml</strong><dd><code>Workflow matrix for multi-branch release verification</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/verify-releases.yaml

<ul><li>Added get-branches job to dynamically list branches using new script<br> <li> Converted verify-release job to use matrix strategy for multiple <br>branches<br> <li> Updated checkout to use matrix branch reference with full fetch<br> <li> Modified verify-releases.sh call to pass branch parameter<br> <li> Updated issue creation to reference branch-specific verification <br>details<br> <li> Changed output variable from GITHUB_ENV to step output for better <br>isolation</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5428/files#diff-31847da423a3a5c37cc93196273319c746678b265733a5e3a794f11aef29387b">+36/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>excluded-release-branches.yaml</strong><dd><code>Configuration for excluded release branches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/excluded-release-branches.yaml

<ul><li>New configuration file to exclude branches from release verification<br> <li> Contains example excluded branches (release-999.999, release-888.888)<br> <li> Used by list-release-branches.sh to filter branches</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5428/files#diff-124a34ac2fae5524575514c0c4b392f2ad68918b511305e2b3e870f7f44766e6">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

