### PR TITLE
feat: enable e2e conformance tests on OpenShift deployments

### DIFF
--- a/dependencies/smee/smee-client.yaml
+++ b/dependencies/smee/smee-client.yaml
@@ -23,7 +23,7 @@ spec:
         - name: shared-health
           emptyDir: {}
       securityContext:
-        fsGroup: 65532
+        fsGroup: null
       containers:
         - image: ghcr.io/chmouel/gosmee:latest
           imagePullPolicy: Always
@@ -38,7 +38,7 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: 65532
+            runAsUser: null
           resources:
             limits:
               cpu: 100m
@@ -85,7 +85,7 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: 65532
+            runAsUser: null
           resources:
             limits:
               cpu: 100m

--- a/deploy-deps.sh
+++ b/deploy-deps.sh
@@ -331,6 +331,12 @@ deploy_smee() {
         sed "s/$placeholder/$channel_id/g" "$template" > "$patch"
     fi
     kubectl apply -k "${script_path}/dependencies/smee"
+
+    if [[ "${USE_OPENSHIFT_PIPELINES:-false}" == "true" ]]; then
+        echo "  🔧 Patching smee-client for OpenShift Pipelines namespace..." >&2
+        kubectl set env deployment/gosmee-client -n smee-client -c health-check-sidecar \
+            DOWNSTREAM_SERVICE_URL="http://pipelines-as-code-controller.openshift-pipelines.svc.cluster.local:8080"
+    fi
 }
 
 deploy_kyverno() {

--- a/deploy-konflux-on-ocp.sh
+++ b/deploy-konflux-on-ocp.sh
@@ -24,6 +24,9 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+# Determine the absolute path of the repository root
+REPO_ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
 # On OCP, use 'oc' as kubectl if kubectl is not available
 # oc is a superset of kubectl and works for all kubectl commands
 if ! command -v kubectl &>/dev/null && command -v oc &>/dev/null; then
@@ -82,36 +85,61 @@ echo "Operator image is available!"
 # - USE_OPENSHIFT_CERTMANAGER: Use Red Hat cert-manager operator instead of upstream
 # - SKIP_INTERNAL_REGISTRY: OCP has its own registry
 # - SKIP_DEX: OCP has its own OAuth/authentication
-# - SKIP_SMEE: Webhook relay not needed for CI testing
+# - SKIP_SMEE: Skip Smee when no channel is configured
 echo ""
-echo "=== Step 1/5: Deploying dependencies ==="
-USE_OPENSHIFT_PIPELINES=true USE_OPENSHIFT_CERTMANAGER=true SKIP_INTERNAL_REGISTRY=true SKIP_DEX=true SKIP_SMEE=true ./deploy-deps.sh
+echo "=== Step 1/6: Deploying dependencies ==="
+
+# Pre-configure Smee channel if specified
+if [ -n "${SMEE_CHANNEL:-}" ]; then
+    echo "Configuring Smee channel: ${SMEE_CHANNEL}"
+    SMEE_DIR="${REPO_ROOT}/dependencies/smee"
+    sed "s|https://smee.io/CHANNELID|${SMEE_CHANNEL}|g" \
+        "${SMEE_DIR}/smee-channel-id.tpl" \
+        > "${SMEE_DIR}/smee-channel-id.yaml"
+    SKIP_SMEE=false
+else
+    SKIP_SMEE=true
+fi
+
+USE_OPENSHIFT_PIPELINES=true \
+USE_OPENSHIFT_CERTMANAGER=true \
+SKIP_INTERNAL_REGISTRY=true \
+SKIP_DEX=true \
+SKIP_SMEE="${SKIP_SMEE}" \
+"${REPO_ROOT}/deploy-deps.sh"
 
 # Step 2: Install CRDs from the checked-out branch
 echo ""
-echo "=== Step 2/5: Installing Operator CRDs ==="
+echo "=== Step 2/6: Installing Operator CRDs ==="
 cd operator
 # Clear GOFLAGS to allow downloading tools (CI may have -mod=vendor set)
 GOFLAGS="" make install
 
 # Step 3: Deploy the operator using the Konflux-built image
 echo ""
-echo "=== Step 3/5: Deploying Operator ==="
+echo "=== Step 3/6: Deploying Operator ==="
 echo "Image: ${OPERATOR_IMAGE}"
 # GOFLAGS="" needed because CI sets -mod=vendor which blocks kustomize download
 GOFLAGS="" make deploy IMG="${OPERATOR_IMAGE}"
 
 # Step 4: Wait for the operator deployment to be available
 echo ""
-echo "=== Step 4/5: Waiting for Operator to be ready ==="
+echo "=== Step 4/6: Waiting for Operator to be ready ==="
 oc wait --for=condition=Available deployment/konflux-operator-controller-manager \
     -n konflux-operator --timeout=300s
 echo "Operator is ready!"
 
 # Step 5: Create Konflux CR instance
 echo ""
-echo "=== Step 5/5: Creating Konflux CR ==="
-oc apply -f config/samples/konflux_v1alpha1_konflux.yaml
+echo "=== Step 5/6: Creating Konflux CR ==="
+KONFLUX_CR=$("${REPO_ROOT}/scripts/resolve-konflux-cr.sh")
+echo "Applying: ${KONFLUX_CR}"
+oc apply -f "${KONFLUX_CR}"
+
+# Step 6: Deploy secrets
+echo ""
+echo "=== Step 6/6: Deploying secrets ==="
+USE_OPENSHIFT_PIPELINES=true "${REPO_ROOT}/scripts/deploy-secrets.sh"
 
 # Wait for Konflux to be fully ready
 echo ""

--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
@@ -54,6 +54,12 @@ const (
 
 	// Container names
 	buildManagerContainerName = "manager"
+
+	// PaC webhook URL env var name and platform-specific defaults.
+	// On upstream/Kind, PaC is deployed in the "pipelines-as-code" namespace on port 8180.
+	// On OpenShift, PaC is deployed by the OpenShift Pipelines operator in "openshift-pipelines" on port 8080.
+	pacWebhookURLEnvName   = "PAC_WEBHOOK_URL"
+	pacWebhookURLOpenShift = "http://pipelines-as-code-controller.openshift-pipelines.svc.cluster.local:8080"
 )
 
 // BuildServiceCleanupGVKs defines which resource types should be cleaned up when they are
@@ -167,7 +173,7 @@ func (r *KonfluxBuildServiceReconciler) applyManifests(ctx context.Context, tc *
 	for _, obj := range objects {
 		// Apply customizations for deployments
 		if deployment, ok := obj.(*appsv1.Deployment); ok {
-			if err := applyBuildServiceDeploymentCustomizations(deployment, owner.Spec); err != nil {
+			if err := applyBuildServiceDeploymentCustomizations(deployment, owner.Spec, r.ClusterInfo); err != nil {
 				return fmt.Errorf("failed to apply customizations to deployment %s: %w", deployment.Name, err)
 			}
 		}
@@ -192,14 +198,15 @@ func (r *KonfluxBuildServiceReconciler) applyManifests(ctx context.Context, tc *
 	return nil
 }
 
-// applyBuildServiceDeploymentCustomizations applies user-defined customizations to BuildService deployments.
-func applyBuildServiceDeploymentCustomizations(deployment *appsv1.Deployment, spec konfluxv1alpha1.KonfluxBuildServiceSpec) error {
+// applyBuildServiceDeploymentCustomizations applies user-defined and platform-specific
+// customizations to BuildService deployments.
+func applyBuildServiceDeploymentCustomizations(deployment *appsv1.Deployment, spec konfluxv1alpha1.KonfluxBuildServiceSpec, clusterInfo *clusterinfo.Info) error {
 	switch deployment.Name {
 	case buildControllerManagerDeploymentName:
 		if spec.BuildControllerManager != nil {
 			deployment.Spec.Replicas = &spec.BuildControllerManager.Replicas
 		}
-		if err := buildBuildControllerManagerOverlay(spec.BuildControllerManager).ApplyToDeployment(deployment); err != nil {
+		if err := buildBuildControllerManagerOverlay(spec.BuildControllerManager, clusterInfo).ApplyToDeployment(deployment); err != nil {
 			return err
 		}
 	}
@@ -207,17 +214,35 @@ func applyBuildServiceDeploymentCustomizations(deployment *appsv1.Deployment, sp
 }
 
 // buildBuildControllerManagerOverlay builds the pod overlay for the controller-manager deployment.
-func buildBuildControllerManagerOverlay(spec *konfluxv1alpha1.ControllerManagerDeploymentSpec) *customization.PodOverlay {
-	if spec == nil {
-		return customization.NewPodOverlay()
+// On OpenShift, the PaC webhook URL is automatically set to the OpenShift Pipelines service
+// endpoint. User-provided env vars from the CR spec take precedence via strategic merge.
+func buildBuildControllerManagerOverlay(spec *konfluxv1alpha1.ControllerManagerDeploymentSpec, clusterInfo *clusterinfo.Info) *customization.PodOverlay {
+	var containerOpts []customization.ContainerOption
+
+	// Set platform-specific PaC webhook URL before user overrides so CR values take precedence.
+	if clusterInfo != nil && clusterInfo.IsOpenShift() {
+		containerOpts = append(containerOpts, customization.WithEnv(corev1.EnvVar{
+			Name:  pacWebhookURLEnvName,
+			Value: pacWebhookURLOpenShift,
+		}))
 	}
+
+	if spec == nil {
+		return customization.NewPodOverlay(
+			customization.WithContainerOpts(buildManagerContainerName, customization.DeploymentContext{}, containerOpts...),
+		)
+	}
+
+	containerOpts = append(containerOpts,
+		customization.FromContainerSpec(spec.Manager),
+		customization.WithLeaderElection(),
+	)
 
 	return customization.BuildPodOverlay(
 		customization.DeploymentContext{Replicas: spec.Replicas},
 		customization.WithContainerBuilder(
 			buildManagerContainerName,
-			customization.FromContainerSpec(spec.Manager),
-			customization.WithLeaderElection(),
+			containerOpts...,
 		),
 	)
 }

--- a/operator/internal/controller/buildservice/konfluxbuildservice_customization_test.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_customization_test.go
@@ -22,11 +22,15 @@ import (
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 )
 
@@ -53,14 +57,14 @@ func getBuildServiceDeployment(t *testing.T) *appsv1.Deployment {
 func TestBuildBuildControllerManagerOverlay(t *testing.T) {
 	t.Run("nil spec returns empty overlay", func(t *testing.T) {
 		g := gomega.NewWithT(t)
-		overlay := buildBuildControllerManagerOverlay(nil)
+		overlay := buildBuildControllerManagerOverlay(nil, nil)
 		g.Expect(overlay).NotTo(gomega.BeNil())
 	})
 
 	t.Run("empty spec returns overlay without customizations", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 		spec := &konfluxv1alpha1.ControllerManagerDeploymentSpec{}
-		overlay := buildBuildControllerManagerOverlay(spec)
+		overlay := buildBuildControllerManagerOverlay(spec, nil)
 		g.Expect(overlay).NotTo(gomega.BeNil())
 	})
 
@@ -82,7 +86,7 @@ func TestBuildBuildControllerManagerOverlay(t *testing.T) {
 		}
 
 		deployment := getBuildServiceDeployment(t)
-		overlay := buildBuildControllerManagerOverlay(spec)
+		overlay := buildBuildControllerManagerOverlay(spec, nil)
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -111,7 +115,7 @@ func TestBuildBuildControllerManagerOverlay(t *testing.T) {
 		g.Expect(managerContainer).NotTo(gomega.BeNil(), "manager container must exist in controller-manager deployment")
 		originalImage := managerContainer.Image
 
-		overlay := buildBuildControllerManagerOverlay(spec)
+		overlay := buildBuildControllerManagerOverlay(spec, nil)
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -137,7 +141,7 @@ func TestApplyBuildServiceDeploymentCustomizations(t *testing.T) {
 		}
 
 		deployment := getBuildServiceDeployment(t)
-		err := applyBuildServiceDeploymentCustomizations(deployment, spec)
+		err := applyBuildServiceDeploymentCustomizations(deployment, spec, nil)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
@@ -172,7 +176,7 @@ func TestApplyBuildServiceDeploymentCustomizations(t *testing.T) {
 			},
 		}
 
-		err := applyBuildServiceDeploymentCustomizations(deployment, spec)
+		err := applyBuildServiceDeploymentCustomizations(deployment, spec, nil)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Should not panic and container should be unchanged
@@ -186,7 +190,7 @@ func TestApplyBuildServiceDeploymentCustomizations(t *testing.T) {
 		}
 
 		deployment := getBuildServiceDeployment(t)
-		err := applyBuildServiceDeploymentCustomizations(deployment, spec)
+		err := applyBuildServiceDeploymentCustomizations(deployment, spec, nil)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Should not panic
@@ -199,7 +203,7 @@ func TestApplyBuildServiceDeploymentCustomizations(t *testing.T) {
 		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{}
 
 		deployment := getBuildServiceDeployment(t)
-		err := applyBuildServiceDeploymentCustomizations(deployment, spec)
+		err := applyBuildServiceDeploymentCustomizations(deployment, spec, nil)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Should not panic
@@ -215,7 +219,7 @@ func TestApplyBuildServiceDeploymentCustomizations(t *testing.T) {
 		}
 
 		deployment := getBuildServiceDeployment(t)
-		err := applyBuildServiceDeploymentCustomizations(deployment, spec)
+		err := applyBuildServiceDeploymentCustomizations(deployment, spec, nil)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		g.Expect(deployment.Spec.Replicas).NotTo(gomega.BeNil())
@@ -231,7 +235,7 @@ func TestApplyBuildServiceDeploymentCustomizations(t *testing.T) {
 		}
 
 		deployment := getBuildServiceDeployment(t)
-		err := applyBuildServiceDeploymentCustomizations(deployment, spec)
+		err := applyBuildServiceDeploymentCustomizations(deployment, spec, nil)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		g.Expect(deployment.Spec.Replicas).NotTo(gomega.BeNil())
@@ -246,7 +250,7 @@ func TestApplyBuildServiceDeploymentCustomizations(t *testing.T) {
 
 		deployment := getBuildServiceDeployment(t)
 		originalReplicas := deployment.Spec.Replicas
-		err := applyBuildServiceDeploymentCustomizations(deployment, spec)
+		err := applyBuildServiceDeploymentCustomizations(deployment, spec, nil)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		g.Expect(deployment.Spec.Replicas).To(gomega.Equal(originalReplicas))
@@ -268,7 +272,7 @@ func TestApplyBuildServiceDeploymentCustomizations(t *testing.T) {
 		}
 
 		deployment := getBuildServiceDeployment(t)
-		err := applyBuildServiceDeploymentCustomizations(deployment, spec)
+		err := applyBuildServiceDeploymentCustomizations(deployment, spec, nil)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Check replicas
@@ -279,6 +283,174 @@ func TestApplyBuildServiceDeploymentCustomizations(t *testing.T) {
 		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
 		g.Expect(managerContainer).NotTo(gomega.BeNil())
 		g.Expect(managerContainer.Resources.Limits.Cpu().String()).To(gomega.Equal("2"))
+	})
+}
+
+func newOpenShiftClusterInfo(t *testing.T) *clusterinfo.Info {
+	t.Helper()
+	info, err := clusterinfo.DetectWithClient(&mockDiscoveryClient{
+		resources: map[string]*metav1.APIResourceList{
+			"config.openshift.io/v1": {APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create OpenShift cluster info: %v", err)
+	}
+	return info
+}
+
+func newDefaultClusterInfo(t *testing.T) *clusterinfo.Info {
+	t.Helper()
+	info, err := clusterinfo.DetectWithClient(&mockDiscoveryClient{
+		resources: map[string]*metav1.APIResourceList{},
+	})
+	if err != nil {
+		t.Fatalf("failed to create default cluster info: %v", err)
+	}
+	return info
+}
+
+type mockDiscoveryClient struct {
+	resources map[string]*metav1.APIResourceList
+}
+
+func (m *mockDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	if rl, ok := m.resources[groupVersion]; ok {
+		return rl, nil
+	}
+	return nil, errors.NewNotFound(schema.GroupResource{Group: groupVersion}, "")
+}
+
+func (m *mockDiscoveryClient) ServerVersion() (*version.Info, error) {
+	return &version.Info{}, nil
+}
+
+func TestApplyBuildServiceDeploymentCustomizations_PaCWebhookURL(t *testing.T) {
+	t.Run("sets OpenShift PAC_WEBHOOK_URL on OpenShift", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{}
+
+		deployment := getBuildServiceDeployment(t)
+		err := applyBuildServiceDeploymentCustomizations(deployment, spec, newOpenShiftClusterInfo(t))
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+
+		var pacURL string
+		for _, env := range managerContainer.Env {
+			if env.Name == pacWebhookURLEnvName {
+				pacURL = env.Value
+			}
+		}
+		g.Expect(pacURL).To(gomega.Equal(pacWebhookURLOpenShift))
+	})
+
+	t.Run("preserves manifest default PAC_WEBHOOK_URL on non-OpenShift", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{}
+
+		deployment := getBuildServiceDeployment(t)
+
+		// Capture the original value from the manifest
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		var originalURL string
+		for _, env := range managerContainer.Env {
+			if env.Name == pacWebhookURLEnvName {
+				originalURL = env.Value
+			}
+		}
+		g.Expect(originalURL).NotTo(gomega.BeEmpty(), "manifest should have a default PAC_WEBHOOK_URL")
+
+		err := applyBuildServiceDeploymentCustomizations(deployment, spec, newDefaultClusterInfo(t))
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer = testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		var pacURL string
+		for _, env := range managerContainer.Env {
+			if env.Name == pacWebhookURLEnvName {
+				pacURL = env.Value
+			}
+		}
+		g.Expect(pacURL).To(gomega.Equal(originalURL))
+	})
+
+	t.Run("CR env override takes precedence over OpenShift default", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		customURL := "http://custom-pac.example.com:9999"
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			BuildControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Manager: &konfluxv1alpha1.ContainerSpec{
+					Env: []corev1.EnvVar{
+						{Name: pacWebhookURLEnvName, Value: customURL},
+					},
+				},
+			},
+		}
+
+		deployment := getBuildServiceDeployment(t)
+		err := applyBuildServiceDeploymentCustomizations(deployment, spec, newOpenShiftClusterInfo(t))
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+
+		// Strategic merge uses env name as merge key, so the last value wins.
+		// The CR value should take precedence.
+		var pacURL string
+		for _, env := range managerContainer.Env {
+			if env.Name == pacWebhookURLEnvName {
+				pacURL = env.Value
+			}
+		}
+		g.Expect(pacURL).To(gomega.Equal(customURL))
+	})
+
+	t.Run("nil ClusterInfo preserves manifest default", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{}
+
+		deployment := getBuildServiceDeployment(t)
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		var originalURL string
+		for _, env := range managerContainer.Env {
+			if env.Name == pacWebhookURLEnvName {
+				originalURL = env.Value
+			}
+		}
+
+		err := applyBuildServiceDeploymentCustomizations(deployment, spec, nil)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer = testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		var pacURL string
+		for _, env := range managerContainer.Env {
+			if env.Name == pacWebhookURLEnvName {
+				pacURL = env.Value
+			}
+		}
+		g.Expect(pacURL).To(gomega.Equal(originalURL))
+	})
+
+	t.Run("sets OpenShift PAC_WEBHOOK_URL even with nil spec", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{}
+
+		deployment := getBuildServiceDeployment(t)
+		err := applyBuildServiceDeploymentCustomizations(deployment, spec, newOpenShiftClusterInfo(t))
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+
+		var pacURL string
+		for _, env := range managerContainer.Env {
+			if env.Name == pacWebhookURLEnvName {
+				pacURL = env.Value
+			}
+		}
+		g.Expect(pacURL).To(gomega.Equal(pacWebhookURLOpenShift))
 	})
 }
 
@@ -307,7 +479,7 @@ func TestApplyBuildServiceDeploymentCustomizations_ResourceMerging(t *testing.T)
 			},
 		}
 
-		err := applyBuildServiceDeploymentCustomizations(deployment, spec)
+		err := applyBuildServiceDeploymentCustomizations(deployment, spec, nil)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		managerContainer = testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
@@ -341,7 +513,7 @@ func TestApplyBuildServiceDeploymentCustomizations_ResourceMerging(t *testing.T)
 			},
 		}
 
-		err := applyBuildServiceDeploymentCustomizations(deployment, spec)
+		err := applyBuildServiceDeploymentCustomizations(deployment, spec, nil)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		managerContainer = testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -63,25 +63,8 @@ if [ -f "${ENV_FILE}" ]; then
     source "${ENV_FILE}"
 fi
 
-# Validate REQUIRED variables
-GITHUB_APP_ID="${GITHUB_APP_ID:?GitHub App ID is required. Set GITHUB_APP_ID}"
-WEBHOOK_SECRET="${WEBHOOK_SECRET:?Webhook secret is required. Set WEBHOOK_SECRET}"
-
-# Validate that at least one private key option is provided
-if [ -z "${GITHUB_PRIVATE_KEY:-}" ] && [ -z "${GITHUB_PRIVATE_KEY_PATH:-}" ]; then
-    echo "ERROR: GitHub private key is required" >&2
-    echo "" >&2
-    echo "Set one of:" >&2
-    echo "  - GITHUB_PRIVATE_KEY (literal key content)" >&2
-    echo "  - GITHUB_PRIVATE_KEY_PATH (path to .pem file)" >&2
-    exit 1
-fi
-
-# Validate private key file exists if path is provided
-if [ -n "${GITHUB_PRIVATE_KEY_PATH:-}" ] && [ ! -f "${GITHUB_PRIVATE_KEY_PATH}" ]; then
-    echo "ERROR: GitHub private key file not found: ${GITHUB_PRIVATE_KEY_PATH}" >&2
-    exit 1
-fi
+# Validate secret-related variables early (before creating the cluster)
+VALIDATE_ONLY=true "${SCRIPT_DIR}/deploy-secrets.sh"
 
 # Optional variables with defaults (using :- pattern)
 KIND_CLUSTER="${KIND_CLUSTER:-konflux}"
@@ -99,32 +82,11 @@ export INCREASE_PODMAN_PIDS_LIMIT ENABLE_IMAGE_CACHE
 export GITHUB_PRIVATE_KEY GITHUB_APP_ID WEBHOOK_SECRET QUAY_TOKEN QUAY_ORGANIZATION
 export SEGMENT_WRITE_KEY
 
-# Get Konflux CR file path (precedence, high->low: command-line arg, env var, default)
+# Get Konflux CR file path (command-line arg takes highest precedence)
 KONFLUX_CR="${1:-${KONFLUX_CR:-}}"
 
-# Auto-select e2e CR when Quay credentials are configured but no explicit CR specified
-if [ -n "${QUAY_TOKEN:-}" ] && [ -n "${QUAY_ORGANIZATION:-}" ] && [ -z "${KONFLUX_CR}" ]; then
-    KONFLUX_CR="${REPO_ROOT}/operator/config/samples/konflux-e2e.yaml"
-    echo ""
-    echo "INFO: Auto-selecting konflux-e2e.yaml because QUAY_TOKEN/QUAY_ORGANIZATION are set"
-    echo "      This CR enables image-controller required for Quay integration"
-    echo "      To use a different CR, set KONFLUX_CR environment variable or pass as argument"
-    echo ""
-else
-    KONFLUX_CR="${KONFLUX_CR:-${REPO_ROOT}/operator/config/samples/konflux_v1alpha1_konflux.yaml}"
-fi
-
-# Convert relative path to absolute (if not already absolute)
-if [[ "${KONFLUX_CR}" != /* ]]; then
-    KONFLUX_CR="${REPO_ROOT}/${KONFLUX_CR}"
-fi
-
-if [ ! -f "${KONFLUX_CR}" ]; then
-    echo "ERROR: Konflux CR file not found: ${KONFLUX_CR}"
-    echo ""
-    echo "Usage: $0 [konflux-cr-file]"
-    exit 1
-fi
+# Resolve CR using shared logic (auto-selects e2e CR when Quay credentials are set)
+KONFLUX_CR=$("${SCRIPT_DIR}/resolve-konflux-cr.sh")
 
 echo "========================================="
 echo "Konflux Local Development Deployment"
@@ -136,30 +98,6 @@ echo "  Konflux CR:  ${KONFLUX_CR}"
 echo ""
 
 INSTALL_METHOD="${OPERATOR_INSTALL_METHOD:-local}"
-
-# Ensure a namespace exists: in 'none' mode, pre-create it immediately;
-# otherwise wait up to 60 s for the operator to create it.
-# Usage: wait_or_create_namespace <namespace> <install_method>
-# Returns 0 on success, 1 if the namespace was not found in time.
-wait_or_create_namespace() {
-    local ns="$1"
-    local method="$2"
-    if [ "${method}" = "none" ]; then
-        echo "Pre-creating namespace: ${ns}"
-        kubectl create namespace "${ns}" --dry-run=client -o yaml | kubectl apply -f -
-    else
-        echo "Waiting for namespace: ${ns}"
-        local timeout=60
-        while ! kubectl get namespace "${ns}" &> /dev/null && [ $timeout -gt 0 ]; do
-            sleep 2
-            timeout=$((timeout - 2))
-        done
-        if [ $timeout -le 0 ]; then
-            echo "WARNING: Namespace ${ns} not created after 60 seconds"
-            return 1
-        fi
-    fi
-}
 
 # For 'build' method, build the operator image before creating the cluster to reduce peak memory (no Kind container during go build)
 if [ "${INSTALL_METHOD}" = "build" ]; then
@@ -283,72 +221,22 @@ else
     echo "========================================="
 fi
 
-# Step 6: Create secrets for GitHub integration
+# Step 6: Create secrets for GitHub integration and optional image-controller
 echo ""
 echo "========================================="
-echo "Step 6: Creating GitHub integration secrets"
+echo "Step 6: Setting up secrets"
 echo "========================================="
-echo "Creating Pipelines-as-Code secrets..."
 
-for ns in pipelines-as-code build-service integration-service; do
-    if ! wait_or_create_namespace "${ns}" "${INSTALL_METHOD}"; then
-        echo "         Secrets will need to be created manually"
-        continue
-    fi
+# In 'none' mode, namespaces don't exist yet (operator isn't running),
+# so create them directly and skip waiting for pods that don't exist yet.
+DEPLOY_SECRETS_ENV=()
+if [ "${INSTALL_METHOD}" = "none" ]; then
+    DEPLOY_SECRETS_ENV+=(CREATE_NAMESPACES=true WAIT_FOR_PODS=false)
+fi
 
-    echo "Creating secret in ${ns}..."
-    # Use different kubectl syntax based on how private key is provided:
-    # - File path: use --from-file (local dev with .pem file)
-    # - Literal value: use --from-literal (CI with env var, matches prepare-e2e.sh)
-    if [ -n "${GITHUB_PRIVATE_KEY_PATH:-}" ] && [ -f "${GITHUB_PRIVATE_KEY_PATH}" ]; then
-        kubectl -n "$ns" create secret generic pipelines-as-code-secret \
-            --from-file=github-private-key="${GITHUB_PRIVATE_KEY_PATH}" \
-            --from-literal github-application-id="$GITHUB_APP_ID" \
-            --from-literal webhook.secret="$WEBHOOK_SECRET" \
-            --dry-run=client -o yaml | kubectl apply -f -
-    else
-        kubectl -n "$ns" create secret generic pipelines-as-code-secret \
-            --from-literal github-private-key="$GITHUB_PRIVATE_KEY" \
-            --from-literal github-application-id="$GITHUB_APP_ID" \
-            --from-literal webhook.secret="$WEBHOOK_SECRET" \
-            --dry-run=client -o yaml | kubectl apply -f -
-    fi
-done
+env "${DEPLOY_SECRETS_ENV[@]}" "${SCRIPT_DIR}/deploy-secrets.sh"
 
 echo "✓ Secrets created"
-
-# Step 6b: Create image-controller secret (optional)
-if [ -n "${QUAY_TOKEN}" ] && [ -n "${QUAY_ORGANIZATION}" ]; then
-    echo ""
-    echo "Creating image-controller Quay secret..."
-
-    if ! wait_or_create_namespace "image-controller" "${INSTALL_METHOD}"; then
-        echo "         Secret will need to be created manually"
-    else
-        echo "Creating secret in image-controller..."
-        kubectl -n image-controller create secret generic quaytoken \
-            --from-literal=quaytoken="${QUAY_TOKEN}" \
-            --from-literal=organization="${QUAY_ORGANIZATION}" \
-            --dry-run=client -o yaml | kubectl apply -f -
-        echo "✓ Image-controller secret created"
-
-        # Wait for image-controller pods to be ready (skip in 'none' mode - no pods yet)
-        if [ "${INSTALL_METHOD}" != "none" ]; then
-            echo "Waiting for image-controller pods to be ready..."
-            if kubectl wait --for=condition=Ready --timeout=240s \
-                -l control-plane=controller-manager -n image-controller pod 2>/dev/null; then
-                echo "✓ Image-controller is ready"
-            else
-                echo "WARNING: Image-controller pods did not become ready within 4 minutes"
-                echo "         This may cause E2E test failures"
-            fi
-        fi
-    fi
-elif [ -n "${QUAY_TOKEN}" ] || [ -n "${QUAY_ORGANIZATION}" ]; then
-    echo ""
-    echo "WARNING: Both QUAY_TOKEN and QUAY_ORGANIZATION must be set to create image-controller secret"
-    echo "         Image-controller secret not created"
-fi
 
 if [ "${INSTALL_METHOD}" != "none" ]; then
     # Step 7: Wait for Konflux to be ready

--- a/scripts/deploy-secrets.sh
+++ b/scripts/deploy-secrets.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# Setup Konflux Secrets
+#
+# Creates the required secrets for a Konflux deployment.
+#
+# Prerequisites:
+#   - kubectl configured with cluster access
+#
+# Required environment variables:
+#   GITHUB_APP_ID            - GitHub App ID for Pipelines-as-Code
+#   WEBHOOK_SECRET           - GitHub webhook secret
+#   GITHUB_PRIVATE_KEY       - GitHub App private key (literal content)
+#     OR
+#   GITHUB_PRIVATE_KEY_PATH  - Path to GitHub App private key .pem file
+#
+# Optional environment variables:
+#   QUAY_TOKEN               - Quay.io push token (for image-controller)
+#   QUAY_ORGANIZATION        - Quay.io organization (for image-controller)
+#   USE_OPENSHIFT_PIPELINES  - Set to "true" to indicate that OpenShift Pipelines is being used
+#                              instead of upstream Tekton (default: false)
+#   CREATE_NAMESPACES        - Set to "true" to create namespaces instead of waiting
+#                              for the operator to create them (for OPERATOR_INSTALL_METHOD=none)
+#   WAIT_FOR_PODS            - Set to "false" to skip waiting for pods to become ready
+#                              (default: true)
+
+set -euo pipefail
+
+validate_inputs() {
+    GITHUB_APP_ID="${GITHUB_APP_ID:?GITHUB_APP_ID is required}"
+    WEBHOOK_SECRET="${WEBHOOK_SECRET:?WEBHOOK_SECRET is required}"
+
+    if [ -z "${GITHUB_PRIVATE_KEY:-}" ] && [ -z "${GITHUB_PRIVATE_KEY_PATH:-}" ]; then
+        echo "ERROR: GitHub private key is required" >&2
+        echo "Set GITHUB_PRIVATE_KEY or GITHUB_PRIVATE_KEY_PATH" >&2
+        exit 1
+    fi
+
+    if [ -n "${GITHUB_PRIVATE_KEY_PATH:-}" ] && [ ! -f "${GITHUB_PRIVATE_KEY_PATH}" ]; then
+        echo "ERROR: GitHub private key file not found: ${GITHUB_PRIVATE_KEY_PATH}" >&2
+        exit 1
+    fi
+}
+
+main() {
+    validate_inputs
+
+    if [ "${VALIDATE_ONLY:-}" = "true" ]; then
+        return
+    fi
+
+    echo "Deploying secrets..."
+    create_github_integration_secrets
+    create_image_controller_secret
+}
+
+# Ensure a namespace exists. In CREATE_NAMESPACES mode, create it immediately.
+# Otherwise, wait up to 60s for the operator to create it.
+ensure_namespace() {
+    local ns="$1"
+    if [ "${CREATE_NAMESPACES:-}" = "true" ]; then
+        echo "Creating namespace: ${ns}"
+        kubectl create namespace "${ns}" --dry-run=client -o yaml | kubectl apply -f -
+    else
+        echo "Waiting for namespace: ${ns}"
+        local timeout=60
+        while ! kubectl get namespace "${ns}" &> /dev/null && [ $timeout -gt 0 ]; do
+            sleep 2
+            timeout=$((timeout - 2))
+        done
+        if [ $timeout -le 0 ]; then
+            echo "WARNING: Namespace ${ns} not found after 60 seconds"
+            return 1
+        fi
+    fi
+}
+
+create_github_integration_secrets() {
+    echo "=== Creating GitHub integration secrets ==="
+
+    local pac_ns="pipelines-as-code"
+    if [ "${USE_OPENSHIFT_PIPELINES:-false}" = "true" ]; then
+        pac_ns="openshift-pipelines"
+    fi
+
+    for ns in "${pac_ns}" build-service integration-service; do
+        if ! ensure_namespace "${ns}"; then
+            echo "         Secret will need to be created manually in ${ns}"
+            continue
+        fi
+
+        echo "Creating secret in ${ns}..."
+        if [ -n "${GITHUB_PRIVATE_KEY_PATH:-}" ] && [ -f "${GITHUB_PRIVATE_KEY_PATH}" ]; then
+            kubectl -n "$ns" create secret generic pipelines-as-code-secret \
+                --from-file=github-private-key="${GITHUB_PRIVATE_KEY_PATH}" \
+                --from-literal github-application-id="$GITHUB_APP_ID" \
+                --from-literal webhook.secret="$WEBHOOK_SECRET" \
+                --dry-run=client -o yaml | kubectl apply -f -
+        else
+            kubectl -n "$ns" create secret generic pipelines-as-code-secret \
+                --from-literal github-private-key="$GITHUB_PRIVATE_KEY" \
+                --from-literal github-application-id="$GITHUB_APP_ID" \
+                --from-literal webhook.secret="$WEBHOOK_SECRET" \
+                --dry-run=client -o yaml | kubectl apply -f -
+        fi
+    done
+
+    echo "GitHub integration secrets created."
+}
+
+create_image_controller_secret() {
+    if [ -n "${QUAY_TOKEN:-}" ] && [ -n "${QUAY_ORGANIZATION:-}" ]; then
+        echo ""
+        echo "=== Creating image-controller Quay secret ==="
+
+        if ! ensure_namespace "image-controller"; then
+            echo "         Secret will need to be created manually"
+            return
+        fi
+
+        kubectl -n image-controller create secret generic quaytoken \
+            --from-literal=quaytoken="${QUAY_TOKEN}" \
+            --from-literal=organization="${QUAY_ORGANIZATION}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+        echo "Image-controller secret created."
+
+        if [ "${WAIT_FOR_PODS:-true}" = "true" ]; then
+            echo "Waiting for image-controller pods..."
+            if kubectl wait --for=condition=Ready --timeout=240s \
+                -l control-plane=controller-manager -n image-controller pod 2>/dev/null; then
+                echo "Image-controller is ready."
+            else
+                echo "WARNING: Image-controller pods did not become ready within 4 minutes"
+            fi
+        fi
+    elif [ -n "${QUAY_TOKEN:-}" ] || [ -n "${QUAY_ORGANIZATION:-}" ]; then
+        echo ""
+        echo "WARNING: Both QUAY_TOKEN and QUAY_ORGANIZATION must be set for image-controller"
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/scripts/resolve-konflux-cr.sh
+++ b/scripts/resolve-konflux-cr.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Resolve Konflux CR file path
+#
+# Determines which Konflux CR to apply based on environment variables
+# and prints the resolved path to stdout.
+#
+# Precedence (high to low):
+#   1. KONFLUX_CR environment variable (if already set)
+#   2. Auto-select konflux-e2e.yaml when QUAY_TOKEN and QUAY_ORGANIZATION are set
+#   3. Default: konflux_v1alpha1_konflux.yaml
+#
+# Usage:
+#   KONFLUX_CR=$(./scripts/resolve-konflux-cr.sh)
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+REPO_ROOT=$(dirname "$SCRIPT_DIR")
+
+if [ -n "${KONFLUX_CR:-}" ]; then
+    # Explicit CR specified — use it as-is
+    true
+elif [ -n "${QUAY_TOKEN:-}" ] && [ -n "${QUAY_ORGANIZATION:-}" ]; then
+    KONFLUX_CR="${REPO_ROOT}/operator/config/samples/konflux-e2e.yaml"
+    echo "INFO: Auto-selecting konflux-e2e.yaml because QUAY_TOKEN/QUAY_ORGANIZATION are set" >&2
+    echo "      This CR enables image-controller required for Quay integration" >&2
+    echo "      To use a different CR, set KONFLUX_CR environment variable" >&2
+else
+    KONFLUX_CR="${REPO_ROOT}/operator/config/samples/konflux_v1alpha1_konflux.yaml"
+fi
+
+# Convert relative path to absolute
+if [[ "${KONFLUX_CR}" != /* ]]; then
+    KONFLUX_CR="${REPO_ROOT}/${KONFLUX_CR}"
+fi
+
+if [ ! -f "${KONFLUX_CR}" ]; then
+    echo "ERROR: Konflux CR file not found: ${KONFLUX_CR}" >&2
+    exit 1
+fi
+
+echo "${KONFLUX_CR}"


### PR DESCRIPTION
Support running the e2e conformance test suite against the operator when deployed on OpenShift.

Operator PAC_WEBHOOK_URL auto-detection:

On upstream/Kind clusters, Pipelines-as-Code runs in the "pipelines-as-code" namespace on port 8180. On OpenShift, PaC is deployed by the OpenShift Pipelines operator into the "openshift-pipelines" namespace on port 8080. The build-service controller uses PAC_WEBHOOK_URL to POST to PaC's incoming webhook endpoint when retriggering builds, so the wrong URL causes retrigger failures (DNS lookup fails). The operator now auto-detects OpenShift via ClusterInfo and sets the correct PAC_WEBHOOK_URL default. User- provided env overrides in the KonfluxBuildService CR still take precedence via strategic merge.

Smee client OpenShift compatibility:

The smee-client deployment forwards GitHub webhooks from smee.io to the in-cluster PaC controller. On OpenShift, PaC lives in a different namespace and port than upstream, so the health-check sidecar's DOWNSTREAM_SERVICE_URL must be patched to target
openshift-pipelines:8080. The smee-client manifest also had hardcoded runAsUser/fsGroup values that conflict with OpenShift's restricted SCC, so those are set to null to let OpenShift assign them.

Script refactoring:

deploy-secrets.sh and resolve-konflux-cr.sh were extracted from deploy-local.sh so they can be shared with deploy-konflux-on-ocp.sh, which needs the same secret creation and CR resolution logic when deploying on OpenShift.

Assisted-by: Claude claude-opus-4-6