### PR TITLE
feat: publish to candidate channels

### DIFF
--- a/.github/scripts/generate-release-artifacts.sh
+++ b/.github/scripts/generate-release-artifacts.sh
@@ -77,12 +77,20 @@ echo "✅ Generated OLM bundle at: $(pwd)/bundle"
 
 # Generate release-config.yaml (for OLM catalog configuration)
 # https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_autorelease/
+# For SemVer: allowed channels are Fast, Stable, Candidate. Use Candidate for RC versions.
 echo "Generating release-config.yaml..."
-cat > release-config.yaml << 'EOF'
+if [[ "${VERSION_WITH_V}" == *"rc"* ]]; then
+  RELEASE_CHANNEL="Candidate"
+  echo "Version contains 'rc'; using catalog channel: ${RELEASE_CHANNEL}"
+else
+  RELEASE_CHANNEL="Stable"
+  echo "Using catalog channel: ${RELEASE_CHANNEL}"
+fi
+cat > release-config.yaml << EOF
 ---
 catalog_templates:
   - template_name: semver.yaml
-    channels: [Stable]
+    channels: [${RELEASE_CHANNEL}]
 EOF
 echo "✅ Generated release-config.yaml"
 cat release-config.yaml

--- a/.github/workflows/community-operator-pr.yaml
+++ b/.github/workflows/community-operator-pr.yaml
@@ -14,8 +14,8 @@ jobs:
   create-pr:
     name: Create Community Operator PR
     runs-on: ubuntu-latest
-    # Skip pre-releases for automatic triggers
-    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
+    # Run for both stable and candidate (prerelease) releases; skip only for non-dispatch non-release events
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -91,7 +91,8 @@ The workflow:
 
 - The `release-config.yaml` file (generated in
   [generate-release-artifacts.sh](.github/scripts/generate-release-artifacts.sh))
-  specifies the OLM channel (`Stable`) for the bundle
+  specifies the OLM channel for the bundle: `Stable` for stable releases,
+  `Candidate` for release-candidate (prerelease) versions (e.g. tags containing `rc`).
 - The [ci.yaml](https://github.com/redhat-openshift-ecosystem/community-operators-prod/blob/main/operators/konflux/ci.yaml)
   file in the upstream repository defines which OpenShift catalog versions the
   operator is published to (catalog versions correspond to OpenShift versions)


### PR DESCRIPTION
Add logic for publishing to candidate channels in the operator catalog.

Assisted-by: Cursor