### PR TITLE
fix: mintmaker does not track tekton resources

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,13 @@
     }
   ],
   "tekton": {
-    "fileMatch": ["^\\.tekton/.*\\.ya?ml$"]
+    "fileMatch": [".*\\.ya?ml$"],
+    "includePaths": [
+      ".tekton/**",
+      "tasks/**",
+      "pipelines/**"
+    ],
+    "schedule": ["* * * * *"]
   },
   "customManagers": [
     {


### PR DESCRIPTION
We're not getting our tekton pipelines updated with mintmaker (only renovate), so we're missing migrations to new task versions.

Comparing to other repos we maintain, includePaths was missing from current renovate.json. Hopefully, adding it will address the issue.

Assisted-by: Cursor