### PR TITLE
test: remove branch filtering from workflows

### DIFF
--- a/.github/workflows/differential-shellcheck.yaml
+++ b/.github/workflows/differential-shellcheck.yaml
@@ -1,9 +1,6 @@
 name: Differential ShellCheck
 on:
-  push:
-    branches: main
   pull_request:
-    branches: main
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/operator-lint.yaml
+++ b/.github/workflows/operator-lint.yaml
@@ -1,10 +1,7 @@
 name: Operator Lint
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -1,10 +1,7 @@
 name: Operator Tests
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/operator-verify-generated-files.yml
+++ b/.github/workflows/operator-verify-generated-files.yml
@@ -1,10 +1,7 @@
 name: Verify Generated Operator Files
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,6 +21,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  issues: write
 
 concurrency:
   group: "pages"
@@ -133,3 +134,17 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Notify on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_NAME: Deploy to GitHub Pages
+        run: |
+          .github/scripts/create-or-update-issue.sh \
+            "⚠️ GitHub Pages Deploy Failed" \
+            "The Deploy to GitHub Pages workflow failed while publishing documentation from **main**. The live docs site may not have been updated."


### PR DESCRIPTION
Workflows running for pull requests should run for pull requests, regardless of the target branch. This now becomes an issue as we're going to create PRs to release branches, and not only to main.

Also removing the on-push trigger to allow workflows (nothing is tracking their results), but the one that releases to GitHub pages. For that workflow, we now enable error reporting so failures don't go unnoticed.

Assisted-by: Cursor