### PR TITLE
fix: add retry on kyverno policies

### DIFF
--- a/deploy-deps.sh
+++ b/deploy-deps.sh
@@ -325,7 +325,8 @@ deploy_kyverno() {
     echo "  ⏳ Waiting for Kyverno admission controller..." >&2
     retry "kubectl wait --for=condition=Available deployment/kyverno-admission-controller -n kyverno --timeout=30s" \
           "Kyverno admission controller did not become available within the allocated time"
-    kubectl apply -k "${script_path}/dependencies/kyverno/policy"
+    retry "kubectl apply -k ${script_path}/dependencies/kyverno/policy" \
+          "Failed to apply Kyverno policies (webhook may not be ready yet)"
 }
 
 deploy_konflux_info() {


### PR DESCRIPTION
The previous fix which waited for the admission controller to be ready was not enough to ensure the policies could be applied. This adds a retry loop to the policy application step.

Assisted-by: Cursor