### PR TITLE
feat(operator): reconcile Segment config secret for konflux-ui

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -332,10 +332,11 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&ui.KonfluxUIReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		ObjectStore: objectStore,
-		ClusterInfo: clusterInfo,
+		Client:               mgr.GetClient(),
+		Scheme:               mgr.GetScheme(),
+		ObjectStore:          objectStore,
+		ClusterInfo:          clusterInfo,
+		GetDefaultSegmentKey: segment.GetDefaultWriteKey,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KonfluxUI")
 		os.Exit(1)

--- a/operator/internal/controller/segmentbridge/konfluxsegmentbridge_controller.go
+++ b/operator/internal/controller/segmentbridge/konfluxsegmentbridge_controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/predicate"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/segment"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
 )
 
@@ -159,18 +160,10 @@ func (r *KonfluxSegmentBridgeReconciler) applyManifests(ctx context.Context, tc 
 func (r *KonfluxSegmentBridgeReconciler) reconcileSegmentBridgeSecret(ctx context.Context, tc *tracking.Client, spec *konfluxv1alpha1.KonfluxSegmentBridgeSpec) error {
 	log := logf.FromContext(ctx)
 
-	segmentKey := spec.GetSegmentKey()
-	keySource := "cr"
-	if segmentKey == "" {
-		segmentKey = r.GetDefaultSegmentKey()
-		keySource = "build-time-default"
-	}
-	if segmentKey == "" {
-		log.Info("No Segment write key configured (neither CR nor build-time default); skipping Secret creation")
+	segmentKey, source := segment.ResolveWriteKey(spec.GetSegmentKey(), r.GetDefaultSegmentKey())
+	if !segment.LogWriteKeyResolution(log, segmentKey, source) {
 		return nil
 	}
-
-	log.Info("Resolved Segment write key", "source", keySource)
 
 	batchURL, err := url.JoinPath(spec.GetSegmentAPIURL(), "batch")
 	if err != nil {

--- a/operator/internal/controller/ui/konfluxui_controller.go
+++ b/operator/internal/controller/ui/konfluxui_controller.go
@@ -35,20 +35,24 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/segmentbridge"
 	"github.com/konflux-ci/konflux-ci/operator/internal/predicate"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/consolelink"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/customization"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/dex"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/hashedconfigmap"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/hashedsecret"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/ingress"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/oauth2proxy"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/segment"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
 )
 
@@ -79,6 +83,12 @@ const (
 	dexConfigKey           = "config.yaml"
 	dexConfigMapLabel      = "app.kubernetes.io/managed-by-konflux-ui-reconciler"
 	dexConfigMapVolumeName = "dex"
+
+	// Segment Secret constants
+	segmentSecretBaseName = "segment-bridge-config"
+	segmentSecretVolume   = "segment-bridge-config"
+	segmentKeyWriteKey    = "key"
+	segmentKeyAPIURL      = "url"
 )
 
 // UICleanupGVKs defines which resource types should be cleaned up when they are
@@ -110,14 +120,16 @@ var UIClusterScopedAllowList = tracking.ClusterScopedAllowList{
 // KonfluxUIReconciler reconciles a KonfluxUI object
 type KonfluxUIReconciler struct {
 	client.Client
-	Scheme      *runtime.Scheme
-	ObjectStore *manifests.ObjectStore
-	ClusterInfo *clusterinfo.Info
+	Scheme               *runtime.Scheme
+	ObjectStore          *manifests.ObjectStore
+	ClusterInfo          *clusterinfo.Info
+	GetDefaultSegmentKey func() string
 }
 
 // +kubebuilder:rbac:groups=konflux.konflux-ci.dev,resources=konfluxuis,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=konflux.konflux-ci.dev,resources=konfluxuis/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=konflux.konflux-ci.dev,resources=konfluxuis/finalizers,verbs=update
+// +kubebuilder:rbac:groups=konflux.konflux-ci.dev,resources=konfluxsegmentbridges,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;patch;delete
@@ -186,8 +198,15 @@ func (r *KonfluxUIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return errHandler.HandleWithReason(ctx, err, condition.ReasonConfigMapFailed, "reconcile Dex ConfigMap")
 	}
 
+	// Reconcile the Segment config Secret for the UI frontend.
+	// Creates a content-hashed Secret so the proxy deployment rolls out on changes.
+	segmentSecretName, err := r.reconcileSegmentSecret(ctx, tc)
+	if err != nil {
+		return errHandler.HandleWithReason(ctx, err, condition.ReasonSecretCreationFailed, "reconcile segment config secret")
+	}
+
 	// Apply all embedded manifests
-	if err := r.applyManifests(ctx, tc, ui, dexConfigMapName, endpoint); err != nil {
+	if err := r.applyManifests(ctx, tc, ui, dexConfigMapName, segmentSecretName, endpoint); err != nil {
 		return errHandler.HandleApplyError(ctx, err)
 	}
 
@@ -267,8 +286,9 @@ func (r *KonfluxUIReconciler) ensureNamespaceExists(ctx context.Context, tc *tra
 // applyManifests loads and applies all embedded manifests to the cluster.
 // Manifests are parsed once and cached; deep copies are used during reconciliation.
 // dexConfigMapName is the name of the Dex ConfigMap to use (empty if not configured).
+// segmentSecretName is the name of the content-hashed Segment Secret (empty if not configured).
 // endpoint is the base URL used to configure oauth2-proxy.
-func (r *KonfluxUIReconciler) applyManifests(ctx context.Context, tc *tracking.Client, ui *konfluxv1alpha1.KonfluxUI, dexConfigMapName string, endpoint *url.URL) error {
+func (r *KonfluxUIReconciler) applyManifests(ctx context.Context, tc *tracking.Client, ui *konfluxv1alpha1.KonfluxUI, dexConfigMapName, segmentSecretName string, endpoint *url.URL) error {
 	objects, err := r.ObjectStore.GetForComponent(manifests.UI)
 	if err != nil {
 		return fmt.Errorf("failed to get parsed manifests for UI: %w", err)
@@ -277,7 +297,7 @@ func (r *KonfluxUIReconciler) applyManifests(ctx context.Context, tc *tracking.C
 	for _, obj := range objects {
 		// Apply customizations for deployments
 		if deployment, ok := obj.(*appsv1.Deployment); ok {
-			if err := applyUIDeploymentCustomizations(deployment, ui, r.ClusterInfo, dexConfigMapName, endpoint); err != nil {
+			if err := applyUIDeploymentCustomizations(deployment, ui, r.ClusterInfo, dexConfigMapName, segmentSecretName, endpoint); err != nil {
 				return fmt.Errorf("failed to apply customizations to deployment %s: %w", deployment.Name, err)
 			}
 		}
@@ -296,7 +316,7 @@ func (r *KonfluxUIReconciler) applyManifests(ctx context.Context, tc *tracking.C
 }
 
 // applyUIDeploymentCustomizations applies user-defined customizations to UI deployments.
-func applyUIDeploymentCustomizations(deployment *appsv1.Deployment, ui *konfluxv1alpha1.KonfluxUI, clusterInfo *clusterinfo.Info, dexConfigMapName string, endpoint *url.URL) error {
+func applyUIDeploymentCustomizations(deployment *appsv1.Deployment, ui *konfluxv1alpha1.KonfluxUI, clusterInfo *clusterinfo.Info, dexConfigMapName, segmentSecretName string, endpoint *url.URL) error {
 	openShiftLoginEnabled := isOpenShiftLoginEnabled(ui, clusterInfo)
 
 	switch deployment.Name {
@@ -305,7 +325,7 @@ func applyUIDeploymentCustomizations(deployment *appsv1.Deployment, ui *konfluxv
 		deployment.Spec.Replicas = &proxySpec.Replicas
 		// Build oauth2-proxy options based on endpoint URL and OpenShift login state
 		oauth2ProxyOpts := buildOAuth2ProxyOptions(endpoint, openShiftLoginEnabled)
-		if err := buildProxyOverlay(ui.Spec.Proxy, oauth2ProxyOpts...).ApplyToDeployment(deployment); err != nil {
+		if err := buildProxyOverlay(ui.Spec.Proxy, segmentSecretName, oauth2ProxyOpts...).ApplyToDeployment(deployment); err != nil {
 			return err
 		}
 	case dexDeploymentName:
@@ -344,8 +364,9 @@ func applyUIServiceCustomizations(service *corev1.Service, ui *konfluxv1alpha1.K
 }
 
 // buildProxyOverlay builds the pod overlay for the proxy deployment.
+// segmentSecretName is the content-hashed Secret name (empty if segment is not configured).
 // oauth2ProxyOpts are applied to the oauth2-proxy container before user-provided overrides.
-func buildProxyOverlay(spec *konfluxv1alpha1.ProxyDeploymentSpec, oauth2ProxyOpts ...customization.ContainerOption) *customization.PodOverlay {
+func buildProxyOverlay(spec *konfluxv1alpha1.ProxyDeploymentSpec, segmentSecretName string, oauth2ProxyOpts ...customization.ContainerOption) *customization.PodOverlay {
 	// Create CA bundle volume that will be mounted in oauth2-proxy container.
 	// The Secret is created by cert-manager from the oauth2-proxy-cert Certificate resource
 	// (see operator/upstream-kustomizations/ui/dex/dex.yaml).
@@ -375,20 +396,30 @@ func buildProxyOverlay(spec *konfluxv1alpha1.ProxyDeploymentSpec, oauth2ProxyOpt
 		},
 	}
 
+	// Build the list of pod-level options
+	podOpts := []customization.PodOverlayOption{
+		customization.WithVolumes(caVolume),
+	}
+
+	// Update the segment-bridge-config volume's Secret name when segment is configured.
+	// This triggers a deployment rollout because the volume reference changes.
+	if segmentSecretName != "" {
+		podOpts = append(podOpts, customization.WithSecretVolumeUpdate(segmentSecretVolume, segmentSecretName))
+	}
+
 	if spec == nil {
-		return customization.NewPodOverlay(
-			customization.WithVolumes(caVolume),
+		podOpts = append(podOpts,
 			customization.WithContainerBuilder(oauth2ProxyContainerName, oauth2ProxyOpts...)(
 				customization.DeploymentContext{},
 			),
 		)
+		return customization.NewPodOverlay(podOpts...)
 	}
 
 	// Append user overrides after oauth2proxy options
 	oauth2ProxyOpts = append(oauth2ProxyOpts, customization.FromContainerSpec(spec.OAuth2Proxy))
 
-	return customization.NewPodOverlay(
-		customization.WithVolumes(caVolume),
+	podOpts = append(podOpts,
 		customization.WithContainerBuilder(
 			nginxContainerName,
 			customization.FromContainerSpec(spec.Nginx),
@@ -398,6 +429,7 @@ func buildProxyOverlay(spec *konfluxv1alpha1.ProxyDeploymentSpec, oauth2ProxyOpt
 			oauth2ProxyOpts...,
 		)(customization.DeploymentContext{Replicas: spec.Replicas}),
 	)
+	return customization.NewPodOverlay(podOpts...)
 }
 
 // buildOAuth2ProxyOptions builds the container options for oauth2-proxy configuration.
@@ -565,6 +597,60 @@ func (r *KonfluxUIReconciler) reconcileDexConfigMap(ctx context.Context, ui *kon
 	return result.ConfigMapName, nil
 }
 
+// reconcileSegmentSecret creates a content-hashed Secret in the konflux-ui namespace
+// containing the Segment write key and API URL. The Secret is mounted into the
+// nginx container.
+//
+// The Secret name includes a hash suffix derived from its content, so whenever the
+// Segment key or API URL changes the name changes, which updates the volume reference
+// in the proxy Deployment and triggers a rollout.
+//
+// Returns the full Secret name (base + hash) for the volume reference, or empty string
+// if no Segment key is configured (the tracking client will clean up any stale Secret).
+func (r *KonfluxUIReconciler) reconcileSegmentSecret(ctx context.Context, tc *tracking.Client) (string, error) {
+	log := logf.FromContext(ctx)
+
+	// Fetch the KonfluxSegmentBridge CR to read the segment configuration
+	segmentBridge := &konfluxv1alpha1.KonfluxSegmentBridge{}
+	if err := r.Get(ctx, client.ObjectKey{Name: segmentbridge.CRName}, segmentBridge); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return "", fmt.Errorf("failed to get KonfluxSegmentBridge CR: %w", err)
+		}
+		log.Info("KonfluxSegmentBridge CR not found, skipping segment config secret")
+		return "", nil
+	}
+
+	// Resolve the write key (CR spec → build-time default → empty)
+	segmentKey, source := segment.ResolveWriteKey(segmentBridge.Spec.GetSegmentKey(), r.GetDefaultSegmentKey())
+	if !segment.LogWriteKeyResolution(log, segmentKey, source) {
+		return "", nil
+	}
+
+	apiURL := segmentBridge.Spec.GetSegmentAPIURL()
+
+	// Create the content-hashed Secret and apply it via the tracking client
+	secret := hashedsecret.Build(
+		segmentSecretBaseName,
+		uiNamespace, map[string]string{
+			segmentKeyWriteKey: segmentKey,
+			segmentKeyAPIURL:   apiURL,
+		},
+	)
+
+	log.Info("Applying segment config secret", "name", secret.Name, "apiURL", apiURL)
+	if err := tc.ApplyOwned(ctx, secret); err != nil {
+		return "", fmt.Errorf("failed to apply segment config secret: %w", err)
+	}
+
+	return secret.Name, nil
+}
+
+// mapSegmentBridgeToUI maps KonfluxSegmentBridge events to KonfluxUI reconcile requests
+// so that changes to the Segment configuration trigger a UI reconcile.
+func (r *KonfluxUIReconciler) mapSegmentBridgeToUI(_ context.Context, _ client.Object) []ctrl.Request {
+	return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: CRName}}}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *KonfluxUIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
@@ -582,6 +668,10 @@ func (r *KonfluxUIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
 		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
 		Owns(&networkingv1.Ingress{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
+		// Watch KonfluxSegmentBridge CR so Segment config changes trigger a UI reconcile
+		Watches(&konfluxv1alpha1.KonfluxSegmentBridge{},
+			handler.EnqueueRequestsFromMapFunc(r.mapSegmentBridgeToUI),
+			builder.WithPredicates(predicate.GenerationChangedPredicate)).
 		Complete(r)
 }
 

--- a/operator/internal/controller/ui/konfluxui_controller_test.go
+++ b/operator/internal/controller/ui/konfluxui_controller_test.go
@@ -31,18 +31,24 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	consolev1 "github.com/openshift/api/console/v1"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/segmentbridge"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/consolelink"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/dex"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/hashedsecret"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/ingress"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 )
+
+func noDefaultSegmentKey() string             { return "" }
+func staticSegmentKey(k string) func() string { return func() string { return k } }
 
 var _ = Describe("KonfluxUI Controller", func() {
 	Context("When reconciling a resource", func() {
@@ -82,9 +88,10 @@ var _ = Describe("KonfluxUI Controller", func() {
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &KonfluxUIReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				ObjectStore:          objectStore,
+				GetDefaultSegmentKey: noDefaultSegmentKey,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -136,9 +143,10 @@ var _ = Describe("KonfluxUI Controller", func() {
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
 
 			reconciler = &KonfluxUIReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				ObjectStore:          objectStore,
+				GetDefaultSegmentKey: noDefaultSegmentKey,
 			}
 
 			By("creating the UI namespace")
@@ -500,9 +508,10 @@ var _ = Describe("KonfluxUI Controller", func() {
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
 
 			reconciler = &KonfluxUIReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				ObjectStore:          objectStore,
+				GetDefaultSegmentKey: noDefaultSegmentKey,
 			}
 		})
 
@@ -730,10 +739,11 @@ var _ = Describe("KonfluxUI Controller", func() {
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
 
 			reconciler = &KonfluxUIReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-				ClusterInfo: nil, // Will be set in individual tests
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				ObjectStore:          objectStore,
+				ClusterInfo:          nil, // Will be set in individual tests
+				GetDefaultSegmentKey: noDefaultSegmentKey,
 			}
 		})
 
@@ -962,9 +972,10 @@ var _ = Describe("KonfluxUI Controller", func() {
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
 
 			reconciler = &KonfluxUIReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				ObjectStore:          objectStore,
+				GetDefaultSegmentKey: noDefaultSegmentKey,
 			}
 		})
 
@@ -1154,10 +1165,11 @@ var _ = Describe("KonfluxUI Controller", func() {
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
 
 			reconciler = &KonfluxUIReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-				ClusterInfo: nil, // Will be set in individual tests
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				ObjectStore:          objectStore,
+				ClusterInfo:          nil, // Will be set in individual tests
+				GetDefaultSegmentKey: noDefaultSegmentKey,
 			}
 		})
 
@@ -1269,6 +1281,328 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 			By("verifying the ConsoleLink href was updated")
 			Expect(getConsoleLink(ctx).Spec.Href).To(Equal("https://updated-consolelink.example.com"))
+		})
+	})
+
+	Context("Segment Secret reconciliation via Reconcile", Serial, func() {
+		var ui *konfluxv1alpha1.KonfluxUI
+		var reconciler *KonfluxUIReconciler
+		var segmentBridgeCR *konfluxv1alpha1.KonfluxSegmentBridge
+
+		// Helper: reconcile and expect success
+		reconcileUI := func(ctx context.Context) {
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: ui.Name},
+			})
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		}
+
+		// Helper: build the expected hashed secret name for given data
+		expectedSecretName := func(writeKey, apiURL string) string {
+			s := hashedsecret.Build(segmentSecretBaseName, uiNamespace, map[string]string{
+				segmentKeyWriteKey: writeKey,
+				segmentKeyAPIURL:   apiURL,
+			})
+			return s.Name
+		}
+
+		// Helper: list all Secrets in the UI namespace matching the segment base name prefix
+		listSegmentSecrets := func(ctx context.Context) []corev1.Secret {
+			secretList := &corev1.SecretList{}
+			err := k8sClient.List(ctx, secretList, client.InNamespace(uiNamespace))
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			var result []corev1.Secret
+			for _, s := range secretList.Items {
+				if len(s.Name) > len(segmentSecretBaseName) && s.Name[:len(segmentSecretBaseName)] == segmentSecretBaseName {
+					result = append(result, s)
+				}
+			}
+			return result
+		}
+
+		BeforeEach(func(ctx context.Context) {
+			By("cleaning up any existing segment secrets from previous tests")
+			for _, s := range listSegmentSecrets(ctx) {
+				_ = k8sClient.Delete(ctx, &s)
+			}
+
+			By("cleaning up any existing KonfluxSegmentBridge CR")
+			existingBridge := &konfluxv1alpha1.KonfluxSegmentBridge{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: segmentbridge.CRName,
+				},
+			}
+			_ = k8sClient.Delete(ctx, existingBridge)
+
+			By("creating the KonfluxUI resource")
+			ui = &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: CRName,
+				},
+				Spec: konfluxv1alpha1.KonfluxUISpec{},
+			}
+			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
+
+			segmentBridgeCR = nil
+
+			reconciler = &KonfluxUIReconciler{
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				ObjectStore:          objectStore,
+				GetDefaultSegmentKey: noDefaultSegmentKey,
+			}
+		})
+
+		AfterEach(func(ctx context.Context) {
+			By("cleaning up segment secrets")
+			for _, s := range listSegmentSecrets(ctx) {
+				_ = k8sClient.Delete(ctx, &s)
+			}
+
+			By("cleaning up KonfluxSegmentBridge CR")
+			if segmentBridgeCR != nil {
+				_ = k8sClient.Delete(ctx, segmentBridgeCR)
+			}
+
+			By("cleaning up KonfluxUI resource")
+			_ = k8sClient.Delete(ctx, ui)
+		})
+
+		It("Should not create segment secret when KonfluxSegmentBridge CR does not exist", func(ctx context.Context) {
+			By("reconciling without a KonfluxSegmentBridge CR")
+			reconcileUI(ctx)
+
+			By("verifying no segment secret was created")
+			Expect(listSegmentSecrets(ctx)).To(BeEmpty())
+		})
+
+		It("Should not create segment secret when no write key is configured", func(ctx context.Context) {
+			By("creating a KonfluxSegmentBridge CR without a write key")
+			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: segmentbridge.CRName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+
+			By("reconciling with no default key either")
+			reconcileUI(ctx)
+
+			By("verifying no segment secret was created")
+			Expect(listSegmentSecrets(ctx)).To(BeEmpty())
+		})
+
+		It("Should create segment secret with CR write key and default API URL", func(ctx context.Context) {
+			By("creating a KonfluxSegmentBridge CR with a write key")
+			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: segmentbridge.CRName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+
+			// Update to add segment key (default spec is empty)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
+			segmentBridgeCR.Spec.SegmentKey = "test-write-key"
+			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+
+			By("reconciling the resource")
+			reconcileUI(ctx)
+
+			By("verifying the segment secret was created with correct data")
+			name := expectedSecretName("test-write-key", konfluxv1alpha1.DefaultSegmentAPIURL)
+			secret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      name,
+				Namespace: uiNamespace,
+			}, secret)).To(Succeed())
+
+			Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("test-write-key"))
+			Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal(konfluxv1alpha1.DefaultSegmentAPIURL))
+		})
+
+		It("Should create segment secret with CR write key and custom API URL", func(ctx context.Context) {
+			By("creating a KonfluxSegmentBridge CR with a write key and custom API URL")
+			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: segmentbridge.CRName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
+			segmentBridgeCR.Spec.SegmentKey = "test-write-key"
+			segmentBridgeCR.Spec.SegmentAPIURL = "https://console.redhat.com/connections/api/v1"
+			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+
+			By("reconciling the resource")
+			reconcileUI(ctx)
+
+			By("verifying the segment secret was created with custom API URL")
+			name := expectedSecretName("test-write-key", "https://console.redhat.com/connections/api/v1")
+			secret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      name,
+				Namespace: uiNamespace,
+			}, secret)).To(Succeed())
+
+			Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("test-write-key"))
+			Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal("https://console.redhat.com/connections/api/v1"))
+		})
+
+		It("Should use build-time default key when CR key is empty", func(ctx context.Context) {
+			By("creating a KonfluxSegmentBridge CR without a write key")
+			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: segmentbridge.CRName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+
+			By("configuring a build-time default key")
+			reconciler.GetDefaultSegmentKey = staticSegmentKey("build-time-key")
+
+			By("reconciling the resource")
+			reconcileUI(ctx)
+
+			By("verifying the segment secret uses the build-time default key")
+			name := expectedSecretName("build-time-key", konfluxv1alpha1.DefaultSegmentAPIURL)
+			secret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      name,
+				Namespace: uiNamespace,
+			}, secret)).To(Succeed())
+
+			Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("build-time-key"))
+		})
+
+		It("Should prefer CR key over build-time default", func(ctx context.Context) {
+			By("creating a KonfluxSegmentBridge CR with a write key")
+			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: segmentbridge.CRName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
+			segmentBridgeCR.Spec.SegmentKey = "cr-override-key"
+			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+
+			By("configuring a build-time default key")
+			reconciler.GetDefaultSegmentKey = staticSegmentKey("build-time-key")
+
+			By("reconciling the resource")
+			reconcileUI(ctx)
+
+			By("verifying the segment secret uses the CR key, not the build-time default")
+			name := expectedSecretName("cr-override-key", konfluxv1alpha1.DefaultSegmentAPIURL)
+			secret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      name,
+				Namespace: uiNamespace,
+			}, secret)).To(Succeed())
+
+			Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("cr-override-key"))
+		})
+
+		It("Should create a new secret and clean up old one when segment key changes", func(ctx context.Context) {
+			By("creating a KonfluxSegmentBridge CR with an initial write key")
+			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: segmentbridge.CRName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
+			segmentBridgeCR.Spec.SegmentKey = "initial-key"
+			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+
+			By("reconciling to create the initial secret")
+			reconcileUI(ctx)
+
+			initialName := expectedSecretName("initial-key", konfluxv1alpha1.DefaultSegmentAPIURL)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      initialName,
+				Namespace: uiNamespace,
+			}, &corev1.Secret{})).To(Succeed())
+
+			By("changing the segment key")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
+			segmentBridgeCR.Spec.SegmentKey = "updated-key"
+			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+
+			By("reconciling again")
+			reconcileUI(ctx)
+
+			By("verifying the new secret was created")
+			updatedName := expectedSecretName("updated-key", konfluxv1alpha1.DefaultSegmentAPIURL)
+			Expect(updatedName).NotTo(Equal(initialName), "hash should differ for different keys")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      updatedName,
+				Namespace: uiNamespace,
+			}, &corev1.Secret{})).To(Succeed())
+
+			By("verifying the old secret was cleaned up")
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      initialName,
+				Namespace: uiNamespace,
+			}, &corev1.Secret{})
+			Expect(errors.IsNotFound(err)).To(BeTrue(), "old segment secret should be deleted")
+		})
+
+		It("Should clean up segment secret when key becomes empty", func(ctx context.Context) {
+			By("creating a KonfluxSegmentBridge CR with a write key")
+			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: segmentbridge.CRName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
+			segmentBridgeCR.Spec.SegmentKey = "temporary-key"
+			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+
+			By("reconciling to create the secret")
+			reconcileUI(ctx)
+			Expect(listSegmentSecrets(ctx)).To(HaveLen(1))
+
+			By("removing the segment key")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
+			segmentBridgeCR.Spec.SegmentKey = ""
+			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+
+			By("reconciling again")
+			reconcileUI(ctx)
+
+			By("verifying the secret was cleaned up")
+			Expect(listSegmentSecrets(ctx)).To(BeEmpty())
+		})
+
+		It("Should set owner reference on created segment secret", func(ctx context.Context) {
+			By("creating a KonfluxSegmentBridge CR with a write key")
+			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: segmentbridge.CRName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
+			segmentBridgeCR.Spec.SegmentKey = "owner-ref-test-key"
+			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+
+			By("reconciling the resource")
+			reconcileUI(ctx)
+
+			By("verifying the secret has owner reference")
+			secrets := listSegmentSecrets(ctx)
+			Expect(secrets).To(HaveLen(1))
+			Expect(secrets[0].OwnerReferences).To(HaveLen(1))
+			Expect(secrets[0].OwnerReferences[0].Name).To(Equal(CRName))
+			Expect(secrets[0].OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
 		})
 	})
 })

--- a/operator/internal/controller/ui/konfluxui_customization_test.go
+++ b/operator/internal/controller/ui/konfluxui_customization_test.go
@@ -98,7 +98,7 @@ func assertNoConflictingEnvVars(g *gomega.WithT, container *corev1.Container) {
 func TestBuildProxyOverlay(t *testing.T) {
 	t.Run("nil spec returns overlay with oauth2-proxy config", func(t *testing.T) {
 		g := gomega.NewWithT(t)
-		overlay := buildProxyOverlay(nil, buildOAuth2ProxyOptions(testEndpoint, false)...)
+		overlay := buildProxyOverlay(nil, "", buildOAuth2ProxyOptions(testEndpoint, false)...)
 		g.Expect(overlay).NotTo(gomega.BeNil())
 
 		deployment := getUIDeployment(t, proxyDeploymentName)
@@ -114,7 +114,7 @@ func TestBuildProxyOverlay(t *testing.T) {
 	t.Run("empty spec returns overlay with oauth2-proxy config", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 		spec := &konfluxv1alpha1.ProxyDeploymentSpec{}
-		overlay := buildProxyOverlay(spec, buildOAuth2ProxyOptions(testEndpoint, false)...)
+		overlay := buildProxyOverlay(spec, "", buildOAuth2ProxyOptions(testEndpoint, false)...)
 		g.Expect(overlay).NotTo(gomega.BeNil())
 
 		deployment := getUIDeployment(t, proxyDeploymentName)
@@ -129,7 +129,7 @@ func TestBuildProxyOverlay(t *testing.T) {
 
 	t.Run("adds CA bundle volume and mount", func(t *testing.T) {
 		g := gomega.NewWithT(t)
-		overlay := buildProxyOverlay(nil, buildOAuth2ProxyOptions(testEndpoint, false)...)
+		overlay := buildProxyOverlay(nil, "", buildOAuth2ProxyOptions(testEndpoint, false)...)
 		g.Expect(overlay).NotTo(gomega.BeNil())
 
 		deployment := getUIDeployment(t, proxyDeploymentName)
@@ -188,7 +188,7 @@ func TestBuildProxyOverlay(t *testing.T) {
 		}
 
 		deployment := getUIDeployment(t, proxyDeploymentName)
-		overlay := buildProxyOverlay(spec, buildOAuth2ProxyOptions(testEndpoint, false)...)
+		overlay := buildProxyOverlay(spec, "", buildOAuth2ProxyOptions(testEndpoint, false)...)
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -214,7 +214,7 @@ func TestBuildProxyOverlay(t *testing.T) {
 		}
 
 		deployment := getUIDeployment(t, proxyDeploymentName)
-		overlay := buildProxyOverlay(spec, buildOAuth2ProxyOptions(testEndpoint, false)...)
+		overlay := buildProxyOverlay(spec, "", buildOAuth2ProxyOptions(testEndpoint, false)...)
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -247,7 +247,7 @@ func TestBuildProxyOverlay(t *testing.T) {
 		}
 
 		deployment := getUIDeployment(t, proxyDeploymentName)
-		overlay := buildProxyOverlay(spec, buildOAuth2ProxyOptions(testEndpoint, false)...)
+		overlay := buildProxyOverlay(spec, "", buildOAuth2ProxyOptions(testEndpoint, false)...)
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -280,7 +280,7 @@ func TestBuildProxyOverlay(t *testing.T) {
 		g.Expect(nginxContainer).NotTo(gomega.BeNil(), "nginx container must exist in proxy deployment")
 		originalImage := nginxContainer.Image
 
-		overlay := buildProxyOverlay(spec, buildOAuth2ProxyOptions(testEndpoint, false)...)
+		overlay := buildProxyOverlay(spec, "", buildOAuth2ProxyOptions(testEndpoint, false)...)
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -554,7 +554,7 @@ func TestApplyUIDeploymentCustomizations(t *testing.T) {
 		})
 
 		deployment := getUIDeployment(t, proxyDeploymentName)
-		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, testEndpoint)
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, "", testEndpoint)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		nginxContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, nginxContainerName)
@@ -577,7 +577,7 @@ func TestApplyUIDeploymentCustomizations(t *testing.T) {
 		})
 
 		deployment := getUIDeployment(t, dexDeploymentName)
-		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, testEndpoint)
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, "", testEndpoint)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		dexContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, dexContainerName)
@@ -612,7 +612,7 @@ func TestApplyUIDeploymentCustomizations(t *testing.T) {
 			},
 		}
 
-		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, testEndpoint)
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, "", testEndpoint)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Should not panic and container should be unchanged
@@ -626,7 +626,7 @@ func TestApplyUIDeploymentCustomizations(t *testing.T) {
 		})
 
 		deployment := getUIDeployment(t, proxyDeploymentName)
-		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, testEndpoint)
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, "", testEndpoint)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Should not panic
@@ -641,7 +641,7 @@ func TestApplyUIDeploymentCustomizations(t *testing.T) {
 		})
 
 		deployment := getUIDeployment(t, dexDeploymentName)
-		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, testEndpoint)
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, "", testEndpoint)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Should not panic
@@ -654,7 +654,7 @@ func TestApplyUIDeploymentCustomizations(t *testing.T) {
 		ui := buildUIFromSpec(konfluxv1alpha1.KonfluxUISpec{})
 
 		deployment := getUIDeployment(t, proxyDeploymentName)
-		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, testEndpoint)
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, "", testEndpoint)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Should not panic
@@ -670,7 +670,7 @@ func TestApplyUIDeploymentCustomizations(t *testing.T) {
 		})
 
 		deployment := getUIDeployment(t, proxyDeploymentName)
-		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, testEndpoint)
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, "", testEndpoint)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		g.Expect(deployment.Spec.Replicas).NotTo(gomega.BeNil())
@@ -686,7 +686,7 @@ func TestApplyUIDeploymentCustomizations(t *testing.T) {
 		})
 
 		deployment := getUIDeployment(t, dexDeploymentName)
-		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, testEndpoint)
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, "", testEndpoint)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		g.Expect(deployment.Spec.Replicas).NotTo(gomega.BeNil())
@@ -702,7 +702,7 @@ func TestApplyUIDeploymentCustomizations(t *testing.T) {
 		})
 
 		deployment := getUIDeployment(t, proxyDeploymentName)
-		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, testEndpoint)
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, "", testEndpoint)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		g.Expect(deployment.Spec.Replicas).NotTo(gomega.BeNil())
@@ -717,7 +717,7 @@ func TestApplyUIDeploymentCustomizations(t *testing.T) {
 
 		deployment := getUIDeployment(t, proxyDeploymentName)
 		originalReplicas := deployment.Spec.Replicas
-		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, testEndpoint)
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, "", testEndpoint)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		g.Expect(deployment.Spec.Replicas).To(gomega.Equal(originalReplicas))
@@ -739,7 +739,7 @@ func TestApplyUIDeploymentCustomizations(t *testing.T) {
 		})
 
 		deployment := getUIDeployment(t, proxyDeploymentName)
-		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, testEndpoint)
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, "", testEndpoint)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Check replicas
@@ -757,7 +757,7 @@ func TestApplyUIDeploymentCustomizations(t *testing.T) {
 		ui := buildUIFromSpec(konfluxv1alpha1.KonfluxUISpec{})
 
 		deployment := getUIDeployment(t, dexDeploymentName)
-		err := applyUIDeploymentCustomizations(deployment, ui, nil, "dex-custom-config-abc", testEndpoint)
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, "dex-custom-config-abc", "", testEndpoint)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Find the dex volume and verify ConfigMap name was updated
@@ -771,6 +771,59 @@ func TestApplyUIDeploymentCustomizations(t *testing.T) {
 		g.Expect(dexVolume).NotTo(gomega.BeNil(), "dex volume must exist")
 		g.Expect(dexVolume.ConfigMap).NotTo(gomega.BeNil())
 		g.Expect(dexVolume.ConfigMap.Name).To(gomega.Equal("dex-custom-config-abc"))
+	})
+
+	t.Run("updates segment secret volume reference when configured", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		ui := buildUIFromSpec(konfluxv1alpha1.KonfluxUISpec{})
+
+		deployment := getUIDeployment(t, proxyDeploymentName)
+		hashedSecretName := "segment-bridge-config-abc1234567"
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, hashedSecretName, testEndpoint)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Find the segment-bridge-config volume and verify Secret name was updated
+		var segmentVolume *corev1.Volume
+		for i := range deployment.Spec.Template.Spec.Volumes {
+			if deployment.Spec.Template.Spec.Volumes[i].Name == segmentSecretVolume {
+				segmentVolume = &deployment.Spec.Template.Spec.Volumes[i]
+				break
+			}
+		}
+		g.Expect(segmentVolume).NotTo(gomega.BeNil(), "segment-bridge-config volume must exist")
+		g.Expect(segmentVolume.Secret).NotTo(gomega.BeNil())
+		g.Expect(segmentVolume.Secret.SecretName).To(gomega.Equal(hashedSecretName))
+	})
+
+	t.Run("does not update segment secret volume when not configured", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		ui := buildUIFromSpec(konfluxv1alpha1.KonfluxUISpec{})
+
+		deployment := getUIDeployment(t, proxyDeploymentName)
+
+		// Get the original secret name
+		var originalSecretName string
+		for _, vol := range deployment.Spec.Template.Spec.Volumes {
+			if vol.Name == segmentSecretVolume && vol.Secret != nil {
+				originalSecretName = vol.Secret.SecretName
+				break
+			}
+		}
+
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, "", testEndpoint)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Volume should retain its original secret name
+		var segmentVolume *corev1.Volume
+		for i := range deployment.Spec.Template.Spec.Volumes {
+			if deployment.Spec.Template.Spec.Volumes[i].Name == segmentSecretVolume {
+				segmentVolume = &deployment.Spec.Template.Spec.Volumes[i]
+				break
+			}
+		}
+		g.Expect(segmentVolume).NotTo(gomega.BeNil(), "segment-bridge-config volume must exist")
+		g.Expect(segmentVolume.Secret).NotTo(gomega.BeNil())
+		g.Expect(segmentVolume.Secret.SecretName).To(gomega.Equal(originalSecretName))
 	})
 }
 
@@ -801,7 +854,7 @@ func TestApplyUIDeploymentCustomizations_ResourceMerging(t *testing.T) {
 			},
 		})
 
-		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, testEndpoint)
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, "", testEndpoint)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		nginxContainer = testutil.FindContainer(deployment.Spec.Template.Spec.Containers, nginxContainerName)
@@ -835,7 +888,7 @@ func TestApplyUIDeploymentCustomizations_ResourceMerging(t *testing.T) {
 			},
 		})
 
-		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, testEndpoint)
+		err := applyUIDeploymentCustomizations(deployment, ui, nil, testConfigMapName, "", testEndpoint)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		nginxContainer = testutil.FindContainer(deployment.Spec.Template.Spec.Containers, nginxContainerName)

--- a/operator/pkg/contenthash/contenthash.go
+++ b/operator/pkg/contenthash/contenthash.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package contenthash provides deterministic hash-suffix generators for
+// Kubernetes resource names. A content-based suffix ensures that the
+// resource name changes whenever its payload changes, which triggers a
+// rollout when the resource is referenced by a Deployment volume.
+package contenthash
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"maps"
+	"slices"
+	"strings"
+)
+
+// suffixLength is the number of hex characters kept from the SHA-256 digest.
+const suffixLength = 10
+
+// String returns a short deterministic hash suffix for the given string.
+func String(content string) string {
+	hash := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(hash[:])[:suffixLength]
+}
+
+// Map returns a short deterministic hash suffix for the given map.
+// Keys are sorted before hashing so that iteration order does not affect
+// the result.
+func Map(data map[string]string) string {
+	keys := slices.Sorted(maps.Keys(data))
+
+	pairs := make([]string, 0, len(keys))
+	for _, k := range keys {
+		pairs = append(pairs, k+"="+data[k])
+	}
+
+	hash := sha256.Sum256([]byte(strings.Join(pairs, "\n")))
+	return hex.EncodeToString(hash[:])[:suffixLength]
+}

--- a/operator/pkg/contenthash/contenthash_test.go
+++ b/operator/pkg/contenthash/contenthash_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contenthash
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestString(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	t.Run("same input produces same hash", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(String("hello")).To(gomega.Equal(String("hello")))
+	})
+
+	t.Run("different input produces different hash", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(String("hello")).NotTo(gomega.Equal(String("world")))
+	})
+
+	t.Run("hash has expected length", func(t *testing.T) {
+		g.Expect(String("anything")).To(gomega.HaveLen(suffixLength))
+	})
+}
+
+func TestMap(t *testing.T) {
+	t.Run("same data produces same hash", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		d := map[string]string{"a": "1", "b": "2"}
+		g.Expect(Map(d)).To(gomega.Equal(Map(d)))
+	})
+
+	t.Run("different data produces different hash", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(Map(map[string]string{"a": "1"})).
+			NotTo(gomega.Equal(Map(map[string]string{"a": "2"})))
+	})
+
+	t.Run("key order does not affect the hash", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(Map(map[string]string{"a": "1", "b": "2"})).
+			To(gomega.Equal(Map(map[string]string{"b": "2", "a": "1"})))
+	})
+
+	t.Run("hash has expected length", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(Map(map[string]string{"k": "v"})).To(gomega.HaveLen(suffixLength))
+	})
+}

--- a/operator/pkg/customization/pod.go
+++ b/operator/pkg/customization/pod.go
@@ -31,6 +31,8 @@ type PodOverlay struct {
 	containerOverlays map[string]*corev1.Container
 	// configMapVolumeUpdates holds updates to existing ConfigMap volume references
 	configMapVolumeUpdates map[string]string
+	// secretVolumeUpdates holds updates to existing Secret volume references
+	secretVolumeUpdates map[string]string
 }
 
 // PodOverlayOption is a functional option for configuring a PodOverlay.
@@ -127,6 +129,18 @@ func WithConfigMapVolumeUpdate(volumeName, configMapName string) PodOverlayOptio
 	}
 }
 
+// WithSecretVolumeUpdate updates an existing Secret volume's Secret name.
+// This modifies the volume in-place during ApplyToPodTemplateSpec, preserving other fields
+// like items, defaultMode, and optional.
+func WithSecretVolumeUpdate(volumeName, secretName string) PodOverlayOption {
+	return func(p *PodOverlay) {
+		if p.secretVolumeUpdates == nil {
+			p.secretVolumeUpdates = make(map[string]string)
+		}
+		p.secretVolumeUpdates[volumeName] = secretName
+	}
+}
+
 // WithServiceAccountName sets the service account name for the pod.
 func WithServiceAccountName(name string) PodOverlayOption {
 	return func(p *PodOverlay) {
@@ -187,6 +201,9 @@ func (p *PodOverlay) ApplyToPodTemplateSpec(template *corev1.PodTemplateSpec) er
 	// Apply ConfigMap volume updates
 	applyConfigMapVolumeUpdates(template.Spec.Volumes, p.configMapVolumeUpdates)
 
+	// Apply Secret volume updates
+	applySecretVolumeUpdates(template.Spec.Volumes, p.secretVolumeUpdates)
+
 	return nil
 }
 
@@ -239,6 +256,19 @@ func applyConfigMapVolumeUpdates(volumes []corev1.Volume, updates map[string]str
 		vol := &volumes[i]
 		if configMapName, ok := updates[vol.Name]; ok && vol.ConfigMap != nil {
 			vol.ConfigMap.Name = configMapName
+		}
+	}
+}
+
+// applySecretVolumeUpdates updates Secret volume references in-place.
+func applySecretVolumeUpdates(volumes []corev1.Volume, updates map[string]string) {
+	if updates == nil {
+		return
+	}
+	for i := range volumes {
+		vol := &volumes[i]
+		if secretName, ok := updates[vol.Name]; ok && vol.Secret != nil {
+			vol.Secret.SecretName = secretName
 		}
 	}
 }

--- a/operator/pkg/customization/pod_test.go
+++ b/operator/pkg/customization/pod_test.go
@@ -531,6 +531,239 @@ func TestComplexScenario(t *testing.T) {
 	})
 }
 
+func TestWithConfigMapVolumeUpdate(t *testing.T) {
+	t.Run("updates existing configmap volume reference", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		p := NewPodOverlay(
+			WithConfigMapVolumeUpdate("dex-config", "dex-config-abc1234567"),
+		)
+
+		template := &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "app:v1"}},
+				Volumes: []corev1.Volume{
+					{
+						Name: "dex-config",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "dex-config-old"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToPodTemplateSpec(template)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(template.Spec.Volumes[0].ConfigMap.Name).To(gomega.Equal("dex-config-abc1234567"))
+	})
+
+	t.Run("ignores volumes without configmap source", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		p := NewPodOverlay(
+			WithConfigMapVolumeUpdate("my-vol", "new-cm"),
+		)
+
+		template := &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "app:v1"}},
+				Volumes: []corev1.Volume{
+					{
+						Name: "my-vol",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToPodTemplateSpec(template)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		// Volume source should remain unchanged
+		g.Expect(template.Spec.Volumes[0].EmptyDir).NotTo(gomega.BeNil())
+		g.Expect(template.Spec.Volumes[0].ConfigMap).To(gomega.BeNil())
+	})
+
+	t.Run("does not affect non-matching volumes", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		p := NewPodOverlay(
+			WithConfigMapVolumeUpdate("target-vol", "new-cm"),
+		)
+
+		template := &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "app:v1"}},
+				Volumes: []corev1.Volume{
+					{
+						Name: "other-vol",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "original-cm"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToPodTemplateSpec(template)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(template.Spec.Volumes[0].ConfigMap.Name).To(gomega.Equal("original-cm"))
+	})
+}
+
+func TestWithSecretVolumeUpdate(t *testing.T) {
+	t.Run("updates existing secret volume reference", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		p := NewPodOverlay(
+			WithSecretVolumeUpdate("segment-config", "segment-config-abc1234567"),
+		)
+
+		template := &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "nginx", Image: "nginx:1.21"}},
+				Volumes: []corev1.Volume{
+					{
+						Name: "segment-config",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "segment-config-old",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToPodTemplateSpec(template)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(template.Spec.Volumes[0].Secret.SecretName).To(gomega.Equal("segment-config-abc1234567"))
+	})
+
+	t.Run("preserves other secret volume fields", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		optional := true
+		p := NewPodOverlay(
+			WithSecretVolumeUpdate("my-secret", "my-secret-new"),
+		)
+
+		template := &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "app:v1"}},
+				Volumes: []corev1.Volume{
+					{
+						Name: "my-secret",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "my-secret-old",
+								Optional:   &optional,
+								Items: []corev1.KeyToPath{
+									{Key: "key", Path: "key"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToPodTemplateSpec(template)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		vol := template.Spec.Volumes[0].Secret
+		g.Expect(vol.SecretName).To(gomega.Equal("my-secret-new"))
+		g.Expect(*vol.Optional).To(gomega.BeTrue(), "optional field should be preserved")
+		g.Expect(vol.Items).To(gomega.HaveLen(1), "items should be preserved")
+		g.Expect(vol.Items[0].Key).To(gomega.Equal("key"))
+	})
+
+	t.Run("ignores volumes without secret source", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		p := NewPodOverlay(
+			WithSecretVolumeUpdate("my-vol", "new-secret"),
+		)
+
+		template := &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "app:v1"}},
+				Volumes: []corev1.Volume{
+					{
+						Name: "my-vol",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToPodTemplateSpec(template)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(template.Spec.Volumes[0].EmptyDir).NotTo(gomega.BeNil())
+		g.Expect(template.Spec.Volumes[0].Secret).To(gomega.BeNil())
+	})
+
+	t.Run("does not affect non-matching volumes", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		p := NewPodOverlay(
+			WithSecretVolumeUpdate("target-vol", "new-secret"),
+		)
+
+		template := &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "app:v1"}},
+				Volumes: []corev1.Volume{
+					{
+						Name: "other-vol",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{SecretName: "original-secret"},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToPodTemplateSpec(template)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(template.Spec.Volumes[0].Secret.SecretName).To(gomega.Equal("original-secret"))
+	})
+
+	t.Run("can update multiple secret volumes", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		p := NewPodOverlay(
+			WithSecretVolumeUpdate("secret-a", "secret-a-new"),
+			WithSecretVolumeUpdate("secret-b", "secret-b-new"),
+		)
+
+		template := &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "app:v1"}},
+				Volumes: []corev1.Volume{
+					{
+						Name: "secret-a",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{SecretName: "secret-a-old"},
+						},
+					},
+					{
+						Name: "secret-b",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{SecretName: "secret-b-old"},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToPodTemplateSpec(template)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(template.Spec.Volumes[0].Secret.SecretName).To(gomega.Equal("secret-a-new"))
+		g.Expect(template.Spec.Volumes[1].Secret.SecretName).To(gomega.Equal("secret-b-new"))
+	})
+}
+
 // TestApplyToPodTemplateSpec_ContainerDeletionBug tests for a regression where
 // applying pod-level customizations (like ServiceAccountName) would accidentally
 // delete all containers from the deployment.

--- a/operator/pkg/hashedsecret/hashedsecret.go
+++ b/operator/pkg/hashedsecret/hashedsecret.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package hashedsecret provides a utility for building Kubernetes Secrets with
+// content-based hash suffixes, similar to kustomize. When the Secret is
+// referenced by a Deployment volume, a name change triggers a rollout.
+package hashedsecret
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/konflux-ci/konflux-ci/operator/pkg/contenthash"
+)
+
+// Build creates a Secret with a content-based hash suffix appended to baseName.
+// The hash is derived from the data map (sorted by key for determinism), so the
+// Secret name changes whenever the data changes — triggering a deployment rollout
+// when used as a volume reference.
+//
+// The returned Secret uses StringData and has TypeMeta set for server-side apply.
+func Build(baseName, namespace string, data map[string]string) *corev1.Secret {
+	name := fmt.Sprintf("%s-%s", baseName, contenthash.Map(data))
+
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		StringData: data,
+	}
+}

--- a/operator/pkg/hashedsecret/hashedsecret_test.go
+++ b/operator/pkg/hashedsecret/hashedsecret_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hashedsecret
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestBuild(t *testing.T) {
+	const (
+		baseName  = "my-secret"
+		namespace = "test-ns"
+	)
+
+	t.Run("creates secret with hashed name and correct data", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		data := map[string]string{"key": "write-key", "url": "https://api.segment.io/v1"}
+		secret := Build(baseName, namespace, data)
+
+		g.Expect(secret.Name).To(gomega.HavePrefix(baseName + "-"))
+		g.Expect(secret.Namespace).To(gomega.Equal(namespace))
+		g.Expect(secret.StringData).To(gomega.Equal(data))
+	})
+
+	t.Run("has correct TypeMeta for server-side apply", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		secret := Build(baseName, namespace, map[string]string{"k": "v"})
+
+		g.Expect(secret.APIVersion).To(gomega.Equal("v1"))
+		g.Expect(secret.Kind).To(gomega.Equal("Secret"))
+	})
+
+	t.Run("different content produces different names", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		s1 := Build(baseName, namespace, map[string]string{"k": "a"})
+		s2 := Build(baseName, namespace, map[string]string{"k": "b"})
+
+		g.Expect(s1.Name).NotTo(gomega.Equal(s2.Name))
+	})
+
+	t.Run("same content produces same name", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		s1 := Build(baseName, namespace, map[string]string{"k": "v"})
+		s2 := Build(baseName, namespace, map[string]string{"k": "v"})
+
+		g.Expect(s1.Name).To(gomega.Equal(s2.Name))
+	})
+
+	t.Run("hash suffix has expected length", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		secret := Build(baseName, namespace, map[string]string{"k": "v"})
+		suffix := secret.Name[len(baseName)+1:] // strip "baseName-"
+
+		g.Expect(suffix).To(gomega.HaveLen(10))
+	})
+
+	t.Run("key order does not affect the hash", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		s1 := Build(baseName, namespace, map[string]string{"a": "1", "b": "2"})
+		s2 := Build(baseName, namespace, map[string]string{"b": "2", "a": "1"})
+
+		g.Expect(s1.Name).To(gomega.Equal(s2.Name))
+	})
+
+	t.Run("different namespaces do not affect the hash", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		s1 := Build(baseName, "ns-a", map[string]string{"k": "v"})
+		s2 := Build(baseName, "ns-b", map[string]string{"k": "v"})
+
+		// Same data → same hash suffix, but different namespace field
+		g.Expect(s1.Name).To(gomega.Equal(s2.Name))
+		g.Expect(s1.Namespace).NotTo(gomega.Equal(s2.Namespace))
+	})
+}

--- a/operator/pkg/manifests/ui/manifests.yaml
+++ b/operator/pkg/manifests/ui/manifests.yaml
@@ -159,6 +159,10 @@ data:
             location = /404.html {
             }
 
+            location /segment {
+                default_type text/plain;
+            }
+
             location = /oauth2/auth {
                 internal;
                 proxy_pass       http://127.0.0.1:6000;
@@ -254,7 +258,7 @@ data:
     }
 kind: ConfigMap
 metadata:
-  name: proxy-mhd28tm54t
+  name: proxy-5f87fc6759
   namespace: konflux-ui
 ---
 apiVersion: v1
@@ -487,6 +491,8 @@ spec:
           name: nginx-generated-location-config
         - mountPath: /opt/app-root/src/static-content
           name: static-content
+        - mountPath: /opt/app-root/src/segment
+          name: segment-bridge-config
       - env:
         - name: OAUTH2_PROXY_CLIENT_SECRET
           valueFrom:
@@ -594,7 +600,7 @@ spec:
           items:
           - key: nginx.conf
             path: nginx.conf
-          name: proxy-mhd28tm54t
+          name: proxy-5f87fc6759
         name: proxy
       - configMap:
           defaultMode: 420
@@ -618,6 +624,15 @@ spec:
           secretName: proxy
       - emptyDir: {}
         name: static-content
+      - name: segment-bridge-config
+        secret:
+          items:
+          - key: key
+            path: key
+          - key: url
+            path: url
+          optional: true
+          secretName: segment-bridge-config
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/operator/pkg/segment/segment.go
+++ b/operator/pkg/segment/segment.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package segment
 
+import (
+	"github.com/go-logr/logr"
+)
+
 // defaultWriteKey is the Segment write key baked into production builds.
 // Empty in development; set via -ldflags during container image builds.
 // Used as a fallback when the KonfluxSegmentBridge CR does not specify a key.
@@ -24,4 +28,29 @@ var defaultWriteKey = ""
 // GetDefaultWriteKey returns the build-time Segment write key.
 func GetDefaultWriteKey() string {
 	return defaultWriteKey
+}
+
+// ResolveWriteKey determines the effective Segment write key.
+// It prefers crKey (from the CR spec); if empty, falls back to defaultKey
+// (typically the build-time value injected via ldflags).
+// Returns the key and its source ("cr", "build-time-default", or "" if unresolved).
+func ResolveWriteKey(crKey, defaultKey string) (key, source string) {
+	if crKey != "" {
+		return crKey, "cr"
+	}
+	if defaultKey != "" {
+		return defaultKey, "build-time-default"
+	}
+	return "", ""
+}
+
+// LogWriteKeyResolution logs how the Segment write key was resolved.
+// Returns true if a key is available, false if no key was configured.
+func LogWriteKeyResolution(log logr.Logger, key, source string) bool {
+	if key == "" {
+		log.Info("No Segment write key configured (neither CR nor build-time default)")
+		return false
+	}
+	log.Info("Resolved Segment write key", "source", source)
+	return true
 }

--- a/operator/pkg/segment/segment_test.go
+++ b/operator/pkg/segment/segment_test.go
@@ -18,10 +18,74 @@ package segment
 
 import (
 	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/onsi/gomega"
 )
 
 func TestGetDefaultWriteKey(t *testing.T) {
-	if got := GetDefaultWriteKey(); got != "" {
-		t.Errorf("GetDefaultWriteKey() should return empty in source, got %q", got)
+	g := gomega.NewWithT(t)
+	g.Expect(GetDefaultWriteKey()).To(gomega.BeEmpty(), "should return empty in source (no ldflags)")
+}
+
+func TestResolveWriteKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		crKey      string
+		defaultKey string
+		wantKey    string
+		wantSource string
+	}{
+		{
+			name:       "CR key takes precedence",
+			crKey:      "cr-key",
+			wantKey:    "cr-key",
+			wantSource: "cr",
+		},
+		{
+			name:       "CR key takes precedence over default",
+			crKey:      "cr-key",
+			defaultKey: "build-key",
+			wantKey:    "cr-key",
+			wantSource: "cr",
+		},
+		{
+			name:       "falls back to default when CR key is empty",
+			crKey:      "",
+			defaultKey: "build-key",
+			wantKey:    "build-key",
+			wantSource: "build-time-default",
+		},
+		{
+			name:       "returns empty when neither is set",
+			crKey:      "",
+			defaultKey: "",
+			wantKey:    "",
+			wantSource: "",
+		},
 	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			gotKey, gotSource := ResolveWriteKey(tt.crKey, tt.defaultKey)
+			g.Expect(gotKey).To(gomega.Equal(tt.wantKey))
+			g.Expect(gotSource).To(gomega.Equal(tt.wantSource))
+		})
+	}
+}
+
+func TestLogWriteKeyResolution(t *testing.T) {
+	log := logr.Discard()
+
+	t.Run("returns false when key is empty", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(LogWriteKeyResolution(log, "", "")).To(gomega.BeFalse())
+	})
+
+	t.Run("returns true when key is present", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(LogWriteKeyResolution(log, "some-key", "cr")).To(gomega.BeTrue())
+	})
 }

--- a/operator/upstream-kustomizations/ui/core/proxy/nginx.conf
+++ b/operator/upstream-kustomizations/ui/core/proxy/nginx.conf
@@ -48,6 +48,10 @@ http {
         location = /404.html {
         }
 
+        location /segment {
+            default_type text/plain;
+        }
+
         location = /oauth2/auth {
             internal;
             proxy_pass       http://127.0.0.1:6000;

--- a/operator/upstream-kustomizations/ui/core/proxy/proxy.yaml
+++ b/operator/upstream-kustomizations/ui/core/proxy/proxy.yaml
@@ -159,6 +159,8 @@ spec:
             mountPath: /mnt/nginx-generated-location-config
           - name: static-content
             mountPath: /opt/app-root/src/static-content
+          - name: segment-bridge-config
+            mountPath: /opt/app-root/src/segment
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -221,6 +223,15 @@ spec:
             secretName: proxy
         - name: static-content
           emptyDir: {}
+        - name: segment-bridge-config
+          secret:
+            secretName: segment-bridge-config
+            optional: true
+            items:
+              - key: key
+                path: key
+              - key: url
+                path: url
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Create a content-hashed Secret with the Segment write key and API URL, and mount it to the nginx container. Name includes a hash suffix so content changes trigger a Deployment rollout.

Expose the Segment key and url in the following endpoints:

/segment/key
/segment/url

- Extract write key resolution into pkg/segment for reuse
- Add pkg/contenthash and pkg/hashedsecret generic utilities
- Add WithSecretVolumeUpdate to pkg/customization
- Make segment-bridge-config volume optional in manifests
- Add unit and envtest coverage for all new code

Assisted-By: Cursor