### PR TITLE
fix: replace hardcoded user-ns2 with configurable TARGET_NS in generate-err-logs.sh

### DIFF
--- a/generate-err-logs.sh
+++ b/generate-err-logs.sh
@@ -14,6 +14,7 @@ generate_logs() {
     local event_messages_file="$logs_dir/failed-deployment-event-log.log"
     local pipelinerun_res_file="$logs_dir/pipelinerun-res.log"
     local taskrun_res_file="$logs_dir/taskrun-res.log"
+    local target_ns="${TARGET_NS:-user-ns2}"
 
     rm -rf "$logs_dir"
     mkdir -p "$logs_dir"
@@ -128,9 +129,9 @@ generate_logs() {
         docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}" 2>&1 || echo "Failed to list containers"
     } > "$logs_dir/container-resources.log"
 
-echo "logs from all pods from user-ns2 namespace"
-kubectl get pods -n user-ns2 -o name \
-  | xargs -I {} kubectl logs -n user-ns2 --all-containers {}
+    echo "logs from all pods from ${target_ns} namespace"
+    kubectl get pods -n "${target_ns}" -o name \
+      | xargs -I {} kubectl logs -n "${target_ns}" --all-containers {}
 
     # Collect Konflux Operator logs unconditionally (critical for debugging)
     {


### PR DESCRIPTION
Problem

Closes #5827

generate-err-logs.sh had the namespace user-ns2 hardcoded in three places:

echo "logs from all pods from user-ns2 namespace"
kubectl get pods -n user-ns2 -o name \
  | xargs -I {} kubectl logs -n user-ns2 --all-containers {}

This caused silent failures or empty logs when the target namespace differed from user-ns2, with no error output.

---

Solution

Introduce a configurable TARGET_NS environment variable, defaulting to user-ns2, declared alongside other locals in generate_logs():

local target_ns="${TARGET_NS:-user-ns2}"

All three hardcoded references are replaced with ${target_ns}, making the script flexible while remaining backward compatible for callers who don’t set TARGET_NS.

---

Testing
Default behavior: still uses user-ns2
./generate-err-logs.sh

Override namespace
TARGET_NS=my-namespace ./generate-err-logs.sh

