### PR TITLE
fix: manually backport all scripts to release-0.0

### DIFF
--- a/.github/scripts/changelog-lib.sh
+++ b/.github/scripts/changelog-lib.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Shared changelog library
+# Provides common functions for filtering and formatting conventional commits
+# from the GitHub Compare API.
+#
+# Sourced by: generate-changelog.sh, prepare-release-notes.sh
+#
+# Functions:
+#   changelog_filter_commits  - jq filter: GitHub Compare API JSON → feat/fix commit messages
+#   changelog_strip_prefix    - sed pipe: remove conventional commit type prefix
+#   changelog_qualify_refs    - sed pipe: replace bare (#NNN) with (owner/repo#NNN) for GitHub linking
+#   changelog_format_grouped  - stdin commit messages → grouped #### Features / #### Bug Fixes markdown
+
+# Bot authors to exclude from changelog
+CHANGELOG_BOT_AUTHORS='["dependabot[bot]", "renovate[bot]", "github-actions[bot]", "konflux-internal-p02[bot]", "red-hat-konflux[bot]"]'
+
+# changelog_filter_commits filters GitHub Compare API JSON on stdin to conventional
+# commit messages. Keeps only feat/fix commits, excludes bot authors, outputs the
+# first line of each matching commit message.
+changelog_filter_commits() {
+  jq -r --argjson bots "$CHANGELOG_BOT_AUTHORS" '
+    .commits[]
+    | select(
+        ((.author.login // "") as $login |
+          ($bots | map(. == $login) | any | not))
+        and
+        (.commit.message | split("\n")[0] | test("^(feat|fix)(\\(.*\\))?!?:"))
+      )
+    | .commit.message | split("\n")[0]
+  '
+}
+
+# changelog_strip_prefix removes the conventional commit type prefix from a message,
+# returning just the description as a markdown list item.
+# "feat(scope): add X"  → "- add X"
+# "fix: broken Y"       → "- broken Y"
+# "feat!: breaking Z"   → "- breaking Z"
+changelog_strip_prefix() {
+  sed 's/^[a-z]*([^)]*)\!*:[[:space:]]*/- /; s/^[a-z]*\!*:[[:space:]]*/- /'
+}
+
+# changelog_qualify_refs replaces bare PR references (#NNN) with qualified
+# references (owner/repo#NNN) so GitHub auto-links to the correct repository.
+# Reads commit messages from stdin, writes qualified messages to stdout.
+# Args: $1=github_repo (e.g., "konflux-ci/build-service")
+changelog_qualify_refs() {
+  local repo="$1"
+  sed "s|(#\([0-9]\{1,\}\))|(${repo}#\1)|g"
+}
+
+# changelog_format_grouped reads conventional commit messages from stdin,
+# splits them by type (feat/fix), and outputs grouped markdown sub-sections.
+# Returns 0 if stdin is empty (no commits is a valid state, not an error).
+changelog_format_grouped() {
+  local commits
+  commits=$(cat)
+
+  if [ -z "$commits" ]; then
+    return 0
+  fi
+
+  local feat_commits fix_commits
+  feat_commits=$(echo "$commits" | grep -E '^feat(\(.*\))?!?:' || true)
+  fix_commits=$(echo "$commits" | grep -E '^fix(\(.*\))?!?:' || true)
+
+  if [ -n "$feat_commits" ]; then
+    echo "#### Features"
+    echo "$feat_commits" | changelog_strip_prefix
+    echo ""
+  fi
+  if [ -n "$fix_commits" ]; then
+    echo "#### Bug Fixes"
+    echo "$fix_commits" | changelog_strip_prefix
+    echo ""
+  fi
+}

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
+# shellcheck source-path=SCRIPTDIR
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091 source=changelog-lib.sh
+source "${SCRIPT_DIR}/changelog-lib.sh"
 
 # Generate Changelog Script
 # Generates a markdown changelog from upstream conventional commits between two operator tags.
@@ -74,9 +79,6 @@ declare -A COMPONENT_CONFIG=(
   ["release-service"]="operator/upstream-kustomizations/release/core/kustomization.yaml|konflux-ci/release-service|konflux-ci/release-service|Release Service|ref"
   ["ui"]="operator/upstream-kustomizations/ui/core/proxy/kustomization.yaml|quay.io/konflux-ci/konflux-ui|konflux-ci/konflux-ui|UI|digest"
 )
-
-# Bot authors to exclude from changelog
-BOT_AUTHORS='["dependabot[bot]", "renovate[bot]", "github-actions[bot]", "konflux-internal-p02[bot]", "red-hat-konflux[bot]"]'
 
 # Determine which components to process.
 # Sort keys for deterministic output order (bash associative arrays are unordered).
@@ -157,14 +159,6 @@ extract_sha_from_ref_url() {
     | head -n 1 || true
 }
 
-# strip_commit_prefix removes the conventional commit type prefix from a message,
-# returning just the description as a markdown list item.
-# "feat(scope): add X" -> "- add X"
-# "fix: broken Y"      -> "- broken Y"
-strip_commit_prefix() {
-  sed 's/^[a-z]*([^)]*):[[:space:]]*/- /; s/^[a-z]*:[[:space:]]*/- /'
-}
-
 # generate_component_changelog generates the changelog section for a single component.
 # Args: $1=component_name
 # Returns: 0 if changes were found, 1 otherwise
@@ -229,8 +223,12 @@ generate_component_changelog() {
   echo "  Comparing ${old_sha:0:12}..${new_sha:0:12}" >&2
 
   # Query GitHub API for commits between the two SHAs
+  local encoded_old encoded_new
+  encoded_old=$(printf '%s' "$old_sha" | jq -sRr @uri)
+  encoded_new=$(printf '%s' "$new_sha" | jq -sRr @uri)
+
   local api_response
-  api_response=$(gh api "repos/${github_repo}/compare/${old_sha}...${new_sha}" \
+  api_response=$(gh api "repos/${github_repo}/compare/${encoded_old}...${encoded_new}" \
     --header "Accept: application/vnd.github+json" 2>/dev/null) || {
     echo "  Warning: GitHub API call failed for ${github_repo}" >&2
     return 1
@@ -246,19 +244,13 @@ generate_component_changelog() {
 
   # Filter commits: keep feat/fix, exclude bots
   local filtered_commits
-  filtered_commits=$(echo "$api_response" | jq -r --argjson bots "$BOT_AUTHORS" '
-    .commits[]
-    | select(
-        ((.author.login // "") as $login |
-          ($bots | map(. == $login) | any | not))
-        and
-        (.commit.message | split("\n")[0] | test("^(feat|fix)(\\(.*\\))?:"))
-      )
-    | .commit.message | split("\n")[0]
-  ' 2>/dev/null) || {
+  filtered_commits=$(echo "$api_response" | changelog_filter_commits 2>/dev/null) || {
     echo "  Warning: Failed to filter commits for ${github_repo}" >&2
     return 1
   }
+
+  # Qualify PR references: (#NNN) → (owner/repo#NNN) for correct GitHub auto-linking
+  filtered_commits=$(echo "$filtered_commits" | changelog_qualify_refs "$github_repo")
 
   if [ -z "$filtered_commits" ]; then
     # Fallback: show commit count and compare URL for repos without conventional commits
@@ -274,22 +266,9 @@ generate_component_changelog() {
   fi
 
   # Split commits by type and output grouped markdown sections
-  local feat_commits fix_commits
-  feat_commits=$(echo "$filtered_commits" | grep -E '^feat(\(.*\))?:' || true)
-  fix_commits=$(echo "$filtered_commits" | grep -E '^fix(\(.*\))?:' || true)
-
   echo "### ${display_name}"
   echo ""
-  if [ -n "$feat_commits" ]; then
-    echo "#### Features"
-    echo "$feat_commits" | strip_commit_prefix
-    echo ""
-  fi
-  if [ -n "$fix_commits" ]; then
-    echo "#### Bug Fixes"
-    echo "$fix_commits" | strip_commit_prefix
-    echo ""
-  fi
+  echo "$filtered_commits" | changelog_format_grouped
 
   local count
   count=$(echo "$filtered_commits" | wc -l | tr -d ' ')

--- a/.github/scripts/generate-release-artifacts.sh
+++ b/.github/scripts/generate-release-artifacts.sh
@@ -77,12 +77,20 @@ echo "✅ Generated OLM bundle at: $(pwd)/bundle"
 
 # Generate release-config.yaml (for OLM catalog configuration)
 # https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_autorelease/
+# For SemVer: allowed channels are Fast, Stable, Candidate. Use Candidate for RC versions.
 echo "Generating release-config.yaml..."
-cat > release-config.yaml << 'EOF'
+if [[ "${VERSION_WITH_V}" == *"rc"* ]]; then
+  RELEASE_CHANNEL="Candidate"
+  echo "Version contains 'rc'; using catalog channel: ${RELEASE_CHANNEL}"
+else
+  RELEASE_CHANNEL="Stable"
+  echo "Using catalog channel: ${RELEASE_CHANNEL}"
+fi
+cat > release-config.yaml << EOF
 ---
 catalog_templates:
   - template_name: semver.yaml
-    channels: [Stable]
+    channels: [${RELEASE_CHANNEL}]
 EOF
 echo "✅ Generated release-config.yaml"
 cat release-config.yaml

--- a/.github/scripts/prepare-release-notes.sh
+++ b/.github/scripts/prepare-release-notes.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck source-path=SCRIPTDIR
 set -euo pipefail
 
 # Prepare Release Notes Script
@@ -29,6 +30,47 @@ GIT_REF="$3"
 OUTPUT_FILE="$4"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091 source=changelog-lib.sh
+source "${SCRIPT_DIR}/changelog-lib.sh"
+
+# generate_operator_changelog generates a curated "## Changes" section from
+# conventional commits in the operator repo between two refs.
+# Args: $1=base_ref, $2=head_ref
+# Output: Markdown to stdout (empty if no conventional commits found)
+generate_operator_changelog() {
+  local base_ref="$1"
+  local head_ref="$2"
+
+  local encoded_base encoded_head
+  encoded_base=$(printf '%s' "$base_ref" | jq -sRr @uri)
+  encoded_head=$(printf '%s' "$head_ref" | jq -sRr @uri)
+
+  local api_response
+  api_response=$(gh api "repos/konflux-ci/konflux-ci/compare/${encoded_base}...${encoded_head}" \
+    --header "Accept: application/vnd.github+json" 2>/dev/null) || {
+    echo "  Warning: GitHub API call failed for operator changelog" >&2
+    return 1
+  }
+
+  local filtered_commits
+  filtered_commits=$(echo "$api_response" | changelog_filter_commits 2>/dev/null) || {
+    echo "  Warning: Failed to filter operator commits" >&2
+    return 1
+  }
+
+  if [ -z "$filtered_commits" ]; then
+    echo "  No conventional commits found in operator repo" >&2
+    return 0
+  fi
+
+  echo "## Changes"
+  echo ""
+  echo "$filtered_commits" | changelog_format_grouped
+
+  local count
+  count=$(echo "$filtered_commits" | wc -l | tr -d ' ')
+  echo "  Found ${count} operator conventional commit(s)" >&2
+}
 
 # get_comparison_base finds the commit to compare against for changelog generation.
 # First finds the highest previous stable release tag (semantic version sort,
@@ -67,7 +109,7 @@ kubectl apply -f https://github.com/konflux-ci/konflux-ci/releases/download/${VE
 ### Image
 - **Repository**: quay.io/konflux-ci/konflux-operator
 - **Tag**: ${IMAGE_TAG}
-- **Git Ref**: ${GIT_REF}
+- **Git Ref**: [${GIT_REF}](https://github.com/konflux-ci/konflux-ci/tree/${GIT_REF})
 - **Pull command**: \`podman pull quay.io/konflux-ci/konflux-operator:${IMAGE_TAG}\`
 
 ### Artifacts
@@ -75,19 +117,27 @@ kubectl apply -f https://github.com/konflux-ci/konflux-ci/releases/download/${VE
 - samples.tar.gz - Sample Custom Resources
 
 ### Documentation
-- [README.md](https://github.com/konflux-ci/konflux-ci/blob/main/README.md) - Installation and usage instructions
+- [Documentation](https://konflux-ci.dev/konflux-ci/) - Installation and usage instructions
 EOF
 
-# Append upstream changelog (failures here must never block the release)
+# Append changelogs (failures here must never block the release)
 COMPARISON_BASE=$(get_comparison_base)
 if [ -n "$COMPARISON_BASE" ]; then
+  # Operator changelog: curated feat/fix commits from this repo
+  echo "Generating operator changelog: ${COMPARISON_BASE} -> ${GIT_REF}" >&2
+  operator_changelog=$(generate_operator_changelog "$COMPARISON_BASE" "$GIT_REF") || true
+  if [ -n "$operator_changelog" ]; then
+    printf '\n%s\n' "$operator_changelog" >> "${OUTPUT_FILE}"
+  fi
+
+  # Upstream changelog: curated feat/fix commits from upstream component repos
   echo "Generating upstream changelog: ${COMPARISON_BASE} -> ${GIT_REF}" >&2
   changelog=$("${SCRIPT_DIR}/generate-changelog.sh" "$COMPARISON_BASE" "$GIT_REF") || true
   if [ -n "$changelog" ]; then
     printf '\n%s\n' "$changelog" >> "${OUTPUT_FILE}"
   fi
 else
-  echo "No comparison base found, skipping upstream changelog" >&2
+  echo "No comparison base found, skipping changelogs" >&2
 fi
 
 echo "Release notes generated at: ${OUTPUT_FILE}" >&2

--- a/.github/scripts/verify-releases.sh
+++ b/.github/scripts/verify-releases.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #   2. Find the latest tag for this stream (vX.Y.Z or vX.Y.Z-rc.W).
 #   3. Verify every stable tag (vX.Y.Z) for this stream created in the past 7 days
 #      has a corresponding GitHub release.
-#   4. If the latest tag is an RC, verify it also has a GitHub release.
+#   4. If the latest tag is an RC and its stable counterpart is not yet tagged, verify it has a GitHub release.
 #
 # Usage:
 #   verify-releases.sh <repository> <branch>
@@ -61,7 +61,9 @@ set_output "verification_failed" "false"
 STABLE_PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+$'
 VERSION_PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'
 
-# Determine stream: from branch name for release-x.y, from latest tag for main
+# Determine the version stream (X.Y) to scope all tag lookups.
+# For release-x.y branches the stream is encoded in the branch name.
+# For main we derive it from the highest version tag reachable from HEAD.
 if [[ "$BRANCH" =~ ^release-([0-9]+\.[0-9]+)$ ]]; then
   STREAM="${BASH_REMATCH[1]}"
   echo "Stream from branch name: $STREAM"
@@ -82,9 +84,17 @@ fi
 
 TAG_PREFIX="v${STREAM}."
 
-# Latest tag for this stream reachable from HEAD
-LATEST=$(git tag --merged=HEAD 2>/dev/null \
-  | grep -E "$VERSION_PATTERN" | grep -F "${TAG_PREFIX}" | sort -V | tail -1 || true)
+# All version tags for this stream reachable from HEAD.
+# Captured once and reused for both LATEST and the Check 2 stable-counterpart lookup,
+# so both checks share the same --merged=HEAD reachability scope.
+STREAM_TAGS=$(git tag --merged=HEAD 2>/dev/null \
+  | grep -E "$VERSION_PATTERN" | grep -F "${TAG_PREFIX}" || true)
+
+# Latest tag for this stream.
+# Note: sort -V ranks RC suffixes after the bare version (v0.0.12 < v0.0.12-rc.0).
+# When both an RC and its stable counterpart exist for the same version (e.g. v0.0.12
+# and v0.0.12-rc.0), LATEST will be the RC tag.
+LATEST=$(echo "$STREAM_TAGS" | sort -V | tail -1 || true)
 
 if [ -z "$LATEST" ]; then
   echo "Error: No version tags for stream ${STREAM} reachable from HEAD."
@@ -93,12 +103,15 @@ fi
 
 echo "Latest tag for stream ${STREAM}: $LATEST"
 
+# Limit Check 1 to tags created within the past 7 days to avoid re-checking
+# historical releases on every run.
 START_TIMESTAMP=$(date -u --date='7 days ago' +%s)
 echo "Verification window: past 7 days (since $(date -u --date="@$START_TIMESTAMP" +%Y-%m-%dT%H:%M:%SZ))"
 
 FAILURE_REASONS=""
 
-# Check 1: stable tags for this stream in the verification window must have a release
+# Check 1: every stable tag for this stream created in the verification window
+# must have a corresponding GitHub release.
 echo ""
 echo "=== Checking stable tags for stream ${STREAM} in verification period ==="
 TAGS_WITHOUT_RELEASE=""
@@ -107,8 +120,11 @@ while IFS= read -r line; do
   [ -z "$line" ] && continue
   tag="${line%% *}"
   cdate="${line##* }"
+  # Skip tags outside the 7-day window.
   [ "$cdate" -lt "$START_TIMESTAMP" ] 2>/dev/null && continue
+  # Skip RC tags — only stable releases are checked here.
   [[ ! "$tag" =~ $STABLE_PATTERN ]] && continue
+  # Skip tags that belong to a different stream.
   [[ "$tag" != "${TAG_PREFIX}"* ]] && continue
   STABLE_CHECKED=$((STABLE_CHECKED + 1))
   echo "  Checking stable tag: $tag"
@@ -129,17 +145,30 @@ if [ -n "$TAGS_WITHOUT_RELEASE" ]; then
 ${TAGS_WITHOUT_RELEASE}"
 fi
 
-# Check 2: if latest tag is an RC, it must have a release
+# Check 2: if the latest tag is an RC, verify its stable counterpart has been tagged.
+# - If the stable counterpart exists and is reachable from HEAD (e.g. v0.0.12 for
+#   v0.0.12-rc.0), the RC was promoted and Check 1 already covers the stable release — skip.
+# - If the stable counterpart is absent or not reachable from HEAD, the RC is still
+#   active and must have a GitHub prerelease.
 if [[ ! "$LATEST" =~ $STABLE_PATTERN ]]; then
-  echo ""
-  echo "=== Latest tag is RC: checking for release ==="
-  echo "  Checking RC tag: $LATEST"
-  if ! gh release view "$LATEST" --repo "$REPOSITORY" >/dev/null 2>&1; then
-    [ -n "$FAILURE_REASONS" ] && FAILURE_REASONS="${FAILURE_REASONS}"$'\n\n'
-    FAILURE_REASONS="${FAILURE_REASONS}Latest RC tag ${LATEST} has no GitHub release."
-    echo "    ❌ No GitHub release found"
+  # Strip the -rc.N suffix to get the stable version this RC targets.
+  STABLE_FOR_RC="${LATEST%-rc.*}"
+  # Use STREAM_TAGS (already scoped to --merged=HEAD) so we only treat the RC as
+  # promoted when the stable tag is reachable from the current branch HEAD.
+  if echo "$STREAM_TAGS" | grep -qxF "$STABLE_FOR_RC"; then
+    echo ""
+    echo "=== Latest RC ${LATEST} already promoted to stable (${STABLE_FOR_RC}) — skipping RC check ==="
   else
-    echo "    ✅ GitHub release exists"
+    echo ""
+    echo "=== Latest tag is RC: checking for prerelease ==="
+    echo "  Checking RC tag: $LATEST"
+    if ! gh release view "$LATEST" --repo "$REPOSITORY" >/dev/null 2>&1; then
+      [ -n "$FAILURE_REASONS" ] && FAILURE_REASONS="${FAILURE_REASONS}"$'\n\n'
+      FAILURE_REASONS="${FAILURE_REASONS}Latest RC tag ${LATEST} has no GitHub release."
+      echo "    ❌ No GitHub release found"
+    else
+      echo "    ✅ GitHub release exists"
+    fi
   fi
 fi
 


### PR DESCRIPTION
Some of the workflows triggered for release branches use the scripts in the release branch. We need the scripts there as well.