### PR TITLE
feat: Add TPA scan to the docker-build-min-pipeline

### DIFF
--- a/operator/pkg/manifests/build-service/manifests.yaml
+++ b/operator/pkg/manifests/build-service/manifests.yaml
@@ -354,7 +354,7 @@ data:
     - name: tekton-bundle-builder-oci-ta
       bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder-oci-ta@sha256:b03bad786fa7f434e6fdd78473231b5328ab3f71594f8d538edb89a259a7bed2
     - name: docker-build-oci-ta-min
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta-min@sha256:23d7841dd76e9a5e73375ff709ef263482b90932b5aa725708c86d339ec2c1b6
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta-min@sha256:ec844602597497340d5a0d1c6fc8268ee176192d3ebaa54cfe28d59bba310ab9
       description: minimal version of the docker-build-oci-ta pipeline, which requires less compute resources. In addition, it doesn't contain tasks which require user provided secrets.
 kind: ConfigMap
 metadata:

--- a/operator/upstream-kustomizations/build-service/core/build-pipeline-config.yaml
+++ b/operator/upstream-kustomizations/build-service/core/build-pipeline-config.yaml
@@ -18,5 +18,5 @@ data:
     - name: tekton-bundle-builder-oci-ta
       bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder-oci-ta@sha256:1536d56740f62c76da0e205ab21ec0225ddc26593637f7606d4a3222b979adab
     - name: docker-build-oci-ta-min
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta-min@sha256:581c283a13e717ee9d11211e31139395234415e57bb03e1db9f518abab0f86a8
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta-min@sha256:ec844602597497340d5a0d1c6fc8268ee176192d3ebaa54cfe28d59bba310ab9
       description: minimal version of the docker-build-oci-ta pipeline, which requires less compute resources. In addition, it doesn't contain tasks which require user provided secrets.


### PR DESCRIPTION
Bump the version of the docker-build-min-pipeline which has the TPA CVE scan.