### PR TITLE
fix: increase release-service memory limits to prevent OOMKill

### DIFF
--- a/operator/config/samples/konflux-e2e.yaml
+++ b/operator/config/samples/konflux-e2e.yaml
@@ -68,10 +68,10 @@ spec:
           resources:
             requests:
               cpu: 30m
-              memory: 128Mi
+              memory: 256Mi
             limits:
               cpu: 30m
-              memory: 128Mi
+              memory: 256Mi
   buildService:
     spec:
       buildControllerManager:


### PR DESCRIPTION
The release-service controller-manager was being OOMKilled (9 restarts observed) with the 128Mi memory limit during E2E conformance tests on OpenShift, preventing Release PipelineRuns from ever being created. Increase to 256Mi in the E2E sample CR.

Evidence of an OOMKilled pod from https://github.com/openshift/release/pull/76428 found [here](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/76428/rehearse-76428-pull-ci-konflux-ci-konflux-ci-main-konflux-e2e-v420-arm64-optional/2034354523488653312/artifacts/konflux-e2e-v420-arm64-optional/redhat-appstudio-gather/artifacts/must-gather-appstudio/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-7d8358110fe3be89aeee11dd8a125d1caba5b3d6abe316893576446387f67b6f/namespaces/release-service/pods/release-service-controller-manager-7cd45646f-m7kng/release-service-controller-manager-7cd45646f-m7kng.yaml).

Assisted-by: Claude claude-opus-4-6