### PR TITLE
chore: update pac location

### DIFF
--- a/dependencies/pipelines-as-code/kustomization.yml
+++ b/dependencies/pipelines-as-code/kustomization.yml
@@ -2,8 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # renovate: datasource=git-refs depName=https://github.com/openshift-pipelines/pipelines-as-code versioning=semver
-  - https://github.com/openshift-pipelines/pipelines-as-code/releases/download/v0.42.0/release.k8s.yaml
+  # renovate: datasource=git-refs depName=https://github.com/tektoncd/pipelines-as-code versioning=semver
+  - https://github.com/tektoncd/pipelines-as-code/releases/download/v0.42.0/release.k8s.yaml
 patches:
   - path: custom-console-patch.yaml
     target:

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,8 @@
       "groupName": "tekton-core",
       "matchPackageNames": [
         "https://github.com/tektoncd/operator",
-        "https://github.com/tektoncd/pipeline"
+        "https://github.com/tektoncd/pipeline",
+        "https://github.com/tektoncd/pipelines-as-code"
       ],
       "description": "Group core Tekton components for coordinated updates. Note: tektoncd/results is managed by the operator and its version is determined by the operator version."
     },


### PR DESCRIPTION
pipelines-as-code was moved under the tekton org. Changing our references accordingly.

Assisted-by: Cursor