### PR TITLE
feat: add tektonChainsIdentity field to cluster-config ConfigMap

### DIFF
--- a/operator/api/v1alpha1/konfluxinfo_types.go
+++ b/operator/api/v1alpha1/konfluxinfo_types.go
@@ -269,6 +269,11 @@ type ClusterConfigData struct {
 	// used by Trustification clients.
 	// +optional
 	TrustifyOIDCIssuerUrl string `json:"trustifyOIDCIssuerUrl,omitempty"`
+
+	// TektonChainsIdentity is the identity of Tekton Chains used when verifying
+	// the signature of attestations produced by Tekton Chains.
+	// +optional
+	TektonChainsIdentity string `json:"tektonChainsIdentity,omitempty"`
 }
 
 // All is an iterator that yields all non-empty key-value pairs from ClusterConfigData.
@@ -332,6 +337,11 @@ func (d ClusterConfigData) All(yield func(key, value string) bool) {
 	}
 	if d.TrustifyOIDCIssuerUrl != "" {
 		if !yield("trustifyOIDCIssuerUrl", d.TrustifyOIDCIssuerUrl) {
+			return
+		}
+	}
+	if d.TektonChainsIdentity != "" {
+		if !yield("tektonChainsIdentity", d.TektonChainsIdentity) {
 			return
 		}
 	}

--- a/operator/api/v1alpha1/konfluxinfo_types_test.go
+++ b/operator/api/v1alpha1/konfluxinfo_types_test.go
@@ -41,11 +41,12 @@ func TestClusterConfigData_All(t *testing.T) {
 			TrustifyServerExternalUrl: "https://trustify-external.example.com",
 			BuildIdentityRegexp:       "^https://konflux\\.dev/build/.*$",
 			TrustifyOIDCIssuerUrl:     "https://keycloak-external/realm/foobar",
+			TektonChainsIdentity:      "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller",
 		}
 
 		collected := maps.Collect(data.All)
 
-		g.Expect(collected).To(gomega.HaveLen(12))
+		g.Expect(collected).To(gomega.HaveLen(13))
 		g.Expect(collected["defaultOIDCIssuer"]).To(gomega.Equal("https://oidc.example.com"))
 		g.Expect(collected["enableKeylessSigning"]).To(gomega.Equal("true"))
 		g.Expect(collected["fulcioInternalUrl"]).To(gomega.Equal("https://fulcio-internal.example.com"))
@@ -58,6 +59,7 @@ func TestClusterConfigData_All(t *testing.T) {
 		g.Expect(collected["trustifyServerExternalUrl"]).To(gomega.Equal("https://trustify-external.example.com"))
 		g.Expect(collected["buildIdentityRegexp"]).To(gomega.Equal("^https://konflux\\.dev/build/.*$"))
 		g.Expect(collected["trustifyOIDCIssuerUrl"]).To(gomega.Equal("https://keycloak-external/realm/foobar"))
+		g.Expect(collected["tektonChainsIdentity"]).To(gomega.Equal("https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller"))
 	})
 
 	t.Run("should not yield empty fields", func(t *testing.T) {
@@ -83,6 +85,7 @@ func TestClusterConfigData_All(t *testing.T) {
 		g.Expect(collected).NotTo(gomega.HaveKey("trustifyServerExternalUrl"))
 		g.Expect(collected).NotTo(gomega.HaveKey("buildIdentityRegexp"))
 		g.Expect(collected).NotTo(gomega.HaveKey("trustifyOIDCIssuerUrl"))
+		g.Expect(collected).NotTo(gomega.HaveKey("tektonChainsIdentity"))
 	})
 
 	t.Run("should yield nothing for empty struct", func(t *testing.T) {
@@ -111,6 +114,7 @@ func TestClusterConfigData_All(t *testing.T) {
 			TrustifyServerExternalUrl: "https://trustify-external.example.com",
 			BuildIdentityRegexp:       "^https://konflux\\.dev/build/.*$",
 			TrustifyOIDCIssuerUrl:     "https://keycloak-external/realm/foobar",
+			TektonChainsIdentity:      "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller",
 		}
 
 		var yielded []string
@@ -140,6 +144,7 @@ func TestClusterConfigData_All(t *testing.T) {
 			TrustifyServerExternalUrl: "trustify-external",
 			BuildIdentityRegexp:       "^https://konflux\\.dev/build/.*$",
 			TrustifyOIDCIssuerUrl:     "https://keycloak-external/realm/foobar",
+			TektonChainsIdentity:      "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller",
 		}
 
 		var keys []string
@@ -161,6 +166,7 @@ func TestClusterConfigData_All(t *testing.T) {
 			"trustifyServerExternalUrl",
 			"buildIdentityRegexp",
 			"trustifyOIDCIssuerUrl",
+			"tektonChainsIdentity",
 		}
 
 		g.Expect(keys).To(gomega.Equal(expectedOrder))
@@ -291,6 +297,7 @@ func TestClusterConfigData_MergeOver(t *testing.T) {
 			TrustifyServerExternalUrl: "base-trustify-external",
 			BuildIdentityRegexp:       "base-build-identity",
 			TrustifyOIDCIssuerUrl:     "base-trustify-issuer",
+			TektonChainsIdentity:      "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/base-tekton-chains-controller",
 		}
 
 		override := ClusterConfigData{
@@ -306,11 +313,12 @@ func TestClusterConfigData_MergeOver(t *testing.T) {
 			TrustifyServerExternalUrl: "override-trustify-external",
 			BuildIdentityRegexp:       "override-build-identity",
 			TrustifyOIDCIssuerUrl:     "override-trustify-issuer",
+			TektonChainsIdentity:      "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/override-tekton-chains-controller",
 		}
 
 		result := override.MergeOver(base)
 
-		g.Expect(result).To(gomega.HaveLen(12))
+		g.Expect(result).To(gomega.HaveLen(13))
 		g.Expect(result["defaultOIDCIssuer"]).To(gomega.Equal("override-oidc"))
 		g.Expect(result["enableKeylessSigning"]).To(gomega.Equal("true"))
 		g.Expect(result["fulcioInternalUrl"]).To(gomega.Equal("override-fulcio-internal"))
@@ -323,6 +331,7 @@ func TestClusterConfigData_MergeOver(t *testing.T) {
 		g.Expect(result["trustifyServerExternalUrl"]).To(gomega.Equal("override-trustify-external"))
 		g.Expect(result["buildIdentityRegexp"]).To(gomega.Equal("override-build-identity"))
 		g.Expect(result["trustifyOIDCIssuerUrl"]).To(gomega.Equal("override-trustify-issuer"))
+		g.Expect(result["tektonChainsIdentity"]).To(gomega.Equal("https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/override-tekton-chains-controller"))
 	})
 
 	t.Run("should combine base and override when no conflicts", func(t *testing.T) {

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
@@ -450,6 +450,11 @@ spec:
                                 description: RekorInternalUrl is the internal Rekor
                                   URL.
                                 type: string
+                              tektonChainsIdentity:
+                                description: |-
+                                  TektonChainsIdentity is the identity of Tekton Chains used when verifying
+                                  the signature of attestations produced by Tekton Chains.
+                                type: string
                               trustifyOIDCIssuerUrl:
                                 description: |-
                                   TrustifyOIDCIssuerUrl is the URL of the OIDC issuer

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxinfoes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxinfoes.yaml
@@ -140,6 +140,11 @@ spec:
                       rekorInternalUrl:
                         description: RekorInternalUrl is the internal Rekor URL.
                         type: string
+                      tektonChainsIdentity:
+                        description: |-
+                          TektonChainsIdentity is the identity of Tekton Chains used when verifying
+                          the signature of attestations produced by Tekton Chains.
+                        type: string
                       trustifyOIDCIssuerUrl:
                         description: |-
                           TrustifyOIDCIssuerUrl is the URL of the OIDC issuer

--- a/operator/internal/controller/info/konfluxinfo_controller.go
+++ b/operator/internal/controller/info/konfluxinfo_controller.go
@@ -100,6 +100,8 @@ const (
 	ClusterConfigKeyBuildIdentityRegexp = "buildIdentityRegexp"
 	// ClusterConfigKeyTrustifyOIDCIssuerUrl is the ConfigMap key for URL of the OIDC issuer used by Trustification clients.
 	ClusterConfigKeyTrustifyOIDCIssuerUrl = "trustifyOIDCIssuerUrl"
+	// ClusterConfigKeyTektonChainsIdentity is the ConfigMap key for the Tekton Chains identity used when verifying attestation signatures.
+	ClusterConfigKeyTektonChainsIdentity = "tektonChainsIdentity"
 )
 
 // ClusterConfigDiscoverer is an interface for discovering cluster configuration values.


### PR DESCRIPTION
Add a new `tektonChainsIdentity` field to `ClusterConfigData` so that the identity of Tekton Chains can be configured and exposed in the cluster-config ConfigMap. This identity is used when verifying the signature of attestations produced by Tekton Chains.

Assiste-By: Cursor