### PR TITLE
feat(KFLUXVNGD-845): add OpenShift CI trigger script for release gating

### DIFF
--- a/.github/scripts/trigger-openshift-ci-tests.sh
+++ b/.github/scripts/trigger-openshift-ci-tests.sh
@@ -5,14 +5,14 @@ set -euo pipefail
 # Triggers multiple Prow jobs via the Gangway REST API, polls for completion,
 # and returns success only if all jobs pass. Used to gate release promotions.
 #
-# The script derives the operator image tag from the git SHA of the RC tag.
-# Images are tagged with release-sha-<short-sha> by Konflux builds.
+# The script derives the operator image tag from the git SHA of the provided ref.
+# Images are tagged with their full commit SHA by Konflux builds.
 #
 # Usage:
-#   trigger-openshift-ci-tests.sh <rc_tag>
+#   trigger-openshift-ci-tests.sh <git_ref>
 #
 # Arguments:
-#   rc_tag - Release candidate tag (e.g., v0.1.5-rc.2)
+#   git_ref - Any git reference (tag, branch, SHA) e.g., v0.1.5-rc.2
 #
 # Environment:
 #   OPENSHIFT_CI_TOKEN - Gangway API token (required)
@@ -62,32 +62,33 @@ trap cleanup SIGINT SIGTERM SIGHUP
 
 # Validate arguments
 if [ $# -ne 1 ]; then
-  echo "Error: RC tag argument required"
-  echo "Usage: $0 <rc_tag>"
+  echo "Error: git ref argument required"
+  echo "Usage: $0 <git_ref>"
   echo "Example: $0 v0.1.5-rc.2"
   exit 1
 fi
 
-RC_TAG="$1"
+GIT_REF="$1"
 
-# Verify required environment variables
+# Verify required environment variables (disable tracing to avoid leaking token)
+{ set +x; } 2>/dev/null
 if [ -z "${OPENSHIFT_CI_TOKEN:-}" ]; then
   echo "Error: OPENSHIFT_CI_TOKEN environment variable is not set"
   exit 1
 fi
 
-# Derive operator image tag from the git SHA of the RC tag
-echo "Resolving git SHA for ${RC_TAG}..."
-COMMIT_SHA=$(git rev-parse "${RC_TAG}^{commit}" 2>/dev/null) || {
-  echo "Error: Failed to resolve git SHA for tag ${RC_TAG}"
-  echo "Ensure the tag exists and the repository has been fetched with tags"
+# Derive operator image tag from the git SHA of the provided ref
+echo "Resolving git SHA for ${GIT_REF}..."
+COMMIT_SHA=$(git rev-parse "${GIT_REF}^{commit}" 2>/dev/null) || {
+  echo "Error: Failed to resolve git SHA for ref ${GIT_REF}"
+  echo "Ensure the ref exists and the repository has been fetched"
   exit 1
 }
 
-SHORT_SHA="${COMMIT_SHA:0:7}"
-OPERATOR_IMAGE="${OPERATOR_REPO}:release-sha-${SHORT_SHA}"
+OPERATOR_IMAGE="${OPERATOR_REPO}:${COMMIT_SHA}"
 echo "Commit SHA: ${COMMIT_SHA}"
 echo "Operator image: ${OPERATOR_IMAGE}"
+echo "(KONFLUX_REF will be derived from image tag by step scripts)"
 echo ""
 
 # Trigger all jobs
@@ -105,7 +106,7 @@ for job_name in "${JOBS[@]}"; do
       job_execution_type: "1",
       pod_spec_options: {
         envs: {
-          OPERATOR_IMAGE: $operator_image
+          MULTISTAGE_PARAM_OVERRIDE_OPERATOR_IMAGE: $operator_image
         }
       }
     }')
@@ -114,17 +115,32 @@ for job_name in "${JOBS[@]}"; do
   JOB_ID=""
   
   while [ -z "$JOB_ID" ] && [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-    RESPONSE=$(curl -s -X POST \
+    HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
       -H "Authorization: Bearer ${OPENSHIFT_CI_TOKEN}" \
       -H "Content-Type: application/json" \
       -d "$REQUEST_PAYLOAD" \
       "${GANGWAY_URL}")
 
-    JOB_ID=$(echo "$RESPONSE" | jq -r '.id // empty')
+    HTTP_CODE=$(echo "$HTTP_RESPONSE" | tail -n1)
+    RESPONSE=$(echo "$HTTP_RESPONSE" | sed '$d')
+
+    if [[ ! "$HTTP_CODE" =~ ^2[0-9][0-9]$ ]]; then
+      RETRY_COUNT=$((RETRY_COUNT + 1))
+      echo "  HTTP ${HTTP_CODE} error (attempt ${RETRY_COUNT}/${MAX_RETRIES}). Response: ${RESPONSE}"
+      [ $RETRY_COUNT -lt $MAX_RETRIES ] && sleep 10
+      continue
+    fi
+
+    JOB_ID=$(echo "$RESPONSE" | jq -r '.id // empty' 2>/dev/null) || {
+      RETRY_COUNT=$((RETRY_COUNT + 1))
+      echo "  JSON parse error (attempt ${RETRY_COUNT}/${MAX_RETRIES}). Response: ${RESPONSE}"
+      [ $RETRY_COUNT -lt $MAX_RETRIES ] && sleep 10
+      continue
+    }
 
     if [ -z "$JOB_ID" ]; then
       RETRY_COUNT=$((RETRY_COUNT + 1))
-      echo "  Failed to trigger (attempt ${RETRY_COUNT}/${MAX_RETRIES}). Response: ${RESPONSE}"
+      echo "  Missing job ID (attempt ${RETRY_COUNT}/${MAX_RETRIES}). Response: ${RESPONSE}"
       [ $RETRY_COUNT -lt $MAX_RETRIES ] && sleep 10
     fi
   done
@@ -174,8 +190,16 @@ while [ $COMPLETED -lt ${#JOBS[@]} ]; do
       continue
     fi
 
-    RESPONSE=$(curl -s -H "Authorization: Bearer ${OPENSHIFT_CI_TOKEN}" \
+    HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" -H "Authorization: Bearer ${OPENSHIFT_CI_TOKEN}" \
       "${GANGWAY_URL}/${JOB_IDS[$job_name]}")
+    HTTP_CODE=$(echo "$HTTP_RESPONSE" | tail -n1)
+    RESPONSE=$(echo "$HTTP_RESPONSE" | sed '$d')
+
+    if [[ ! "$HTTP_CODE" =~ ^2[0-9][0-9]$ ]]; then
+      echo "[$(date '+%H:%M:%S')] ${job_name}: HTTP ${HTTP_CODE} error polling status"
+      continue
+    fi
+
     NEW_STATUS=$(echo "$RESPONSE" | jq -r '.job_status // empty' 2>/dev/null || echo "")
 
     if [ -n "$NEW_STATUS" ] && [ "$NEW_STATUS" != "$current_status" ]; then
@@ -196,7 +220,7 @@ echo ""
 echo "========================================"
 echo "RESULTS"
 echo "========================================"
-echo "RC Tag: ${RC_TAG}"
+echo "Git Ref: ${GIT_REF}"
 echo "Operator Image: ${OPERATOR_IMAGE}"
 echo "Duration: ${ELAPSED}s"
 echo ""

--- a/.github/workflows/promote-release.yaml
+++ b/.github/workflows/promote-release.yaml
@@ -7,9 +7,15 @@ on:
         description: 'Release candidate tag to promote (e.g. v1.2.3-rc.2)'
         required: true
         type: string
+      dry_run:
+        description: 'Run e2e tests but skip actual promotion (for testing)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
+  issues: write
 
 # Prevent concurrent promotions of the same RC tag to avoid race conditions.
 # If the same RC tag is triggered multiple times, subsequent runs will queue
@@ -34,8 +40,31 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
+      - name: Run OpenShift CI e2e tests
+        env:
+          OPENSHIFT_CI_TOKEN: ${{ secrets.OPENSHIFT_CI_TOKEN }}
+          RC_TAG: ${{ inputs.release_candidate_tag }}
+        run: |
+          .github/scripts/trigger-openshift-ci-tests.sh "$RC_TAG"
+
       - name: Promote release candidate to release tag
+        if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RC_TAG: ${{ inputs.release_candidate_tag }}
         run: |
-          .github/scripts/promote-release.sh "${{ inputs.release_candidate_tag }}"
+          .github/scripts/promote-release.sh "$RC_TAG"
+
+      - name: Create issue on failure
+        if: ${{ failure() && !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_NAME: Promote Release
+          RC_TAG: ${{ inputs.release_candidate_tag }}
+        run: |
+          .github/scripts/create-or-update-issue.sh \
+            "Release Promotion Failure" \
+            "E2E tests or promotion failed for $RC_TAG. See workflow run for details."


### PR DESCRIPTION
Adds a script to trigger openshift ci e2e tests via gangway API, passing the operator image derived from the rc tag's git sha, to gate release promotions on passing tests.

Assisted By: Cursor
