### PR TITLE
fix: broken pipe for find

### DIFF
--- a/.github/scripts/create-community-operator-pr.sh
+++ b/.github/scripts/create-community-operator-pr.sh
@@ -188,7 +188,7 @@ echo "✅ Copied all bundle contents"
 
 echo ""
 echo "Operator directory contents:"
-find "${OPERATOR_DIR}" -type f | head -20
+find "${OPERATOR_DIR}" -type f | head -20 || true
 
 # Prepare commit/PR message
 COMMIT_TITLE="operator ${OPERATOR_NAME} (${VERSION})"


### PR DESCRIPTION
It seems as find can sometimes fail for broken pipe as piping it to head can close it prematurely.

The line where it fails is used for logging. This commit makes sure that the error is ignored so we don't fail on this.

Assisted-by: Cursor