### PR TITLE
fix: Add wait logic for trust-manager deployment

### DIFF
--- a/deploy-deps.sh
+++ b/deploy-deps.sh
@@ -231,6 +231,20 @@ deploy_openshift_certmanager() {
     retry "kubectl wait --for=condition=Available --timeout=300s deployment -l app.kubernetes.io/instance=cert-manager -n cert-manager" \
           "cert-manager did not become available within the allocated time"
 
+    # Wait for webhook to be fully functional (TLS certificate ready)
+    # This prevents both "no endpoints" and "certificate signed by unknown authority" errors
+    echo "  ⏳ Waiting for cert-manager webhook to be fully ready..." >&2
+    local webhook_timeout=120
+    local webhook_waited=0
+    until kubectl get --raw /apis/cert-manager.io/v1 &>/dev/null; do
+        if [[ $webhook_waited -ge $webhook_timeout ]]; then
+            echo "ERROR: cert-manager webhook not responding after ${webhook_timeout}s" >&2
+            exit 1
+        fi
+        sleep 5
+        webhook_waited=$((webhook_waited + 5))
+    done
+
     echo "  ✅ Red Hat cert-manager Operator is ready!" >&2
 }
 


### PR DESCRIPTION
The cert-manager webhook may need time to obtain its TLS certificate from the CA, which can cause transient validation failures when deploying trust-manager.

Add wait logic to handle this race condition and make the deployment more robust.

Assisted By: Cursor