### PR TITLE
fix(deploy-local): update template

### DIFF
--- a/scripts/deploy-local.env.template
+++ b/scripts/deploy-local.env.template
@@ -7,6 +7,26 @@
 # in your environment (useful for CI/automated deployments).
 #
 # IMPORTANT: deploy-local.env is in .gitignore - never commit secrets!
+#
+# ==============================================================================
+# Variable Precedence (high to low)
+# ==============================================================================
+#
+#   1. Injected env vars (CLI)  -  highest priority, always wins
+#        OPERATOR_INSTALL_METHOD=none ./scripts/deploy-local.sh
+#
+#   2. Values in this file (deploy-local.env)
+#        Sourced by the script; only takes effect when the variable was NOT
+#        already provided on the command line.
+#
+#   3. Script defaults  -  lowest priority
+#        Fallback values defined inside deploy-local.sh with ${VAR:-default}.
+#        Applied only when the variable is unset or empty after steps 1 and 2.
+#
+# This means you can always override a value from this file for a single run
+# without editing the file:
+#   KIND_MEMORY_GB=16 ./scripts/deploy-local.sh
+# ==============================================================================
 
 # ==============================================================================
 # Operator Installation Configuration
@@ -22,6 +42,7 @@
 # NOTE: 'local' applies manifests from your checkout with the latest released
 # image. To avoid mismatches, checkout a specific release tag first:
 #   git checkout v1.0.0 && OPERATOR_INSTALL_METHOD=local ./scripts/deploy-local.sh
+#
 OPERATOR_INSTALL_METHOD=release
 
 # Operator image (used with 'local' and 'build' methods)
@@ -118,7 +139,7 @@ SMEE_CHANNEL=""
 
 # Segment write key for telemetry data collection (OPTIONAL)
 # Only needed with OPERATOR_INSTALL_METHOD=build (local operator development).
-# The 'release' method does not require a local secret. 
+# The 'release' method does not require a local secret.
 # Find the test write key in Segment workspace settings → Sources.
 # Leave empty to skip telemetry secret creation.
 # SEGMENT_WRITE_KEY=""

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -55,12 +55,19 @@ set -euo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 REPO_ROOT=$(dirname "$SCRIPT_DIR")
 
-# Optional: Load environment configuration from file if it exists
+# Optional: Load environment configuration from file if it exists.
+# Precedence (high to low): injected env vars > env file > script defaults.
+# Snapshot the caller's environment first so that any vars passed on the
+# command line (e.g. OPERATOR_INSTALL_METHOD=none ./scripts/deploy-local.sh)
+# are restored after sourcing and therefore take priority over the env file.
 ENV_FILE="${SCRIPT_DIR}/deploy-local.env"
 if [ -f "${ENV_FILE}" ]; then
     echo "Loading configuration from ${ENV_FILE}"
+    _pre_env=$(export -p)
     # shellcheck disable=SC1090
     source "${ENV_FILE}"
+    eval "$_pre_env"
+    unset _pre_env
 fi
 
 # Validate REQUIRED variables


### PR DESCRIPTION
Updating the precedence of the variables in the deploy-local.sh.
The script now follows the precedence of the variables.
1 - Injected env vars (CLI)
2 - Values in this file (deploy-local.env)
3 - Script defaults
