### PR TITLE
chore: tweak release notes

### DIFF
--- a/.github/scripts/prepare-release-notes.sh
+++ b/.github/scripts/prepare-release-notes.sh
@@ -109,7 +109,7 @@ kubectl apply -f https://github.com/konflux-ci/konflux-ci/releases/download/${VE
 ### Image
 - **Repository**: quay.io/konflux-ci/konflux-operator
 - **Tag**: ${IMAGE_TAG}
-- **Git Ref**: ${GIT_REF}
+- **Git Ref**: [${GIT_REF}](https://github.com/konflux-ci/konflux-ci/tree/${GIT_REF})
 - **Pull command**: \`podman pull quay.io/konflux-ci/konflux-operator:${IMAGE_TAG}\`
 
 ### Artifacts
@@ -117,7 +117,7 @@ kubectl apply -f https://github.com/konflux-ci/konflux-ci/releases/download/${VE
 - samples.tar.gz - Sample Custom Resources
 
 ### Documentation
-- [README.md](https://github.com/konflux-ci/konflux-ci/blob/main/README.md) - Installation and usage instructions
+- [Documentation](https://konflux-ci.dev/konflux-ci/) - Installation and usage instructions
 EOF
 
 # Append changelogs (failures here must never block the release)


### PR DESCRIPTION
Release notes were pointing to the changes in the last commit, which is not very useful. Instead, we should point to browse the repo at that commit.

Also, instead of pointing to the README for documentation, we should point to the website deployed by GitHub Pages, which serves the docs in a more user-friendly way.

Assisted-by: Cursor