### PR TITLE
feat: mark community operator PRs as non-draft

### DIFF
--- a/.github/scripts/create-community-operator-pr.sh
+++ b/.github/scripts/create-community-operator-pr.sh
@@ -1,21 +1,29 @@
 #!/bin/bash
 set -euo pipefail
 
-# Create Community Operator PR Script
-# This script creates a PR to the community-operators-prod repository
-# with a new bundle version for the Konflux operator.
+# Create or update Community Operator PR Script
+# Creates a PR to the community-operators-prod repository with a new bundle
+# version for the Konflux operator, or updates an existing PR branch (rebase
+# on current main) and marks it ready for review.
 #
 # Usage:
-#   create-community-operator-pr.sh <release_tag>
+#   create-community-operator-pr.sh <release_tag> [--draft|--no-draft]
+#   create-community-operator-pr.sh <release_tag> --update
 #
 # Arguments:
 #   release_tag - GitHub release tag (e.g., v0.0.4)
+#   --draft     - Create PR as draft (default when creating)
+#   --no-draft  - Create PR ready for review
+#   --update    - Update mode: re-run same steps (clone main, apply bundle, force-push),
+#                 then find the PR by head branch and mark it ready.
+#   --dry-run   - Validate args and print branch name; no gh/git operations. No token needed.
 #
-# Environment Variables (required):
-#   GITHUB_TOKEN - PAT with public_repo scope for all operations
+# Environment Variables (required unless --dry-run):
+#   GITHUB_TOKEN - PAT with public_repo scope (same identity as PR author for --update)
 #
-# Example:
-#   GITHUB_TOKEN=ghp_xxx create-community-operator-pr.sh v0.0.4
+# Examples:
+#   GITHUB_TOKEN=ghp_xxx create-community-operator-pr.sh v0.0.4 --draft
+#   GITHUB_TOKEN=ghp_xxx create-community-operator-pr.sh v0.0.4 --update
 
 # Configuration
 UPSTREAM_REPO="redhat-openshift-ecosystem/community-operators-prod"
@@ -23,17 +31,68 @@ FORK_REPO="konflux-ci/community-operators-prod"
 SOURCE_REPO="konflux-ci/konflux-ci"
 OPERATOR_NAME="konflux"
 
-if [ $# -ne 1 ]; then
-  echo "Error: Invalid number of arguments"
-  echo "Usage: $0 <release_tag>"
+RELEASE_TAG=""
+CREATE_DRAFT="true"
+UPDATE_MODE="false"
+DRY_RUN="false"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --draft)
+      CREATE_DRAFT="true"
+      shift
+      ;;
+    --no-draft)
+      CREATE_DRAFT="false"
+      shift
+      ;;
+    --update)
+      UPDATE_MODE="true"
+      CREATE_DRAFT="false"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    -*)
+      echo "Error: Unknown option $1"
+      exit 1
+      ;;
+    *)
+      if [ -z "${RELEASE_TAG}" ]; then
+        RELEASE_TAG="$1"
+      else
+        echo "Error: Unexpected argument $1"
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "${RELEASE_TAG}" ]; then
+  echo "Error: release_tag is required"
+  echo "Usage: $0 <release_tag> [--draft|--no-draft] [--update] [--dry-run]"
   exit 1
 fi
 
-RELEASE_TAG="$1"
-
-if [ -z "${GITHUB_TOKEN:-}" ]; then
+if [ "${DRY_RUN}" != "true" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
   echo "Error: GITHUB_TOKEN environment variable is required"
   exit 1
+fi
+
+# Dry-run: validate and print what would be done; no network or git operations
+if [ "${DRY_RUN}" = "true" ]; then
+  VERSION="${RELEASE_TAG#v}"
+  BRANCH_NAME="${OPERATOR_NAME}-${VERSION}"
+  echo "=== Dry run ==="
+  echo "Release tag: ${RELEASE_TAG}"
+  echo "Version: ${VERSION}"
+  echo "Branch name: ${BRANCH_NAME}"
+  echo "Mode: $([ "${UPDATE_MODE}" = "true" ] && echo "update (refresh branch, mark PR ready)" || echo "create (draft=${CREATE_DRAFT})")"
+  echo "Would use: SOURCE_REPO=${SOURCE_REPO} FORK_REPO=${FORK_REPO} UPSTREAM_REPO=${UPSTREAM_REPO}"
+  exit 0
 fi
 
 echo "=== Creating Community Operator PR ==="
@@ -157,22 +216,37 @@ echo ""
 echo "=== Pushing to fork ==="
 git push --force origin "${BRANCH_NAME}"
 
-# Create PR to upstream
+# Create PR or mark existing PR ready
 echo ""
-echo "=== Creating Pull Request ==="
-
-# Create PR to upstream repository (as draft so we can later mark one ready at a time
-# and avoid catalog-update PR conflicts)
-PR_URL=$(GH_TOKEN="${GITHUB_TOKEN}" gh pr create \
-  --draft \
-  --repo "${UPSTREAM_REPO}" \
-  --head "${FORK_REPO%%/*}:${BRANCH_NAME}" \
-  --base main \
-  --title "${COMMIT_TITLE}" \
-  --body "${COMMIT_BODY}")
-
-echo ""
-echo "=== PR Created Successfully ==="
-echo "PR URL: ${PR_URL}"
+if [ "${UPDATE_MODE}" = "true" ]; then
+  PR_NUM=$(GH_TOKEN="${GITHUB_TOKEN}" gh pr list --repo "${UPSTREAM_REPO}" \
+    --head "${FORK_REPO%%/*}:${BRANCH_NAME}" --state open --json number -q '.[0].number')
+  if [ -z "${PR_NUM}" ] || [ "${PR_NUM}" = "null" ]; then
+    echo "Error: No open PR found for head ${FORK_REPO%%/*}:${BRANCH_NAME}"
+    exit 1
+  fi
+  echo "=== Marking PR #${PR_NUM} ready for review ==="
+  GH_TOKEN="${GITHUB_TOKEN}" gh pr ready "${PR_NUM}" --repo "${UPSTREAM_REPO}"
+  PR_URL="https://github.com/${UPSTREAM_REPO}/pull/${PR_NUM}"
+  echo ""
+  echo "=== PR updated and marked ready ==="
+  echo "PR URL: ${PR_URL}"
+else
+  echo "=== Creating Pull Request ==="
+  DRAFT_ARGS=""
+  if [ "${CREATE_DRAFT}" = "true" ]; then
+    DRAFT_ARGS="--draft"
+  fi
+  PR_URL=$(GH_TOKEN="${GITHUB_TOKEN}" gh pr create \
+    ${DRAFT_ARGS} \
+    --repo "${UPSTREAM_REPO}" \
+    --head "${FORK_REPO%%/*}:${BRANCH_NAME}" \
+    --base main \
+    --title "${COMMIT_TITLE}" \
+    --body "${COMMIT_BODY}")
+  echo ""
+  echo "=== PR Created Successfully ==="
+  echo "PR URL: ${PR_URL}"
+fi
 echo ""
 echo "Done!"

--- a/.github/scripts/list-draft-community-operator-pr.sh
+++ b/.github/scripts/list-draft-community-operator-pr.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+# List one draft Community Operator PR by the current user and output its release tag.
+# Used by the "mark one ready" workflow to pick a draft PR to update and mark ready.
+#
+# Output (stdout, for GITHUB_OUTPUT):
+#   count=0  when no draft PR or release tag could not be parsed
+#   count=1
+#   tag=<release_tag>
+#
+# Exits 1 (workflow failure → issue created) when there is already an open non-draft
+# PR from the bot; we only allow one ready PR at a time to avoid catalog-update conflicts.
+#
+# Environment:
+#   GH_TOKEN or GITHUB_TOKEN - used for gh (same identity that created the PRs)
+#   GITHUB_OUTPUT (optional)  - if set, write key=value lines here; else print to stdout
+
+UPSTREAM_REPO="${UPSTREAM_REPO:-redhat-openshift-ecosystem/community-operators-prod}"
+
+write_output() {
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "$1" >> "$GITHUB_OUTPUT"
+  else
+    echo "$1"
+  fi
+}
+
+log() { echo "$*" >&2; }
+
+if [ -z "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ]; then
+  log "Error: GH_TOKEN or GITHUB_TOKEN is required"
+  exit 1
+fi
+
+PR_JSON=$(GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN}}" gh pr list --repo "${UPSTREAM_REPO}" \
+  --author "@me" --state open --search "is:draft" --json number,body --limit 1)
+
+if [ -z "$PR_JSON" ] || [ "$PR_JSON" = "[]" ]; then
+  log "No draft PRs found. Skipping."
+  write_output "count=0"
+  exit 0
+fi
+
+PR_NUMBER=$(echo "$PR_JSON" | jq -r '.[0].number')
+BODY=$(echo "$PR_JSON" | jq -r '.[0].body')
+RELEASE_TAG=$(echo "$BODY" | grep -oE 'releases/tag/[^ )]+' | head -1 | sed 's|releases/tag/||' || true)
+
+if [ -z "$RELEASE_TAG" ]; then
+  log "Could not parse release tag from PR #${PR_NUMBER} body. Skipping."
+  write_output "count=0"
+  exit 0
+fi
+
+# Only one non-draft (ready) PR at a time to avoid catalog-update PR conflicts.
+OPEN_READY=$(GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN}}" gh pr list --repo "${UPSTREAM_REPO}" \
+  --author "@me" --state open --json number,isDraft -q '[.[] | select(.isDraft == false)] | length')
+if [ "${OPEN_READY:-0}" -gt 0 ]; then
+  log "A non-draft PR from this bot is already open. Not marking another draft ready."
+  log "Wait for it to be merged or closed before the next run can promote a draft."
+  exit 1
+fi
+
+log "Found draft PR #${PR_NUMBER} (release ${RELEASE_TAG}). Will update and mark ready."
+write_output "count=1"
+write_output "tag=${RELEASE_TAG}"

--- a/.github/workflows/community-operator-pr-ready.yaml
+++ b/.github/workflows/community-operator-pr-ready.yaml
@@ -1,0 +1,48 @@
+# Mark one draft Community Operator PR ready for review (daily).
+# Uses the same script as PR creation to refresh the PR branch from current main
+# and the same bundle, then marks the PR ready. This avoids catalog-update PR
+# conflicts by having only one konflux bundle PR ready at a time.
+name: Community Operator PR — mark one ready
+
+on:
+  schedule:
+    # Run daily at 06:00 UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  mark-one-ready:
+    name: Mark one draft PR ready
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: List draft PRs by bot
+        id: list
+        env:
+          GH_TOKEN: ${{ secrets.KONFLUX_CI_BOT_PAT }}
+        run: .github/scripts/list-draft-community-operator-pr.sh
+
+      - name: Update PR branch and mark ready
+        if: steps.list.outputs.count == '1'
+        env:
+          GITHUB_TOKEN: ${{ secrets.KONFLUX_CI_BOT_PAT }}
+        run: |
+          .github/scripts/create-community-operator-pr.sh "${{ steps.list.outputs.tag }}" --update
+
+      - name: Create issue on failure
+        if: failure()
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_NAME: Community Operator PR — mark one ready
+          RELEASE_VERSION: ${{ steps.list.outputs.tag }}
+        run: |
+          .github/scripts/create-or-update-issue.sh \
+            "Community Operator PR (mark one ready) Failure" \
+            "Updating the draft Community Operator PR and marking it ready failed."

--- a/.github/workflows/community-operator-pr.yaml
+++ b/.github/workflows/community-operator-pr.yaml
@@ -35,7 +35,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.KONFLUX_CI_BOT_PAT }}
         run: |
-          .github/scripts/create-community-operator-pr.sh "${{ steps.release.outputs.tag }}"
+          .github/scripts/create-community-operator-pr.sh "${{ steps.release.outputs.tag }}" --draft
 
       - name: Create issue on failure
         if: failure()


### PR DESCRIPTION
Periodically check if we have catalog PRs which are still in draft
and mark them as non-draft if there are no other non-draft PRs.
   
This should help us avoiding conflicts in FBC PRs.
    
Assisted-by: Cursor