### PR TITLE
feat(KFLUXVNGD-852): add clusterId to info.json

### DIFF
--- a/operator/internal/controller/info/konfluxinfo_controller.go
+++ b/operator/internal/controller/info/konfluxinfo_controller.go
@@ -322,16 +322,18 @@ func (r *KonfluxInfoReconciler) ensureNamespaceExists(ctx context.Context, tc *t
 
 // generateInfoJSON generates info.json content from PublicInfo.
 // Provides defaults if fields are missing. k8sVersion is the current cluster Kubernetes version (non-cached).
-func (r *KonfluxInfoReconciler) generateInfoJSON(config *konfluxv1alpha1.PublicInfo, k8sVersion, openShiftVersion string) ([]byte, error) {
-	info := r.applyInfoDefaults(config, k8sVersion, openShiftVersion)
+// clusterId is the stable cluster identifier (OpenShift ClusterVersion UID or kube-system namespace UID).
+func (r *KonfluxInfoReconciler) generateInfoJSON(config *konfluxv1alpha1.PublicInfo, k8sVersion, openShiftVersion, clusterId string) ([]byte, error) {
+	info := r.applyInfoDefaults(config, k8sVersion, openShiftVersion, clusterId)
 	return json.MarshalIndent(info, "", "    ")
 }
 
 // applyInfoDefaults applies default values to PublicInfo if not specified.
-func (r *KonfluxInfoReconciler) applyInfoDefaults(config *konfluxv1alpha1.PublicInfo, k8sVersion, openShiftVersion string) *infoJSON {
+func (r *KonfluxInfoReconciler) applyInfoDefaults(config *konfluxv1alpha1.PublicInfo, k8sVersion, openShiftVersion, clusterId string) *infoJSON {
 	info := &infoJSON{
 		Environment:       "development",
 		Visibility:        "public",
+		ClusterId:         clusterId,
 		KonfluxVersion:    version.Version,
 		KubernetesVersion: k8sVersion,
 		OpenShiftVersion:  openShiftVersion,
@@ -381,6 +383,7 @@ func (r *KonfluxInfoReconciler) reconcileInfoConfigMap(ctx context.Context, tc *
 
 	k8sVersion := ""
 	openShiftVersion := ""
+	clusterId := ""
 	if r.ClusterInfo != nil {
 		if v, err := r.ClusterInfo.K8sVersion(); err == nil && v != nil {
 			k8sVersion = v.GitVersion
@@ -391,19 +394,28 @@ func (r *KonfluxInfoReconciler) reconcileInfoConfigMap(ctx context.Context, tc *
 			if err != nil {
 				return fmt.Errorf("failed to get OpenShift version: %w", err)
 			}
+			clusterId, err = clusterinfo.GetOpenShiftClusterID(ctx, r.Client)
+			if err != nil {
+				return fmt.Errorf("failed to get OpenShift cluster ID: %w", err)
+			}
+		} else {
+			var err error
+			clusterId, err = clusterinfo.GetKubeSystemUID(ctx, r.Client)
+			if err != nil {
+				return fmt.Errorf("failed to get kube-system UID for cluster ID: %w", err)
+			}
 		}
 	}
 
 	var infoJSON []byte
 	var err error
 	if info.Spec.PublicInfo != nil {
-		infoJSON, err = r.generateInfoJSON(info.Spec.PublicInfo, k8sVersion, openShiftVersion)
+		infoJSON, err = r.generateInfoJSON(info.Spec.PublicInfo, k8sVersion, openShiftVersion, clusterId)
 		if err != nil {
 			return fmt.Errorf("failed to generate info.json: %w", err)
 		}
 	} else {
-		// Use default development config
-		infoJSON, err = r.generateInfoJSON(nil, k8sVersion, openShiftVersion)
+		infoJSON, err = r.generateInfoJSON(nil, k8sVersion, openShiftVersion, clusterId)
 		if err != nil {
 			return fmt.Errorf("failed to generate default info.json: %w", err)
 		}
@@ -499,6 +511,7 @@ func (r *KonfluxInfoReconciler) reconcileClusterConfigConfigMap(ctx context.Cont
 type infoJSON struct {
 	Environment       string                              `json:"environment"`
 	Visibility        string                              `json:"visibility"`
+	ClusterId         string                              `json:"clusterId,omitempty"`
 	KonfluxVersion    string                              `json:"konfluxVersion,omitempty"`
 	KubernetesVersion string                              `json:"kubernetesVersion,omitempty"`
 	OpenShiftVersion  string                              `json:"openshiftVersion,omitempty"`

--- a/operator/internal/controller/info/konfluxinfo_customization_test.go
+++ b/operator/internal/controller/info/konfluxinfo_customization_test.go
@@ -31,6 +31,7 @@ import (
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/version"
 )
 
@@ -641,6 +642,98 @@ func TestKonfluxInfoBannerCustomization(t *testing.T) {
 		bannerContent := bannerConfigMap.Data["banner-content.yaml"]
 		// No banner specified should produce an empty array in YAML
 		g.Expect(bannerContent).To(gomega.ContainSubstring("[]"))
+	})
+}
+
+func TestApplyInfoDefaultsClusterId(t *testing.T) {
+	r := &KonfluxInfoReconciler{}
+
+	t.Run("should include clusterId when provided", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		info := r.applyInfoDefaults(nil, "v1.29.0", "", "test-cluster-id-123")
+		g.Expect(info.ClusterId).To(gomega.Equal("test-cluster-id-123"))
+	})
+
+	t.Run("should omit clusterId when empty", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		info := r.applyInfoDefaults(nil, "v1.29.0", "", "")
+		g.Expect(info.ClusterId).To(gomega.BeEmpty())
+
+		jsonBytes, err := json.Marshal(info)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(string(jsonBytes)).NotTo(gomega.ContainSubstring("clusterId"))
+	})
+
+	t.Run("should serialize clusterId in JSON output", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		jsonBytes, err := r.generateInfoJSON(nil, "v1.29.0", "", "my-cluster-uid")
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		var data map[string]interface{}
+		err = json.Unmarshal(jsonBytes, &data)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(data["clusterId"]).To(gomega.Equal("my-cluster-uid"))
+	})
+}
+
+func TestKonfluxInfoClusterIdIntegration(t *testing.T) {
+	if k8sClient == nil || objectStore == nil {
+		t.Skip("Skipping test: k8sClient or objectStore not initialized. Run tests via Ginkgo suite.")
+	}
+
+	ctx := context.Background()
+	typeNamespacedName := types.NamespacedName{
+		Name: CRName,
+	}
+
+	t.Run("should include clusterId from kube-system UID in info.json", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		mockDiscovery := &MockDiscoveryClient{}
+		mockDiscovery.SetVersion("v1.29.0")
+		ci, err := clusterinfo.DetectWithClient(mockDiscovery)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		resource := &konfluxv1alpha1.KonfluxInfo{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: CRName,
+			},
+			Spec: konfluxv1alpha1.KonfluxInfoSpec{},
+		}
+		err = k8sClient.Create(ctx, resource)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			_ = k8sClient.Delete(ctx, resource)
+		}()
+
+		controllerReconciler := &KonfluxInfoReconciler{
+			Client:      k8sClient,
+			Scheme:      k8sClient.Scheme(),
+			ObjectStore: objectStore,
+			ClusterInfo: ci,
+		}
+		_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		infoConfigMap := &corev1.ConfigMap{}
+		err = k8sClient.Get(ctx, types.NamespacedName{
+			Name:      infoConfigMapName,
+			Namespace: infoNamespace,
+		}, infoConfigMap)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		var infoData map[string]interface{}
+		err = json.Unmarshal([]byte(infoConfigMap.Data["info.json"]), &infoData)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(infoData).To(gomega.HaveKey("clusterId"))
+		g.Expect(infoData["clusterId"]).NotTo(gomega.BeEmpty())
+
+		kubeSystemNs := &corev1.Namespace{}
+		err = k8sClient.Get(ctx, types.NamespacedName{Name: "kube-system"}, kubeSystemNs)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(infoData["clusterId"]).To(gomega.Equal(string(kubeSystemNs.UID)))
 	})
 }
 

--- a/operator/pkg/clusterinfo/clusterinfo.go
+++ b/operator/pkg/clusterinfo/clusterinfo.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -142,6 +143,34 @@ func GetOpenShiftVersion(ctx context.Context, c client.Client) (string, error) {
 
 	// No completed version found
 	return UnknownVersion, ErrNoCompletedVersion
+}
+
+// GetOpenShiftClusterID retrieves the cluster ID from the ClusterVersion resource's spec.clusterID field.
+// This should only be called when running on OpenShift (check with Info.IsOpenShift() first).
+func GetOpenShiftClusterID(ctx context.Context, c client.Client) (string, error) {
+	clusterVersion := &configv1.ClusterVersion{}
+	if err := c.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion); err != nil {
+		return "", err
+	}
+	id := string(clusterVersion.Spec.ClusterID)
+	if id == "" {
+		return "", fmt.Errorf("ClusterVersion spec.clusterID is empty")
+	}
+	return id, nil
+}
+
+// GetKubeSystemUID retrieves the UID of the kube-system namespace as a stable cluster identifier.
+// Used as a fallback when OpenShift ClusterVersion is not available.
+func GetKubeSystemUID(ctx context.Context, c client.Client) (string, error) {
+	ns := &corev1.Namespace{}
+	if err := c.Get(ctx, types.NamespacedName{Name: "kube-system"}, ns); err != nil {
+		return "", err
+	}
+	uid := string(ns.UID)
+	if uid == "" {
+		return "", fmt.Errorf("kube-system namespace has empty UID")
+	}
+	return uid, nil
 }
 
 // HasResource checks if a specific resource kind exists in the given API group version.

--- a/operator/pkg/clusterinfo/clusterinfo_test.go
+++ b/operator/pkg/clusterinfo/clusterinfo_test.go
@@ -23,10 +23,12 @@ import (
 
 	"github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -681,24 +683,8 @@ func TestGetOpenShiftVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
+			fakeClient := newClusterVersionFakeClient(tt.clusterVersion)
 
-			// Create scheme and fake client
-			scheme := runtime.NewScheme()
-			_ = configv1.Install(scheme)
-
-			var fakeClient client.Client
-			if tt.clusterVersion != nil {
-				fakeClient = fake.NewClientBuilder().
-					WithScheme(scheme).
-					WithObjects(tt.clusterVersion).
-					Build()
-			} else {
-				fakeClient = fake.NewClientBuilder().
-					WithScheme(scheme).
-					Build()
-			}
-
-			// Call the standalone function directly
 			version, err := GetOpenShiftVersion(context.Background(), fakeClient)
 
 			if tt.expectError {
@@ -710,6 +696,131 @@ func TestGetOpenShiftVersion(t *testing.T) {
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 			g.Expect(version).To(gomega.Equal(tt.expectedVersion))
+		})
+	}
+}
+
+func newClusterVersionFakeClient(cv *configv1.ClusterVersion) client.Client {
+	scheme := runtime.NewScheme()
+	_ = configv1.Install(scheme)
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	if cv != nil {
+		builder = builder.WithObjects(cv)
+	}
+	return builder.Build()
+}
+
+func TestGetOpenShiftClusterID(t *testing.T) {
+	tests := []struct {
+		name           string
+		clusterVersion *configv1.ClusterVersion
+		expectedID     string
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name: "Valid cluster ID",
+			clusterVersion: &configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{Name: "version"},
+				Spec: configv1.ClusterVersionSpec{
+					ClusterID: "d3a1f2b4-5678-90ab-cdef-1234567890ab",
+				},
+			},
+			expectedID:  "d3a1f2b4-5678-90ab-cdef-1234567890ab",
+			expectError: false,
+		},
+		{
+			name:           "ClusterVersion resource not found",
+			clusterVersion: nil,
+			expectedID:     "",
+			expectError:    true,
+			errorContains:  "not found",
+		},
+		{
+			name: "Empty clusterID in spec",
+			clusterVersion: &configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{Name: "version"},
+				Spec:       configv1.ClusterVersionSpec{},
+			},
+			expectedID:    "",
+			expectError:   true,
+			errorContains: "empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			fakeClient := newClusterVersionFakeClient(tt.clusterVersion)
+
+			id, err := GetOpenShiftClusterID(context.Background(), fakeClient)
+
+			if tt.expectError {
+				g.Expect(err).To(gomega.HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(gomega.ContainSubstring(tt.errorContains))
+				}
+			} else {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			g.Expect(id).To(gomega.Equal(tt.expectedID))
+		})
+	}
+}
+
+func TestGetKubeSystemUID(t *testing.T) {
+	tests := []struct {
+		name        string
+		namespace   *corev1.Namespace
+		expectedUID string
+		expectError bool
+	}{
+		{
+			name: "kube-system exists with UID",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kube-system",
+					UID:  k8stypes.UID("abc-123-def-456"),
+				},
+			},
+			expectedUID: "abc-123-def-456",
+			expectError: false,
+		},
+		{
+			name:        "kube-system namespace not found",
+			namespace:   nil,
+			expectedUID: "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+
+			var fakeClient client.Client
+			if tt.namespace != nil {
+				fakeClient = fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(tt.namespace).
+					Build()
+			} else {
+				fakeClient = fake.NewClientBuilder().
+					WithScheme(scheme).
+					Build()
+			}
+
+			uid, err := GetKubeSystemUID(context.Background(), fakeClient)
+
+			if tt.expectError {
+				g.Expect(err).To(gomega.HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			g.Expect(uid).To(gomega.Equal(tt.expectedUID))
 		})
 	}
 }


### PR DESCRIPTION
Populate the clusterId field in the konflux-public-info ConfigMap so both UI and backend share a stable cluster identifier for Segment event hashing. On OpenShift the value comes from ClusterVersion.spec.clusterID; on vanilla K8s it falls back to the kube-system namespace UID.


Made-with: Cursor