### PR TITLE
add OPERATOR_INSTALL_METHOD=none for local operator development

### DIFF
--- a/scripts/deploy-local.env.template
+++ b/scripts/deploy-local.env.template
@@ -16,6 +16,8 @@
 #   release (default) - Install from latest GitHub release
 #   local             - Install from current checkout using kustomize
 #   build             - Build operator image locally (for operator development)
+#   none              - Skip operator install and Konflux CR creation
+#                       (for running the operator locally with 'make install && make run')
 #
 # NOTE: 'local' applies manifests from your checkout with the latest released
 # image. To avoid mismatches, checkout a specific release tag first:
@@ -59,7 +61,6 @@ ENABLE_REGISTRY_PORT=1
 # Increase Podman PID limits for better Tekton performance (1=enabled, 0=disabled)
 # Recommended: enabled for Tekton pipelines
 INCREASE_PODMAN_PIDS_LIMIT=1
-
 # ==============================================================================
 # Secrets (REQUIRED - never commit these values!)
 # ==============================================================================


### PR DESCRIPTION
Add a 'none' install method that sets up the Kind cluster, deploys dependencies, and creates secrets, but skips operator installation and Konflux CR creation. This is useful for operator developers who run the operator using 'make install' and 'make run'.

When using 'none' mode:
- Steps 3-5 and 7 (operator deploy, wait, CR apply, readiness check) are skipped
- Namespaces for secrets are pre-created instead of waiting for the operator to create them
- The final output shows next steps for running the operator locally

Also refactor namespace wait/create logic into a reusable wait_or_create_namespace() helper function to reduce duplication.

Assisted-By: Cursor