### PR TITLE
fix: create catalog PRs as draft

### DIFF
--- a/.github/scripts/create-community-operator-pr.sh
+++ b/.github/scripts/create-community-operator-pr.sh
@@ -161,8 +161,10 @@ git push --force origin "${BRANCH_NAME}"
 echo ""
 echo "=== Creating Pull Request ==="
 
-# Create PR to upstream repository
+# Create PR to upstream repository (as draft so we can later mark one ready at a time
+# and avoid catalog-update PR conflicts)
 PR_URL=$(GH_TOKEN="${GITHUB_TOKEN}" gh pr create \
+  --draft \
   --repo "${UPSTREAM_REPO}" \
   --head "${FORK_REPO%%/*}:${BRANCH_NAME}" \
   --base main \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,9 +83,14 @@ The `repository_dispatch` event triggers the
 
 When a GitHub release is published, the
 [Community Operator PR workflow](.github/workflows/community-operator-pr.yaml)
-automatically creates a pull request to the
-[Red Hat Community Operators repository](https://github.com/redhat-openshift-ecosystem/community-operators-prod)
-to publish the Konflux operator in the OpenShift catalog.
+creates a **draft** pull request to the
+[Red Hat Community Operators repository](https://github.com/redhat-openshift-ecosystem/community-operators-prod).
+Draft PRs are used so that only one catalog PR is mergeable at a time (when multiple
+releases from different branches create PRs in parallel, marking them all ready would
+cause conflicts in the downstream catalog-update PRs).
+
+For the operator to be published to the OpenShift catalog, a draft PR must be marked
+**Ready for review**.
 
 The workflow:
 


### PR DESCRIPTION
The catalog PR workflow is triggered in parallel for multiple streams. This results with multiple catalog PRs being created and merged at the same time. Each triggers the creation of FBC PRs on the catalog repo, and when the first one is merged, the next one has conflicts, which require human intervention.

To avoid that, create the catalog PRs as draft, which should be marked as ready one at a time. At first this can be done manually, and in the future we can add a workflow to do that.