### PR TITLE
feat: add run-e2e.sh script to consolidate e2e test execution

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -296,9 +296,7 @@ jobs:
           RELEASE_CATALOG_TA_QUAY_TOKEN: ${{ secrets.RELEASE_CATALOG_TA_QUAY_TOKEN }}
           E2E_APPLICATIONS_NAMESPACE: user-ns2
         run: |
-          cd test/go-tests
-          go test ./tests/conformance -v -timeout 30m \
-            -ginkgo.vv \
+          ./test/e2e/run-e2e.sh \
             -ginkgo.github-output \
             -ginkgo.junit-report=${{ github.workspace }}/junit-conformance-${{ matrix.arch }}.xml
 

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -157,9 +157,7 @@ jobs:
           RELEASE_CATALOG_TA_QUAY_TOKEN: ${{ secrets.RELEASE_CATALOG_TA_QUAY_TOKEN }}
           E2E_APPLICATIONS_NAMESPACE: user-ns2
         run: |
-          cd test/go-tests
-          go test ./tests/conformance -v -timeout 30m \
-            -ginkgo.vv \
+          ./test/e2e/run-e2e.sh \
             -ginkgo.github-output \
             -ginkgo.junit-report=${{ github.workspace }}/junit-conformance.xml
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ and ARM64 architectures. There are **two test suites** in `test/go-tests`:
 - **E2E tests** (suite "Konflux E2E"): Full end-to-end flow (application, component,
   build, integration test, release). Requires cluster and E2E credentials. Copy
   `test/e2e/e2e.env.template` to `test/e2e/e2e.env`, fill in the values, then
-  source it and run (from repo root; no cd, repeat as needed): `source test/e2e/e2e.env` then `go -C test/go-tests test ./tests/conformance -v`
+  source it and run (from repo root): `source test/e2e/e2e.env` then `./test/e2e/run-e2e.sh`
   The E2E test code lives in `test/go-tests/tests/conformance/` and is maintained in this repo.
   The release-service-catalog revision is read from `test/e2e/release-service-catalog-revision` when not set in env (so your copy of `e2e.env` does not drift).
 
@@ -147,17 +147,18 @@ See `test/e2e/e2e.env.template` for all E2E variables and descriptions. You do n
 
 ## Running the test
 
-Deploy Konflux and test resources (in one terminal):
+Deploy Konflux (in one terminal):
 ```bash
 ./scripts/deploy-local.sh
-./deploy-test-resources.sh
 ```
 
 Run the E2E tests (source E2E env in the same terminal where you run the test, or in a second terminal). From repo root:
 ```bash
 source test/e2e/e2e.env
-go -C test/go-tests test ./tests/conformance -v
+./test/e2e/run-e2e.sh
 ```
+
+The script deploys test resources and runs the conformance suite.
 
 Note: The deploy step uses `scripts/deploy-local.env` (GitHub App, Quay for image-controller, Smee). The E2E step uses `test/e2e/e2e.env` (GitHub/Quay for E2E flows only). They are separate so you never load deploy secrets into the shell where you only run tests.
 

--- a/test/e2e/e2e.env.template
+++ b/test/e2e/e2e.env.template
@@ -5,7 +5,7 @@
 #
 # Source it before running E2E tests (from repo root):
 #   source test/e2e/e2e.env
-#   go -C test/go-tests test ./tests/conformance -v
+#   ./test/e2e/run-e2e.sh
 #
 # This template sources test/e2e/release-service-catalog-revision so the catalog revision
 # comes from the single tracked file (same as CI). Override by setting RELEASE_SERVICE_CATALOG_REVISION here.

--- a/test/e2e/run-e2e.sh
+++ b/test/e2e/run-e2e.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Deploy test resources and run E2E conformance tests.
+# Extra arguments are forwarded to "go test", e.g.:
+#   ./test/e2e/run-e2e.sh -ginkgo.focus="build" -ginkgo.junit-report=report.xml
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# If kubectl is not available, alias oc as kubectl for this session.
+if ! command -v kubectl &>/dev/null; then
+    if command -v oc &>/dev/null; then
+        echo "kubectl not found; aliasing oc as kubectl for this session"
+        function kubectl() { oc "$@"; }
+        export -f kubectl
+    else
+        echo "Error: neither kubectl nor oc found in PATH" >&2
+        exit 1
+    fi
+fi
+
+# Deploy test resources (idempotent — safe to run if already deployed)
+SKIP_SAMPLE_COMPONENTS="true" "${REPO_ROOT}/deploy-test-resources.sh"
+
+# Run E2E conformance tests
+echo "Running E2E conformance tests..."
+cd "${REPO_ROOT}/test/go-tests"
+# -mod=mod overrides GOFLAGS=-mod=vendor that may be present on some systems; this repo doesn't vendor.
+go test -mod=mod ./tests/conformance -v -timeout 30m -ginkgo.vv "$@"
+

--- a/test/go-tests/tests/conformance/README.md
+++ b/test/go-tests/tests/conformance/README.md
@@ -34,7 +34,15 @@ They run against an upstream Konflux instance deployed via scripts in the [konfl
 ### How to run
 
 1) Follow the instructions in the [konflux-ci repository](https://github.com/konflux-ci/konflux-ci/blob/main/CONTRIBUTING.md#running-e2e-test) to install Konflux
-2) Run: `ginkgo -v` (or `go test . -v` from this directory)
+2) From the repo root, run:
+   ```bash
+   ./test/e2e/run-e2e.sh
+   ```
+   This deploys test resources and runs the conformance suite.
+
+   You can also run `go test . -v` directly from this directory, but that
+   skips test resource deployment — you must ensure resources are already
+   deployed (e.g. via `deploy-test-resources.sh`).
 
 ### Configuration
 


### PR DESCRIPTION
Centralizes e2e test resource deployment and conformance test execution into a single script so that CI workflows, the OpenShift CI step, and local developers all use the same entrypoint. This avoids duplicating go test invocations and flags across multiple places.

The script supports both OpenShift (oc) and Kubernetes (kubectl) environments.

Assisted-by: Claude claude-opus-4-6