### PR TITLE
feat(RELEASE-2158): Deploy self-hosted Quay to the cluster

### DIFF
--- a/dependencies/quay/certificate.yaml
+++ b/dependencies/quay/certificate.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: quay-cert
+  namespace: quay
+spec:
+  isCA: true
+  subject:
+    organizations:
+      - konflux
+  dnsNames:
+    - localhost
+    - quay-service.quay
+    - quay-service.quay.svc.cluster.local
+  issuerRef:
+    kind: ClusterIssuer
+    name: ca-issuer
+  secretName: quay-tls

--- a/dependencies/quay/kustomization.yml
+++ b/dependencies/quay/kustomization.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - postgres.yaml
+  - redis.yaml
+  - certificate.yaml
+  - quay.yaml
+images:
+  - name: quay.io/projectquay/quay
+    newTag: "3.16.2"
+  - name: quay.io/sclorg/postgresql-15-c9s
+    newTag: "20260302"
+  - name: quay.io/sclorg/redis-7-c9s
+    newTag: "20250108"

--- a/dependencies/quay/namespace.yaml
+++ b/dependencies/quay/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: quay

--- a/dependencies/quay/postgres.yaml
+++ b/dependencies/quay/postgres.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: quay-postgres-init
+  namespace: quay
+data:
+  setup-extensions.sh: |
+    #!/bin/bash
+    psql -d "${POSTGRESQL_DATABASE}" -U "${POSTGRESQL_USER}" -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: quay-postgres
+  namespace: quay
+  labels:
+    app: quay-postgres
+  annotations:
+    ignore-check.kube-linter.io/no-read-only-root-fs: >-
+      PostgreSQL sclorg image writes to /var/lib/pgsql/passwd at startup
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: quay-postgres
+  template:
+    metadata:
+      labels:
+        app: quay-postgres
+    spec:
+      containers:
+      - name: postgres
+        image: quay.io/sclorg/postgresql-15-c9s
+        securityContext:
+          runAsNonRoot: true
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        env:
+        - name: POSTGRESQL_USER
+          value: quay
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: quay-postgres-creds
+              key: password
+        - name: POSTGRESQL_DATABASE
+          value: quay
+        ports:
+        - containerPort: 5432
+        volumeMounts:
+        - name: init-scripts
+          mountPath: /opt/app-root/src/postgresql-start
+          readOnly: true
+        - name: data
+          mountPath: /var/lib/pgsql/data
+      volumes:
+      - name: init-scripts
+        configMap:
+          name: quay-postgres-init
+      - name: data
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: quay-postgres
+  namespace: quay
+spec:
+  selector:
+    app: quay-postgres
+  ports:
+  - port: 5432
+    targetPort: 5432

--- a/dependencies/quay/quay-config.yaml.tpl
+++ b/dependencies/quay/quay-config.yaml.tpl
@@ -1,0 +1,24 @@
+BUILDLOGS_REDIS:
+    host: quay-redis.quay
+    port: 6379
+CREATE_NAMESPACE_ON_PUSH: true
+DATABASE_SECRET_KEY: ${DATABASE_SECRET_KEY}
+DB_URI: postgresql://quay:${POSTGRES_PASSWORD}@quay-postgres.quay:5432/quay
+DISTRIBUTED_STORAGE_CONFIG:
+    default:
+        - LocalStorage
+        - storage_path: /datastorage/registry
+DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS: []
+DISTRIBUTED_STORAGE_PREFERENCE:
+    - default
+FEATURE_MAILING: false
+FEATURE_USER_INITIALIZE: true
+PREFERRED_URL_SCHEME: https
+SECRET_KEY: ${SECRET_KEY}
+SERVER_HOSTNAME: quay-service.quay
+SETUP_COMPLETE: true
+SUPER_USERS:
+    - quayadmin
+USER_EVENTS_REDIS:
+    host: quay-redis.quay
+    port: 6379

--- a/dependencies/quay/quay.yaml
+++ b/dependencies/quay/quay.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: quay
+  namespace: quay
+  labels:
+    app: quay
+  annotations:
+    ignore-check.kube-linter.io/no-read-only-root-fs: >-
+      Quay writes to system CA trust store paths at startup
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: quay
+  template:
+    metadata:
+      labels:
+        app: quay
+    spec:
+      containers:
+      - name: quay
+        image: quay.io/projectquay/quay
+        securityContext:
+          runAsNonRoot: true
+        resources:
+          requests:
+            cpu: 200m
+            memory: 4Gi
+          limits:
+            cpu: 4000m
+            memory: 8Gi
+        startupProbe:
+          httpGet:
+            path: /health/instance
+            port: 8443
+            scheme: HTTPS
+          periodSeconds: 10
+          failureThreshold: 30
+        readinessProbe:
+          httpGet:
+            path: /health/instance
+            port: 8443
+            scheme: HTTPS
+          periodSeconds: 10
+          failureThreshold: 3
+        ports:
+        - containerPort: 8443
+          name: https
+        - containerPort: 8080
+          name: http
+        volumeMounts:
+        - name: config-stack
+          mountPath: /conf/stack
+          readOnly: true
+        - name: storage
+          mountPath: /datastorage
+      volumes:
+      - name: config-stack
+        projected:
+          sources:
+          - secret:
+              name: quay-config
+              items:
+              - key: config.yaml
+                path: config.yaml
+          - secret:
+              name: quay-tls
+              items:
+              - key: tls.crt
+                path: ssl.cert
+              - key: tls.key
+                path: ssl.key
+      - name: storage
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: quay-service
+  namespace: quay
+spec:
+  type: NodePort
+  selector:
+    app: quay
+  ports:
+  - name: https
+    protocol: TCP
+    nodePort: 30002
+    port: 443
+    targetPort: 8443

--- a/dependencies/quay/redis.yaml
+++ b/dependencies/quay/redis.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: quay-redis
+  namespace: quay
+  labels:
+    app: quay-redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: quay-redis
+  template:
+    metadata:
+      labels:
+        app: quay-redis
+    spec:
+      containers:
+      - name: redis
+        image: quay.io/sclorg/redis-7-c9s
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        resources:
+          requests:
+            cpu: 5m
+            memory: 8Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+        ports:
+        - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: quay-redis
+  namespace: quay
+spec:
+  selector:
+    app: quay-redis
+  ports:
+  - port: 6379
+    targetPort: 6379

--- a/deploy-deps.sh
+++ b/deploy-deps.sh
@@ -87,6 +87,8 @@ deploy() {
     deploy_kyverno
     echo "📋 Deploying Konflux Info..." >&2
     deploy_konflux_info
+    echo "🐳 Deploying Quay..." >&2
+    deploy_quay
 }
 
 test_pvc_binding(){
@@ -201,6 +203,48 @@ deploy_konflux_info() {
         return 0
     fi
     kubectl apply -k "${script_path}/dependencies/konflux-info"
+}
+
+deploy_quay() {
+    : "${SKIP_QUAY:=true}"
+    if [[ "${SKIP_QUAY}" == "true" ]]; then
+        echo "⏭️  Skipping Quay deployment" >&2
+        return 0
+    fi
+    kubectl apply -k "${script_path}/dependencies/quay"
+
+    local POSTGRES_PASSWORD
+    if ! kubectl get secret quay-postgres-creds -n quay &>/dev/null; then
+        echo "🔑 Creating quay-postgres-creds secret" >&2
+        POSTGRES_PASSWORD="$(openssl rand -base64 20 | tr '+/' '-_' | tr -d '\n' | tr -d '=')"
+        kubectl create secret generic quay-postgres-creds \
+            --namespace=quay \
+            --from-literal=password="$POSTGRES_PASSWORD"
+    else
+        POSTGRES_PASSWORD="$(kubectl get secret quay-postgres-creds -n quay \
+            -o jsonpath='{.data.password}' | base64 -d)"
+    fi
+
+    if ! kubectl get secret quay-config -n quay &>/dev/null; then
+        echo "🔑 Creating quay-config secret" >&2
+        local DATABASE_SECRET_KEY SECRET_KEY config
+        DATABASE_SECRET_KEY="$(openssl rand -hex 16)"
+        SECRET_KEY="$(openssl rand -hex 16)"
+        config="$(sed -e "s|\${POSTGRES_PASSWORD}|${POSTGRES_PASSWORD}|g" \
+                      -e "s|\${DATABASE_SECRET_KEY}|${DATABASE_SECRET_KEY}|g" \
+                      -e "s|\${SECRET_KEY}|${SECRET_KEY}|g" \
+                      "${script_path}/dependencies/quay/quay-config.yaml.tpl")"
+        kubectl create secret generic quay-config \
+            --namespace=quay \
+            --from-literal=config.yaml="$config"
+    fi
+
+    retry "kubectl wait --for=condition=Ready --timeout=240s -n quay -l app=quay-postgres pod" \
+          "Quay Postgres did not become available within the allocated time"
+    retry "kubectl wait --for=condition=Ready --timeout=240s -n quay -l app=quay-redis pod" \
+          "Quay Redis did not become available within the allocated time"
+    retry "kubectl wait --for=condition=Ready --timeout=240s -n quay -l app=quay pod" \
+          "Quay did not become available within the allocated time"
 }
 
 retry() {

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -26,3 +26,7 @@ nodes:
   - containerPort: 30001
     hostPort: 5001
     protocol: TCP
+    # Quay
+  - containerPort: 30002
+    hostPort: 8443
+    protocol: TCP


### PR DESCRIPTION
The self-hosted Quay instance will be used in the
release-service-catalog's integration tests, verifying that the pipeline can successfully use self-hosted Quay. The deployment is minimalist, only having resources that are necessary for the basic functions of Quay. Operator was not used because it creates too heavy, production-ready deployment. Despite this, Quay still requires 8GB of memory and 4 CPU cores to run smoothly and not have OOM issues. That's why the deployment is disabled by default and will only run if SKIP_QUAY=false. Cert manager is used to create a certificate that Quay will use as a CA cert. This way, the cert can be trusted through the trusted-ca configmap, and 3rd party tools in the pipeline can interact with the instance.

Assisted-by: Cursor