### PR TITLE
feat(operator): add buildIdentityRegexp to ClusterConfigData

### DIFF
--- a/operator/api/v1alpha1/konfluxinfo_types.go
+++ b/operator/api/v1alpha1/konfluxinfo_types.go
@@ -259,6 +259,11 @@ type ClusterConfigData struct {
 	// TrustifyServerExternalUrl is the external URL for the Trustify server.
 	// +optional
 	TrustifyServerExternalUrl string `json:"trustifyServerExternalUrl,omitempty"`
+
+	// BuildIdentityRegexp is a regex pattern used for matching the identity
+	// that signed artifacts as part of the build pipeline.
+	// +optional
+	BuildIdentityRegexp string `json:"buildIdentityRegexp,omitempty"`
 }
 
 // All is an iterator that yields all non-empty key-value pairs from ClusterConfigData.
@@ -312,6 +317,11 @@ func (d ClusterConfigData) All(yield func(key, value string) bool) {
 	}
 	if d.TrustifyServerExternalUrl != "" {
 		if !yield("trustifyServerExternalUrl", d.TrustifyServerExternalUrl) {
+			return
+		}
+	}
+	if d.BuildIdentityRegexp != "" {
+		if !yield("buildIdentityRegexp", d.BuildIdentityRegexp) {
 			return
 		}
 	}

--- a/operator/api/v1alpha1/konfluxinfo_types_test.go
+++ b/operator/api/v1alpha1/konfluxinfo_types_test.go
@@ -39,11 +39,12 @@ func TestClusterConfigData_All(t *testing.T) {
 			TufExternalUrl:            "https://tuf-external.example.com",
 			TrustifyServerInternalUrl: "https://trustify-internal.example.com",
 			TrustifyServerExternalUrl: "https://trustify-external.example.com",
+			BuildIdentityRegexp:       "^https://konflux\\.dev/build/.*$",
 		}
 
 		collected := maps.Collect(data.All)
 
-		g.Expect(collected).To(gomega.HaveLen(10))
+		g.Expect(collected).To(gomega.HaveLen(11))
 		g.Expect(collected["defaultOIDCIssuer"]).To(gomega.Equal("https://oidc.example.com"))
 		g.Expect(collected["enableKeylessSigning"]).To(gomega.Equal("true"))
 		g.Expect(collected["fulcioInternalUrl"]).To(gomega.Equal("https://fulcio-internal.example.com"))
@@ -54,6 +55,7 @@ func TestClusterConfigData_All(t *testing.T) {
 		g.Expect(collected["tufExternalUrl"]).To(gomega.Equal("https://tuf-external.example.com"))
 		g.Expect(collected["trustifyServerInternalUrl"]).To(gomega.Equal("https://trustify-internal.example.com"))
 		g.Expect(collected["trustifyServerExternalUrl"]).To(gomega.Equal("https://trustify-external.example.com"))
+		g.Expect(collected["buildIdentityRegexp"]).To(gomega.Equal("^https://konflux\\.dev/build/.*$"))
 	})
 
 	t.Run("should not yield empty fields", func(t *testing.T) {
@@ -77,6 +79,7 @@ func TestClusterConfigData_All(t *testing.T) {
 		g.Expect(collected).NotTo(gomega.HaveKey("tufExternalUrl"))
 		g.Expect(collected).NotTo(gomega.HaveKey("trustifyServerInternalUrl"))
 		g.Expect(collected).NotTo(gomega.HaveKey("trustifyServerExternalUrl"))
+		g.Expect(collected).NotTo(gomega.HaveKey("buildIdentityRegexp"))
 	})
 
 	t.Run("should yield nothing for empty struct", func(t *testing.T) {
@@ -103,6 +106,7 @@ func TestClusterConfigData_All(t *testing.T) {
 			TufExternalUrl:            "https://tuf-external.example.com",
 			TrustifyServerInternalUrl: "https://trustify-internal.example.com",
 			TrustifyServerExternalUrl: "https://trustify-external.example.com",
+			BuildIdentityRegexp:       "^https://konflux\\.dev/build/.*$",
 		}
 
 		var yielded []string
@@ -130,6 +134,7 @@ func TestClusterConfigData_All(t *testing.T) {
 			TufExternalUrl:            "tuf-external",
 			TrustifyServerInternalUrl: "trustify-internal",
 			TrustifyServerExternalUrl: "trustify-external",
+			BuildIdentityRegexp:       "^https://konflux\\.dev/build/.*$",
 		}
 
 		var keys []string
@@ -149,6 +154,7 @@ func TestClusterConfigData_All(t *testing.T) {
 			"tufExternalUrl",
 			"trustifyServerInternalUrl",
 			"trustifyServerExternalUrl",
+			"buildIdentityRegexp",
 		}
 
 		g.Expect(keys).To(gomega.Equal(expectedOrder))
@@ -277,6 +283,7 @@ func TestClusterConfigData_MergeOver(t *testing.T) {
 			TufExternalUrl:            "base-tuf-external",
 			TrustifyServerInternalUrl: "base-trustify-internal",
 			TrustifyServerExternalUrl: "base-trustify-external",
+			BuildIdentityRegexp:       "base-build-identity",
 		}
 
 		override := ClusterConfigData{
@@ -290,11 +297,12 @@ func TestClusterConfigData_MergeOver(t *testing.T) {
 			TufExternalUrl:            "override-tuf-external",
 			TrustifyServerInternalUrl: "override-trustify-internal",
 			TrustifyServerExternalUrl: "override-trustify-external",
+			BuildIdentityRegexp:       "override-build-identity",
 		}
 
 		result := override.MergeOver(base)
 
-		g.Expect(result).To(gomega.HaveLen(10))
+		g.Expect(result).To(gomega.HaveLen(11))
 		g.Expect(result["defaultOIDCIssuer"]).To(gomega.Equal("override-oidc"))
 		g.Expect(result["enableKeylessSigning"]).To(gomega.Equal("true"))
 		g.Expect(result["fulcioInternalUrl"]).To(gomega.Equal("override-fulcio-internal"))
@@ -305,6 +313,7 @@ func TestClusterConfigData_MergeOver(t *testing.T) {
 		g.Expect(result["tufExternalUrl"]).To(gomega.Equal("override-tuf-external"))
 		g.Expect(result["trustifyServerInternalUrl"]).To(gomega.Equal("override-trustify-internal"))
 		g.Expect(result["trustifyServerExternalUrl"]).To(gomega.Equal("override-trustify-external"))
+		g.Expect(result["buildIdentityRegexp"]).To(gomega.Equal("override-build-identity"))
 	})
 
 	t.Run("should combine base and override when no conflicts", func(t *testing.T) {

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
@@ -420,6 +420,11 @@ spec:
                               WARNING: Changing field names or JSON tags is a BREAKING CHANGE that will affect
                               all PipelineRuns reading from the ConfigMap. Field names must remain stable.
                             properties:
+                              buildIdentityRegexp:
+                                description: |-
+                                  BuildIdentityRegexp is a regex pattern used for matching the identity
+                                  that signed artifacts as part of the build pipeline.
+                                type: string
                               defaultOIDCIssuer:
                                 description: DefaultOIDCIssuer is the default OIDC
                                   issuer URL.

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxinfoes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxinfoes.yaml
@@ -114,6 +114,11 @@ spec:
                       WARNING: Changing field names or JSON tags is a BREAKING CHANGE that will affect
                       all PipelineRuns reading from the ConfigMap. Field names must remain stable.
                     properties:
+                      buildIdentityRegexp:
+                        description: |-
+                          BuildIdentityRegexp is a regex pattern used for matching the identity
+                          that signed artifacts as part of the build pipeline.
+                        type: string
                       defaultOIDCIssuer:
                         description: DefaultOIDCIssuer is the default OIDC issuer
                           URL.

--- a/operator/internal/controller/info/konfluxinfo_controller.go
+++ b/operator/internal/controller/info/konfluxinfo_controller.go
@@ -96,6 +96,8 @@ const (
 	ClusterConfigKeyTrustifyServerInternalUrl = "trustifyServerInternalUrl"
 	// ClusterConfigKeyTrustifyServerExternalUrl is the ConfigMap key for external Trustify server URL.
 	ClusterConfigKeyTrustifyServerExternalUrl = "trustifyServerExternalUrl"
+	// ClusterConfigKeyBuildIdentityRegexp is the ConfigMap key for the regex pattern matching build pipeline signing identities.
+	ClusterConfigKeyBuildIdentityRegexp = "buildIdentityRegexp"
 )
 
 // ClusterConfigDiscoverer is an interface for discovering cluster configuration values.


### PR DESCRIPTION
Add a new `buildIdentityRegexp` field to ClusterConfigData that holds a regex pattern for matching the identity that signed artifacts as part of the build pipeline. The field is exposed in the cluster-config ConfigMap and follows the same conventions as existing fields.

Assisted-By: Cursor