### PR TITLE
setup-release.sh: fix auto releases

### DIFF
--- a/operator/hack/setup-release.sh
+++ b/operator/hack/setup-release.sh
@@ -357,7 +357,7 @@ kind: ReleasePlan
 metadata:
   labels:
     release.appstudio.openshift.io/auto-release: "true"
-    release.appstudio.openshift.io/standing-attribution: "false"
+    release.appstudio.openshift.io/standing-attribution: "true"
   name: ${RELEASE_NAME}
   namespace: ${TENANT_NS}
 spec:


### PR DESCRIPTION
In order to enable releases to automatically happen, the standing attribution must be set to true:
https://konflux.pages.redhat.com/docs/users/releasing/releasing-products.html#authoring-releases