### PR TITLE
chore: update upstream manifests for segment-bridge

### DIFF
--- a/operator/pkg/manifests/segment-bridge/manifests.yaml
+++ b/operator/pkg/manifests/segment-bridge/manifests.yaml
@@ -34,6 +34,14 @@ rules:
   - get
   - list
 - apiGroups:
+  - results.tekton.dev
+  resources:
+  - results
+  - records
+  verbs:
+  - get
+  - list
+- apiGroups:
   - konflux.konflux-ci.dev
   resources:
   - konfluxes
@@ -74,7 +82,7 @@ spec:
             - secretRef:
                 name: segment-bridge-config
                 optional: true
-            image: quay.io/konflux-ci/segment-bridge:6cf6f19d52dade233e037ee3c4abbc6f22496b53
+            image: quay.io/konflux-ci/segment-bridge:1be10d5827416d034becc02c02673af937af3770
             imagePullPolicy: IfNotPresent
             name: segment-bridge
             resources:

--- a/operator/upstream-kustomizations/segment-bridge/kustomization.yaml
+++ b/operator/upstream-kustomizations/segment-bridge/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/segment-bridge/config/base?ref=6cf6f19d52dade233e037ee3c4abbc6f22496b53
+- https://github.com/konflux-ci/segment-bridge/config/base?ref=1be10d5827416d034becc02c02673af937af3770
 images:
 - name: quay.io/konflux-ci/segment-bridge
   newName: quay.io/konflux-ci/segment-bridge
-  newTag: 6cf6f19d52dade233e037ee3c4abbc6f22496b53
+  newTag: 1be10d5827416d034becc02c02673af937af3770


### PR DESCRIPTION
Bump segment-bridge to 1be10d5 (main HEAD), picking up:
- Tekton Results RBAC (PR #53)
- Default TEKTON_NAMESPACE to all-namespaces (PR #53)
- Konflux CR read access for public info (PR #77)
