### PR TITLE
 docs: clarify GitHub App webhook URL configuration for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,8 +369,13 @@ The script will not recreate the patch file if it already exists.
 
    For `Homepage URL` you can insert `https://localhost:9443/` (it doesn't matter).
 
-   For `Webhook URL` insert the smee client's webhook proxy URL from previous steps.
-
+   For `Webhook URL`, insert the **full smee.io URL** from the previous step (e.g., `https://smee.io/XXXXXXXXXXXXXXXX`).
+   
+   > **Important:** 
+   > - Use the **full smee.io URL as-is** - do **NOT** add any path suffix like `/api/webhook`, `/webhook`, etc.
+   > - The webhook URL should look like: `https://smee.io/XXXXXXXXXXXXXXXX` (without trailing paths)
+   > - This is different from using ngrok directly, which would require proper endpoint configuration
+   
    :gear: Per the instructions on the link, generate and download the private key and create a
    secret on the cluster providing the location of the private key, the App ID, and the
    openssl-generated secret created during the process.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -159,6 +159,56 @@ added there. Please refer to
 [this document](https://pipelinesascode.com/docs/install/github_apps/#manual-setup)
 on how to create webhook secret.
 
+# Webhook URL Configuration Issues
+
+If you encounter webhook-related errors when setting up GitHub webhooks, particularly timeouts 
+like "timed out waiting for the condition on pods/trust-manager" or "timed out waiting for 
+the condition on deployments/cert-manager", verify your GitHub App webhook URL configuration.
+
+## Common Webhook URL Mistakes
+
+**❌ INCORRECT:**
+- `https://XCD.ngrok-free.app` ← Missing path or using ngrok directly
+- `https://smee.io/XXXXXXXXXXXXXXXX/api/webhook` ← Adding path suffix 
+- `https://smee.io/XXXXXXXXXXXXXXXX/webhook` ← Adding path suffix
+- `https://localhost:9443` ← Using localhost (webhooks are external)
+
+**✅ CORRECT:**
+- `https://smee.io/XXXXXXXXXXXXXXXX` ← Full URL, no path suffix
+
+## Webhook URL Setup Guide
+
+For local development with Kind, you **must use Smee.io** for webhook forwarding since 
+GitHub cannot reach services inside your cluster:
+
+1. **Create a Smee Channel:**
+   Go to https://smee.io/ and create a new channel. You'll get a URL like:
+   ```
+   https://smee.io/abc123def456xyz789
+   ```
+
+2. **Configure GitHub App Webhook:**
+   In your GitHub App settings, under "Webhook", set:
+   - **Webhook URL:** `https://smee.io/abc123def456xyz789` (use the URL exactly as-is)
+   - **Do NOT** add any path suffix like `/webhook`, `/api/webhook`, `/hook`, etc.
+   - The pipelines-as-code controller handles all webhook processing internally on port 8180
+
+3. **Verify Smee Forwarding:**
+   The Smee client deployed in the cluster will forward webhooks to:
+   ```
+   http://pipelines-as-code-controller.pipelines-as-code.svc.cluster.local:8180
+   ```
+   No additional path configuration is needed.
+
+## Why Ngrok Alone Won't Work
+
+If you try to use ngrok directly without Smee:
+- You'd need to configure the exact endpoint path the pipelines-as-code controller expects
+- Without proper path configuration, webhooks won't be routed correctly
+- This can cause cluster instability as components try to reach non-existent endpoints
+
+Always use **Smee.io as the intermediary** for local Kind cluster webhook forwarding.
+
 # UI Not Accessible (Kind)
 
 If you cannot reach `https://localhost:9443` on a Kind cluster, verify that your Konflux

--- a/scripts/deploy-local.env.template
+++ b/scripts/deploy-local.env.template
@@ -98,7 +98,13 @@ QUAY_ORGANIZATION=""
 # Smee forwards GitHub webhooks to non-publicly-accessible clusters
 # Create a channel at: https://smee.io/
 # If not set, a random channel will be generated automatically
-# See docs for configuring your GitHub App to use this webhook URL
-# This should be the full URL, e.g.:
-# SMEE_CHANNEL="https://smee.io/XXXXXXXXXXXXXXXX"
+#
+# WEBHOOK URL FORMAT (Critical):
+# - Use the FULL smee.io URL as the GitHub App Webhook URL
+# - Do NOT add any path suffix like /api/webhook, /webhook, /hook, etc.
+# - Format: https://smee.io/XXXXXXXXXXXXXXXX (no trailing paths)
+# - This URL is used directly in your GitHub App settings
+#
+# Example:
+# SMEE_CHANNEL="https://smee.io/abc123def456"
 SMEE_CHANNEL=""


### PR DESCRIPTION

Description:
Fixes webhook setup confusion for Kind cluster deployments by clarifying the correct webhook URL format.

## Problem
Users encountered timeout errors and unclear webhook configuration when setting up GitHub App webhooks for local development with Kind clusters.

## Solution
- Clarified that webhook URL should be the full Smee.io URL without path suffixes
- Added examples of incorrect vs correct webhook URL formats
- Explained why Smee.io is required for local Kind clusters
- Added troubleshooting guide for common webhook configuration errors

## Files Changed
- README.md: Enhanced webhook setup instructions
- scripts/deploy-local.env.template: Detailed URL format comments
- docs/troubleshooting.md: New troubleshooting section for webhook issues

## Related Errors Fixed
- "timed out waiting for the condition on pods/trust-manager"
- "timed out waiting for the condition on deployments/cert-manager"
- Webhook configuration failures when using ngrok directly