### PR TITLE
Remove deprecated client.Apply to restore controller-runtime v0.23.1 compatibility

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -3,7 +3,7 @@ module github.com/konflux-ci/konflux-ci/operator
 go 1.25.0
 
 require (
-	github.com/cert-manager/cert-manager v1.19.4
+	github.com/cert-manager/cert-manager v1.20.0
 	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
@@ -14,7 +14,7 @@ require (
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
-	sigs.k8s.io/controller-runtime v0.22.4
+	sigs.k8s.io/controller-runtime v0.23.1
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -10,8 +10,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
-github.com/cert-manager/cert-manager v1.19.4 h1:7lOkSYj+nJNjgGFfAznQzPpOfWX+1Kgz6xUXwTa/K5k=
-github.com/cert-manager/cert-manager v1.19.4/go.mod h1:9uBnn3IK9NxjjuXmQDYhwOwFUU5BtGVB1g/voPvvcVw=
+github.com/cert-manager/cert-manager v1.20.0 h1:czZamsFJ1YdKPhpv+SopJZN9t3W68vQBnFYUevSHGqY=
+github.com/cert-manager/cert-manager v1.20.0/go.mod h1:3oparI7R5JyJMNXntYod9p6DucIZ84st7y/9kL6cbBE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -261,8 +261,8 @@ k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 h1:AZYQSJemyQB5eRxqcPky+/7EdBj0x
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 h1:hSfpvjjTQXQY2Fol2CS0QHMNs/WI1MOSGzCm1KhM5ec=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327UfMq9A=
-sigs.k8s.io/controller-runtime v0.22.4/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
+sigs.k8s.io/controller-runtime v0.23.1 h1:TjJSM80Nf43Mg21+RCy3J70aj/W6KyvDtOlpKf+PupE=
+sigs.k8s.io/controller-runtime v0.23.1/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/gateway-api v1.5.0 h1:duoo14Ky/fJXpjpmyMISE2RTBGnfCg8zICfTYLTnBJA=
 sigs.k8s.io/gateway-api v1.5.0/go.mod h1:GvCETiaMAlLym5CovLxGjS0NysqFk3+Yuq3/rh6QL2o=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/operator/internal/condition/reconcile_error_test.go
+++ b/operator/internal/condition/reconcile_error_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
@@ -48,6 +49,10 @@ func (m *mockStatusWriter) Patch(ctx context.Context, obj client.Object, patch c
 }
 
 func (m *mockStatusWriter) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	return nil
+}
+
+func (m *mockStatusWriter) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
 	return nil
 }
 

--- a/operator/pkg/hashedconfigmap/hashedconfigmap.go
+++ b/operator/pkg/hashedconfigmap/hashedconfigmap.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -127,7 +128,7 @@ func (h *HashedConfigMap) Apply(ctx context.Context, content string, owner clien
 
 	// Apply using server-side apply
 	patchOpts := []client.PatchOption{client.FieldOwner(h.fieldManager), client.ForceOwnership}
-	if err := h.client.Patch(ctx, configMap, client.Apply, patchOpts...); err != nil {
+	if err := h.client.Patch(ctx, configMap, kubernetes.SSAApplyPatch, patchOpts...); err != nil {
 		return nil, fmt.Errorf("failed to apply ConfigMap %s: %w", configMapName, err)
 	}
 

--- a/operator/pkg/kubernetes/crd.go
+++ b/operator/pkg/kubernetes/crd.go
@@ -18,7 +18,10 @@ limitations under the License.
 package kubernetes
 
 import (
+	"encoding/json"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -33,4 +36,18 @@ func IsCustomResourceDefinition(obj client.Object) bool {
 	// Fallback for typed CRD when GVK is not set (e.g. struct literal).
 	_, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
 	return ok
+}
+
+// SSAApplyPatch is a client.Patch that uses server-side apply.
+// Use this instead of the deprecated client.Apply constant.
+var SSAApplyPatch client.Patch = ssaPatch{}
+
+type ssaPatch struct{}
+
+func (p ssaPatch) Type() types.PatchType {
+	return types.ApplyPatchType
+}
+
+func (p ssaPatch) Data(obj client.Object) ([]byte, error) {
+	return json.Marshal(obj)
 }

--- a/operator/pkg/tracking/tracking.go
+++ b/operator/pkg/tracking/tracking.go
@@ -206,7 +206,7 @@ func (c *Client) ApplyObject(
 	opts ...client.PatchOption,
 ) error {
 	patchOpts := append([]client.PatchOption{client.FieldOwner(fieldManager), client.ForceOwnership}, opts...)
-	if err := c.Client.Patch(ctx, obj, client.Apply, patchOpts...); err != nil {
+	if err := c.Client.Patch(ctx, obj, kubernetes.SSAApplyPatch, patchOpts...); err != nil {
 		return err
 	}
 	c.track(obj)

--- a/operator/pkg/tracking/tracking_test.go
+++ b/operator/pkg/tracking/tracking_test.go
@@ -162,7 +162,7 @@ func TestClient_Patch(t *testing.T) {
 		},
 	}
 
-	err := tc.Patch(ctx, patched, client.Apply, client.FieldOwner("test-manager"), client.ForceOwnership)
+	err := tc.Patch(ctx, patched, kubernetes.SSAApplyPatch, client.FieldOwner("test-manager"), client.ForceOwnership)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// Verify the resource is tracked


### PR DESCRIPTION
Fixes: #6025
Addressed two CI failures introduced by the controller-runtime v0.23.1 upgrade in the cert-manager update (https://github.com/konflux-ci/konflux-ci/pull/5926): first, by adding the missing Apply method to mockStatusWriter to match the updated client.SubResourceWriter interface and resolve typecheck errors, and second, by addressing the deprecation of client.Apply by introducing a shared ssaPatch (based on types.ApplyPatchType) that preserves the existing Patch-based behavior without requiring a larger refactor to Client.Apply().

Changes made:

Added the missing Apply method to mockStatusWriter
Introduced a shared ssaPatch helper in pkg/kubernetes/crd.go
Replaced client.Apply with ssaPatch in:
pkg/hashedconfigmap
pkg/tracking
pkg/tracking tests
Verification

Lint passes with no issues (golangci-lint run)
All tests pass (make test)
No lint suppressions used