### PR TITLE
fix: use digest for resources without upstream git

### DIFF
--- a/operator/pkg/manifests/ui/manifests.yaml
+++ b/operator/pkg/manifests/ui/manifests.yaml
@@ -357,7 +357,7 @@ spec:
             secretKeyRef:
               key: client-secret
               name: oauth2-proxy-client-secret
-        image: quay.io/konflux-ci/dex:8b787ea30e1b202c61edb653f3ebc814bdd93f5d6c4f0cdf419bfd83c8173499
+        image: quay.io/konflux-ci/dex@sha256:bb7c21eecd597b743846b7a7698dcc2a12bebfcd2308f9cbb9624f5499433675
         name: dex
         ports:
         - containerPort: 9443
@@ -498,7 +498,7 @@ spec:
             secretKeyRef:
               key: cookie-secret
               name: oauth2-proxy-cookie-secret
-        image: quay.io/konflux-ci/oauth2-proxy:1422fa87ad5d68f490e76c2f9bb5b5fdadfc56c0
+        image: quay.io/konflux-ci/oauth2-proxy@sha256:1f4a37529de4f750099af18e113556bd995fe6922030c614b7d6d23eaa0bd318
         name: oauth2-proxy
         ports:
         - containerPort: 6000
@@ -520,7 +520,7 @@ spec:
         - -R
         - /opt/app-root/src/.
         - /mnt/static-content/
-        image: quay.io/konflux-ci/konflux-ui:fa9b7642f2bb87ad9f599cf5b17ae2aa23ffb57e
+        image: quay.io/konflux-ci/konflux-ui@sha256:ef89e2da5482e333b3985e91a515a6fce7c5c2012291fba8e1d992e833152c27
         name: copy-static-content
         resources:
           limits:
@@ -559,7 +559,7 @@ spec:
           fi
           sed "s/__TEKTON_RESULTS_HOSTNAME__/$results_hostname/" /mnt/nginx-templates/tekton-results.conf > /mnt/nginx-generated-location-config/tekton-results.conf
           chmod 640 /mnt/nginx-generated-location-config/tekton-results.conf
-        image: quay.io/konflux-ci/konflux-ui:fa9b7642f2bb87ad9f599cf5b17ae2aa23ffb57e
+        image: quay.io/konflux-ci/konflux-ui@sha256:ef89e2da5482e333b3985e91a515a6fce7c5c2012291fba8e1d992e833152c27
         name: generate-nginx-configs
         resources:
           limits:

--- a/operator/upstream-kustomizations/ui/core/proxy/kustomization.yaml
+++ b/operator/upstream-kustomizations/ui/core/proxy/kustomization.yaml
@@ -7,10 +7,10 @@ resources:
 images:
 - name: quay.io/konflux-ci/konflux-ui
   newName: quay.io/konflux-ci/konflux-ui
-  newTag: fa9b7642f2bb87ad9f599cf5b17ae2aa23ffb57e
+  digest: sha256:ef89e2da5482e333b3985e91a515a6fce7c5c2012291fba8e1d992e833152c27
 - name: quay.io/konflux-ci/oauth2-proxy
   newName: quay.io/konflux-ci/oauth2-proxy
-  newTag: 1422fa87ad5d68f490e76c2f9bb5b5fdadfc56c0
+  digest: sha256:1f4a37529de4f750099af18e113556bd995fe6922030c614b7d6d23eaa0bd318
 - name: registry.access.redhat.com/ubi9/nginx-124
   digest: sha256:ece0c2d70199f0bcd3316d6913ef4b8e815d0229693156dee4bad8d69b13edc6
 

--- a/operator/upstream-kustomizations/ui/dex/kustomization.yml
+++ b/operator/upstream-kustomizations/ui/dex/kustomization.yml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: quay.io/konflux-ci/dex
     newName: quay.io/konflux-ci/dex
-    newTag: 8f7c435ef3e20b3c6fe647e74c5061db105425a6511b28f9eb7b9ab383898929
+    digest: sha256:bb7c21eecd597b743846b7a7698dcc2a12bebfcd2308f9cbb9624f5499433675


### PR DESCRIPTION
### **User description**
We had some upstream images (all in UI) that were not getting updates as the kustomization files were using a tag that cannot be used by Renovate. That tag worked for images that had upstream kustomization, as in reality, what was tracked was the upstream file and the image tag was identical to it.

In the absence of an upstream kustomization, the image did not get updates. Moving to using Digest instead of newTag should address this.

Assisted-by: Cursor


___

### **PR Type**
Bug fix


___

### **Description**
- Replace image tags with digest references for Renovate compatibility

- Update dex, oauth2-proxy, and konflux-ui images to use SHA256 digests

- Modify kustomization files to use digest instead of newTag fields

- Enable automatic image updates for resources without upstream git


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Image Tags<br/>newTag field"] -->|"Replace with"| B["SHA256 Digests<br/>digest field"]
  B -->|"Enables"| C["Renovate Updates<br/>for UI images"]
  D["dex<br/>oauth2-proxy<br/>konflux-ui"] -->|"Updated in"| E["Manifests &<br/>Kustomization files"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifests.yaml</strong><dd><code>Update UI manifest images to use digests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/pkg/manifests/ui/manifests.yaml

<ul><li>Replace dex image tag with SHA256 digest reference<br> <li> Replace oauth2-proxy image tag with SHA256 digest reference<br> <li> Replace two konflux-ui image tags with matching SHA256 digest <br>reference<br> <li> Update all three container image references to use digest format</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5513/files#diff-b4087adab82021e5f589128ca400b3542479df861a6ecc3c5cb018510a5faeca">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Convert proxy kustomization to digest references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/upstream-kustomizations/ui/core/proxy/kustomization.yaml

<ul><li>Replace konflux-ui newTag with corresponding SHA256 digest<br> <li> Replace oauth2-proxy newTag with corresponding SHA256 digest<br> <li> Maintain existing nginx digest reference unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5513/files#diff-61b6578e5585b1459a2de76c894c3fd69c750262daa25e6a4a3898d818bc1fae">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kustomization.yml</strong><dd><code>Convert dex kustomization to digest reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

operator/upstream-kustomizations/ui/dex/kustomization.yml

<ul><li>Replace dex image newTag with SHA256 digest reference<br> <li> Update kustomization to use digest field instead of newTag</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5513/files#diff-e12bd72b3f9618b39dcead4914ebf89314ae1d21b5eb64acb257abb23cc62737">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

