### PR TITLE
fix(segment-bridge): Writable tmpdir

### DIFF
--- a/operator/pkg/manifests/segment-bridge/manifests.yaml
+++ b/operator/pkg/manifests/segment-bridge/manifests.yaml
@@ -83,10 +83,16 @@ spec:
                 drop:
                 - ALL
               readOnlyRootFilesystem: true
+            volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           restartPolicy: OnFailure
           securityContext:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
           serviceAccountName: segment-bridge
+          volumes:
+          - name: tmp
+            emptyDir: {}
   schedule: 0 * * * *


### PR DESCRIPTION
Mount an empty dir for the segment-bridge job so it can write to `/tmp`.

Assisted-by: Gemini (via Cursor)
Signed-off-by: Barak Korren <bkorren@redhat.com>