### PR TITLE
fix: flaky broken pipe in kube-linter debug output

### DIFF
--- a/.github/scripts/run-kube-linter.sh
+++ b/.github/scripts/run-kube-linter.sh
@@ -92,11 +92,6 @@ echo "Running kube-linter scan..."
 echo "Config file: ./.github/.kube-linter-config.yaml"
 echo "Scan directory: ./.kube-linter/"
 
-# Show some debug info
-echo "Files to be scanned:"
-find ./.kube-linter -name "*.yaml" -o -name "*.yml" | head -5
-echo ""
-
 # Run the scan with verbose output
 kube-linter lint ./.kube-linter/ --config ./.github/.kube-linter-config.yaml --verbose
 


### PR DESCRIPTION
A debug print was causing flakiness in the kube-linter workflow. Removing the print statement to avoid this issue.

Example failure: https://github.com/konflux-ci/konflux-ci/actions/runs/23004419891/job/66797145633