### PR TITLE
feat(quay): add script to configure image-controller for self-hosted Quay

### DIFF
--- a/integrations/quay/configure-image-controller.sh
+++ b/integrations/quay/configure-image-controller.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+set -euo pipefail
+
+# Configures image-controller to use the self-hosted Quay instance deployed
+# by deploy-deps.sh. Creates a Quay organization, sets up the
+# image-controller secret with the admin token and internal API URL, and
+# patches the Konflux CR with the Quay CA bundle.
+#
+# Prerequisites: curl, jq, kubectl
+# Requires: Self-hosted Quay deployed (SKIP_QUAY=false in deploy-deps.sh)
+#
+# Usage:
+#   ./integrations/quay/configure-image-controller.sh
+#
+# Environment variables:
+#   QUAY_ORGANIZATION  - Organization name to create (default: konflux)
+#   QUAY_URL           - External Quay URL (default: https://localhost:8443)
+
+: "${QUAY_URL:=https://localhost:8443}"
+: "${QUAY_ORGANIZATION:=konflux}"
+
+QUAY_INTERNAL_API_URL="https://quay-service.quay/api/v1"
+
+for cmd in curl jq kubectl; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "❌ '$cmd' is required but not found" >&2
+        exit 1
+    fi
+done
+
+if ! kubectl get secret quay-admin-token -n quay &>/dev/null; then
+    echo "❌ quay-admin-token secret not found in namespace 'quay'" >&2
+    echo "   Deploy Quay first: SKIP_QUAY=false ./scripts/deploy-local.sh" >&2
+    exit 1
+fi
+
+ADMIN_TOKEN="$(kubectl get secret quay-admin-token -n quay \
+    -o jsonpath='{.data.token}' | base64 -d)"
+
+quay_api() {
+    local method="$1" path="$2"
+    shift 2
+    curl -4 -sk --connect-timeout 10 \
+        -X "$method" \
+        -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+        -H "Content-Type: application/json" \
+        "$@" \
+        "${QUAY_URL}/api/v1${path}"
+}
+
+# ── Create organization ──────────────────────────────────────────────────────
+
+echo "📦 Creating organization '${QUAY_ORGANIZATION}'..." >&2
+ORG_HTTP_CODE="$(curl -4 -sk --connect-timeout 10 -o /dev/null -w '%{http_code}' \
+    -X POST \
+    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "{\"name\": \"${QUAY_ORGANIZATION}\"}" \
+    "${QUAY_URL}/api/v1/organization/")" || true
+
+case "$ORG_HTTP_CODE" in
+    200|201)
+        echo "✅ Organization '${QUAY_ORGANIZATION}' created" >&2
+        ;;
+    400)
+        echo "✅ Organization '${QUAY_ORGANIZATION}' already exists" >&2
+        ;;
+    *)
+        echo "❌ Failed to create organization (HTTP ${ORG_HTTP_CODE})" >&2
+        exit 1
+        ;;
+esac
+
+# ── Extract CA certificate ────────────────────────────────────────────────────
+
+echo "🔐 Extracting Quay CA certificate..." >&2
+CA_CERT="$(kubectl get secret quay-tls -n quay -o jsonpath='{.data.ca\.crt}' | base64 -d)"
+
+if [ -z "$CA_CERT" ]; then
+    echo "❌ Could not extract CA certificate from quay-tls secret" >&2
+    exit 1
+fi
+echo "✅ CA certificate extracted" >&2
+
+# ── Create image-controller resources ─────────────────────────────────────────
+
+echo "📝 Configuring image-controller..." >&2
+
+kubectl create namespace image-controller --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create configmap quay-ca-bundle \
+    --namespace=image-controller \
+    --from-literal=ca-bundle.crt="$CA_CERT" \
+    --dry-run=client -o yaml | kubectl apply -f -
+echo "✅ CA bundle ConfigMap created in image-controller namespace" >&2
+
+kubectl create secret generic quaytoken \
+    --namespace=image-controller \
+    --from-literal=quaytoken="${ADMIN_TOKEN}" \
+    --from-literal=organization="${QUAY_ORGANIZATION}" \
+    --from-literal=quayapiurl="${QUAY_INTERNAL_API_URL}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+echo "✅ quaytoken secret created in image-controller namespace" >&2
+
+# ── Patch Konflux CR ──────────────────────────────────────────────────────────
+
+if kubectl get crd konfluxes.konflux.konflux-ci.dev &>/dev/null &&
+   kubectl get konflux konflux &>/dev/null; then
+    echo "🔧 Patching Konflux CR with Quay CA bundle..." >&2
+    kubectl patch konflux konflux --type=merge -p "
+spec:
+  imageController:
+    enabled: true
+    spec:
+      quayCABundle:
+        configMapName: quay-ca-bundle
+        key: ca-bundle.crt
+"
+    echo "✅ Konflux CR patched" >&2
+
+    echo "⏳ Waiting for image-controller pods to be ready..." >&2
+    if kubectl wait --for=condition=Ready --timeout=240s \
+        -l control-plane=controller-manager -n image-controller pod 2>/dev/null; then
+        echo "✅ image-controller is ready" >&2
+    else
+        echo "⚠️  image-controller pods did not become ready within 4 minutes" >&2
+    fi
+else
+    echo "ℹ️  Konflux CR not found, skipping CR patch" >&2
+    echo "   Apply the CR manually with imageController.enabled: true and quayCABundle configured" >&2
+fi
+
+echo "" >&2
+echo "🎉 Self-hosted Quay integration complete!" >&2
+echo "   Organization: ${QUAY_ORGANIZATION}" >&2
+echo "   Quay API URL: ${QUAY_INTERNAL_API_URL}" >&2
+echo "   Quay UI:      ${QUAY_URL}" >&2

--- a/operator/pkg/manifests/image-controller/manifests.yaml
+++ b/operator/pkg/manifests/image-controller/manifests.yaml
@@ -57,6 +57,11 @@ spec:
               credentials:
                 description: Credentials management.
                 properties:
+                  regenerate-namespace-pull-token:
+                    description: |-
+                      RegenerateNamespacePullToken defines a request to refresh namespace pull robot credentials.
+                      The field gets cleared after the refresh.
+                    type: boolean
                   regenerate-token:
                     description: |-
                       RegenerateToken defines a request to refresh image accessing credentials.
@@ -311,10 +316,10 @@ rules:
   - ""
   resources:
   - configmaps
+  - namespaces
   verbs:
   - get
   - list
-  - update
   - watch
 - apiGroups:
   - ""
@@ -473,7 +478,6 @@ data:
     )
     LOGGER = logging.getLogger(__name__)
     QUAY_API_URL = "https://quay.io/api/v1"
-    RETRY_LIMIT = 5
 
     processed_repos_counter = itertools.count()
 
@@ -481,12 +485,11 @@ data:
     ImageRepo = Dict[str, Any]
 
 
-    def get_quay_tags(quay_token: str, namespace: str, name: str) -> List[ImageRepo]:
+    def get_quay_tags(quay_token: str, namespace: str, name: str) -> Dict[str, Any]:
         next_page = None
         resp: HTTPResponse
 
-        all_tags = []
-        retry_count = 0
+        all_tags = {}
         while True:
             query_args = {"limit": 100, "onlyActiveTags": True}
             if next_page is not None:
@@ -502,27 +505,23 @@ data:
                     if resp.status != 200:
                         raise RuntimeError(resp.reason)
                     json_data = json.loads(resp.read())
-                    retry_count = 0
             except HTTPError as ex:
                 if ex.status == 404:
                     LOGGER.info("Repository doesn't exist anymore %s/%s", namespace, name)
-                    return []
+                    return {}
 
                 if ex.status == 502 or ex.status == 504:
-                    if retry_count > RETRY_LIMIT:
-                        LOGGER.info("Gateway error, retry reached retry limit %s", RETRY_LIMIT)
-                        raise
-
-                    retry_count += 1
                     LOGGER.info("Gateway error, will retry")
-                    time.sleep(2)
+                    time.sleep(1)
                     continue
                 raise
+            except json.JSONDecodeError:
+                LOGGER.info("Json decoder error, will retry")
+                continue
 
             tags = json_data.get("tags", [])
             # store only name & manifest_digest keys, as others aren't used and take memory
-            new_tags = [{"name": tag["name"], "manifest_digest": tag["manifest_digest"]} for tag in tags]
-            all_tags.extend(new_tags)
+            all_tags.update({tag["name"]: tag["manifest_digest"] for tag in tags})
 
             if not tags:
                 LOGGER.debug("No tags found.")
@@ -577,12 +576,10 @@ data:
         return manifest_exists
 
 
-    def remove_tags(tags: List[Dict[str, Any]], quay_token: str, namespace: str, name: str, dry_run: bool = False) -> None:
-        tags_map = {tag_info["name"]: tag_info["manifest_digest"] for tag_info in tags}
-        # delete tags to save memory
-        del(tags)
-        image_digests = [digest for _, digest in tags_map.items()]
-        tag_regex = re.compile(r"^sha256-([0-9a-f]+)(\.sbom|\.att|\.src|\.sig|\.dockerfile)$")
+    def remove_tags(tags_map: Dict[str, Any], quay_token: str, namespace: str, name: str, dry_run: bool = False) -> None:
+        image_digests = set(tags_map.values())
+        # sha without any extension is clair report
+        tag_regex = re.compile(r"^sha256-([0-9a-f]+)(\.sbom|\.att|\.src|\.sig|\.dockerfile)?$")
         manifests_checked = {}
         for tag_name in tags_map:
             # attestation or sbom image
@@ -623,7 +620,11 @@ data:
         for repo in repos:
             namespace = repo["namespace"]
             name = repo["name"]
+            # skip huge repository for which we can't get all tags
+            if name == "ocp-art-tenant/art-images":
+                continue
             LOGGER.info("Processing repository %s: %s/%s", next(processed_repos_counter), namespace, name)
+
             all_tags = get_quay_tags(quay_token, namespace, name)
 
             if not all_tags:
@@ -645,10 +646,14 @@ data:
                 "Authorization": f"Bearer {access_token}",
             })
 
-            with urlopen(request) as resp:
-                if resp.status != 200:
-                    raise RuntimeError(resp.reason)
-                json_data = json.loads(resp.read())
+            try:
+                with urlopen(request) as resp:
+                    if resp.status != 200:
+                        raise RuntimeError(resp.reason)
+                    json_data = json.loads(resp.read())
+            except json.JSONDecodeError:
+                LOGGER.info("Json decoder error, will retry")
+                continue
 
             repos = json_data.get("repositories", [])
             if not repos:
@@ -684,7 +689,7 @@ data:
         main()
 kind: ConfigMap
 metadata:
-  name: image-controller-image-pruner-configmap-tc4f9c8t66
+  name: image-controller-image-pruner-configmap-mmk4bf6tc8
   namespace: image-controller
 ---
 apiVersion: v1
@@ -972,7 +977,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: quay.io/konflux-ci/image-controller:13e073c337902510319cf5ef239bc12098ce8d68
+        image: quay.io/konflux-ci/image-controller:9eaca64ad351b05c450708ea5dae6d4705240154
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1072,7 +1077,7 @@ spec:
             runAsNonRoot: true
           volumes:
           - configMap:
-              name: image-controller-image-pruner-configmap-tc4f9c8t66
+              name: image-controller-image-pruner-configmap-mmk4bf6tc8
             name: image-pruner-volume
           - name: quaytoken
             secret:

--- a/operator/upstream-kustomizations/image-controller/core/kustomization.yaml
+++ b/operator/upstream-kustomizations/image-controller/core/kustomization.yaml
@@ -1,12 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/image-controller/config/default?ref=a67b7b08484e59ce4b07a46d0c4833f4cf372659
+- https://github.com/konflux-ci/image-controller/config/default?ref=9eaca64ad351b05c450708ea5dae6d4705240154
 
 images:
 - name: quay.io/konflux-ci/image-controller
   newName: quay.io/konflux-ci/image-controller
-  newTag: a67b7b08484e59ce4b07a46d0c4833f4cf372659
+  newTag: 9eaca64ad351b05c450708ea5dae6d4705240154
 
 namespace: image-controller
 


### PR DESCRIPTION
Add integrations/quay/configure-image-controller.sh which automates the setup of image-controller against the local self-hosted Quay instance:

- Creates a Quay organization via the API using the admin token
- Extracts the CA certificate from the quay-tls secret
- Creates the quaytoken secret and CA bundle ConfigMap in the image-controller namespace
- Patches the Konflux CR to enable image-controller with the CA bundle

Also bumps image-controller to 9eaca64 which includes https://github.com/konflux-ci/image-controller/commit/9eaca64ad351b05c450708ea5dae6d4705240154

Assisted-By: Cursor