### PR TITLE
fix: output image in new branch

### DIFF
--- a/.github/scripts/create-release-branch-and-pr.sh
+++ b/.github/scripts/create-release-branch-and-pr.sh
@@ -102,6 +102,11 @@ for f in "${TEKTON_DIR}"/konflux-operator-push.yaml "${TEKTON_DIR}"/konflux-oper
   ' "$f"
 done
 
+# Set output-image param so builds push to the versioned repo (e.g. konflux-operator-0-0) matching the ImageRepository.
+[ -f "${TEKTON_DIR}/konflux-operator-push.yaml" ] && yq -i '(.spec.params[] | select(.name == "output-image")) |= .value = "quay.io/redhat-user-workloads/konflux-vanguard-tenant/" + env(APP_COMPONENT) + ":{{revision}}"' "${TEKTON_DIR}/konflux-operator-push.yaml"
+[ -f "${TEKTON_DIR}/konflux-operator-pull-request.yaml" ] && yq -i '(.spec.params[] | select(.name == "output-image")) |= .value = "quay.io/redhat-user-workloads/konflux-vanguard-tenant/" + env(APP_COMPONENT) + ":on-pr-{{revision}}"' "${TEKTON_DIR}/konflux-operator-pull-request.yaml"
+[ -f "${TEKTON_DIR}/konflux-operator-tag.yaml" ] && yq -i '(.spec.params[] | select(.name == "output-image")) |= .value = "quay.io/redhat-user-workloads/konflux-vanguard-tenant/" + env(APP_COMPONENT) + ":{{revision}}-{{git_tag}}"' "${TEKTON_DIR}/konflux-operator-tag.yaml"
+
 # shellcheck disable=SC2090
 export PUSH_CEL
 yq -i '.metadata.name = env(APP_COMPONENT) + "-on-push" | .metadata.annotations["pipelinesascode.tekton.dev/on-cel-expression"] = env(PUSH_CEL)' "${TEKTON_DIR}/konflux-operator-push.yaml"


### PR DESCRIPTION
### **User description**
Assisted-by: Cursor


___

### **PR Type**
Enhancement


___

### **Description**
- Configure output-image parameters in Tekton pipeline files

- Set versioned repository paths for push, pull-request, and tag workflows

- Use component-specific image tags matching ImageRepository naming convention


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Tekton Pipeline Files"] -->|"Set output-image param"| B["Push Workflow"]
  A -->|"Set output-image param"| C["Pull-Request Workflow"]
  A -->|"Set output-image param"| D["Tag Workflow"]
  B -->|"quay.io/.../component:revision"| E["Versioned Repo"]
  C -->|"quay.io/.../component:on-pr-revision"| E
  D -->|"quay.io/.../component:revision-git_tag"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-release-branch-and-pr.sh</strong><dd><code>Add output-image parameter configuration for Tekton workflows</code></dd></summary>
<hr>

.github/scripts/create-release-branch-and-pr.sh

<ul><li>Added three new yq commands to set the <code>output-image</code> parameter in <br>Tekton pipeline YAML files<br> <li> Configured push workflow to use <br><code>quay.io/redhat-user-workloads/konflux-vanguard-tenant/{component}:{{revision}}</code><br> <li> Configured pull-request workflow to use <br><code>quay.io/redhat-user-workloads/konflux-vanguard-tenant/{component}:on-pr-{{revision}}</code><br> <li> Configured tag workflow to use <br><code>quay.io/redhat-user-workloads/konflux-vanguard-tenant/{component}:{{revision}}-{{git_tag}}</code></ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/konflux-ci/pull/5593/files#diff-1169b58cb07878af0caed308212e014b0191f44d5a4b10a023d7e73afb4f9105">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

