### PR TITLE
fix: tagging logic for release branches

### DIFF
--- a/.github/scripts/verify-releases.sh
+++ b/.github/scripts/verify-releases.sh
@@ -84,7 +84,7 @@ TAG_PREFIX="v${STREAM}."
 
 # Latest tag for this stream reachable from HEAD
 LATEST=$(git tag --merged=HEAD 2>/dev/null \
-  | grep -E "$VERSION_PATTERN" | grep "^${TAG_PREFIX}" | sort -V | tail -1 || true)
+  | grep -E "$VERSION_PATTERN" | grep -F "${TAG_PREFIX}" | sort -V | tail -1 || true)
 
 if [ -z "$LATEST" ]; then
   echo "Error: No version tags for stream ${STREAM} reachable from HEAD."

--- a/.github/workflows/auto-tag-weekly.yaml
+++ b/.github/workflows/auto-tag-weekly.yaml
@@ -80,7 +80,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          .github/scripts/auto-tag-branch.sh
+          .github/scripts/auto-tag-branch.sh "${{ matrix.branch }}"
 
       - name: Notify on failure
         if: failure()


### PR DESCRIPTION
The tagging logic needs to only consider tags with the pattern relevant to the branch, otherwise it tries to apply a tag from a different branch.

This logic already existed in the verification workflow/script so copying it from there.

Assisted-by: Cursor