### PR TITLE
feat(KFLUXVNGD-833): Update enterprise contract policies to use digests

### DIFF
--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_all.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_all.yaml
@@ -17,8 +17,8 @@ spec:
       include:
       - '*'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:cc03b2c00a336b9b264fbb5a077150a0a27549be75fa3ba4fb5c1aa1e826bc3c
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=671e5c26f93de6a0931f49e2e2d7f0eb4d5df6c8
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:konflux@sha256:be53571e210f76978fb3d89233aa9740cde4e3c66707db029728a81479ad3f73

--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
@@ -17,8 +17,8 @@ spec:
       include:
       - '@slsa3'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:cc03b2c00a336b9b264fbb5a077150a0a27549be75fa3ba4fb5c1aa1e826bc3c
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=dd1a3dd1bf2299e1da9936b89e7279b6ab443bec
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:konflux@sha256:be53571e210f76978fb3d89233aa9740cde4e3c66707db029728a81479ad3f73

--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-no-hermetic.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-no-hermetic.yaml
@@ -19,8 +19,8 @@ spec:
       include:
       - '@redhat'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:cc03b2c00a336b9b264fbb5a077150a0a27549be75fa3ba4fb5c1aa1e826bc3c
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=671e5c26f93de6a0931f49e2e2d7f0eb4d5df6c8
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:konflux@sha256:be53571e210f76978fb3d89233aa9740cde4e3c66707db029728a81479ad3f73

--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-trusted-tasks.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-trusted-tasks.yaml
@@ -12,7 +12,7 @@ spec:
       include:
       - kind
     data:
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=dd1a3dd1bf2299e1da9936b89e7279b6ab443bec
     name: Default
     policy:
     - oci::quay.io/conforma/task-policy:konflux@sha256:fb2c1cfc0b68f6aca13eb9c63ae90bbabbc5384818484d8358f66cd9b53d82c9

--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat.yaml
@@ -16,8 +16,8 @@ spec:
       include:
       - '@redhat'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:d0e34b6ed08e9e6922134693f7ca8130e04849b82318150c4b4b2f721b8a4bfb
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=dd1a3dd1bf2299e1da9936b89e7279b6ab443bec
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:konflux@sha256:be53571e210f76978fb3d89233aa9740cde4e3c66707db029728a81479ad3f73

--- a/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_slsa3.yaml
+++ b/konflux-ci/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_slsa3.yaml
@@ -18,8 +18,8 @@ spec:
       - '@minimal'
       - '@slsa3'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:cc03b2c00a336b9b264fbb5a077150a0a27549be75fa3ba4fb5c1aa1e826bc3c
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=dd1a3dd1bf2299e1da9936b89e7279b6ab443bec
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:konflux@sha256:be53571e210f76978fb3d89233aa9740cde4e3c66707db029728a81479ad3f73

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: example.com/konflux-operator
-  newTag: v0.0.1
+  newName: localhost/konflux-operator
+  newTag: local

--- a/operator/pkg/manifests/enterprise-contract/manifests.yaml
+++ b/operator/pkg/manifests/enterprise-contract/manifests.yaml
@@ -398,8 +398,8 @@ spec:
       include:
       - '*'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:cc03b2c00a336b9b264fbb5a077150a0a27549be75fa3ba4fb5c1aa1e826bc3c
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=671e5c26f93de6a0931f49e2e2d7f0eb4d5df6c8
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:konflux@sha256:be53571e210f76978fb3d89233aa9740cde4e3c66707db029728a81479ad3f73
@@ -423,8 +423,8 @@ spec:
       include:
       - '@slsa3'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:cc03b2c00a336b9b264fbb5a077150a0a27549be75fa3ba4fb5c1aa1e826bc3c
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=dd1a3dd1bf2299e1da9936b89e7279b6ab443bec
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:konflux@sha256:be53571e210f76978fb3d89233aa9740cde4e3c66707db029728a81479ad3f73
@@ -447,8 +447,8 @@ spec:
       include:
       - '@redhat'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:d0e34b6ed08e9e6922134693f7ca8130e04849b82318150c4b4b2f721b8a4bfb
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=dd1a3dd1bf2299e1da9936b89e7279b6ab443bec
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:konflux@sha256:be53571e210f76978fb3d89233aa9740cde4e3c66707db029728a81479ad3f73
@@ -474,8 +474,8 @@ spec:
       include:
       - '@redhat'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:cc03b2c00a336b9b264fbb5a077150a0a27549be75fa3ba4fb5c1aa1e826bc3c
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=671e5c26f93de6a0931f49e2e2d7f0eb4d5df6c8
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:konflux@sha256:be53571e210f76978fb3d89233aa9740cde4e3c66707db029728a81479ad3f73
@@ -494,7 +494,7 @@ spec:
       include:
       - kind
     data:
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=dd1a3dd1bf2299e1da9936b89e7279b6ab443bec
     name: Default
     policy:
     - oci::quay.io/conforma/task-policy:konflux@sha256:fb2c1cfc0b68f6aca13eb9c63ae90bbabbc5384818484d8358f66cd9b53d82c9
@@ -519,8 +519,8 @@ spec:
       - '@minimal'
       - '@slsa3'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:cc03b2c00a336b9b264fbb5a077150a0a27549be75fa3ba4fb5c1aa1e826bc3c
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=dd1a3dd1bf2299e1da9936b89e7279b6ab443bec
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:konflux@sha256:be53571e210f76978fb3d89233aa9740cde4e3c66707db029728a81479ad3f73

--- a/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_all.yaml
+++ b/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_all.yaml
@@ -17,8 +17,8 @@ spec:
       include:
       - '*'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:cc03b2c00a336b9b264fbb5a077150a0a27549be75fa3ba4fb5c1aa1e826bc3c
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=671e5c26f93de6a0931f49e2e2d7f0eb4d5df6c8
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:konflux@sha256:be53571e210f76978fb3d89233aa9740cde4e3c66707db029728a81479ad3f73

--- a/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
+++ b/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
@@ -17,8 +17,8 @@ spec:
       include:
       - '@slsa3'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:cc03b2c00a336b9b264fbb5a077150a0a27549be75fa3ba4fb5c1aa1e826bc3c
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=dd1a3dd1bf2299e1da9936b89e7279b6ab443bec
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:konflux@sha256:be53571e210f76978fb3d89233aa9740cde4e3c66707db029728a81479ad3f73

--- a/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-no-hermetic.yaml
+++ b/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-no-hermetic.yaml
@@ -19,8 +19,8 @@ spec:
       include:
       - '@redhat'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:cc03b2c00a336b9b264fbb5a077150a0a27549be75fa3ba4fb5c1aa1e826bc3c
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=671e5c26f93de6a0931f49e2e2d7f0eb4d5df6c8
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:konflux@sha256:be53571e210f76978fb3d89233aa9740cde4e3c66707db029728a81479ad3f73

--- a/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-trusted-tasks.yaml
+++ b/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat-trusted-tasks.yaml
@@ -12,7 +12,7 @@ spec:
       include:
       - kind
     data:
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=dd1a3dd1bf2299e1da9936b89e7279b6ab443bec
     name: Default
     policy:
     - oci::quay.io/conforma/task-policy:konflux@sha256:fb2c1cfc0b68f6aca13eb9c63ae90bbabbc5384818484d8358f66cd9b53d82c9

--- a/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat.yaml
+++ b/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_redhat.yaml
@@ -16,8 +16,8 @@ spec:
       include:
       - '@redhat'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:d0e34b6ed08e9e6922134693f7ca8130e04849b82318150c4b4b2f721b8a4bfb
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=dd1a3dd1bf2299e1da9936b89e7279b6ab443bec
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:konflux@sha256:be53571e210f76978fb3d89233aa9740cde4e3c66707db029728a81479ad3f73

--- a/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_slsa3.yaml
+++ b/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_slsa3.yaml
@@ -18,8 +18,8 @@ spec:
       - '@minimal'
       - '@slsa3'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:cc03b2c00a336b9b264fbb5a077150a0a27549be75fa3ba4fb5c1aa1e826bc3c
+    - github.com/release-engineering/rhtap-ec-policy.git//data?ref=dd1a3dd1bf2299e1da9936b89e7279b6ab443bec
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:konflux@sha256:be53571e210f76978fb3d89233aa9740cde4e3c66707db029728a81479ad3f73

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
         "https://github.com/conforma/*",
         "https://github.com/konflux-ci/*",
         "https://github.com/redhat-appstudio/*",
+        "https://github.com/release-engineering/*",
         "quay.io/conforma/*",
         "quay.io/enterprise-contract/*",
         "quay.io/konflux-ci/*",
@@ -152,6 +153,33 @@
       ],
       "datasourceTemplate": "docker",
       "currentValueTemplate": "konflux"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "konflux-ci/enterprise-contract/policies/.*\\.yaml$",
+        "operator/upstream-kustomizations/enterprise-contract/policies/.*\\.yaml$"
+      ],
+      "matchStrings": [
+        "- oci::(?<depName>quay\\.io/konflux-ci/tekton-catalog/data-acceptable-bundles):latest@(?<currentDigest>sha256:[a-f0-9]{64})"
+      ],
+      "autoReplaceStringTemplate": "- oci::{{depName}}:latest@{{newDigest}}",
+      "datasourceTemplate": "docker",
+      "currentValueTemplate": "latest"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "konflux-ci/enterprise-contract/policies/.*\\.yaml$",
+        "operator/upstream-kustomizations/enterprise-contract/policies/.*\\.yaml$"
+      ],
+      "matchStrings": [
+        "- github\\.com/(?<depName>release-engineering/rhtap-ec-policy)\\.git//data\\?ref=(?<currentDigest>[a-f0-9]{40})"
+      ],
+      "packageNameTemplate": "https://github.com/{{depName}}",
+      "autoReplaceStringTemplate": "- github.com/{{depName}}.git//data?ref={{newDigest}}",
+      "datasourceTemplate": "git-refs",
+      "currentValueTemplate": "main"
     },
     {
       "description": "Track kind version in GitHub Actions workflows",


### PR DESCRIPTION
- Update the enterprise contract policies to use digests instead of tags.
- Update the renovate.json file.
- Update enterprise contract manifests.yaml file.

When a release of the operator is cut, the data-acceptable-bundles:latest tag keeps moving.
This means:

- At build time, a specific digest is baked into the image.
- After release, the latest tag shifts to a newer version.
- At runtime (or when EC evaluates), the bundle list it pulls may differ
from what the pipeline tasks were validated against at build time which can
lead to a potential policy mismatch.

The same goes for the rhtap-ec-policy git repository.

Assited-By: Cursor