### PR TITLE
test(KFLUXVNGD-842): e2e on tekton

### DIFF
--- a/.tekton/konflux-operator-e2e-pull-request.yaml
+++ b/.tekton/konflux-operator-e2e-pull-request.yaml
@@ -1,0 +1,56 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/konflux-ci/konflux-ci?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "2"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" && target_branch == "main" ||
+      event == "push" && target_branch.startsWith("gh-readonly-queue/main/")
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: konflux-operator
+    appstudio.openshift.io/component: konflux-operator
+    pipelines.appstudio.openshift.io/type: test
+  name: konflux-operator-e2e-on-pull-request
+  namespace: konflux-vanguard-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: overrides-yaml
+      # Optional; See example in .tekton/pipelines/operator-e2e/pipeline.yaml.
+      value: ""
+    - name: konflux-ready-timeout
+      value: 15m
+    # OCI artifact prefix for kind-aws provision/deprovision (tag = PipelineRun name). Credentials secret must allow push/pull to this repo.
+    - name: oci-container-repo
+      value: quay.io/konflux-vanguard/konflux-operator-e2e-artifacts
+    # Secret in this namespace: registry creds for oci-container-repo above (not a pipeline default).
+    - name: oci-container-repo-credentials-secret
+      value: konflux-test-infra
+    - name: aws-credentials-secret
+      value: konflux-mapt-us-east-1
+    - name: deprovision-aws-credentials-secret
+      value: konflux-mapt-us-east-1
+    - name: release-ta-oci-storage
+      value: ""
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: '{{source_url}}'
+      - name: revision
+        value: '{{revision}}'
+      - name: pathInRepo
+        value: .tekton/pipelines/operator-e2e/pipeline.yaml
+  taskRunTemplate:
+    # kind-aws provision creates/patches Secret kfg-<PipelineRun name>; konflux-integration-runner has secrets create/patch (build-pipeline-* SAs do not).
+    serviceAccountName: konflux-integration-runner
+status: {}

--- a/.tekton/pipelines/operator-e2e/README.md
+++ b/.tekton/pipelines/operator-e2e/README.md
@@ -1,0 +1,113 @@
+# `operator-e2e-pipeline`
+
+Tekton pipeline for operator E2E that provisions Kind on AWS, deploys Konflux, runs E2E tests, and deprovisions.
+
+## Scope
+
+- Operator install uses Tekton `none` mode: the deploy task runs out-of-cluster `bin/manager` (not an operator image).
+- Deploy and tests are split across `deploy-konflux` and `konflux-e2e-tests`.
+- There are **no Pipeline workspaces**: each Task clones `konflux-ci` into an `emptyDir` (see the Task YAML). This is so the pipeline can be triggered both by Pipelines as Code and as IntegrationTestScenario.
+
+### Operator process vs. test phase
+
+In `none` mode, `bin/manager` is started as a **background process inside the `deploy-konflux` Task pod** (see `scripts/operator-e2e/tekton-deploy-operator-and-wait.sh`). When that Task finishes, the pod exits and **that operator process terminates** — it is not left running on the Kind cluster.
+
+The **`konflux-e2e-tests` Task** runs in a **separate pod** with kubeconfig only. There is **no `bin/manager` reconciliation loop** during integration or conformance tests. The cluster still runs the workloads the operator applied (build-service, integration-service, PaC, and so on); those controllers keep reconciling their own resources.
+
+The current conformance suite is written for that model: it exercises deployed services and GitHub flows, not “delete a Deployment and expect the Konflux operator to recreate it.” A test that assumed operator-level reconciliation during the test phase would not behave like a long-running operator install.
+
+## Inputs (params)
+
+- `git-url` (default: `https://github.com/konflux-ci/konflux-ci.git`): repository URL used for clone + git-resolved local tasks.
+- `revision` (required): git ref from `git-url` to test.
+- `overrides-yaml` (default: empty): optional inline overrides consumed by deploy task.
+- `konflux-ready-timeout` (default: `30m`): readiness timeout for Konflux CR.
+- `oci-container-repo` (required): OCI registry/repo prefix for kind-aws provision/deprovision artifacts (logs/state); no tag suffix—the pipeline appends `:$(context.pipelineRun.name)` for provision/deprovision. The deploy task also pushes **post-prep** `operator/pkg/manifests` to the **same repo** with tag `$(context.pipelineRun.name).pkg-manifests` so it does not replace the provision artifact.
+- `oci-container-repo-credentials-secret` (required): name of a Secret with registry credentials for `oci-container-repo` (kind-aws `oci-credentials`). This repo’s PAC PipelineRun uses `konflux-test-infra`.
+- `aws-credentials-secret` (default: `konflux-mapt-us-east-1`): AWS credentials for provision task.
+- `deprovision-aws-credentials-secret` (default: `konflux-mapt-us-east-1`): AWS credentials for deprovision task.
+- `release-ta-oci-storage` (default: empty): optional OCI ref for conformance trusted-artifacts flow.
+- `integration-go-test-extra-args` (default: empty): optional space-separated extra flags appended to integration `go test . ./pkg/...` (e.g. `-run=TestFoo -count=1`).
+- `conformance-go-test-extra-args` (default: empty): optional space-separated extra flags appended to conformance `go test` after the fixed Ginkgo options (e.g. `-ginkgo.focus=Subsuite`), same idea as `./test/e2e/run-e2e.sh` forwarding `"$@"`.
+- `catalog-url` (default: `https://github.com/konflux-ci/tekton-integration-catalog.git`): integration catalog repository.
+- `catalog-revision` (default: pinned commit SHA): `tekton-integration-catalog` ref for catalog tasks; override to move to a different commit.
+
+### Examples: `integration-go-test-extra-args` / `conformance-go-test-extra-args`
+
+Params are a **single string**; the Task passes them into the shell **without extra quoting**, so **spaces separate flags** (same as typing multiple words after `go test` locally). Do not wrap the whole value in inner quotes unless you intend one literal argument.
+
+**IntegrationTestScenario** — add under `spec.params` next to your other params:
+
+```yaml
+    - name: integration-go-test-extra-args
+      value: "-run=TestKonfluxIntegration -count=1"
+    - name: conformance-go-test-extra-args
+      value: "-ginkgo.skip=Flaky -ginkgo.v=false"
+```
+
+**Pipelines as Code** — in the PipelineRun template, set param values (adjust to your PAC variable syntax):
+
+```yaml
+    - name: integration-go-test-extra-args
+      value: ""
+    - name: conformance-go-test-extra-args
+      value: "-ginkgo.skip=Flaky"
+```
+
+**Direct `tkn` / YAML PipelineRun** — same shape: each param is one scalar string; use `=` style Ginkgo flags to avoid embedded spaces when possible.
+
+## Expected Secret shapes
+
+The pipeline passes **Secret names** as parameters. The **keys and formats** below match what **kind-aws-provision 0.2** and **kind-aws-deprovision 0.1** expect; open those task files at the same Git commit as `catalog-revision` in `pipeline.yaml` (for example [provision 0.2](https://github.com/konflux-ci/tekton-integration-catalog/blob/489cd0a413f52fd3fac90f38694f8fe51871be4a/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml) and [deprovision 0.1](https://github.com/konflux-ci/tekton-integration-catalog/blob/489cd0a413f52fd3fac90f38694f8fe51871be4a/tasks/mapt-oci/kind-aws-spot/deprovision/0.1/kind-aws-deprovision.yaml) at the default pin). Re-verify whenever you bump `catalog-revision`.
+
+### `oci-container-repo-credentials-secret` (registry auth for `oci-container-repo`)
+
+- **Type:** `Opaque` is typical.
+- **Required data key:** `oci-storage-dockerconfigjson` — value must be the **contents of a `.dockerconfigjson`** file (same JSON `docker`/`podman` use). In manifests, use `stringData` for the raw JSON body, or put base64-encoded content under `data`.
+- The key name must be exactly `oci-storage-dockerconfigjson` (used by the catalog `secure-push-oci` step action).
+
+Example (replace placeholders; prefer creating via `kubectl create secret generic` or your GitOps tool rather than committing raw credentials):
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-oci-push-secret
+type: Opaque
+stringData:
+  # Body must be valid .dockerconfigjson; auth is base64("username:password").
+  oci-storage-dockerconfigjson: '{"auths":{"quay.io":{"auth":"<base64(username:password)>"}}}'
+```
+
+### `aws-credentials-secret` and `deprovision-aws-credentials-secret`
+
+Both reference the **same shape** of Secret unless your deprovision catalog task differs (this pipeline uses the same catalog family for both).
+
+- **Type:** `Opaque`
+- **Required data keys** (values are plain strings in `stringData`, or base64 in `data`):
+  - `access-key` — AWS access key ID
+  - `secret-key` — AWS secret access key
+  - `region` — AWS region name (e.g. `us-east-1`)
+  - `bucket` — S3 bucket name used by Mapt for this flow
+
+Example:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: konflux-mapt-us-east-1
+type: Opaque
+stringData:
+  access-key: AKIA...
+  secret-key: ...
+  region: us-east-1
+  bucket: my-mapt-bucket
+```
+
+## Resolution model
+
+- The pipeline itself is intended to be git-resolved by PipelineRun (`pipelineRef.resolver: git`) from `.tekton/pipelines/operator-e2e/pipeline.yaml`.
+- Catalog tasks are resolved via git resolver from `catalog-url`/`catalog-revision`.
+- Local tasks (`deploy-konflux`, `konflux-e2e-tests`) are resolved via git resolver from `git-url`/`revision`.
+- This allows external repos to reference this pipeline and pin which `konflux-ci` revision provides task logic.

--- a/.tekton/pipelines/operator-e2e/pipeline.yaml
+++ b/.tekton/pipelines/operator-e2e/pipeline.yaml
@@ -1,0 +1,331 @@
+# Kind on AWS (tekton-integration-catalog) -> clone inside deploy/e2e Tasks -> operator E2E
+# (overrides optional) -> deprovision.
+#
+# The deploy Task builds and runs bin/manager in-process
+# (no operator image). This pipeline intentionally does not support local image-based
+# operator install to keep the first upstream iteration minimal.
+#
+# No Pipeline workspaces: deploy-konflux and konflux-e2e-tests clone konflux-ci into a Task emptyDir.
+#
+# Input modes:
+# - PAC / direct PipelineRun: leave SNAPSHOT empty; git-url, revision, overrides-yaml
+#   drive clone inside tasks, deploy resolver, and e2e.
+# - IntegrationTestScenario: set SNAPSHOT (JSON); test-metadata supplies git-url and
+#   git-revision for clone inside tasks. Git taskRef for deploy/e2e Task YAML uses fixed
+#   konflux-ci + branch (Tekton does not substitute task results in remote Task resolver params).
+# - overrides-yaml examples:
+#   * PAC (from Pipelines as Code template values):
+#     ref: {{revision}}
+#     replacement: ...:on-pr-{{revision}}
+#   * ITS (from test-metadata results; use container-image for the snapshot component image —
+#     instrumented-container-image is only set for coverage-instrumented builds):
+#     ref: $(tasks.test-metadata.results.git-revision)
+#     replacement: $(tasks.test-metadata.results.container-image)
+#
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: operator-e2e-pipeline
+spec:
+  description: >-
+    Provision Kind (AWS), clone konflux-ci inside Tasks, deploy Konflux to Ready (skip in-cluster Kind),
+    run e2e integration + conformance in a separate Task, then deprovision.
+  params:
+    - name: SNAPSHOT
+      type: string
+      description: >-
+        Snapshot JSON from IntegrationTestScenario. Empty: use git-url/revision params (PAC).
+      default: ""
+    - name: git-url
+      type: string
+      description: konflux-ci git URL (PAC / when SNAPSHOT is empty)
+      default: https://github.com/konflux-ci/konflux-ci.git
+    - name: revision
+      type: string
+      description: Git commit SHA, branch, or tag to test (PAC / when SNAPSHOT is empty)
+      default: main
+    - name: overrides-yaml
+      type: string
+      description: >-
+        Optional YAML consumed by operator/cmd/overrides (empty string to skip). Do not embed
+        secrets; pipeline params are persisted on PipelineRuns/TaskRuns and are not treated as confidential.
+      default: ""
+      # default: |
+      #   # Pipelines as Code example (when triggered inside a PR by PAC):
+      #   - name: segment-bridge
+      #     git:
+      #       - sourceRepo: konflux-ci/segment-bridge
+      #         remote:
+      #           repo: https://github.com/konflux-ci/segment-bridge
+      #           ref: {{revision}}
+      #     images:
+      #       - orig: quay.io/konflux-ci/segment-bridge
+      #         replacement: quay.io/redhat-user-workloads/konflux-vanguard-tenant/segment-bridge/segment-bridge:on-pr-{{revision}}
+      #
+      #   # IntegrationTestScenario example (values from test-metadata results):
+      #   - name: release-service
+      #     git:
+      #       - sourceRepo: konflux-ci/release-service
+      #         remote:
+      #           repo: $(tasks.test-metadata.results.git-url)
+      #           ref: $(tasks.test-metadata.results.git-revision)
+      #     images:
+      #       - orig: quay.io/konflux-ci/release-service
+      #         replacement: $(tasks.test-metadata.results.container-image)
+    - name: konflux-ready-timeout
+      type: string
+      default: "30m"
+    - name: oci-container-repo
+      type: string
+      description: >-
+        OCI registry/repo prefix for kind-aws provision/deprovision artifacts (logs/state); no tag
+        suffix (PipelineRun name is appended). Must be set by the PipelineRun.
+    - name: oci-container-repo-credentials-secret
+      type: string
+      description: >-
+        Name of a Secret in the PipelineRun namespace with registry credentials for the
+        oci-container-repo prefix (kind-aws oci-credentials for artifact push/pull). Must be set by the PipelineRun.
+    - name: aws-credentials-secret
+      type: string
+      description: AWS credentials secret name for kind-aws-provision
+      default: konflux-mapt-us-east-1
+    - name: deprovision-aws-credentials-secret
+      type: string
+      description: AWS secret for kind-aws-deprovision (often same as provision; override if your catalog differs)
+      default: konflux-mapt-us-east-1
+    - name: release-ta-oci-storage
+      type: string
+      description: Optional OCI ref for conformance trusted-artifacts
+      default: ""
+    - name: integration-go-test-extra-args
+      type: string
+      description: >-
+        Optional extra arguments appended to integration "go test . ./pkg/..." (space-separated).
+        Empty keeps the default test invocation.
+      default: ""
+    - name: conformance-go-test-extra-args
+      type: string
+      description: >-
+        Optional extra arguments appended to conformance go test after fixed Ginkgo flags
+        (e.g. -ginkgo.focus=Name).
+      default: ""
+    - name: catalog-url
+      type: string
+      default: https://github.com/konflux-ci/tekton-integration-catalog.git
+    - name: catalog-revision
+      type: string
+      description: >-
+        Pinned commit of tekton-integration-catalog for kind-aws and other catalog tasks (bump when upgrading tasks).
+      # renovate: datasource=git-refs depName=https://github.com/konflux-ci/tekton-integration-catalog
+      default: 489cd0a413f52fd3fac90f38694f8fe51871be4a
+  tasks:
+    - name: test-metadata
+      when:
+        - input: $(params.SNAPSHOT)
+          operator: notin
+          values: [""]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.catalog-url)
+          - name: revision
+            value: $(params.catalog-revision)
+          - name: pathInRepo
+            value: tasks/test-metadata/0.4/test-metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+    - name: provision-kind-cluster
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.catalog-url)
+          - name: revision
+            value: $(params.catalog-revision)
+          - name: pathInRepo
+            value: tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
+      params:
+        - name: secret-aws-credentials
+          value: $(params.aws-credentials-secret)
+        - name: cluster-access-secret-name
+          value: kfg-$(context.pipelineRun.name)
+        - name: id
+          value: $(context.pipelineRun.name)
+        - name: tags
+          value: owner=konflux-ci,project=konflux-ci,created-by=operator-e2e-pipeline
+        - name: debug
+          value: "false"
+        - name: ownerKind
+          value: PipelineRun
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+        - name: oci-ref
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
+        - name: oci-credentials
+          value: $(params.oci-container-repo-credentials-secret)
+        - name: extra-port-mappings
+          value: >-
+            '[{\"containerPort\":30012,\"hostPort\":8180,\"protocol\":\"TCP\"}]'
+        - name: cpus
+          value: "16"
+        - name: memory
+          value: "32"
+        - name: spot
+          value: "false"
+        - name: harden-control-plane
+          value: "true"
+    - name: deploy-konflux-pac
+      runAfter:
+        - provision-kind-cluster
+      when:
+        - input: $(params.SNAPSHOT)
+          operator: in
+          values: [""]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.revision)
+          - name: pathInRepo
+            value: .tekton/tasks/deploy-konflux/task.yaml
+      params:
+        - name: git-url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.revision)
+        - name: cluster-access-secret
+          value: kfg-$(context.pipelineRun.name)
+        - name: overrides-yaml
+          value: $(params.overrides-yaml)
+        - name: konflux-ready-timeout
+          value: $(params.konflux-ready-timeout)
+        - name: oci-container-repo
+          value: $(params.oci-container-repo)
+        - name: oci-container-repo-credentials-secret
+          value: $(params.oci-container-repo-credentials-secret)
+        - name: pipeline-run-name
+          value: $(context.pipelineRun.name)
+    - name: deploy-konflux-its
+      runAfter:
+        - provision-kind-cluster
+        - test-metadata
+      when:
+        - input: $(params.SNAPSHOT)
+          operator: notin
+          values: [""]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/konflux-ci.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: .tekton/tasks/deploy-konflux/task.yaml
+      params:
+        - name: git-url
+          value: $(tasks.test-metadata.results.git-url)
+        - name: revision
+          value: $(tasks.test-metadata.results.git-revision)
+        - name: cluster-access-secret
+          value: kfg-$(context.pipelineRun.name)
+        - name: overrides-yaml
+          value: $(params.overrides-yaml)
+        - name: konflux-ready-timeout
+          value: $(params.konflux-ready-timeout)
+        - name: oci-container-repo
+          value: $(params.oci-container-repo)
+        - name: oci-container-repo-credentials-secret
+          value: $(params.oci-container-repo-credentials-secret)
+        - name: pipeline-run-name
+          value: $(context.pipelineRun.name)
+    - name: konflux-e2e-tests-pac
+      runAfter:
+        - deploy-konflux-pac
+      when:
+        - input: $(params.SNAPSHOT)
+          operator: in
+          values: [""]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.revision)
+          - name: pathInRepo
+            value: .tekton/tasks/konflux-e2e-tests/task.yaml
+      params:
+        - name: git-url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.revision)
+        - name: cluster-access-secret
+          value: kfg-$(context.pipelineRun.name)
+        - name: konflux-ready-timeout
+          value: $(params.konflux-ready-timeout)
+        - name: release-ta-oci-storage
+          value: $(params.release-ta-oci-storage)
+        - name: integration-go-test-extra-args
+          value: $(params.integration-go-test-extra-args)
+        - name: conformance-go-test-extra-args
+          value: $(params.conformance-go-test-extra-args)
+    - name: konflux-e2e-tests-its
+      runAfter:
+        - deploy-konflux-its
+      when:
+        - input: $(params.SNAPSHOT)
+          operator: notin
+          values: [""]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/konflux-ci.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: .tekton/tasks/konflux-e2e-tests/task.yaml
+      params:
+        - name: git-url
+          value: $(tasks.test-metadata.results.git-url)
+        - name: revision
+          value: $(tasks.test-metadata.results.git-revision)
+        - name: cluster-access-secret
+          value: kfg-$(context.pipelineRun.name)
+        - name: konflux-ready-timeout
+          value: $(params.konflux-ready-timeout)
+        - name: release-ta-oci-storage
+          value: $(params.release-ta-oci-storage)
+        - name: integration-go-test-extra-args
+          value: $(params.integration-go-test-extra-args)
+        - name: conformance-go-test-extra-args
+          value: $(params.conformance-go-test-extra-args)
+  finally:
+    - name: deprovision-kind-cluster
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.catalog-url)
+          - name: revision
+            value: $(params.catalog-revision)
+          - name: pathInRepo
+            value: tasks/mapt-oci/kind-aws-spot/deprovision/0.1/kind-aws-deprovision.yaml
+      params:
+        - name: secret-aws-credentials
+          value: $(params.deprovision-aws-credentials-secret)
+        - name: id
+          value: $(context.pipelineRun.name)
+        - name: cluster-access-secret
+          value: kfg-$(context.pipelineRun.name)
+        - name: oci-container
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
+        - name: oci-credentials
+          value: $(params.oci-container-repo-credentials-secret)

--- a/.tekton/tasks/deploy-konflux/README.md
+++ b/.tekton/tasks/deploy-konflux/README.md
@@ -1,0 +1,70 @@
+# `deploy-konflux` Task
+
+Deploys Konflux on a provisioned cluster and waits for `konflux/konflux` to become `Ready`.
+
+## Inputs (params)
+
+- `cluster-access-secret` (required): Secret name containing kubeconfig data for the target cluster.
+- `kubeconfig-secret-key` (default: `kubeconfig`): key inside the Secret that contains kubeconfig bytes.
+- `overrides-yaml` (default: empty): optional inline YAML consumed by `operator/cmd/overrides`.
+- `konflux-ready-timeout` (default: `30m`): timeout for waiting on Konflux Ready condition.
+- `konflux-cr-relative-path` (default: `operator/config/samples/konflux-e2e.yaml`): path to the Konflux CR YAML **relative to the repository root** of the clone (checkout is at `/mnt/konflux-ci/repo`).
+- `kind-cluster-name` (default: `konflux-operator-e2e`): logical Kind cluster name passed to `deploy-local.sh`.
+
+## Repository checkout (Task volumes)
+
+This Task does **not** use Tekton `workspaces`. It clones `konflux-ci` into an `emptyDir` volume mounted at `/mnt/konflux-ci/repo` (see `task.yaml`).
+
+## Required secrets / env sources
+
+Reads keys from Secret `konflux-operator-e2e-credentials` in the Task namespace:
+
+- `GITHUB_APP_ID`
+- `GITHUB_PRIVATE_KEY`
+- `WEBHOOK_SECRET`
+- `QUAY_TOKEN`
+- `QUAY_ORGANIZATION`
+- `SMEE_CHANNEL`
+- `GH_ORG`
+- `GH_TOKEN`
+- `QUAY_DOCKERCONFIGJSON`
+- `RELEASE_CATALOG_TA_QUAY_TOKEN`
+
+## Steps / images
+
+1. **fetch-kubeconfig** / **copy-shared-tools** — `quay.io/konflux-ci/task-runner:0.2.0` (pinned by digest in `task.yaml`).
+2. **deploy-prep** — `registry.access.redhat.com/ubi10/go-toolset` (pinned by digest): optional overrides via `go run ./cmd/overrides`, then `deploy-local.sh` with `OPERATOR_INSTALL_METHOD=none` (needs credentials below).
+3. **deploy-operator-and-wait** — `registry.access.redhat.com/ubi10/go-toolset` (pinned by digest): uses `kubectl`/`yq`/`jq` from `/mnt/e2e-shared/bin` and **`LD_LIBRARY_PATH=/mnt/e2e-shared/lib`** for `jq`, then `make` + out-of-cluster `bin/manager`, CR apply, Ready wait.
+
+No on-the-fly tool downloads; shared CLIs are copied from task-runner.
+
+## Notes
+
+- This Task is Tekton `none`-mode oriented: it deploys dependencies, runs operator from source (`bin/manager`), applies Konflux CR, and waits for Ready.
+
+## `overrides-yaml` examples
+
+Use multiline YAML in the PipelineRun/TaskRun param value.
+
+Example: image replacement only
+
+```yaml
+- name: segment-bridge
+  images:
+    - orig: quay.io/konflux-ci/segment-bridge
+      replacement: quay.io/redhat-user-workloads/konflux-vanguard-tenant/segment-bridge/segment-bridge:on-pr-{{revision}}
+```
+
+Example: git override + image replacement
+
+```yaml
+- name: segment-bridge
+  git:
+    - sourceRepo: konflux-ci/segment-bridge
+      remote:
+        repo: https://github.com/konflux-ci/segment-bridge
+        ref: {{revision}}
+  images:
+    - orig: quay.io/konflux-ci/segment-bridge
+      replacement: quay.io/redhat-user-workloads/konflux-vanguard-tenant/segment-bridge/segment-bridge:on-pr-{{revision}}
+```

--- a/.tekton/tasks/deploy-konflux/task.yaml
+++ b/.tekton/tasks/deploy-konflux/task.yaml
@@ -1,0 +1,236 @@
+# Deploy Konflux on a cluster whose kubeconfig is stored in a Secret
+# (e.g. created by tekton-integration-catalog kind-aws-provision), with optional
+# manifest overrides, through Konflux Ready.
+#
+# Clones konflux-ci into a Task emptyDir (no Pipeline workspace). Public HTTPS URLs
+# need no git credentials.
+#
+# Requires a ServiceAccount that can read the cluster-access Secret in this namespace.
+#
+# Uses quay.io/konflux-ci/task-runner for kubeconfig/shared tools and
+# registry.access.redhat.com/ubi10/go-toolset for override logic and go/make; shared CLIs are copied
+# to /mnt/e2e-shared/bin and jq shared libraries to /mnt/e2e-shared/lib (no network downloads). After prep, optional oras push of
+# operator/pkg/manifests uses the same task-runner image as fetch-kubeconfig (oras + jq).
+#
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: deploy-konflux
+spec:
+  description: >-
+    Clone konflux-ci (git-url/revision), apply OVERRIDES_YAML (optional), run deploy-local.sh with DEPLOY_LOCAL_SKIP_KIND=1
+    (go-toolset), optionally push operator/pkg/manifests to OCI (${repo}:${run}.pkg-manifests),
+    then make install/build and bin/manager on go-toolset, apply Konflux CR, and wait Ready.
+  volumes:
+    - name: repo
+      emptyDir: {}
+    - name: e2e-shared
+      emptyDir: {}
+    - name: oci-registry-creds
+      secret:
+        secretName: $(params.oci-container-repo-credentials-secret)
+  params:
+    - name: git-url
+      description: HTTPS git URL for konflux-ci (clone source)
+      type: string
+      default: https://github.com/konflux-ci/konflux-ci.git
+    - name: revision
+      description: Git branch, tag, or commit to checkout after clone
+      type: string
+      default: main
+    - name: clone-depth
+      description: >-
+        Shallow clone depth (same default as Tekton task git-clone 0.1 param depth).
+      type: string
+      default: "1"
+    - name: cluster-access-secret
+      description: Secret name containing kubeconfig (e.g. kfg-<pipelinerun name>)
+      type: string
+    - name: kubeconfig-secret-key
+      description: Key inside the Secret holding kubeconfig bytes
+      type: string
+      default: kubeconfig
+    - name: overrides-yaml
+      description: >-
+        Optional apply-overrides-from-yaml body (empty to skip). Do not pass credentials or
+        other secrets; param values are stored on TaskRuns and may appear in UIs and debug output.
+      type: string
+      default: ""
+    - name: konflux-ready-timeout
+      type: string
+      default: "30m"
+    - name: konflux-cr-relative-path
+      type: string
+      default: operator/config/samples/konflux-e2e.yaml
+    - name: kind-cluster-name
+      description: Logical Kind cluster name for deploy-local.sh
+      type: string
+      default: konflux-operator-e2e
+    - name: oci-container-repo
+      description: >-
+        Registry/repo prefix (no tag), same as kind-aws provision oci-ref prefix. Used to push
+        operator/pkg/manifests after prep as ${repo}:${pipelineRun}.pkg-manifests. Empty skips push.
+      type: string
+      default: ""
+    - name: oci-container-repo-credentials-secret
+      description: >-
+        Secret with data key oci-storage-dockerconfigjson (same shape as kind-aws oci-credentials).
+      type: string
+      default: konflux-test-infra
+    - name: pipeline-run-name
+      description: PipelineRun name (for OCI tag suffix .pkg-manifests).
+      type: string
+      default: ""
+  stepTemplate:
+    volumeMounts:
+      - name: repo
+        mountPath: /mnt/konflux-ci/repo
+      - name: e2e-shared
+        mountPath: /mnt/e2e-shared
+  steps:
+    - name: clone-repository
+      image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
+      env:
+        - name: GIT_URL
+          value: $(params.git-url)
+        - name: GIT_REVISION
+          value: $(params.revision)
+        - name: GIT_DEPTH
+          value: $(params.clone-depth)
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        REPO_ROOT=/mnt/konflux-ci/repo
+        mkdir -p "${REPO_ROOT}"
+        # REPO_ROOT is an emptyDir mount point; rm -rf on it fails (device busy). Clear contents only.
+        find "${REPO_ROOT}" -mindepth 1 -delete
+        git init "${REPO_ROOT}"
+        git -C "${REPO_ROOT}" remote add origin "${GIT_URL}"
+        git -C "${REPO_ROOT}" fetch --depth "${GIT_DEPTH}" origin "${GIT_REVISION}"
+        git -C "${REPO_ROOT}" checkout -q FETCH_HEAD
+    - name: fetch-kubeconfig
+      image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
+      workingDir: /mnt/konflux-ci/repo
+      env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        cd /mnt/konflux-ci/repo
+        exec bash scripts/operator-e2e/tekton-fetch-kubeconfig.sh "$(params.cluster-access-secret)" "$(params.kubeconfig-secret-key)"
+    - name: copy-shared-tools
+      image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
+      workingDir: /mnt/konflux-ci/repo
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        exec bash scripts/operator-e2e/tekton-copy-shared-tools.sh
+    - name: deploy-prep
+      image: registry.access.redhat.com/ubi10/go-toolset@sha256:b7f71131f21be923baaaf952309b7940ae7c6a55ca44a7a91460adc6c8afd4de
+      workingDir: /mnt/konflux-ci/repo
+      env:
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: konflux-operator-e2e-credentials
+              key: GITHUB_APP_ID
+        - name: GITHUB_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: konflux-operator-e2e-credentials
+              key: GITHUB_PRIVATE_KEY
+        - name: WEBHOOK_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: konflux-operator-e2e-credentials
+              key: WEBHOOK_SECRET
+        - name: QUAY_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: konflux-operator-e2e-credentials
+              key: QUAY_TOKEN
+        - name: QUAY_ORGANIZATION
+          valueFrom:
+            secretKeyRef:
+              name: konflux-operator-e2e-credentials
+              key: QUAY_ORGANIZATION
+        - name: SMEE_CHANNEL
+          valueFrom:
+            secretKeyRef:
+              name: konflux-operator-e2e-credentials
+              key: SMEE_CHANNEL
+        - name: GH_ORG
+          valueFrom:
+            secretKeyRef:
+              name: konflux-operator-e2e-credentials
+              key: GH_ORG
+        - name: GH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: konflux-operator-e2e-credentials
+              key: GH_TOKEN
+        - name: QUAY_DOCKERCONFIGJSON
+          valueFrom:
+            secretKeyRef:
+              name: konflux-operator-e2e-credentials
+              key: QUAY_DOCKERCONFIGJSON
+        - name: RELEASE_CATALOG_TA_QUAY_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: konflux-operator-e2e-credentials
+              key: RELEASE_CATALOG_TA_QUAY_TOKEN
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        cd /mnt/konflux-ci/repo
+        exec env \
+          E2E_OVERRIDES_YAML="$(params.overrides-yaml)" \
+          E2E_KONFLUX_CR="$(params.konflux-cr-relative-path)" \
+          E2E_KIND_CLUSTER="$(params.kind-cluster-name)" \
+          E2E_KONFLUX_READY_TIMEOUT="$(params.konflux-ready-timeout)" \
+          bash scripts/operator-e2e/tekton-deploy-prep.sh /mnt/konflux-ci/repo
+    - name: push-operator-pkg-manifests-oci
+      image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
+      workingDir: /mnt/konflux-ci/repo
+      volumeMounts:
+        - name: repo
+          mountPath: /mnt/konflux-ci/repo
+        - name: e2e-shared
+          mountPath: /mnt/e2e-shared
+        - name: oci-registry-creds
+          mountPath: /mnt/oci-registry/.docker/config.json
+          subPath: oci-storage-dockerconfigjson
+          readOnly: true
+      env:
+        - name: DOCKER_CONFIG
+          value: /mnt/oci-registry/.docker
+        - name: E2E_OCI_CONTAINER_REPO
+          value: $(params.oci-container-repo)
+        - name: E2E_PIPELINE_RUN_NAME
+          value: $(params.pipeline-run-name)
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        cd /mnt/konflux-ci/repo
+        exec bash scripts/operator-e2e/tekton-push-operator-pkg-manifests-oci.sh /mnt/konflux-ci/repo
+    - name: deploy-operator-and-wait
+      computeResources:
+        requests:
+          cpu: "500m"
+          memory: "2Gi"
+        limits:
+          cpu: "2"
+          memory: "8Gi"
+      workingDir: /mnt/konflux-ci/repo
+      image: registry.access.redhat.com/ubi10/go-toolset@sha256:b7f71131f21be923baaaf952309b7940ae7c6a55ca44a7a91460adc6c8afd4de
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        cd /mnt/konflux-ci/repo
+        exec env \
+          E2E_KONFLUX_CR="$(params.konflux-cr-relative-path)" \
+          E2E_KONFLUX_READY_TIMEOUT="$(params.konflux-ready-timeout)" \
+          bash scripts/operator-e2e/tekton-deploy-operator-and-wait.sh /mnt/konflux-ci/repo

--- a/.tekton/tasks/konflux-e2e-tests/README.md
+++ b/.tekton/tasks/konflux-e2e-tests/README.md
@@ -1,0 +1,49 @@
+# `konflux-e2e-tests` Task
+
+Runs Konflux E2E test phases against an already deployed Konflux instance.
+
+## Inputs (params)
+
+- `cluster-access-secret` (required): Secret name containing kubeconfig data for the target cluster.
+- `kubeconfig-secret-key` (default: `kubeconfig`): key inside the Secret that contains kubeconfig bytes.
+- `konflux-ready-timeout` (default: `30m`): timeout used while waiting for Konflux CR readiness before tests start.
+- `release-ta-oci-storage` (default: empty): optional OCI location passed to conformance trusted-artifacts flow.
+- `integration-go-test-extra-args` (default: empty): optional space-separated flags appended to `go test . ./pkg/...`.
+- `conformance-go-test-extra-args` (default: empty): optional space-separated flags appended to conformance `go test` after `-ginkgo.junit-report=...` (e.g. `-ginkgo.focus=...`).
+
+These map to env vars `E2E_INTEGRATION_GO_TEST_EXTRA_ARGS` and `E2E_CONFORMANCE_GO_TEST_EXTRA_ARGS` on the `run-tests` step. The helper scripts expand them **unquoted** so each token becomes a separate `go test` argument (Shellcheck SC2086 is intentionally disabled there).
+
+### Examples (param values)
+
+```yaml
+# Integration only: narrow packages/tests
+integration-go-test-extra-args: "-run=TestFoo -count=1"
+
+# Conformance: skip a label, reduce Ginkgo verbosity (fixed flags still add -ginkgo.vv unless you override)
+conformance-go-test-extra-args: "-ginkgo.skip=Upstream -ginkgo.v=false"
+```
+
+Prefer **`-flag=value`** forms for Ginkgo when values might contain spaces. See also `scripts/operator-e2e/README.md` § “Extra go test arguments”.
+
+## Repository checkout (Task volumes)
+
+This Task does **not** use Tekton `workspaces`. It clones `konflux-ci` into an `emptyDir` volume mounted at `/mnt/konflux-ci/repo` (see `task.yaml`).
+
+## Required secrets / env sources
+
+Reads keys from Secret `konflux-operator-e2e-credentials` in the Task namespace:
+
+- `GH_ORG`
+- `GH_TOKEN`
+
+## Steps / images
+
+1. **fetch-kubeconfig** / **copy-shared-tools** — `quay.io/konflux-ci/task-runner:0.2.0` (copies `kubectl`/`yq`/`jq` to `/mnt/e2e-shared/bin` and `jq`’s `.so` deps to `/mnt/e2e-shared/lib`).
+2. **run-tests** — `registry.access.redhat.com/ubi10/go-toolset`: integration + conformance (`go test`), plus `kubectl`/`curl` from shared bin and image.
+
+## Notes
+
+- This Task waits for the `konflux/konflux` resource to exist and be `Ready`, then runs:
+  - `deploy-test-resources.sh` (with `SKIP_SAMPLE_COMPONENTS=true`)
+  - `go test . ./pkg/...` under `test/go-tests` (integration)
+  - conformance tests (`run-conformance-tests.sh`)

--- a/.tekton/tasks/konflux-e2e-tests/task.yaml
+++ b/.tekton/tasks/konflux-e2e-tests/task.yaml
@@ -1,0 +1,141 @@
+# Run Konflux E2E tests against a pre-deployed cluster.
+# Clones konflux-ci into a Task emptyDir (no Pipeline workspace).
+#
+# Requires a ServiceAccount that can read the cluster-access Secret in this namespace.
+#
+# task-runner: clone + kubeconfig fetch + copy kubectl/yq/jq to /mnt/e2e-shared/bin (+ jq .so to /mnt/e2e-shared/lib).
+# go-toolset: port-forward, go test (integration + conformance).
+#
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: konflux-e2e-tests
+spec:
+  description: >-
+    Clone konflux-ci (git-url/revision), fetch kubeconfig, copy shared CLIs, wait for Konflux CR Ready,
+    then run deploy-test-resources, integration tests, and conformance tests.
+  volumes:
+    - name: repo
+      emptyDir: {}
+    - name: e2e-shared
+      emptyDir: {}
+  params:
+    - name: git-url
+      description: HTTPS git URL for konflux-ci (clone source)
+      type: string
+      default: https://github.com/konflux-ci/konflux-ci.git
+    - name: revision
+      description: Git branch, tag, or commit to checkout after clone
+      type: string
+      default: main
+    - name: clone-depth
+      description: >-
+        Shallow clone depth (same default as Tekton task git-clone 0.1 param depth).
+      type: string
+      default: "1"
+    - name: cluster-access-secret
+      description: Secret name containing kubeconfig (e.g. kfg-<pipelinerun name>)
+      type: string
+    - name: kubeconfig-secret-key
+      description: Key inside the Secret holding kubeconfig bytes
+      type: string
+      default: kubeconfig
+    - name: konflux-ready-timeout
+      type: string
+      default: "30m"
+    - name: release-ta-oci-storage
+      description: Optional; passed through to conformance trusted-artifacts flow
+      type: string
+      default: ""
+    - name: integration-go-test-extra-args
+      description: >-
+        Optional extra arguments appended to "go test . ./pkg/..." (integration suite). Space-separated;
+        same quoting rules as shell (e.g. -run=TestFoo -count=1). Empty uses default invocation only.
+      type: string
+      default: ""
+    - name: conformance-go-test-extra-args
+      description: >-
+        Optional extra arguments appended to conformance "go test ./tests/conformance ..." after fixed flags
+        (e.g. -ginkgo.focus=Subsuite -ginkgo.skip=Flaky). Empty uses default flags only.
+      type: string
+      default: ""
+  stepTemplate:
+    volumeMounts:
+      - name: repo
+        mountPath: /mnt/konflux-ci/repo
+      - name: e2e-shared
+        mountPath: /mnt/e2e-shared
+  steps:
+    - name: clone-repository
+      image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
+      env:
+        - name: GIT_URL
+          value: $(params.git-url)
+        - name: GIT_REVISION
+          value: $(params.revision)
+        - name: GIT_DEPTH
+          value: $(params.clone-depth)
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        REPO_ROOT=/mnt/konflux-ci/repo
+        mkdir -p "${REPO_ROOT}"
+        # emptyDir mount: clear contents only (cannot rm the mount point).
+        find "${REPO_ROOT}" -mindepth 1 -delete
+        git init "${REPO_ROOT}"
+        git -C "${REPO_ROOT}" remote add origin "${GIT_URL}"
+        git -C "${REPO_ROOT}" fetch --depth "${GIT_DEPTH}" origin "${GIT_REVISION}"
+        git -C "${REPO_ROOT}" checkout -q FETCH_HEAD
+    - name: fetch-kubeconfig
+      image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
+      workingDir: /mnt/konflux-ci/repo
+      env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        cd /mnt/konflux-ci/repo
+        exec bash scripts/operator-e2e/tekton-fetch-kubeconfig.sh "$(params.cluster-access-secret)" "$(params.kubeconfig-secret-key)"
+    - name: copy-shared-tools
+      image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
+      workingDir: /mnt/konflux-ci/repo
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        exec bash scripts/operator-e2e/tekton-copy-shared-tools.sh
+    - name: run-tests
+      computeResources:
+        requests:
+          cpu: "500m"
+          memory: "2Gi"
+        limits:
+          cpu: "2"
+          memory: "8Gi"
+      workingDir: /mnt/konflux-ci/repo
+      image: registry.access.redhat.com/ubi10/go-toolset@sha256:b7f71131f21be923baaaf952309b7940ae7c6a55ca44a7a91460adc6c8afd4de
+      env:
+        - name: GH_ORG
+          valueFrom:
+            secretKeyRef:
+              name: konflux-operator-e2e-credentials
+              key: GH_ORG
+        - name: GH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: konflux-operator-e2e-credentials
+              key: GH_TOKEN
+        - name: E2E_INTEGRATION_GO_TEST_EXTRA_ARGS
+          value: $(params.integration-go-test-extra-args)
+        - name: E2E_CONFORMANCE_GO_TEST_EXTRA_ARGS
+          value: $(params.conformance-go-test-extra-args)
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        cd /mnt/konflux-ci/repo
+        exec env \
+          E2E_KONFLUX_READY_TIMEOUT="$(params.konflux-ready-timeout)" \
+          E2E_RELEASE_TA_OCI_STORAGE="$(params.release-ta-oci-storage)" \
+          bash scripts/operator-e2e/tekton-run-e2e-tests.sh /mnt/konflux-ci/repo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ and ARM64 architectures. There are **two test suites** in `test/go-tests`:
   `test/e2e/e2e.env.template` to `test/e2e/e2e.env`, fill in the values, then
   source it and run (from repo root): `source test/e2e/e2e.env` then `./test/e2e/run-e2e.sh`
   The E2E test code lives in `test/go-tests/tests/conformance/` and is maintained in this repo.
-  The release-service-catalog revision is read from `test/e2e/release-service-catalog-revision` when not set in env (so your copy of `e2e.env` does not drift).
+  The default release catalog revision is `CATALOG_REVISION` in `operator/upstream-kustomizations/cli/setup-release.sh` (Renovate-tracked). Conformance tests that need a pinned build pipeline bundle read `CUSTOM_DOCKER_BUILD_OCI_TA_MIN_PIPELINE_BUNDLE` from the same `build-service` manifests as CI; the Tekton flow sets that via `scripts/operator-e2e/prepare-conformance-env.sh`.
 
 Workflow `.github/workflows/operator-test-e2e.yaml` runs both suites when
 operator-related changes are detected: first integration (`go test .`), then E2E
@@ -153,7 +153,7 @@ cp test/e2e/e2e.env.template test/e2e/e2e.env
 # Edit test/e2e/e2e.env with GH_ORG, GH_TOKEN, etc.
 ```
 
-See `test/e2e/e2e.env.template` for all E2E variables and descriptions. Release infrastructure (managed namespace, ImageRepositories, ReleasePlan, etc.) is set up automatically by `operator/hack/setup-release.sh`, which the test calls during `BeforeAll`. The release-service-catalog revision is embedded in the script as its default and tracked by Renovate.
+See `test/e2e/e2e.env.template` for all E2E variables and descriptions. Release infrastructure (managed namespace, ImageRepositories, ReleasePlan, etc.) is set up automatically by `operator/upstream-kustomizations/cli/setup-release.sh`, which the test calls during `BeforeAll`. The release-service-catalog revision is embedded in the script as its default and tracked by Renovate.
 
 ## Running the test
 

--- a/operator/cmd/overrides/main.go
+++ b/operator/cmd/overrides/main.go
@@ -1,0 +1,89 @@
+// Command overrides applies Konflux operator override YAML to a checkout of konflux-ci.
+//
+// It is the CLI entrypoint for package github.com/konflux-ci/konflux-ci/operator/pkg/overrides:
+// parse and validate rules, then Apply rewrites upstream kustomizations (git URLs, image entries,
+// optional kustomize rebuild) and replaces image strings in generated manifests under pkg/manifests.
+//
+// Typical use is from an environment in which a change is made to an upstream resource
+// (e.g. A Konflux service deployed by the operator). This tool facilitates building
+// Vanilla upstream Konflux together with modified upstream component(s).
+// For example, for testing upstream service changes for regressions.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/konflux-ci/konflux-ci/operator/pkg/overrides"
+)
+
+func main() {
+	var (
+		upstreamDir  string
+		manifestsDir string
+		tmpDir       string
+		overridesYML string
+	)
+
+	flag.StringVar(&upstreamDir, "upstream-dir", "", "Path to upstream-kustomizations directory")
+	flag.StringVar(&manifestsDir, "manifests-dir", "", "Path to manifests directory")
+	flag.StringVar(&tmpDir, "tmp-dir", "", "Path to temp working directory")
+	flag.StringVar(&overridesYML, "overrides-yaml", "", "Inline overrides YAML content")
+	flag.Parse()
+
+	if upstreamDir == "" {
+		fmt.Fprintln(os.Stderr, "error: --upstream-dir is required")
+		os.Exit(1)
+	}
+	if manifestsDir == "" {
+		fmt.Fprintln(os.Stderr, "error: --manifests-dir is required")
+		os.Exit(1)
+	}
+	if tmpDir == "" {
+		fmt.Fprintln(os.Stderr, "error: --tmp-dir is required")
+		os.Exit(1)
+	}
+	if overridesYML == "" {
+		fmt.Fprintln(os.Stderr, "error: --overrides-yaml is required")
+		os.Exit(1)
+	}
+
+	overridesConfig, err := overrides.ParseAndValidateFromYAML(overridesYML)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	runner, err := overrides.NewRunner(upstreamDir, manifestsDir, tmpDir, overridesConfig)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if err := runner.Apply(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: apply overrides: %v\n", err)
+		os.Exit(1)
+	}
+
+	if lines := runner.GitSummaryLines(); len(lines) > 0 {
+		fmt.Println("")
+		fmt.Println("Configured git overrides:")
+		for _, line := range lines {
+			fmt.Println(line)
+		}
+	}
+	if lines := runner.SummaryLines(); len(lines) > 0 {
+		fmt.Println("")
+		fmt.Println("Applied image overrides:")
+		for _, line := range lines {
+			fmt.Println(line)
+		}
+	}
+	st := runner.Stats()
+	fmt.Println("")
+	fmt.Printf(
+		"Apply summary: git kustomizations=%d, kustomization image patches=%d, "+
+			"manifest YAML image replacements=%d, components rebuilt=%d\n",
+		st.GitKustomizationsUpdated, st.KustomizationImagesPatched,
+		st.ManifestYAMLsImageTextReplaced, st.ComponentsRebuilt,
+	)
+}

--- a/operator/pkg/overrides/overrides.go
+++ b/operator/pkg/overrides/overrides.go
@@ -1,0 +1,732 @@
+package overrides
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+	yamlv3 "sigs.k8s.io/yaml/goyaml.v3"
+)
+
+type Overrides []ComponentOverride
+
+// ComponentOverride describes per-component git and image substitutions.
+type ComponentOverride struct {
+	Name   string          `json:"name" yaml:"name"`
+	Git    []GitRule       `json:"git" yaml:"git"`
+	Images []ImageOverride `json:"images" yaml:"images"`
+}
+
+// GitRule maps resources from sourceRepo to either a remote repo/ref or localPath.
+type GitRule struct {
+	SourceRepo string     `json:"sourceRepo" yaml:"sourceRepo"`
+	Remote     *RemoteGit `json:"remote,omitempty" yaml:"remote,omitempty"`
+	LocalPath  string     `json:"localPath,omitempty" yaml:"localPath,omitempty"`
+}
+
+// RemoteGit defines a replacement remote repository and reference.
+type RemoteGit struct {
+	Repo string `json:"repo" yaml:"repo"`
+	Ref  string `json:"ref" yaml:"ref"`
+}
+
+// ImageOverride replaces a released image reference with a replacement image.
+type ImageOverride struct {
+	Orig        string `json:"orig" yaml:"orig"`
+	Replacement string `json:"replacement" yaml:"replacement"`
+}
+
+// ApplyStats summarizes filesystem writes performed by the last Apply() call.
+type ApplyStats struct {
+	GitKustomizationsUpdated       int // kustomization.yaml files rewritten for git URL/tag rules
+	KustomizationImagesPatched     int // kustomization.yaml entries: digest stripped, name/tag from overrides
+	ManifestYAMLsImageTextReplaced int // manifests.yaml files with container image strings replaced
+	ComponentsRebuilt              int // components re-built with kustomize into pkg/manifests
+}
+
+// Runner applies validated overrides to upstream kustomizations and generated manifests.
+type Runner struct {
+	UpstreamDir  string
+	ManifestsDir string
+	TmpDir       string
+	Overrides    Overrides
+
+	applyStats ApplyStats
+}
+
+// ParseAndValidateFromYAML parses override YAML and validates schema constraints.
+func ParseAndValidateFromYAML(content string) (Overrides, error) {
+	var o Overrides
+	if err := yaml.Unmarshal([]byte(content), &o); err != nil {
+		return nil, fmt.Errorf("parse overrides yaml: %w", err)
+	}
+	if err := validateOverrides(o); err != nil {
+		return nil, err
+	}
+	return o, nil
+}
+
+// NewRunner creates a Runner with explicit directories after validating overrides.
+func NewRunner(upstreamDir, manifestsDir, tmpDir string, overrides Overrides) (*Runner, error) {
+	if err := validateOverrides(overrides); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(upstreamDir) == "" {
+		return nil, fmt.Errorf("upstreamDir is required")
+	}
+	if strings.TrimSpace(manifestsDir) == "" {
+		return nil, fmt.Errorf("manifestsDir is required")
+	}
+	if strings.TrimSpace(tmpDir) == "" {
+		return nil, fmt.Errorf("tmpDir is required")
+	}
+
+	absUpstreamDir, err := filepath.Abs(upstreamDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve upstreamDir: %w", err)
+	}
+	absManifestsDir, err := filepath.Abs(manifestsDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve manifestsDir: %w", err)
+	}
+	absTmpDir, err := filepath.Abs(tmpDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve tmpDir: %w", err)
+	}
+	return &Runner{
+		UpstreamDir:  absUpstreamDir,
+		ManifestsDir: absManifestsDir,
+		TmpDir:       absTmpDir,
+		Overrides:    overrides,
+	}, nil
+}
+
+// Apply executes override transformations and writes resulting manifest updates.
+func (r *Runner) Apply() error {
+	r.applyStats = ApplyStats{}
+	if err := os.MkdirAll(r.TmpDir, 0o755); err != nil {
+		return fmt.Errorf("create .tmp: %w", err)
+	}
+	if err := r.writeComponentSources(); err != nil {
+		return err
+	}
+
+	workUpstream := r.UpstreamDir
+	componentsWithGit := r.componentsWithGitRules()
+	if len(componentsWithGit) > 0 {
+		workUpstream = filepath.Join(r.TmpDir, "upstream-kustomizations")
+		if err := os.RemoveAll(workUpstream); err != nil {
+			return fmt.Errorf("cleanup temp upstream: %w", err)
+		}
+		if err := copyDir(r.UpstreamDir, workUpstream); err != nil {
+			return fmt.Errorf("copy upstream-kustomizations: %w", err)
+		}
+		if err := r.applyGitRules(workUpstream); err != nil {
+			return err
+		}
+	}
+
+	if err := r.applyImageOverridesInKustomizations(workUpstream); err != nil {
+		return err
+	}
+	if len(componentsWithGit) > 0 {
+		if err := r.rebuildManifests(workUpstream, r.ManifestsDir, componentsWithGit); err != nil {
+			return err
+		}
+	}
+	if err := r.applyImageOverridesInManifests(r.ManifestsDir); err != nil {
+		return err
+	}
+	return nil
+}
+
+// GitSummaryLines returns human-readable git override lines for logs (from config).
+func (r *Runner) GitSummaryLines() []string {
+	var lines []string
+	for _, c := range r.Overrides {
+		for _, g := range c.Git {
+			src, err := normalizeOrgRepo(g.SourceRepo, "sourceRepo")
+			if err != nil {
+				continue
+			}
+			switch {
+			case g.Remote != nil:
+				rr, err := normalizeOrgRepo(g.Remote.Repo, "remote.repo")
+				if err != nil {
+					continue
+				}
+				lines = append(lines, fmt.Sprintf("  [%s] %s -> https://github.com/%s?ref=%s", c.Name, src, rr, g.Remote.Ref))
+			case strings.TrimSpace(g.LocalPath) != "":
+				lines = append(lines, fmt.Sprintf("  [%s] %s -> local %s", c.Name, src, strings.TrimSpace(g.LocalPath)))
+			}
+		}
+	}
+	return lines
+}
+
+// SummaryLines returns human-readable image replacement lines for logs (from config).
+func (r *Runner) SummaryLines() []string {
+	var lines []string
+	for _, c := range r.Overrides {
+		for _, img := range c.Images {
+			lines = append(lines, fmt.Sprintf("  %s -> %s", img.Orig, img.Replacement))
+		}
+	}
+	return lines
+}
+
+// Stats returns filesystem write counters from the last Apply() (zero if Apply never completed successfully).
+func (r *Runner) Stats() ApplyStats {
+	return r.applyStats
+}
+
+func (r *Runner) writeComponentSources() error {
+	type gitOnly struct {
+		Name string    `json:"name"`
+		Git  []GitRule `json:"git"`
+	}
+	out := make([]gitOnly, 0, len(r.Overrides))
+	for _, c := range r.Overrides {
+		out = append(out, gitOnly{Name: c.Name, Git: c.Git})
+	}
+	b, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal component sources: %w", err)
+	}
+	path := filepath.Join(r.TmpDir, "component-sources.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		return fmt.Errorf("write component sources: %w", err)
+	}
+	return nil
+}
+
+func (r *Runner) componentsWithGitRules() []string {
+	var names []string
+	for _, c := range r.Overrides {
+		if len(c.Git) > 0 {
+			names = append(names, c.Name)
+		}
+	}
+	return names
+}
+
+func (r *Runner) applyGitRules(upstreamDir string) error {
+	for _, component := range r.Overrides {
+		if len(component.Git) == 0 {
+			continue
+		}
+		componentDir := filepath.Join(upstreamDir, component.Name)
+		if _, err := os.Stat(componentDir); err != nil {
+			continue
+		}
+		err := filepath.WalkDir(componentDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if d.Name() != "kustomization.yaml" && d.Name() != "kustomization.yml" {
+				return nil
+			}
+			written, err := r.applyGitRulesToKustomization(path, component.Git)
+			if err != nil {
+				return err
+			}
+			if written {
+				r.applyStats.GitKustomizationsUpdated++
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Runner) applyGitRulesToKustomization(path string, rules []GitRule) (bool, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	var k map[string]any
+	if err := yaml.Unmarshal(content, &k); err != nil {
+		return false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	rawResources, ok := k["resources"].([]any)
+	if !ok {
+		return false, nil
+	}
+
+	remoteRefs := map[string]struct{}{}
+	// GitHub org/repo lines (from resource URLs) that matched a remote git rule — used to scope
+	// newTag bumps so unrelated images in the same kustomization are not rewritten.
+	remoteSourceOrgRepos := map[string]struct{}{}
+	updated := false
+	for i, rv := range rawResources {
+		resource, ok := rv.(string)
+		if !ok || !strings.HasPrefix(resource, "https://github.com/") {
+			continue
+		}
+		orgRepo, suffix, ok := githubURLParts(resource)
+		if !ok {
+			continue
+		}
+		rule := firstMatchingRule(orgRepo, rules)
+		if rule == nil {
+			continue
+		}
+		var newResource string
+		switch {
+		case rule.Remote != nil:
+			remoteSourceOrgRepos[orgRepo] = struct{}{}
+			remoteRepo, err := normalizeOrgRepo(rule.Remote.Repo, "remote.repo")
+			if err != nil {
+				return false, err
+			}
+			newResource = fmt.Sprintf("https://github.com/%s%s?ref=%s", remoteRepo, suffix, rule.Remote.Ref)
+			remoteRefs[rule.Remote.Ref] = struct{}{}
+		case strings.TrimSpace(rule.LocalPath) != "":
+			base := filepath.Clean(rule.LocalPath)
+			full := filepath.Join(base, strings.TrimPrefix(suffix, "/"))
+			info, err := os.Stat(full)
+			if err != nil || !info.IsDir() {
+				return false, fmt.Errorf("localPath + suffix is not a directory: %s", full)
+			}
+			kdir := filepath.Dir(path)
+			rel, err := filepath.Rel(kdir, full)
+			if err != nil {
+				return false, fmt.Errorf("compute relative localPath: %w", err)
+			}
+			newResource = rel
+		default:
+			return false, fmt.Errorf("rule must set remote or localPath for sourceRepo=%s", rule.SourceRepo)
+		}
+		if newResource != resource {
+			rawResources[i] = newResource
+			updated = true
+		}
+	}
+	if updated {
+		k["resources"] = rawResources
+	}
+
+	if len(remoteRefs) == 1 && len(remoteSourceOrgRepos) > 0 {
+		var onlyRef string
+		for ref := range remoteRefs {
+			onlyRef = ref
+		}
+		if images, ok := k["images"].([]any); ok {
+			for _, iv := range images {
+				im, ok := iv.(map[string]any)
+				if !ok {
+					continue
+				}
+				if _, hasTag := im["newTag"]; !hasTag {
+					continue
+				}
+				imgRef := imageNameFromMap(im)
+				match := false
+				for orgRepo := range remoteSourceOrgRepos {
+					if imageRefMatchesOrgRepo(imgRef, orgRepo) {
+						match = true
+						break
+					}
+				}
+				if !match {
+					continue
+				}
+				im["newTag"] = onlyRef
+				updated = true
+			}
+		}
+	}
+
+	if !updated {
+		return false, nil
+	}
+	out, err := yaml.Marshal(k)
+	if err != nil {
+		return false, fmt.Errorf("marshal updated kustomization: %w", err)
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (r *Runner) applyImageOverridesInKustomizations(upstreamDir string) error {
+	overrides := r.imageOverrides()
+	if len(overrides) == 0 {
+		return nil
+	}
+	return filepath.WalkDir(upstreamDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || (d.Name() != "kustomization.yaml" && d.Name() != "kustomization.yml") {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		var doc map[string]any
+		if err := yaml.Unmarshal(content, &doc); err != nil {
+			return nil
+		}
+		images, ok := doc["images"].([]any)
+		if !ok || len(images) == 0 {
+			return nil
+		}
+		hasDigest := false
+		for _, iv := range images {
+			im, ok := iv.(map[string]any)
+			if ok {
+				if _, found := im["digest"]; found {
+					hasDigest = true
+					break
+				}
+			}
+		}
+		if !hasDigest {
+			return nil
+		}
+		changed := false
+		for _, ov := range overrides {
+			newName, newTag, newDigest := parseImageReference(ov.Replacement)
+			for _, iv := range images {
+				im, ok := iv.(map[string]any)
+				if !ok {
+					continue
+				}
+				if imageNameFromMap(im) != ov.Orig {
+					continue
+				}
+				im["newName"] = newName
+				if newDigest != "" {
+					im["digest"] = newDigest
+					delete(im, "newTag")
+				} else {
+					im["newTag"] = newTag
+					delete(im, "digest")
+				}
+				changed = true
+			}
+		}
+		if !changed {
+			return nil
+		}
+		doc["images"] = images
+		out, err := yaml.Marshal(doc)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(path, out, 0o644); err != nil {
+			return err
+		}
+		r.applyStats.KustomizationImagesPatched++
+		return nil
+	})
+}
+
+// kustomizeBuildCommand returns a command that renders kustomization at src to stdout.
+// Prefer the standalone kustomize CLI when present; otherwise use kubectl's embedded kustomize
+// (Tekton deploy-prep copies kubectl onto PATH but does not ship the kustomize binary).
+func kustomizeBuildCommand(src string) (*exec.Cmd, string, error) {
+	if _, err := exec.LookPath("kustomize"); err == nil {
+		return exec.Command("kustomize", "build", src), "kustomize build", nil
+	}
+	if _, err := exec.LookPath("kubectl"); err == nil {
+		return exec.Command("kubectl", "kustomize", src), "kubectl kustomize", nil
+	}
+	return nil, "", errors.New("kustomize or kubectl is required in PATH to rebuild manifests")
+}
+
+func (r *Runner) rebuildManifests(upstreamDir, manifestsDir string, components []string) error {
+	for _, component := range components {
+		src := filepath.Join(upstreamDir, component)
+		if _, err := os.Stat(src); err != nil {
+			continue
+		}
+		destDir := filepath.Join(manifestsDir, component)
+		if err := os.MkdirAll(destDir, 0o755); err != nil {
+			return err
+		}
+		cmd, label, err := kustomizeBuildCommand(src)
+		if err != nil {
+			return err
+		}
+		cmd.Dir = manifestsDir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("%s failed for %s: %w: %s", label, component, err, string(out))
+		}
+		dest := filepath.Join(destDir, "manifests.yaml")
+		if err := os.WriteFile(dest, out, 0o644); err != nil {
+			return err
+		}
+		r.applyStats.ComponentsRebuilt++
+	}
+	return nil
+}
+
+func (r *Runner) applyImageOverridesInManifests(manifestsDir string) error {
+	overrides := r.imageOverrides()
+	if len(overrides) == 0 {
+		return nil
+	}
+	return filepath.WalkDir(manifestsDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != "manifests.yaml" {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		decoder := yamlv3.NewDecoder(bytes.NewReader(content))
+		var docs []*yamlv3.Node
+		changed := false
+		for {
+			var doc yamlv3.Node
+			if err := decoder.Decode(&doc); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				return err
+			}
+			if doc.Kind == 0 {
+				break
+			}
+			for _, ov := range overrides {
+				re := regexp.MustCompile("^" + regexp.QuoteMeta(ov.Orig) + `($|:|@)`)
+				if replaceStringNodes(&doc, re, ov.Replacement) {
+					changed = true
+				}
+			}
+			docs = append(docs, &doc)
+		}
+		if !changed {
+			return nil
+		}
+		var out bytes.Buffer
+		enc := yamlv3.NewEncoder(&out)
+		enc.SetIndent(2)
+		for _, doc := range docs {
+			if err := enc.Encode(doc); err != nil {
+				return err
+			}
+		}
+		_ = enc.Close()
+		if err := os.WriteFile(path, out.Bytes(), 0o644); err != nil {
+			return err
+		}
+		r.applyStats.ManifestYAMLsImageTextReplaced++
+		return nil
+	})
+}
+
+func replaceStringNodes(n *yamlv3.Node, re *regexp.Regexp, replacement string) bool {
+	changed := false
+	if n.Kind == yamlv3.ScalarNode && n.Tag == "!!str" && re.MatchString(n.Value) {
+		n.Value = replacement
+		changed = true
+	}
+	for _, c := range n.Content {
+		if replaceStringNodes(c, re, replacement) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+func (r *Runner) imageOverrides() []ImageOverride {
+	var images []ImageOverride
+	for _, c := range r.Overrides {
+		images = append(images, c.Images...)
+	}
+	return images
+}
+
+func validateOverrides(overrides Overrides) error {
+	if len(overrides) == 0 {
+		return fmt.Errorf("need non-empty override list")
+	}
+	seenNames := make(map[string]struct{}, len(overrides))
+	for i, c := range overrides {
+		if strings.TrimSpace(c.Name) == "" {
+			return fmt.Errorf("entry %d: name is required", i)
+		}
+		nameKey := strings.TrimSpace(c.Name)
+		if _, dup := seenNames[nameKey]; dup {
+			return fmt.Errorf("entry %d: duplicate component name %q", i, nameKey)
+		}
+		seenNames[nameKey] = struct{}{}
+		if len(c.Git) == 0 && len(c.Images) == 0 {
+			return fmt.Errorf("entry %d (%s): at least one of git/images must be non-empty", i, c.Name)
+		}
+		for j, g := range c.Git {
+			if strings.TrimSpace(g.SourceRepo) == "" {
+				return fmt.Errorf("entry %d (%s) git[%d]: sourceRepo is required", i, c.Name, j)
+			}
+			if _, err := normalizeOrgRepo(g.SourceRepo, "sourceRepo"); err != nil {
+				return fmt.Errorf("entry %d (%s) git[%d]: %w", i, c.Name, j, err)
+			}
+			hasRemote := g.Remote != nil
+			hasLocal := strings.TrimSpace(g.LocalPath) != ""
+			if hasRemote == hasLocal {
+				return fmt.Errorf("entry %d (%s) git[%d]: exactly one of remote/localPath is required", i, c.Name, j)
+			}
+			if hasRemote {
+				if strings.TrimSpace(g.Remote.Repo) == "" || strings.TrimSpace(g.Remote.Ref) == "" {
+					return fmt.Errorf("entry %d (%s) git[%d]: remote.repo and remote.ref are required", i, c.Name, j)
+				}
+				if _, err := normalizeOrgRepo(g.Remote.Repo, "remote.repo"); err != nil {
+					return fmt.Errorf("entry %d (%s) git[%d]: %w", i, c.Name, j, err)
+				}
+			}
+		}
+		for j, img := range c.Images {
+			if strings.TrimSpace(img.Orig) == "" || strings.TrimSpace(img.Replacement) == "" {
+				return fmt.Errorf("entry %d (%s) images[%d]: orig/replacement are required", i, c.Name, j)
+			}
+			repName, _, _ := parseImageReference(img.Replacement)
+			if strings.TrimSpace(repName) == "" {
+				return fmt.Errorf(
+					"entry %d (%s) images[%d]: replacement must be a valid image reference (non-empty name)",
+					i, c.Name, j,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func normalizeOrgRepo(input, field string) (string, error) {
+	r := strings.TrimSpace(strings.TrimSuffix(strings.TrimSuffix(input, ".git"), "/"))
+	r = strings.TrimPrefix(r, "https://github.com/")
+	parts := strings.Split(r, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("%s must be org/repo or https://github.com/org/repo", field)
+	}
+	return strings.ToLower(parts[0] + "/" + parts[1]), nil
+}
+
+func githubURLParts(url string) (orgRepo string, suffix string, ok bool) {
+	re := regexp.MustCompile(`^https://github\.com/([^/]+/[^/]+)(/[^?]+)(\?ref=[^&]*)?$`)
+	m := re.FindStringSubmatch(url)
+	if len(m) == 0 {
+		return "", "", false
+	}
+	return strings.ToLower(m[1]), m[2], true
+}
+
+func firstMatchingRule(orgRepo string, rules []GitRule) *GitRule {
+	for _, r := range rules {
+		norm, err := normalizeOrgRepo(r.SourceRepo, "sourceRepo")
+		if err != nil {
+			continue
+		}
+		if norm == orgRepo {
+			rcopy := r
+			return &rcopy
+		}
+	}
+	return nil
+}
+
+// parseImageReference splits a container image reference into kustomize newName and either
+// newTag or digest (OCI image digest: algorithm + hex after first ':').
+func parseImageReference(s string) (name, tag, digest string) {
+	s = strings.TrimSpace(s)
+	if at := strings.Index(s, "@"); at >= 0 {
+		name, rest := s[:at], s[at+1:]
+		if isOCIImageDigest(rest) {
+			return name, "", rest
+		}
+		return name, rest, ""
+	}
+	if i := strings.LastIndex(s, ":"); i > strings.LastIndex(s, "/") {
+		return s[:i], s[i+1:], ""
+	}
+	return s, "latest", ""
+}
+
+func isOCIImageDigest(s string) bool {
+	// OCI manifest digest: sha256:<64 hex> or sha512:<128 hex>, etc.
+	for _, prefix := range []string{"sha256:", "sha512:", "sha384:"} {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// splitImageReference returns (name, tag) for callers that only distinguish tag vs bare name;
+// when the reference uses a digest, tag is empty (digest is not a kustomize newTag).
+func splitImageReference(outputImage string) (name, tag string) {
+	n, t, d := parseImageReference(outputImage)
+	if d != "" {
+		return n, ""
+	}
+	return n, t
+}
+
+// imageRefMatchesOrgRepo reports whether a kustomize image name/newName refers to the given
+// GitHub org/repo (e.g. quay.io/konflux-ci/segment-bridge matches konflux-ci/segment-bridge).
+func imageRefMatchesOrgRepo(imageRef, orgRepo string) bool {
+	orgRepo = strings.ToLower(strings.TrimSpace(orgRepo))
+	if orgRepo == "" || !strings.Contains(orgRepo, "/") {
+		return false
+	}
+	base, _, _ := parseImageReference(strings.TrimSpace(imageRef))
+	base = strings.ToLower(base)
+	return strings.HasSuffix(base, "/"+orgRepo)
+}
+
+func imageNameFromMap(image map[string]any) string {
+	for _, k := range []string{"name", "newName"} {
+		if v, ok := image[k].(string); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		mode := fs.FileMode(0o644)
+		if info, statErr := d.Info(); statErr == nil {
+			mode = info.Mode()
+		}
+		return os.WriteFile(target, b, mode)
+	})
+}

--- a/operator/pkg/overrides/overrides_test.go
+++ b/operator/pkg/overrides/overrides_test.go
@@ -1,0 +1,913 @@
+package overrides
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func newTestRunner(g *WithT, root string, o Overrides) *Runner {
+	r, err := NewRunner(
+		filepath.Join(root, "operator", "upstream-kustomizations"),
+		filepath.Join(root, "operator", "pkg", "manifests"),
+		filepath.Join(root, ".tmp"),
+		o,
+	)
+	g.Expect(err).ToNot(HaveOccurred())
+	return r
+}
+
+func TestParseAndValidateFromYAML(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	_, err := ParseAndValidateFromYAML(`
+- name: segment-bridge
+  git:
+    - sourceRepo: konflux-ci/segment-bridge
+      remote:
+        repo: https://github.com/konflux-ci/segment-bridge
+        ref: abc123
+  images:
+    - orig: quay.io/konflux-ci/segment-bridge
+      replacement: quay.io/example/segment-bridge:pr
+`)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestParseAndValidateFromYAMLRejectsInvalidRule(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	_, err := ParseAndValidateFromYAML(`
+- name: segment-bridge
+  git:
+    - sourceRepo: konflux-ci/segment-bridge
+  images: []
+`)
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestParseAndValidateFromYAML_validationFailures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		yaml    string
+		wantSub string
+	}{
+		{
+			name:    "empty list",
+			yaml:    `[]`,
+			wantSub: "non-empty override list",
+		},
+		{
+			name: "empty component name",
+			yaml: `
+- name: "   "
+  images:
+    - orig: quay.io/a/b
+      replacement: quay.io/c/d:1
+`,
+			wantSub: "name is required",
+		},
+		{
+			name: "empty git and images",
+			yaml: `
+- name: segment-bridge
+  git: []
+  images: []
+`,
+			wantSub: "at least one of git/images must be non-empty",
+		},
+		{
+			name: "missing sourceRepo",
+			yaml: `
+- name: segment-bridge
+  git:
+    - remote:
+        repo: konflux-ci/segment-bridge
+        ref: main
+  images:
+    - orig: quay.io/a/b
+      replacement: quay.io/c/d:1
+`,
+			wantSub: "sourceRepo is required",
+		},
+		{
+			name: "invalid sourceRepo shape",
+			yaml: `
+- name: segment-bridge
+  git:
+    - sourceRepo: not-org-repo-format
+      remote:
+        repo: konflux-ci/segment-bridge
+        ref: main
+  images:
+    - orig: quay.io/a/b
+      replacement: quay.io/c/d:1
+`,
+			wantSub: "sourceRepo must be org/repo",
+		},
+		{
+			name: "neither remote nor localPath",
+			yaml: `
+- name: segment-bridge
+  git:
+    - sourceRepo: konflux-ci/segment-bridge
+  images:
+    - orig: quay.io/a/b
+      replacement: quay.io/c/d:1
+`,
+			wantSub: "exactly one of remote/localPath",
+		},
+		{
+			name: "both remote and localPath",
+			yaml: `
+- name: segment-bridge
+  git:
+    - sourceRepo: konflux-ci/segment-bridge
+      localPath: /tmp/x
+      remote:
+        repo: konflux-ci/segment-bridge
+        ref: main
+  images:
+    - orig: quay.io/a/b
+      replacement: quay.io/c/d:1
+`,
+			wantSub: "exactly one of remote/localPath",
+		},
+		{
+			name: "remote with empty ref",
+			yaml: `
+- name: segment-bridge
+  git:
+    - sourceRepo: konflux-ci/segment-bridge
+      remote:
+        repo: konflux-ci/segment-bridge
+        ref: " "
+  images:
+    - orig: quay.io/a/b
+      replacement: quay.io/c/d:1
+`,
+			wantSub: "remote.repo and remote.ref are required",
+		},
+		{
+			name: "invalid remote.repo",
+			yaml: `
+- name: segment-bridge
+  git:
+    - sourceRepo: konflux-ci/segment-bridge
+      remote:
+        repo: https://example.com/not-github
+        ref: main
+  images:
+    - orig: quay.io/a/b
+      replacement: quay.io/c/d:1
+`,
+			wantSub: "remote.repo must be org/repo",
+		},
+		{
+			name: "duplicate component names",
+			yaml: `
+- name: segment-bridge
+  images:
+    - orig: quay.io/a/b
+      replacement: quay.io/c/d:1
+- name: segment-bridge
+  images:
+    - orig: quay.io/e/f
+      replacement: quay.io/g/h:1
+`,
+			wantSub: "duplicate component name",
+		},
+		{
+			name: "replacement not a usable image ref",
+			yaml: `
+- name: segment-bridge
+  images:
+    - orig: quay.io/a/b
+      replacement: ":"
+`,
+			wantSub: "non-empty name",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+			_, err := ParseAndValidateFromYAML(tc.yaml)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring(tc.wantSub))
+		})
+	}
+}
+
+func TestApplyImageOverridesInManifests(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := t.TempDir()
+	manifestDir := filepath.Join(root, "operator", "pkg", "manifests", "segment-bridge")
+	g.Expect(os.MkdirAll(manifestDir, 0o755)).To(Succeed())
+	manifest := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: segment-bridge
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: quay.io/konflux-ci/segment-bridge:old
+`
+	path := filepath.Join(manifestDir, "manifests.yaml")
+	g.Expect(os.WriteFile(path, []byte(manifest), 0o644)).To(Succeed())
+
+	o := Overrides{
+		{
+			Name: "segment-bridge",
+			Images: []ImageOverride{
+				{Orig: "quay.io/konflux-ci/segment-bridge", Replacement: "quay.io/example/segment-bridge:new"},
+			},
+		},
+	}
+	r := newTestRunner(g, root, o)
+	g.Expect(r.applyImageOverridesInManifests(
+		filepath.Join(root, "operator", "pkg", "manifests"),
+	)).To(Succeed())
+	g.Expect(r.Stats().ManifestYAMLsImageTextReplaced).To(Equal(1))
+	got, err := os.ReadFile(path)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(got)).To(ContainSubstring("quay.io/example/segment-bridge:new"))
+}
+
+func TestApplyGitRulesToKustomizationWithRemote(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := t.TempDir()
+	kPath := filepath.Join(root, "kustomization.yaml")
+	src := `resources:
+  - https://github.com/konflux-ci/segment-bridge/config/default?ref=old
+images:
+  - name: quay.io/konflux-ci/segment-bridge
+    newTag: old
+`
+	g.Expect(os.WriteFile(kPath, []byte(src), 0o644)).To(Succeed())
+	r := newTestRunner(g, root, Overrides{
+		{
+			Name: "segment-bridge",
+			Git: []GitRule{
+				{
+					SourceRepo: "konflux-ci/segment-bridge",
+					Remote:     &RemoteGit{Repo: "konflux-ci/segment-bridge", Ref: "newref"},
+				},
+			},
+		},
+	})
+	written, err := r.applyGitRulesToKustomization(kPath, r.Overrides[0].Git)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(written).To(BeTrue())
+	got, err := os.ReadFile(kPath)
+	g.Expect(err).ToNot(HaveOccurred())
+	text := string(got)
+	g.Expect(text).To(ContainSubstring("https://github.com/konflux-ci/segment-bridge/config/default?ref=newref"))
+	g.Expect(text).To(ContainSubstring("newTag: newref"))
+}
+
+// When a single remote ref is applied, newTag must only track repos tied to rewritten GitHub resources,
+// not every images[] entry in the file.
+func TestApplyGitRulesToKustomization_remoteNewTagScopedToMatchingImage(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := t.TempDir()
+	kPath := filepath.Join(root, "kustomization.yaml")
+	src := `resources:
+  - https://github.com/konflux-ci/segment-bridge/config/default?ref=old
+images:
+  - name: quay.io/konflux-ci/segment-bridge
+    newTag: old
+  - name: quay.io/konflux-ci/other-image
+    newTag: keep-me
+`
+	g.Expect(os.WriteFile(kPath, []byte(src), 0o644)).To(Succeed())
+	r := newTestRunner(g, root, Overrides{
+		{
+			Name: "segment-bridge",
+			Git: []GitRule{
+				{
+					SourceRepo: "konflux-ci/segment-bridge",
+					Remote:     &RemoteGit{Repo: "konflux-ci/segment-bridge", Ref: "newref"},
+				},
+			},
+		},
+	})
+	written, err := r.applyGitRulesToKustomization(kPath, r.Overrides[0].Git)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(written).To(BeTrue())
+	got, err := os.ReadFile(kPath)
+	g.Expect(err).ToNot(HaveOccurred())
+	text := string(got)
+	g.Expect(text).To(ContainSubstring("https://github.com/konflux-ci/segment-bridge/config/default?ref=newref"))
+	g.Expect(text).To(ContainSubstring("newTag: newref"))
+	g.Expect(text).To(ContainSubstring("newTag: keep-me"))
+	g.Expect(text).ToNot(ContainSubstring("other-image\n    newTag: newref"))
+}
+
+func TestRunnerApplyWithImageOverrideOnly(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := t.TempDir()
+	upstreamSegBridge := filepath.Join(root, "operator", "upstream-kustomizations", "segment-bridge")
+	g.Expect(os.MkdirAll(upstreamSegBridge, 0o755)).To(Succeed())
+	manifestDir := filepath.Join(root, "operator", "pkg", "manifests", "segment-bridge")
+	g.Expect(os.MkdirAll(manifestDir, 0o755)).To(Succeed())
+
+	manifestPath := filepath.Join(manifestDir, "manifests.yaml")
+	g.Expect(os.WriteFile(manifestPath, []byte(`apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: quay.io/konflux-ci/segment-bridge:old
+`), 0o644)).To(Succeed())
+
+	r := newTestRunner(g, root, Overrides{
+		{
+			Name: "segment-bridge",
+			Images: []ImageOverride{
+				{
+					Orig:        "quay.io/konflux-ci/segment-bridge",
+					Replacement: "quay.io/example/segment-bridge:new",
+				},
+			},
+		},
+	})
+	g.Expect(r.Apply()).To(Succeed())
+	g.Expect(r.Stats()).To(Equal(ApplyStats{
+		ManifestYAMLsImageTextReplaced: 1,
+	}))
+
+	gotManifest, err := os.ReadFile(manifestPath)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(gotManifest)).To(ContainSubstring("quay.io/example/segment-bridge:new"))
+
+	componentSourcesPath := filepath.Join(root, ".tmp", "component-sources.json")
+	componentSources, err := os.ReadFile(componentSourcesPath)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(componentSources)).To(ContainSubstring(`"name": "segment-bridge"`))
+}
+
+func TestRunnerGitSummaryLines(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	r := Runner{
+		Overrides: Overrides{
+			{
+				Name: "segment-bridge",
+				Git: []GitRule{
+					{
+						SourceRepo: "konflux-ci/segment-bridge",
+						Remote:     &RemoteGit{Repo: "konflux-ci/segment-bridge", Ref: "abc123"},
+					},
+					{
+						SourceRepo: "other/org",
+						LocalPath:  "/tmp/local-checkout",
+					},
+				},
+			},
+		},
+	}
+	g.Expect(r.GitSummaryLines()).To(Equal([]string{
+		"  [segment-bridge] konflux-ci/segment-bridge -> https://github.com/konflux-ci/segment-bridge?ref=abc123",
+		"  [segment-bridge] other/org -> local /tmp/local-checkout",
+	}))
+}
+
+func TestRunnerSummaryLines(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	r := Runner{
+		Overrides: Overrides{
+			{
+				Name: "segment-bridge",
+				Images: []ImageOverride{
+					{
+						Orig:        "quay.io/konflux-ci/segment-bridge",
+						Replacement: "quay.io/example/segment-bridge:new",
+					},
+				},
+			},
+		},
+	}
+	g.Expect(r.SummaryLines()).To(Equal([]string{
+		"  quay.io/konflux-ci/segment-bridge -> quay.io/example/segment-bridge:new",
+	}))
+}
+
+// splitImageReference: tag and bare-name cases; digest refs yield empty tag.
+func TestSplitImageReference(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		wantName string
+		wantTag  string
+	}{
+		{
+			name:     "bare name defaults tag to latest",
+			input:    "quay.io/org/app",
+			wantName: "quay.io/org/app",
+			wantTag:  "latest",
+		},
+		{
+			name:     "tag after last slash colon",
+			input:    "quay.io/org/app:mytag",
+			wantName: "quay.io/org/app",
+			wantTag:  "mytag",
+		},
+		{
+			name:     "port in registry",
+			input:    "localhost:5000/org/app:v1",
+			wantName: "localhost:5000/org/app",
+			wantTag:  "v1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotName, gotTag := splitImageReference(tc.input)
+			if gotName != tc.wantName || gotTag != tc.wantTag {
+				t.Fatalf("splitImageReference(%q) = (%q, %q), want (%q, %q)",
+					tc.input, gotName, gotTag, tc.wantName, tc.wantTag)
+			}
+		})
+	}
+}
+
+// Required: a digest reference must not treat the part after @ as a kustomize tag (newTag).
+func TestSplitImageReference_digestNotReturnedAsTag(t *testing.T) {
+	t.Parallel()
+	input := "quay.io/org/app@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	_, gotTag := splitImageReference(input)
+	if strings.HasPrefix(gotTag, "sha256:") {
+		t.Fatalf(
+			"digest after @ must not be returned as tag string "+
+				"(belongs in kustomize digest:, not newTag:); got second return %q",
+			gotTag,
+		)
+	}
+}
+
+// applyImageOverridesInKustomizations only runs when an images entry already has digest: (see overrides.go).
+// Required: digest replacement must set kustomize digest: and must not put the digest in newTag:.
+func TestApplyImageOverridesInKustomizations_digestReplacement(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := t.TempDir()
+	upstream := filepath.Join(root, "operator", "upstream-kustomizations", "segment-bridge")
+	g.Expect(os.MkdirAll(upstream, 0o755)).To(Succeed())
+
+	const oldDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const newDigest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	kustomization := `images:
+  - name: quay.io/konflux-ci/segment-bridge
+    newName: quay.io/konflux-ci/segment-bridge
+    digest: ` + oldDigest + `
+`
+	kPath := filepath.Join(upstream, "kustomization.yaml")
+	g.Expect(os.WriteFile(kPath, []byte(kustomization), 0o644)).To(Succeed())
+
+	o := Overrides{
+		{
+			Name: "segment-bridge",
+			Images: []ImageOverride{
+				{
+					Orig:        "quay.io/konflux-ci/segment-bridge",
+					Replacement: "quay.io/example/segment-bridge@" + newDigest,
+				},
+			},
+		},
+	}
+	r := newTestRunner(g, root, o)
+	g.Expect(r.applyImageOverridesInKustomizations(
+		filepath.Join(root, "operator", "upstream-kustomizations"),
+	)).To(Succeed())
+	g.Expect(r.Stats().KustomizationImagesPatched).To(Equal(1))
+
+	got, err := os.ReadFile(kPath)
+	g.Expect(err).ToNot(HaveOccurred())
+	text := string(got)
+	g.Expect(text).To(ContainSubstring("newName: quay.io/example/segment-bridge"))
+	g.Expect(text).To(ContainSubstring("digest: " + newDigest))
+	g.Expect(text).ToNot(
+		ContainSubstring("newTag: "+newDigest),
+		"digest must not be written to newTag",
+	)
+}
+
+// Tag-shaped replacement on an entry that used digest: must move to newName/newTag and drop digest:.
+func TestApplyImageOverridesInKustomizations_tagReplacementWhenEntryHasDigest(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := t.TempDir()
+	upstream := filepath.Join(root, "operator", "upstream-kustomizations", "segment-bridge")
+	g.Expect(os.MkdirAll(upstream, 0o755)).To(Succeed())
+
+	const oldDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	kustomization := `images:
+  - name: quay.io/konflux-ci/segment-bridge
+    newName: quay.io/konflux-ci/segment-bridge
+    digest: ` + oldDigest + `
+`
+	kPath := filepath.Join(upstream, "kustomization.yaml")
+	g.Expect(os.WriteFile(kPath, []byte(kustomization), 0o644)).To(Succeed())
+
+	o := Overrides{
+		{
+			Name: "segment-bridge",
+			Images: []ImageOverride{
+				{
+					Orig:        "quay.io/konflux-ci/segment-bridge",
+					Replacement: "quay.io/example/segment-bridge:pr-override",
+				},
+			},
+		},
+	}
+	r := newTestRunner(g, root, o)
+	g.Expect(r.applyImageOverridesInKustomizations(
+		filepath.Join(root, "operator", "upstream-kustomizations"),
+	)).To(Succeed())
+	g.Expect(r.Stats().KustomizationImagesPatched).To(Equal(1))
+
+	got, err := os.ReadFile(kPath)
+	g.Expect(err).ToNot(HaveOccurred())
+	text := string(got)
+	g.Expect(text).To(ContainSubstring("newName: quay.io/example/segment-bridge"))
+	g.Expect(text).To(ContainSubstring("newTag: pr-override"))
+	g.Expect(text).ToNot(ContainSubstring("digest: " + oldDigest))
+	g.Expect(text).ToNot(ContainSubstring("digest:"), "switching to a tag pin must not leave digest: on this entry")
+}
+
+// Only images entries matching orig are updated; others are left unchanged.
+func TestApplyImageOverridesInKustomizations_multipleImagesOnlyMatchingRowChanges(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := t.TempDir()
+	upstream := filepath.Join(root, "operator", "upstream-kustomizations", "segment-bridge")
+	g.Expect(os.MkdirAll(upstream, 0o755)).To(Succeed())
+
+	const firstDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const otherDigest = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	kustomization := `images:
+  - name: quay.io/konflux-ci/segment-bridge
+    newName: quay.io/konflux-ci/segment-bridge
+    digest: ` + firstDigest + `
+  - name: quay.io/other/app
+    newName: quay.io/other/app
+    digest: ` + otherDigest + `
+`
+	kPath := filepath.Join(upstream, "kustomization.yaml")
+	g.Expect(os.WriteFile(kPath, []byte(kustomization), 0o644)).To(Succeed())
+
+	o := Overrides{
+		{
+			Name: "segment-bridge",
+			Images: []ImageOverride{
+				{
+					Orig:        "quay.io/konflux-ci/segment-bridge",
+					Replacement: "quay.io/example/segment-bridge:only-first",
+				},
+			},
+		},
+	}
+	r := newTestRunner(g, root, o)
+	g.Expect(r.applyImageOverridesInKustomizations(
+		filepath.Join(root, "operator", "upstream-kustomizations"),
+	)).To(Succeed())
+	g.Expect(r.Stats().KustomizationImagesPatched).To(Equal(1))
+
+	got, err := os.ReadFile(kPath)
+	g.Expect(err).ToNot(HaveOccurred())
+	text := string(got)
+	g.Expect(text).To(ContainSubstring("newName: quay.io/example/segment-bridge"))
+	g.Expect(text).To(ContainSubstring("newTag: only-first"))
+	g.Expect(text).To(ContainSubstring("digest: "+otherDigest), "non-matching image entry must keep its digest")
+	g.Expect(text).To(ContainSubstring("name: quay.io/other/app"))
+}
+
+// Kustomizations that use newTag only (no digest) are skipped by applyImageOverridesInKustomizations entirely.
+func TestApplyImageOverridesInKustomizations_skipsWhenNoDigestInFile(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := t.TempDir()
+	upstream := filepath.Join(root, "operator", "upstream-kustomizations", "segment-bridge")
+	g.Expect(os.MkdirAll(upstream, 0o755)).To(Succeed())
+
+	kustomization := `images:
+  - name: quay.io/konflux-ci/segment-bridge
+    newName: quay.io/konflux-ci/segment-bridge
+    newTag: old
+`
+	kPath := filepath.Join(upstream, "kustomization.yaml")
+	g.Expect(os.WriteFile(kPath, []byte(kustomization), 0o644)).To(Succeed())
+
+	o := Overrides{
+		{
+			Name: "segment-bridge",
+			Images: []ImageOverride{
+				{
+					Orig:        "quay.io/konflux-ci/segment-bridge",
+					Replacement: "quay.io/example/segment-bridge:new",
+				},
+			},
+		},
+	}
+	r := newTestRunner(g, root, o)
+	g.Expect(r.applyImageOverridesInKustomizations(
+		filepath.Join(root, "operator", "upstream-kustomizations"),
+	)).To(Succeed())
+	g.Expect(r.Stats().KustomizationImagesPatched).To(Equal(0))
+
+	got, err := os.ReadFile(kPath)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(got)).To(ContainSubstring("newTag: old"))
+}
+
+// Manifest replacement substitutes the full replacement string; digest-shaped refs are not split.
+func TestApplyImageOverridesInManifests_digestReplacement(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := t.TempDir()
+	manifestDir := filepath.Join(root, "operator", "pkg", "manifests", "segment-bridge")
+	g.Expect(os.MkdirAll(manifestDir, 0o755)).To(Succeed())
+
+	const oldImg = "quay.io/konflux-ci/segment-bridge@sha256:" +
+		"1111111111111111111111111111111111111111111111111111111111111111"
+	const newImg = "quay.io/example/segment-bridge@sha256:" +
+		"2222222222222222222222222222222222222222222222222222222222222222"
+	manifest := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: segment-bridge
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: ` + oldImg + `
+`
+	path := filepath.Join(manifestDir, "manifests.yaml")
+	g.Expect(os.WriteFile(path, []byte(manifest), 0o644)).To(Succeed())
+
+	o := Overrides{
+		{
+			Name: "segment-bridge",
+			Images: []ImageOverride{
+				{Orig: "quay.io/konflux-ci/segment-bridge", Replacement: newImg},
+			},
+		},
+	}
+	r := newTestRunner(g, root, o)
+	g.Expect(r.applyImageOverridesInManifests(
+		filepath.Join(root, "operator", "pkg", "manifests"),
+	)).To(Succeed())
+	g.Expect(r.Stats().ManifestYAMLsImageTextReplaced).To(Equal(1))
+	got, err := os.ReadFile(path)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(got)).To(ContainSubstring(newImg))
+	g.Expect(string(got)).ToNot(ContainSubstring(oldImg))
+}
+
+func TestParseImageReference(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		input      string
+		wantName   string
+		wantTag    string
+		wantDigest string
+	}{
+		{
+			name:       "digest",
+			input:      "quay.io/org/app@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			wantName:   "quay.io/org/app",
+			wantTag:    "",
+			wantDigest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		},
+		{
+			name:       "tag then digest uses digest branch",
+			input:      "quay.io/org/app:mytag@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			wantName:   "quay.io/org/app:mytag",
+			wantTag:    "",
+			wantDigest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		},
+		{
+			name:     "tag only",
+			input:    "registry:5000/ns/img:v1.2",
+			wantName: "registry:5000/ns/img",
+			wantTag:  "v1.2",
+		},
+		{
+			name:     "at without oci digest becomes tag",
+			input:    "quay.io/org/app@edge",
+			wantName: "quay.io/org/app",
+			wantTag:  "edge",
+		},
+		{
+			name:     "bare name defaults latest",
+			input:    "quay.io/org/app",
+			wantName: "quay.io/org/app",
+			wantTag:  "latest",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotName, gotTag, gotDigest := parseImageReference(tc.input)
+			if gotName != tc.wantName || gotTag != tc.wantTag || gotDigest != tc.wantDigest {
+				t.Fatalf("parseImageReference(%q) = (%q, %q, %q), want (%q, %q, %q)",
+					tc.input, gotName, gotTag, gotDigest, tc.wantName, tc.wantTag, tc.wantDigest)
+			}
+		})
+	}
+}
+
+func TestNormalizeOrgRepo(t *testing.T) {
+	t.Parallel()
+
+	ok := []struct {
+		input string
+		want  string
+	}{
+		{"konflux-ci/segment-bridge", "konflux-ci/segment-bridge"},
+		{"Konflux-CI/Segment-Bridge", "konflux-ci/segment-bridge"},
+		{"https://github.com/konflux-ci/segment-bridge", "konflux-ci/segment-bridge"},
+		// `.git` is only trimmed when it is the suffix of the whole string (not `...repo.git/`).
+		{"https://github.com/konflux-ci/segment-bridge.git", "konflux-ci/segment-bridge"},
+	}
+	for _, tc := range ok {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			got, err := normalizeOrgRepo(tc.input, "sourceRepo")
+			if err != nil || got != tc.want {
+				t.Fatalf("normalizeOrgRepo(%q) = (%q, %v), want (%q, nil)", tc.input, got, err, tc.want)
+			}
+		})
+	}
+
+	bad := []string{"", "nohost", "org/", "/repo", "https://gitlab.com/a/b"}
+	for _, input := range bad {
+		t.Run("reject_"+strings.ReplaceAll(input, "/", "_"), func(t *testing.T) {
+			t.Parallel()
+			_, err := normalizeOrgRepo(input, "sourceRepo")
+			if err == nil {
+				t.Fatalf("normalizeOrgRepo(%q) wanted error", input)
+			}
+		})
+	}
+}
+
+func TestGithubURLParts(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		url         string
+		wantOrgRepo string
+		wantSuffix  string
+		ok          bool
+	}{
+		{
+			url:         "https://github.com/konflux-ci/segment-bridge/config/default?ref=abc",
+			wantOrgRepo: "konflux-ci/segment-bridge",
+			wantSuffix:  "/config/default",
+			ok:          true,
+		},
+		{
+			url:         "https://github.com/Konflux-CI/Segment-Bridge/foo?ref=x",
+			wantOrgRepo: "konflux-ci/segment-bridge",
+			wantSuffix:  "/foo",
+			ok:          true,
+		},
+		{
+			url: "https://github.com/org/repo",
+			ok:  false,
+		},
+		{
+			url: "https://gitlab.com/org/repo/foo",
+			ok:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.url, func(t *testing.T) {
+			t.Parallel()
+			orgRepo, suffix, ok := githubURLParts(tc.url)
+			if ok != tc.ok {
+				t.Fatalf("githubURLParts ok = %v, want %v", ok, tc.ok)
+			}
+			if !tc.ok {
+				return
+			}
+			if orgRepo != tc.wantOrgRepo || suffix != tc.wantSuffix {
+				t.Fatalf("githubURLParts(%q) = (%q, %q), want (%q, %q)", tc.url, orgRepo, suffix, tc.wantOrgRepo, tc.wantSuffix)
+			}
+		})
+	}
+}
+
+func TestFirstMatchingRule(t *testing.T) {
+	t.Parallel()
+
+	rules := []GitRule{
+		{SourceRepo: "other/repo", Remote: &RemoteGit{Repo: "x/y", Ref: "r1"}},
+		{SourceRepo: "konflux-ci/segment-bridge", Remote: &RemoteGit{Repo: "fork/segment-bridge", Ref: "r2"}},
+	}
+	got := firstMatchingRule("konflux-ci/segment-bridge", rules)
+	if got == nil || got.Remote == nil || got.Remote.Ref != "r2" {
+		t.Fatalf("firstMatchingRule: got %#v", got)
+	}
+	if firstMatchingRule("missing/repo", rules) != nil {
+		t.Fatal("expected nil for unmatched org/repo")
+	}
+}
+
+// Exercise Apply() git rules + kustomize rebuild (skipped when neither kustomize nor kubectl is on PATH).
+func TestRunnerApply_gitLocalPath_rebuildsManifests(t *testing.T) {
+	if _, err := exec.LookPath("kustomize"); err != nil {
+		if _, err2 := exec.LookPath("kubectl"); err2 != nil {
+			t.Skip("kustomize or kubectl required for rebuild step")
+		}
+	}
+
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := t.TempDir()
+	localSeg := filepath.Join(root, "local-seg", "config", "default")
+	g.Expect(os.MkdirAll(localSeg, 0o755)).To(Succeed())
+	localKustom := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []
+`
+	g.Expect(os.WriteFile(filepath.Join(localSeg, "kustomization.yaml"), []byte(localKustom), 0o644)).To(Succeed())
+
+	upComp := filepath.Join(root, "operator", "upstream-kustomizations", "testcomp")
+	g.Expect(os.MkdirAll(upComp, 0o755)).To(Succeed())
+	upstreamKustom := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/konflux-ci/segment-bridge/config/default?ref=oldpin
+`
+	g.Expect(os.WriteFile(filepath.Join(upComp, "kustomization.yaml"), []byte(upstreamKustom), 0o644)).To(Succeed())
+
+	manifestDir := filepath.Join(root, "operator", "pkg", "manifests", "testcomp")
+	g.Expect(os.MkdirAll(manifestDir, 0o755)).To(Succeed())
+	g.Expect(os.WriteFile(filepath.Join(manifestDir, "manifests.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: placeholder
+`), 0o644)).To(Succeed())
+
+	o := Overrides{
+		{
+			Name: "testcomp",
+			Git: []GitRule{
+				{
+					SourceRepo: "konflux-ci/segment-bridge",
+					LocalPath:  filepath.Join(root, "local-seg"),
+				},
+			},
+		},
+	}
+	r := newTestRunner(g, root, o)
+	g.Expect(r.Apply()).To(Succeed())
+	g.Expect(r.Stats().GitKustomizationsUpdated).To(BeNumerically(">=", 1))
+	g.Expect(r.Stats().ComponentsRebuilt).To(Equal(1))
+
+	// Git edits apply to the temp upstream copy, not the original tree.
+	rewritten := filepath.Join(root, ".tmp", "upstream-kustomizations", "testcomp", "kustomization.yaml")
+	gotK, err := os.ReadFile(rewritten)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(gotK)).ToNot(
+		ContainSubstring("https://github.com/"),
+		"resource should be rewritten to relative local path",
+	)
+}

--- a/renovate.json
+++ b/renovate.json
@@ -255,6 +255,20 @@
       "autoReplaceStringTemplate": "CATALOG_REVISION=\"{{newDigest}}\""
     },
     {
+      "description": "Track tekton-integration-catalog main HEAD in operator-e2e pipeline param default",
+      "customType": "regex",
+      "matchStringsStrategy": "combination",
+      "fileMatch": ["^\\.tekton/pipelines/operator-e2e/pipeline\\.yaml$"],
+      "matchStrings": [
+        "# renovate: datasource=git-refs depName=https://github.com/konflux-ci/tekton-integration-catalog",
+        "default:\\s+(?<currentDigest>[a-f0-9]{40})"
+      ],
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "https://github.com/konflux-ci/tekton-integration-catalog",
+      "currentValueTemplate": "main",
+      "autoReplaceStringTemplate": "default: {{newDigest}}"
+    },
+    {
       "description": "Track cert-manager Helm chart in Update Third-Party Manifests workflow",
       "customType": "regex",
       "fileMatch": [".github/workflows/update-third-party-manifests.yaml"],

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -120,11 +120,17 @@ if [ "${INSTALL_METHOD}" = "build" ]; then
     echo ""
 fi
 
-# Step 1: Setup Kind cluster
-echo "========================================="
-echo "Step 1: Creating Kind cluster"
-echo "========================================="
-"${SCRIPT_DIR}/setup-kind-local-cluster.sh"
+# Step 1: Setup Kind cluster (skip when using an existing kubeconfig, e.g. Tekton kind-aws-provision)
+if [ "${DEPLOY_LOCAL_SKIP_KIND:-0}" = "1" ]; then
+    echo "========================================="
+    echo "Step 1: Skipped (DEPLOY_LOCAL_SKIP_KIND=1 — using current KUBECONFIG)"
+    echo "========================================="
+else
+    echo "========================================="
+    echo "Step 1: Creating Kind cluster"
+    echo "========================================="
+    "${SCRIPT_DIR}/setup-kind-local-cluster.sh"
+fi
 
 # Step 2: Deploy dependencies
 echo ""

--- a/scripts/operator-e2e/README.md
+++ b/scripts/operator-e2e/README.md
@@ -1,0 +1,66 @@
+# Operator E2E helper scripts
+
+Current shell entry points used by the Tekton operator E2E flow.
+
+All scripts take the **konflux-ci repository root** as the first argument unless noted (absolute or relative path is fine).
+
+## Tekton: operator lifecycle
+
+With `OPERATOR_INSTALL_METHOD=none`, `tekton-deploy-operator-and-wait.sh` starts **`bin/manager` in the background** inside the **`deploy-konflux` Task** pod. When that Task completes, the pod is torn down and **that operator process ends**; it does not keep running on the cluster.
+
+**`konflux-e2e-tests`** runs later, in **another pod**, and only uses **`kubectl` / `go test`** against the Kind cluster. **No Konflux operator** is running during that phase. In-cluster services the operator already installed (for example build-service) continue to run; tests should not assume the Konflux **operator** will reconcile or repair arbitrary API changes mid-suite.
+
+For the full pipeline narrative, see **Scope** in `.tekton/pipelines/operator-e2e/README.md`.
+
+## Extra `go test` arguments (integration / conformance)
+
+The Tekton Task sets optional env vars from pipeline params (empty by default). Scripts **omit quotes** around those expansions on purpose: the shell must **split on spaces** so each flag becomes its own argument to `go test`. (Shellcheck rule SC2086 is disabled next to those lines because unquoted expansion is usually risky; here it is required for the same reason as forwarding `"$@"`.)
+
+| Env var | Set by pipeline param | Appended to |
+|--------|------------------------|-------------|
+| `E2E_INTEGRATION_GO_TEST_EXTRA_ARGS` | `integration-go-test-extra-args` | `go test . ./pkg/...` |
+| `E2E_CONFORMANCE_GO_TEST_EXTRA_ARGS` | `conformance-go-test-extra-args` | `go test ./tests/conformance ...` (after fixed Ginkgo flags) |
+
+**Local / ad hoc** (from repo root, same semantics as the Task):
+
+```bash
+export E2E_INTEGRATION_GO_TEST_EXTRA_ARGS='-run=TestKonfluxIntegration -count=1'
+export E2E_CONFORMANCE_GO_TEST_EXTRA_ARGS='-ginkgo.skip=Flaky'
+bash scripts/operator-e2e/tekton-run-e2e-tests.sh "$(pwd)"
+```
+
+Use **one token per flag** where possible (e.g. `-ginkgo.skip=Flaky`). Values with spaces inside one flag are awkward in a flat env string; prefer Ginkgo’s `-name=value` form, or run `./test/e2e/run-e2e.sh` for full `"$@"` forwarding from your shell.
+
+**Tekton** examples: see `.tekton/pipelines/operator-e2e/README.md` (pipeline params) and `.tekton/tasks/konflux-e2e-tests/README.md` (Task params).
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `prepare-conformance-env.sh` | Exports `CUSTOM_DOCKER_BUILD_OCI_TA_MIN_PIPELINE_BUNDLE` from `operator/pkg/manifests/build-service/manifests.yaml` (same pin as GitHub Actions E2E). |
+| `run-conformance-tests.sh` | Runs conformance tests. Requires `GH_ORG`, `GH_TOKEN` (conformance clears `QUAY_TOKEN` for the test run). |
+| `tekton-fetch-kubeconfig.sh` | **Tekton:** decodes kubeconfig from Secret into `/mnt/e2e-shared/kubeconfig`. Args: `SECRET_NAME` `[KEY]`. Env: `POD_NAMESPACE`. |
+| `tekton-copy-shared-tools.sh` | **Tekton:** copies `kubectl`, `yq`, `jq` into `/mnt/e2e-shared/bin` and **`jq`’s shared libraries** (`libjq`, `libonig`) into `/mnt/e2e-shared/lib` for `ubi10/go-toolset` steps. |
+| `tekton-deploy-prep.sh` | **Tekton (go-toolset):** optional overrides via `operator/cmd/overrides`, then `deploy-local.sh` with `OPERATOR_INSTALL_METHOD=none`. |
+| `tekton-push-operator-pkg-manifests-oci.sh` | **Tekton (task-runner):** after prep, push `operator/pkg/manifests` to OCI as `${oci-container-repo}:${pipelineRun}.pkg-manifests` (skips if `E2E_OCI_CONTAINER_REPO` blank). |
+| `tekton-deploy-operator-and-wait.sh` | **Tekton (go-toolset):** `make install`/build, `bin/manager`, apply CR, wait Ready. |
+| `tekton-run-e2e-tests.sh` | **Tekton:** waits for Konflux Ready, `deploy-test-resources.sh` (`SKIP_SAMPLE_COMPONENTS=true`), integration + conformance `go test`. Optional env: `E2E_INTEGRATION_GO_TEST_EXTRA_ARGS`, `E2E_CONFORMANCE_GO_TEST_EXTRA_ARGS` (space-separated; pipeline params `integration-go-test-extra-args` / `conformance-go-test-extra-args` set these). |
+
+## Override YAML schema
+
+Each list item supports:
+
+- `name` (component under `operator/upstream-kustomizations/`)
+- `git` (array of rules; may be empty if only image overrides)
+- `images` (array of `{ orig, replacement }`; may be empty if only git overrides)
+
+At least one of `git` or `images` must be non-empty per item.
+
+Each `git` rule:
+
+- `sourceRepo`: `org/repo` or `https://github.com/org/repo`
+- plus either:
+  - `remote: { repo, ref }`
+  - or `localPath`
+
+`remote.ref` can be branch, tag, or SHA. First matching `sourceRepo` per resource URL wins.

--- a/scripts/operator-e2e/prepare-conformance-env.sh
+++ b/scripts/operator-e2e/prepare-conformance-env.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Set CUSTOM_DOCKER_BUILD_OCI_TA_MIN_PIPELINE_BUNDLE from build-service manifests
+# (same bundle as .github/workflows/operator-test-e2e.yaml "Set build pipeline bundle (min)").
+# If GITHUB_ENV is set (GitHub Actions), append KEY=value lines; else print export statements for sourcing.
+set -euo pipefail
+
+REPO_ROOT="$(cd "${1:?usage: $0 REPO_ROOT}" && pwd)"
+cd "$REPO_ROOT"
+
+append_env() {
+  local line="$1"
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    echo "$line" >> "$GITHUB_ENV"
+  else
+    echo "export $line"
+  fi
+}
+
+BUNDLE="$(yq eval-all 'select(.kind == "ConfigMap" and .metadata.name == "build-pipeline-config") | .data["config.yaml"]' operator/pkg/manifests/build-service/manifests.yaml | yq eval '.pipelines[] | select(.name == "docker-build-oci-ta-min") | .bundle' -)"
+append_env "CUSTOM_DOCKER_BUILD_OCI_TA_MIN_PIPELINE_BUNDLE=${BUNDLE}"

--- a/scripts/operator-e2e/run-conformance-tests.sh
+++ b/scripts/operator-e2e/run-conformance-tests.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Run Ginkgo conformance tests. Requires GH_ORG, GH_TOKEN.
+# QUAY_TOKEN is cleared for this invocation. Optional: RELEASE_TA_OCI_STORAGE, E2E_APPLICATIONS_NAMESPACE.
+# Optional env E2E_CONFORMANCE_GO_TEST_EXTRA_ARGS: extra arguments appended to go test (space-separated),
+# e.g. -ginkgo.focus=Name -ginkgo.skip=Other (same idea as ./test/e2e/run-e2e.sh forwarding "$@").
+# Usage: $0 REPO_ROOT [JUNIT_REPORT_PATH]
+set -euo pipefail
+
+REPO_ROOT="$(cd "${1:?usage: $0 REPO_ROOT [JUNIT_REPORT_PATH]}" && pwd)"
+JUNIT="${2:-${JUNIT_REPORT_PATH:-${GITHUB_WORKSPACE:-$REPO_ROOT}/junit-conformance.xml}}"
+
+export GITHUB_TOKEN="${GH_TOKEN:?GH_TOKEN required}"
+export MY_GITHUB_ORG="${GH_ORG:?GH_ORG required}"
+export QUAY_TOKEN=''
+export E2E_APPLICATIONS_NAMESPACE="${E2E_APPLICATIONS_NAMESPACE:-user-ns2}"
+
+cd "${REPO_ROOT}/test/go-tests"
+# Deliberate word-splitting: each space-separated flag must be its own argv token for go test.
+# Quoting ${E2E_CONFORMANCE_GO_TEST_EXTRA_ARGS} would pass one broken argument (e.g. -ginkgo.focus=...).
+# shellcheck disable=SC2086
+go test ./tests/conformance -v -timeout 40m \
+  -ginkgo.vv \
+  -ginkgo.github-output \
+  -ginkgo.junit-report="$JUNIT" \
+  ${E2E_CONFORMANCE_GO_TEST_EXTRA_ARGS:-}

--- a/scripts/operator-e2e/tekton-copy-shared-tools.sh
+++ b/scripts/operator-e2e/tekton-copy-shared-tools.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copy CLI binaries from task-runner into /mnt/e2e-shared/bin for go-toolset steps
+# (go-toolset has go/make but not kubectl, yq, or jq).
+# jq is dynamically linked to libjq and libonig; copy those .so files into /mnt/e2e-shared/lib
+# and set LD_LIBRARY_PATH in go-toolset scripts (see tekton-run-e2e-tests.sh, deploy-prep, etc.).
+#
+# Clone / fetch-kubeconfig run as root; go-toolset runs non-root. Without fixing modes,
+# apply-overrides and other writers get "permission denied" on root-owned files under the repo.
+set -euo pipefail
+
+DEST="${TEKTON_SHARED_BIN:-/mnt/e2e-shared/bin}"
+DEST_LIB="${TEKTON_SHARED_LIB:-/mnt/e2e-shared/lib}"
+mkdir -p "${DEST}" "${DEST_LIB}"
+cp -a /usr/local/bin/kubectl /usr/local/bin/yq /usr/bin/jq "${DEST}/"
+# EL10 jq RPM: libjq; libonig comes from oniguruma (symlinks + versioned .so).
+cp -a \
+  /usr/lib64/libjq.so.1 \
+  /usr/lib64/libjq.so.1.0.4 \
+  /usr/lib64/libonig.so.5 \
+  /usr/lib64/libonig.so.5.4.0 \
+  "${DEST_LIB}/"
+chmod a+rx "${DEST}/kubectl" "${DEST}/yq" "${DEST}/jq"
+chmod -R a+rX "${DEST_LIB}"
+
+REPO_ROOT="${TEKTON_REPO_ROOT:-/mnt/konflux-ci/repo}"
+if [[ -d "${REPO_ROOT}" ]]; then
+  chmod -R a+rwX "${REPO_ROOT}"
+fi

--- a/scripts/operator-e2e/tekton-deploy-operator-and-wait.sh
+++ b/scripts/operator-e2e/tekton-deploy-operator-and-wait.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Tekton (go-toolset): make install/RBAC/build, out-of-cluster bin/manager, apply Konflux CR, wait Ready.
+# Expects /mnt/e2e-shared/bin from tekton-copy-shared-tools.sh (kubectl for this image).
+set -euo pipefail
+
+REPO_ROOT="$(cd "${1:?usage: $0 REPO_ROOT}" && pwd)"
+cd "${REPO_ROOT}"
+
+export PATH="/mnt/e2e-shared/bin:${PATH}"
+export LD_LIBRARY_PATH="/mnt/e2e-shared/lib:${LD_LIBRARY_PATH:-}"
+export KUBECONFIG="${KUBECONFIG:-/mnt/e2e-shared/kubeconfig}"
+kubectl config current-context
+
+: "${E2E_KONFLUX_CR:?}"
+: "${E2E_KONFLUX_READY_TIMEOUT:?}"
+
+OP_PID=""
+cleanup() {
+  if [[ -n "${OP_PID:-}" ]]; then
+    kill "${OP_PID}" 2>/dev/null || true
+    wait "${OP_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+OPERATOR_LOG=/mnt/e2e-shared/operator-manager.log
+echo "Out-of-cluster operator: make install, install-user-rbac, build (foreground)..."
+(
+  cd "${REPO_ROOT}/operator"
+  make install
+  make install-user-rbac
+  make build
+)
+echo "Starting bin/manager (logs: ${OPERATOR_LOG})..."
+(
+  cd "${REPO_ROOT}/operator"
+  exec ./bin/manager
+) >"${OPERATOR_LOG}" 2>&1 &
+OP_PID=$!
+sleep 5
+echo "Applying Konflux CR: ${E2E_KONFLUX_CR}"
+kubectl apply -f "${REPO_ROOT}/${E2E_KONFLUX_CR}"
+echo "Waiting for Konflux to be Ready (timeout ${E2E_KONFLUX_READY_TIMEOUT})..."
+if ! kubectl wait --for=condition=Ready konflux konflux --timeout="${E2E_KONFLUX_READY_TIMEOUT}"; then
+  echo "Konflux CR did not become Ready; operator log tail:" >&2
+  tail -c 12000 "${OPERATOR_LOG}" >&2 || true
+  exit 1
+fi
+echo "✓ Konflux is ready (out-of-cluster operator)"

--- a/scripts/operator-e2e/tekton-deploy-prep.sh
+++ b/scripts/operator-e2e/tekton-deploy-prep.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Tekton (go-toolset): optional overrides via Go implementation, then deploy-local.sh
+# with OPERATOR_INSTALL_METHOD=none.
+set -euo pipefail
+
+REPO_ROOT="$(cd "${1:?usage: $0 REPO_ROOT}" && pwd)"
+cd "${REPO_ROOT}"
+
+: "${E2E_KONFLUX_CR:?}"
+: "${E2E_KIND_CLUSTER:?}"
+: "${E2E_KONFLUX_READY_TIMEOUT:?}"
+
+export PATH="/mnt/e2e-shared/bin:${PATH}"
+export LD_LIBRARY_PATH="/mnt/e2e-shared/lib:${LD_LIBRARY_PATH:-}"
+export KUBECONFIG="${KUBECONFIG:-/mnt/e2e-shared/kubeconfig}"
+kubectl config current-context
+
+export DEPLOY_LOCAL_SKIP_KIND=1
+export KIND_CLUSTER="${E2E_KIND_CLUSTER}"
+export KONFLUX_CR="${E2E_KONFLUX_CR}"
+export KONFLUX_READY_TIMEOUT="${E2E_KONFLUX_READY_TIMEOUT}"
+export CONTAINER_TOOL=podman
+export OPERATOR_INSTALL_METHOD=none
+
+if [[ -n "${E2E_OVERRIDES_YAML// }" ]]; then
+  (
+    cd "${REPO_ROOT}/operator"
+    go run ./cmd/overrides \
+      --upstream-dir "${REPO_ROOT}/operator/upstream-kustomizations" \
+      --manifests-dir "${REPO_ROOT}/operator/pkg/manifests" \
+      --tmp-dir "${REPO_ROOT}/.tmp" \
+      --overrides-yaml "${E2E_OVERRIDES_YAML}"
+  )
+  echo "Image overrides must be available before Konflux ready timeout (${E2E_KONFLUX_READY_TIMEOUT})."
+fi
+
+./scripts/deploy-local.sh

--- a/scripts/operator-e2e/tekton-fetch-kubeconfig.sh
+++ b/scripts/operator-e2e/tekton-fetch-kubeconfig.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Used by Tekton Task step fetch-kubeconfig: decode cluster kubeconfig from a Secret into a shared volume.
+# Env: POD_NAMESPACE (required). Args: secret-name [key-in-secret]
+set -euo pipefail
+
+SECRET="${1:?usage: $0 SECRET_NAME [KEY]}"
+KEY="${2:-kubeconfig}"
+OUT_DIR="${KUBECONFIG_OUT_DIR:-/mnt/e2e-shared}"
+OUT_FILE="${OUT_DIR}/kubeconfig"
+
+: "${POD_NAMESPACE:?POD_NAMESPACE must be set (e.g. from downward API)}"
+
+mkdir -p "${OUT_DIR}"
+
+for k in "${KEY}" kubeconfig config value KUBECONFIG; do
+  if kubectl get secret "${SECRET}" -n "${POD_NAMESPACE}" -o "jsonpath={.data.${k}}" 2>/dev/null | base64 -d >"${OUT_FILE}" 2>/dev/null; then
+    if [[ -s "${OUT_FILE}" ]]; then
+      echo "Cluster kubeconfig written to shared volume (do not log file contents)."
+      chmod 644 "${OUT_FILE}"
+      exit 0
+    fi
+  fi
+done
+
+echo "Could not decode non-empty kubeconfig from secret ${SECRET} in namespace ${POD_NAMESPACE}." >&2
+if kubectl get secret "${SECRET}" -n "${POD_NAMESPACE}" -o name >/dev/null 2>&1; then
+  echo "Secret exists; kubectl describe (metadata and key sizes only, not values):" >&2
+  kubectl describe secret "${SECRET}" -n "${POD_NAMESPACE}" >&2 || true
+else
+  echo "Secret not found or not readable with current RBAC." >&2
+fi
+exit 1

--- a/scripts/operator-e2e/tekton-push-operator-pkg-manifests-oci.sh
+++ b/scripts/operator-e2e/tekton-push-operator-pkg-manifests-oci.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Push operator/pkg/manifests (after tekton-deploy-prep.sh / overrides) as an OCI artifact.
+#
+# Uses the same registry/repo *prefix* as kind-aws provision (param oci-container-repo), but a
+# distinct tag: ${PIPELINE_RUN_NAME}.pkg-manifests — provision owns ${repo}:${PIPELINE_RUN_NAME}.
+#
+# Requires oras and jq (quay.io/konflux-ci/task-runner matches deploy-konflux fetch-kubeconfig image).
+#
+# Env:
+#   E2E_OCI_CONTAINER_REPO   Registry/repo without tag (e.g. quay.io/org/artifacts). If unset/blank, no-op.
+#   E2E_PIPELINE_RUN_NAME    Used as tag base (required when repo is set).
+#   DOCKER_CONFIG            Directory containing config.json for registry auth (Tekton: mount secret).
+#   E2E_PKG_MANIFESTS_OCI_EXPIRATION  Optional quay.expires-after (default: 30d).
+#
+# Args:
+#   $1  Repository root (konflux-ci checkout).
+set -euo pipefail
+
+REPO_ROOT="$(cd "${1:?usage: $0 REPO_ROOT}" && pwd)"
+MANIFESTS="${REPO_ROOT}/operator/pkg/manifests"
+
+if [[ -z "${E2E_OCI_CONTAINER_REPO// }" ]]; then
+	echo "Skipping OCI push of pkg/manifests (E2E_OCI_CONTAINER_REPO unset or blank)."
+	exit 0
+fi
+
+: "${E2E_PIPELINE_RUN_NAME:?E2E_PIPELINE_RUN_NAME is required when E2E_OCI_CONTAINER_REPO is set}"
+: "${DOCKER_CONFIG:?DOCKER_CONFIG must point to a directory containing config.json}"
+
+if [[ ! -f "${DOCKER_CONFIG}/config.json" ]]; then
+	echo "error: registry auth file missing: ${DOCKER_CONFIG}/config.json" >&2
+	exit 1
+fi
+
+if [[ ! -d "$MANIFESTS" ]]; then
+	echo "error: manifests directory not found: $MANIFESTS" >&2
+	exit 1
+fi
+
+command -v oras >/dev/null 2>&1 || {
+	echo "error: oras not in PATH" >&2
+	exit 1
+}
+
+OCI_REPO="${E2E_OCI_CONTAINER_REPO%/}"
+OCI_REF="${OCI_REPO}:${E2E_PIPELINE_RUN_NAME}.pkg-manifests"
+STAGE="$(mktemp -d)"
+ANN="$(mktemp)"
+cleanup() {
+	rm -rf "${STAGE}"
+	rm -f "${ANN}"
+}
+trap cleanup EXIT
+
+cp -a "${MANIFESTS}" "${STAGE}/manifests"
+TITLE="konflux-ci operator pkg/manifests after prep (PipelineRun ${E2E_PIPELINE_RUN_NAME})"
+jq -n \
+	--arg exp "${E2E_PKG_MANIFESTS_OCI_EXPIRATION:-30d}" \
+	--arg title "$TITLE" \
+	'{"$manifest": {"quay.expires-after": $exp, "org.opencontainers.image.title": $title}}' >"${ANN}"
+
+cd "${STAGE}"
+echo "Pushing operator pkg/manifests to OCI artifact ${OCI_REF} ..."
+# Same layer media type as tekton-integration-catalog secure-push-oci (directory as tar).
+oras push "${OCI_REF}" --annotation-file "${ANN}" \
+	./manifests:application/vnd.acme.rocket.docs.layer.v1+tar
+echo "Pushed ${OCI_REF}"

--- a/scripts/operator-e2e/tekton-run-e2e-tests.sh
+++ b/scripts/operator-e2e/tekton-run-e2e-tests.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Tekton tests step: wait for Konflux CR, run test resources + integration + conformance.
+# Run from konflux-ci repo root with KUBECONFIG and env set by the Task launcher.
+# Optional env (space-separated extra go test flags):
+#   E2E_INTEGRATION_GO_TEST_EXTRA_ARGS — appended to: go test . ./pkg/...
+#   E2E_CONFORMANCE_GO_TEST_EXTRA_ARGS — forwarded to run-conformance-tests.sh (conformance suite only).
+set -euo pipefail
+
+REPO_ROOT="$(cd "${1:?usage: $0 REPO_ROOT}" && pwd)"
+cd "${REPO_ROOT}"
+
+: "${E2E_KONFLUX_READY_TIMEOUT:?}"
+
+# kubectl / yq / jq copied by tekton-copy-shared-tools.sh (go-toolset step); jq needs shared libs in /mnt/e2e-shared/lib.
+export PATH="/mnt/e2e-shared/bin:${PATH}"
+export LD_LIBRARY_PATH="/mnt/e2e-shared/lib:${LD_LIBRARY_PATH:-}"
+
+export KUBECONFIG="${KUBECONFIG:-/mnt/e2e-shared/kubeconfig}"
+export RELEASE_TA_OCI_STORAGE="${E2E_RELEASE_TA_OCI_STORAGE:-}"
+kubectl config current-context
+
+echo "Waiting for Konflux CR to exist..."
+for _ in $(seq 1 120); do
+  if kubectl get konflux konflux >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+if ! kubectl get konflux konflux >/dev/null 2>&1; then
+  echo "Timed out waiting for konflux/konflux resource to be created." >&2
+  exit 1
+fi
+
+echo "Waiting for Konflux to be Ready (timeout ${E2E_KONFLUX_READY_TIMEOUT})..."
+kubectl wait --for=condition=Ready konflux konflux --timeout="${E2E_KONFLUX_READY_TIMEOUT}"
+
+export SKIP_SAMPLE_COMPONENTS=true
+./deploy-test-resources.sh
+
+PF_LOG=/mnt/e2e-shared/port-forward.log
+PF_PID=""
+cleanup() {
+  kill "${PF_PID:-}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+kubectl port-forward -n konflux-ui svc/proxy 9443:9443 >"${PF_LOG}" 2>&1 &
+PF_PID=$!
+
+for _ in $(seq 1 90); do
+  if curl -sk --connect-timeout 2 -o /dev/null "https://127.0.0.1:9443/health" 2>/dev/null; then
+    echo "Konflux UI port-forward ready (127.0.0.1:9443 -> konflux-ui/proxy:9443)."
+    break
+  fi
+  if ! kill -0 "${PF_PID}" 2>/dev/null; then
+    echo "kubectl port-forward exited before becoming ready; log:" >&2
+    cat "${PF_LOG}" >&2 || true
+    exit 1
+  fi
+  sleep 1
+done
+if ! kill -0 "${PF_PID}" 2>/dev/null; then
+  echo "kubectl port-forward is not running." >&2
+  cat "${PF_LOG}" >&2 || true
+  exit 1
+fi
+if ! curl -sk --connect-timeout 2 -o /dev/null "https://127.0.0.1:9443/health" 2>/dev/null; then
+  echo "Timed out waiting for https://localhost:9443/health via port-forward." >&2
+  cat "${PF_LOG}" >&2 || true
+  exit 1
+fi
+
+(
+  cd "${REPO_ROOT}/test/go-tests"
+  # Deliberate word-splitting for multiple flags; see scripts/operator-e2e/README.md.
+  # shellcheck disable=SC2086
+  go test . ./pkg/... ${E2E_INTEGRATION_GO_TEST_EXTRA_ARGS:-}
+)
+eval "$(bash scripts/operator-e2e/prepare-conformance-env.sh "${REPO_ROOT}")"
+export GITHUB_TOKEN="${GH_TOKEN:-}"
+export MY_GITHUB_ORG="${GH_ORG:-}"
+export QUAY_TOKEN=""
+export E2E_APPLICATIONS_NAMESPACE=user-ns2
+JUNIT="${REPO_ROOT}/junit-conformance.xml"
+bash scripts/operator-e2e/run-conformance-tests.sh "${REPO_ROOT}" "${JUNIT}"

--- a/test/e2e/e2e.env.template
+++ b/test/e2e/e2e.env.template
@@ -8,10 +8,10 @@
 #   ./test/e2e/run-e2e.sh
 #
 # Release infrastructure (managed namespace, ImageRepositories, ReleasePlan, etc.)
-# is created automatically by operator/hack/setup-release.sh, which the test calls
+# is created automatically by operator/upstream-kustomizations/cli/setup-release.sh, which the test calls
 # during BeforeAll. No Quay credentials are needed here -- image-controller handles them.
 #
-# The release-service-catalog revision is embedded in operator/hack/setup-release.sh as its default
+# The release-service-catalog revision is embedded in that setup-release.sh as its default
 # (tracked by Renovate). The test calls setup-release.sh without overriding it, so local runs
 # match CI automatically.
 # The build pipeline bundle (docker-build-oci-ta-min) is set from operator/pkg/manifests/build-service/manifests.yaml


### PR DESCRIPTION
Adding Tekton tasks and pipeline for deploying the operator, optionally overriding upstream manifests, and running e2e tests.
    
This can later be used by Konflux teams to verify their changes within Konflux.

Assisted-by: Cursor