### PR TITLE
Add optional Sigstore integration

### DIFF
--- a/integrations/sigstore/install.sh
+++ b/integrations/sigstore/install.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -euo pipefail
+
+# Deploys the Sigstore stack (Fulcio, Rekor, CT Log, Trillian) using the
+# scaffold Helm chart. If a Konflux CR is present on the cluster, it is
+# patched with the in-cluster Sigstore service URLs.
+#
+# Prerequisites: helm, kubectl
+#
+# Usage:
+#   ./integrations/sigstore/install.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# renovate: datasource=helm registryUrl=https://sigstore.github.io/helm-charts depName=scaffold
+SCAFFOLD_VERSION="0.6.103"
+
+HELM_REPO_NAME="sigstore"
+HELM_REPO_URL="https://sigstore.github.io/helm-charts"
+HELM_RELEASE_NAME="sigstore-scaffold"
+
+# In-cluster service URLs created by the scaffold chart.
+# These match the fullnameOverride / forceNamespace defaults in the scaffold
+# chart values.  If you override those in values.yaml, update these accordingly.
+FULCIO_URL="http://fulcio-server.fulcio-system.svc.cluster.local"
+REKOR_URL="http://rekor-server.rekor-system.svc.cluster.local"
+TUF_URL="http://tuf-server.tuf-system.svc.cluster.local"
+
+for tool in helm kubectl; do
+    if ! command -v "$tool" &> /dev/null; then
+        echo "Error: $tool is required but not installed" >&2
+        exit 1
+    fi
+done
+
+# Detect the cluster's OIDC issuer URL from the API server discovery endpoint.
+# This is used to configure both Fulcio's accepted OIDC issuers and the Konflux CR.
+OIDC_ISSUER="$(kubectl get --raw /.well-known/openid-configuration | grep -o '"issuer":"[^"]*"' | cut -d'"' -f4)"
+if [ -z "${OIDC_ISSUER}" ]; then
+    echo "Warning: could not detect OIDC issuer, falling back to https://kubernetes.default.svc" >&2
+    OIDC_ISSUER="https://kubernetes.default.svc"
+fi
+echo "Detected OIDC issuer: ${OIDC_ISSUER}" >&2
+
+echo "🔏 Deploying Sigstore (scaffold v${SCAFFOLD_VERSION})..." >&2
+helm repo add "${HELM_REPO_NAME}" "${HELM_REPO_URL}" --force-update
+
+helm upgrade --install "${HELM_RELEASE_NAME}" "${HELM_REPO_NAME}/scaffold" \
+    --namespace sigstore-system --create-namespace \
+    --version "${SCAFFOLD_VERSION}" \
+    --values "${SCRIPT_DIR}/values.yaml" \
+    --set-json "fulcio.config.contents.OIDCIssuers={\"${OIDC_ISSUER}\":{\"IssuerURL\":\"${OIDC_ISSUER}\",\"ClientID\":\"sigstore\",\"Type\":\"kubernetes\"}}" \
+    --wait \
+    --timeout 15m
+
+echo "✅ Sigstore deployed successfully" >&2
+
+# Patch the Konflux CR with Sigstore service URLs (best-effort)
+if kubectl get crd konfluxes.konflux.konflux-ci.dev &>/dev/null && \
+   kubectl get konflux konflux &>/dev/null; then
+    echo "🔧 Patching Konflux CR with Sigstore service URLs..." >&2
+    kubectl patch konflux konflux --type=merge -p "
+spec:
+  info:
+    spec:
+      clusterConfig:
+        data:
+          fulcioInternalUrl: ${FULCIO_URL}
+          fulcioExternalUrl: ${FULCIO_URL}
+          rekorInternalUrl: ${REKOR_URL}
+          rekorExternalUrl: ${REKOR_URL}
+          tufInternalUrl: ${TUF_URL}
+          tufExternalUrl: ${TUF_URL}
+          defaultOIDCIssuer: ${OIDC_ISSUER}
+          buildIdentityRegexp: "^build-pipeline-[a-z0-9-]+$"
+"
+    echo "✅ Konflux CR patched with Sigstore URLs" >&2
+else
+    echo "ℹ️  Konflux CR not found, skipping CR patch" >&2
+fi

--- a/integrations/sigstore/values.yaml
+++ b/integrations/sigstore/values.yaml
@@ -1,0 +1,139 @@
+# Sigstore scaffold Helm chart values
+# Minimal resource configuration for local/dev deployment
+# Fulcio is configured with the Kubernetes service account issuer (chart default)
+
+# -- Fulcio: certificate authority for code signing
+fulcio:
+  config:
+    contents:
+      OIDCIssuers:
+        https://kubernetes.default.svc:
+          IssuerURL: https://kubernetes.default.svc
+          ClientID: sigstore
+          Type: kubernetes
+  server:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 256Mi
+  createcerts:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+
+# -- CT Log: certificate transparency log
+ctlog:
+  createctconfig:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  createtree:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+
+# -- Rekor: transparency log for supply chain metadata
+rekor:
+  server:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 256Mi
+    initContainerResources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  redis:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  createtree:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+
+# -- TUF: root of trust distribution (needed by cosign)
+tuf:
+  enabled: true
+
+# -- TSA: timestamp authority (required for TUF secret projection)
+tsa:
+  enabled: true
+  server:
+    args:
+      signer: memory
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 256Mi
+
+# -- Secret copying: copies component secrets into tuf-system namespace
+copySecretJob:
+  enabled: true
+
+# -- Trillian: merkle tree backend
+trillian:
+  logServer:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 256Mi
+  logSigner:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 256Mi
+  mysql:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+  createdb:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi

--- a/integrations/sigstore/verify.sh
+++ b/integrations/sigstore/verify.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+set -euo pipefail
+
+# Verifies an OCI image built by Konflux:
+#   1. Image signature  (cosign verify)
+#   2. SBOM attestation (cosign verify-attestation --type spdxjson)
+#
+# Because the Sigstore services are not exposed via ingress, this script
+# sets up kubectl port-forwards to Rekor and TUF before running cosign.
+#
+# Prerequisites: cosign, kubectl, curl
+#
+# Usage:
+#   ./integrations/sigstore/verify.sh <image-reference>
+#
+# Example:
+#   INSECURE_REGISTRY=true ./integrations/sigstore/verify.sh \
+#       localhost:5001/test-component:on-pr-abc123
+#
+# Environment variables (optional):
+#   CERTIFICATE_IDENTITY_REGEXP  - signing identity regexp (default: .*)
+#   CERTIFICATE_OIDC_ISSUER      - OIDC issuer (default: auto-detected)
+#   REKOR_PORT  - local port for Rekor  (default: 30800)
+#   TUF_PORT    - local port for TUF    (default: 30801)
+#   INSECURE_REGISTRY - "true" for insecure registries (default: false)
+
+IMAGE_REF="${1:-}"
+if [ -z "${IMAGE_REF}" ]; then
+    echo "Usage: $0 <image-reference>" >&2
+    exit 1
+fi
+
+for tool in cosign kubectl curl; do
+    if ! command -v "$tool" &>/dev/null; then
+        echo "Error: $tool is required but not installed" >&2
+        exit 1
+    fi
+done
+
+# ---------- configuration ----------
+
+REKOR_PORT="${REKOR_PORT:-30800}"
+TUF_PORT="${TUF_PORT:-30801}"
+REKOR_LOCAL_URL="http://localhost:${REKOR_PORT}"
+TUF_LOCAL_URL="http://localhost:${TUF_PORT}"
+INSECURE_REGISTRY="${INSECURE_REGISTRY:-false}"
+
+if [ -z "${CERTIFICATE_OIDC_ISSUER:-}" ]; then
+    CERTIFICATE_OIDC_ISSUER="$(kubectl get --raw /.well-known/openid-configuration 2>/dev/null \
+        | grep -o '"issuer":"[^"]*"' | cut -d'"' -f4 || true)"
+    if [ -z "${CERTIFICATE_OIDC_ISSUER}" ]; then
+        CERTIFICATE_OIDC_ISSUER="https://kubernetes.default.svc"
+    fi
+    echo "Auto-detected OIDC issuer: ${CERTIFICATE_OIDC_ISSUER}" >&2
+fi
+CERTIFICATE_IDENTITY_REGEXP="${CERTIFICATE_IDENTITY_REGEXP:-.*}"
+
+# ---------- port-forwards ----------
+
+PORT_FORWARD_PIDS=()
+cleanup() {
+    for pid in "${PORT_FORWARD_PIDS[@]}"; do
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    done
+}
+trap cleanup EXIT
+
+wait_for_port() {
+    local port="$1" name="$2"
+    echo "Waiting for ${name} on localhost:${port}..." >&2
+    for ((i = 1; i <= 30; i++)); do
+        if curl -s -f -o /dev/null "http://localhost:${port}/" 2>/dev/null; then
+            echo "${name} is ready" >&2
+            return 0
+        fi
+        sleep 1
+    done
+    echo "Error: ${name} did not become ready on localhost:${port}" >&2
+    return 1
+}
+
+echo "🔌 Setting up port-forwards to Sigstore services..." >&2
+kubectl port-forward -n rekor-system svc/rekor-server "${REKOR_PORT}:80" &>/dev/null &
+PORT_FORWARD_PIDS+=($!)
+kubectl port-forward -n tuf-system svc/tuf-server "${TUF_PORT}:80" &>/dev/null &
+PORT_FORWARD_PIDS+=($!)
+
+wait_for_port "${REKOR_PORT}" "Rekor"
+wait_for_port "${TUF_PORT}"   "TUF"
+
+# ---------- TUF init ----------
+
+TUF_ROOT="$(mktemp -d)"
+export TUF_ROOT
+echo "📦 Initializing cosign TUF root..." >&2
+cosign initialize --mirror="${TUF_LOCAL_URL}" --root="${TUF_LOCAL_URL}/root.json"
+
+# ---------- common args ----------
+
+COMMON_ARGS=(
+    --rekor-url="${REKOR_LOCAL_URL}"
+    --certificate-identity-regexp="${CERTIFICATE_IDENTITY_REGEXP}"
+    --certificate-oidc-issuer="${CERTIFICATE_OIDC_ISSUER}"
+)
+if [ "${INSECURE_REGISTRY}" = "true" ]; then
+    COMMON_ARGS+=(--allow-insecure-registry)
+fi
+
+# ---------- 1. verify image signature ----------
+
+echo "" >&2
+echo "🔍 [1/2] Verifying image signature: ${IMAGE_REF}" >&2
+if cosign verify "${COMMON_ARGS[@]}" "${IMAGE_REF}" > /dev/null; then
+    echo "✅ Image signature OK" >&2
+else
+    echo "❌ Image signature verification FAILED" >&2
+    exit 1
+fi
+
+# ---------- 2. verify SBOM attestation ----------
+
+echo "" >&2
+echo "🔍 [2/2] Verifying SBOM attestation: ${IMAGE_REF}" >&2
+if cosign verify-attestation --type=spdxjson "${COMMON_ARGS[@]}" "${IMAGE_REF}" > /dev/null; then
+    echo "✅ SBOM attestation OK" >&2
+else
+    echo "❌ SBOM attestation verification FAILED" >&2
+    exit 1
+fi
+
+echo "" >&2
+echo "✅ All verifications passed for ${IMAGE_REF}" >&2

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -14,6 +14,11 @@ nodes:
     kind: KubeletConfiguration
     serializeImagePulls: false
     maxParallelImagePulls: 10
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        service-account-issuer: https://kubernetes.default.svc
   extraPortMappings:
   - containerPort: 30010
     hostPort: 8888

--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,18 @@
       "matchDatasources": ["helm"],
       "matchPackageNames": ["cert-manager", "trust-manager"],
       "registryUrls": ["https://charts.jetstack.io"]
+    },
+    {
+      "description": "Use Sigstore Helm repo for scaffold chart",
+      "matchDatasources": ["helm"],
+      "matchPackageNames": ["scaffold"],
+      "registryUrls": ["https://sigstore.github.io/helm-charts"]
+    },
+    {
+      "description": "Sigstore scaffold chart is an optional integration",
+      "matchDatasources": ["helm"],
+      "matchPackageNames": ["scaffold"],
+      "additionalBranchPrefix": "integrations/"
     }
   ],
   "tekton": {
@@ -247,6 +259,16 @@
       "datasourceTemplate": "helm",
       "depNameTemplate": "trust-manager",
       "extractVersionTemplate": "^v?(?<version>.*)$"
+    },
+    {
+      "description": "Track sigstore scaffold Helm chart version in install script",
+      "customType": "regex",
+      "fileMatch": ["integrations/sigstore/install\\.sh$"],
+      "matchStrings": [
+        "# renovate: datasource=helm registryUrl=https://sigstore\\.github\\.io/helm-charts depName=scaffold\\nSCAFFOLD_VERSION=\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "helm",
+      "depNameTemplate": "scaffold"
     }
   ]
 }


### PR DESCRIPTION
Introduce integrations/sigstore/ with a self-contained install script that deploys the Sigstore stack (Fulcio, Rekor, CT Log, TUF, Trillian) using the scaffold Helm chart.

The script:
- Uses helm upgrade --install with a pinned chart version
- Applies minimal resource limits via a values.yaml
- Configures Fulcio with the Kubernetes service account issuer
- Enables TUF for root-of-trust distribution
- Patches the Konflux CR with in-cluster service URLs when present

Renovate is configured to track the scaffold chart version in install.sh and open PRs when new versions are released.

Sigstore is not a core dependency — it requires only helm and kubectl and is deployed independently of deploy-deps.sh.

In addition, add a script for verifying the signature of and image and its SBOM.

Assisted-By: Cursor