### PR TITLE
test: enhance e2e logging when taskrun is missing

### DIFF
--- a/test/go-tests/pkg/clients/has/components.go
+++ b/test/go-tests/pkg/clients/has/components.go
@@ -249,6 +249,14 @@ func (h *Controller) WaitForComponentPipelineToBeFinished(component *appservice.
 			if prLogs, err = t.GetPipelineRunLogs(component.GetName(), pr.Name, pr.Namespace); err != nil {
 				ginkgo.GinkgoWriter.Printf("failed to get logs for PipelineRun %s:%s: %s\n", pr.GetNamespace(), pr.GetName(), err.Error())
 			}
+			// Use condition reason and message when logs are empty (e.g. CouldntGetTask leaves no TaskRuns)
+			if strings.TrimSpace(prLogs) == "" {
+				cond := pr.GetStatusCondition().GetCondition(apis.ConditionSucceeded)
+				prLogs = cond.GetReason()
+				if msg := cond.GetMessage(); msg != "" {
+					prLogs = prLogs + ": " + msg
+				}
+			}
 			return false, fmt.Errorf("%s", prLogs)
 		})
 


### PR DESCRIPTION
When pipelinerun fails with CouldntGetTask, we get no further info about the failure reason. This change adds some more logging in such cases.

Assisted-by: Cursor

Example failure: https://github.com/konflux-ci/konflux-ci/actions/runs/23277948827/job/67684841782?pr=6057
With this change, we should see in the logs in such cases, something like this:
```
CouldntGetTask: Pipeline ... can't be Run; it contains Tasks that don't exist: ... Get "https://quay.io/v2/": tls: failed to verify certificate: x509: certificate signed by unknown authority
```

Not sure yet if we can avoid this issue altogether somehow, but this enhanced logging could make it easier to understand why the pipeline failed.