### PR TITLE
chore(KFLUXVNGD-822): upstream kustomization for segment-bridge

### DIFF
--- a/operator/pkg/manifests/segment-bridge/manifests.yaml
+++ b/operator/pkg/manifests/segment-bridge/manifests.yaml
@@ -67,7 +67,7 @@ spec:
             - secretRef:
                 name: segment-bridge-config
                 optional: true
-            image: quay.io/konflux-ci/segment-bridge:c4dd0df5da300aa02834089c2d2339d20c7c5b2a
+            image: quay.io/konflux-ci/segment-bridge:a49fb41767ac05d94357a9f67d7a23a2d539f2e0
             imagePullPolicy: IfNotPresent
             name: segment-bridge
             resources:

--- a/operator/upstream-kustomizations/segment-bridge/kustomization.yaml
+++ b/operator/upstream-kustomizations/segment-bridge/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/konflux-ci/segment-bridge/config/base?ref=a49fb41767ac05d94357a9f67d7a23a2d539f2e0
+images:
+- name: quay.io/konflux-ci/segment-bridge
+  newName: quay.io/konflux-ci/segment-bridge
+  newTag: a49fb41767ac05d94357a9f67d7a23a2d539f2e0


### PR DESCRIPTION
Adds config files to the operator to automatically keep the segment-bridge image SHA current.

assisted-by: cursor