### PR TITLE
Remove deprecated client.Apply to restore controller-runtime v0.23.1 compatibility

### DIFF
--- a/operator/internal/condition/reconcile_error_test.go
+++ b/operator/internal/condition/reconcile_error_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
@@ -48,6 +49,10 @@ func (m *mockStatusWriter) Patch(ctx context.Context, obj client.Object, patch c
 }
 
 func (m *mockStatusWriter) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	return nil
+}
+
+func (m *mockStatusWriter) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
 	return nil
 }
 

--- a/operator/pkg/hashedconfigmap/hashedconfigmap.go
+++ b/operator/pkg/hashedconfigmap/hashedconfigmap.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -127,7 +128,7 @@ func (h *HashedConfigMap) Apply(ctx context.Context, content string, owner clien
 
 	// Apply using server-side apply
 	patchOpts := []client.PatchOption{client.FieldOwner(h.fieldManager), client.ForceOwnership}
-	if err := h.client.Patch(ctx, configMap, client.Apply, patchOpts...); err != nil {
+	if err := h.client.Patch(ctx, configMap, kubernetes.SSAApplyPatch, patchOpts...); err != nil {
 		return nil, fmt.Errorf("failed to apply ConfigMap %s: %w", configMapName, err)
 	}
 

--- a/operator/pkg/kubernetes/crd.go
+++ b/operator/pkg/kubernetes/crd.go
@@ -18,7 +18,10 @@ limitations under the License.
 package kubernetes
 
 import (
+	"encoding/json"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -33,4 +36,18 @@ func IsCustomResourceDefinition(obj client.Object) bool {
 	// Fallback for typed CRD when GVK is not set (e.g. struct literal).
 	_, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
 	return ok
+}
+
+// SSAApplyPatch is a client.Patch that uses server-side apply.
+// Use this instead of the deprecated client.Apply constant.
+var SSAApplyPatch client.Patch = ssaPatch{}
+
+type ssaPatch struct{}
+
+func (p ssaPatch) Type() types.PatchType {
+	return types.ApplyPatchType
+}
+
+func (p ssaPatch) Data(obj client.Object) ([]byte, error) {
+	return json.Marshal(obj)
 }

--- a/operator/pkg/tracking/tracking.go
+++ b/operator/pkg/tracking/tracking.go
@@ -206,7 +206,7 @@ func (c *Client) ApplyObject(
 	opts ...client.PatchOption,
 ) error {
 	patchOpts := append([]client.PatchOption{client.FieldOwner(fieldManager), client.ForceOwnership}, opts...)
-	if err := c.Client.Patch(ctx, obj, client.Apply, patchOpts...); err != nil {
+	if err := c.Client.Patch(ctx, obj, kubernetes.SSAApplyPatch, patchOpts...); err != nil {
 		return err
 	}
 	c.track(obj)

--- a/operator/pkg/tracking/tracking_test.go
+++ b/operator/pkg/tracking/tracking_test.go
@@ -162,7 +162,7 @@ func TestClient_Patch(t *testing.T) {
 		},
 	}
 
-	err := tc.Patch(ctx, patched, client.Apply, client.FieldOwner("test-manager"), client.ForceOwnership)
+	err := tc.Patch(ctx, patched, kubernetes.SSAApplyPatch, client.FieldOwner("test-manager"), client.ForceOwnership)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// Verify the resource is tracked


### PR DESCRIPTION
Fixes: #6025
Addressed two CI failures introduced by the controller-runtime v0.23.1 upgrade in the cert-manager update (#5926): first, by adding the missing Apply method to mockStatusWriter to match the updated client.SubResourceWriter interface and resolve typecheck errors, and second, by addressing the deprecation of client.Apply by introducing a shared ssaPatch (based on types.ApplyPatchType) that preserves the existing Patch-based behavior without requiring a larger refactor to Client.Apply().

Changes made:
1. Added the missing Apply method to mockStatusWriter
2. Introduced a shared ssaPatch helper in pkg/kubernetes/crd.go
3. Replaced client.Apply with ssaPatch in:
      - pkg/hashedconfigmap
      - pkg/tracking 
      - pkg/tracking tests

Verification
- Lint passes with no issues (golangci-lint run) 
- All tests pass (make test)  
- No lint suppressions used