### PR TITLE
chore: rebase renovate PRs only on conflicts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "ignorePaths": [
     "operator/pkg/manifests/**"
   ],
+  "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
We're seeing GitHub rate limiting issues in CI. Some of the stress is coming from renovate rebasing PRs whenever a PR is merged. Limiting this for Renovate to only rebase on conflicts should reduce the stress.

Assisted-by: Cursor