### PR TITLE
fix: remove null security context fields from smee-client

### DIFF
--- a/dependencies/smee/smee-client.yaml
+++ b/dependencies/smee/smee-client.yaml
@@ -22,8 +22,6 @@ spec:
       volumes:
         - name: shared-health
           emptyDir: {}
-      securityContext:
-        fsGroup: null
       containers:
         - image: ghcr.io/chmouel/gosmee:latest
           imagePullPolicy: Always
@@ -38,7 +36,6 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: null
           resources:
             limits:
               cpu: 100m
@@ -85,7 +82,6 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: null
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
The null values for fsGroup and runAsUser are no-ops in a standalone manifest — they are equivalent to omitting the fields. Both container images (gosmee and smee-sidecar) already define non-root users, so runAsNonRoot: true is sufficient on vanilla Kubernetes. On OpenShift, the SCC assigns UIDs and fsGroup automatically.

Assisted-by: Claude claude-opus-4-6