### PR TITLE
feat: Add slim build pipeline

### DIFF
--- a/operator/pkg/manifests/build-service/manifests.yaml
+++ b/operator/pkg/manifests/build-service/manifests.yaml
@@ -341,18 +341,21 @@ subjects:
 apiVersion: v1
 data:
   config.yaml: |
-    default-pipeline-name: docker-build-oci-ta
+    default-pipeline-name: docker-build-oci-ta-min
     pipelines:
     - name: fbc-builder
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-fbc-builder@sha256:e45f864dfc5e877df3e06e036b654d43b7d4105888cbf3d9978401558dc37550
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-fbc-builder@sha256:b2e9042bbaae277dd798dbd907aac1fcddd70017f0cbb16fa92b66a557a6922f
     - name: docker-build
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build@sha256:250622bf1e66dbce60775a7ac84e340ce893ac8ecf529aeff88f758e087017a3
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build@sha256:b7f8373d8f24756a3ead9be2d0ab17b447c8c85e8208c89c4ec98f5d038e4df3
     - name: docker-build-oci-ta
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta@sha256:a8b9e4af2415ff6cbe0bd2b667ea75d7cbdbdfde5d4464c07f2b7d57a5d1b39c
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta@sha256:6e40e28c5a56e8e6fc9a9409bac4c43d91da9dc808b20437ce25f42c771aa360
     - name: tekton-bundle-builder
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder@sha256:a8ef4284883f0787b532b01cd19cac62bcb11f64e480cd721848683b4cef0f68
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder@sha256:fa6d63446addeb48687c470f5c303ad30c2bfb92712707bc55b7b3a17634398f
     - name: tekton-bundle-builder-oci-ta
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder-oci-ta@sha256:101591c526f1a6abf84c7a00b8397ad601659c14cf12ddd0a38f309ce95f4c7e
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder-oci-ta@sha256:386c79b657d6e90351e96d9e7338c83d9564149d47567ec90802621442e7ba17
+    - name: docker-build-oci-ta-min
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta-min@sha256:3b35c91fb1f69976586f01a859531c0e77651f678023f33a8ac27a6b256f08be
+      description: minimal version of the docker-build-oci-ta pipeline, which requires less compute resources. In addition, it doesn't contain tasks which require user provided secrets.
 kind: ConfigMap
 metadata:
   name: build-pipeline-config

--- a/operator/upstream-kustomizations/build-service/core/build-pipeline-config.yaml
+++ b/operator/upstream-kustomizations/build-service/core/build-pipeline-config.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: build-service
 data:
   config.yaml: |
-    default-pipeline-name: docker-build-oci-ta
+    default-pipeline-name: docker-build-oci-ta-min
     pipelines:
     - name: fbc-builder
       bundle: quay.io/konflux-ci/tekton-catalog/pipeline-fbc-builder@sha256:b2e9042bbaae277dd798dbd907aac1fcddd70017f0cbb16fa92b66a557a6922f
@@ -16,4 +16,7 @@ data:
     - name: tekton-bundle-builder
       bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder@sha256:fa6d63446addeb48687c470f5c303ad30c2bfb92712707bc55b7b3a17634398f
     - name: tekton-bundle-builder-oci-ta
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder-oci-ta@sha256:ef42677c32d3d1d32e065627f23dc7c5995e774a2e198f255a59969fb2133ec0
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder-oci-ta@sha256:386c79b657d6e90351e96d9e7338c83d9564149d47567ec90802621442e7ba17
+    - name: docker-build-oci-ta-min
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta-min@sha256:3b35c91fb1f69976586f01a859531c0e77651f678023f33a8ac27a6b256f08be
+      description: minimal version of the docker-build-oci-ta pipeline, which requires less compute resources. In addition, it doesn't contain tasks which require user provided secrets.

--- a/test/e2e/run-e2e.sh
+++ b/test/e2e/run-e2e.sh
@@ -13,6 +13,14 @@ main() {
     local catalog_revision="${RELEASE_SERVICE_CATALOG_REVISION:?RELEASE_SERVICE_CATALOG_REVISION must be set in vars.sh or env}"
     local release_catalog_ta_quay_token="${RELEASE_CATALOG_TA_QUAY_TOKEN:-}"
 
+    # Use default-pipeline (docker-build-oci-ta-min) bundle from operator manifests so E2E tests run the same pipeline as new onboarded apps.
+    # Override by setting CUSTOM_DOCKER_BUILD_OCI_TA_PIPELINE_BUNDLE_ENV in the environment.
+    local repo_root="${script_path}/../.."
+    local manifests_yaml="${repo_root}/operator/pkg/manifests/build-service/manifests.yaml"
+    if [[ -z "${CUSTOM_DOCKER_BUILD_OCI_TA_PIPELINE_BUNDLE_ENV:-}" && -f "$manifests_yaml" ]]; then
+        CUSTOM_DOCKER_BUILD_OCI_TA_PIPELINE_BUNDLE_ENV=$(yq eval-all 'select(.metadata.name == "build-pipeline-config") | .data["config.yaml"] | from_yaml | .pipelines[] | select(.name == "docker-build-oci-ta-min") | .bundle' "$manifests_yaml")
+    fi
+
     docker run \
         --network=host \
         -v ~/.kube/config:/kube/config \
@@ -24,6 +32,7 @@ main() {
         -e TEST_ENVIRONMENT=upstream \
         -e RELEASE_SERVICE_CATALOG_REVISION="$catalog_revision" \
         -e RELEASE_CATALOG_TA_QUAY_TOKEN="$release_catalog_ta_quay_token" \
+        ${CUSTOM_DOCKER_BUILD_OCI_TA_PIPELINE_BUNDLE_ENV:+ -e CUSTOM_DOCKER_BUILD_OCI_TA_PIPELINE_BUNDLE_ENV="$CUSTOM_DOCKER_BUILD_OCI_TA_PIPELINE_BUNDLE_ENV"} \
         "$E2E_TEST_IMAGE" \
         /bin/bash -c "ginkgo -v --label-filter=upstream-konflux --focus=\"Test local\" /konflux-e2e/konflux-e2e.test"
 }


### PR DESCRIPTION
The slim build pipeline has tasks with reduced resource requests and limits. In addition it doesn't contain tasks which require a secret. Setting this pipeline as the default build pipeline because it's more suitable for upstream.

https://github.com/konflux-ci/build-definitions/pull/3280