### PR TITLE
fix:check meta.IsNoMatchError before skipping Kyverno apply errors

### DIFF
--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -185,8 +186,10 @@ func (r *KonfluxIntegrationServiceReconciler) applyManifests(ctx context.Context
 		if err := tc.ApplyOwned(ctx, obj); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			// TODO: Remove this once we decide if we want to have a dependency on Kyverno
-			if gvk.Group == constant.KyvernoGroup {
-				log.Info("Skipping resource: CRD not installed",
+			// Only skip if the error is specifically because the Kyverno CRD is not installed.
+			// Other errors (RBAC, timeout, invalid manifest) must be propagated.
+			if meta.IsNoMatchError(err) && gvk.Group == constant.KyvernoGroup {
+				log.Info("Skipping Kyverno resource: CRD not installed",
 					"kind", gvk.Kind,
 					"apiVersion", gvk.GroupVersion().String(),
 					"namespace", obj.GetNamespace(),

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
@@ -23,6 +23,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -164,8 +165,10 @@ func (r *KonfluxNamespaceListerReconciler) applyManifests(ctx context.Context, t
 		if err := tc.ApplyOwned(ctx, obj); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			// TODO: Remove this once we decide if we want to have a dependency on Kyverno
-			if gvk.Group == constant.KyvernoGroup {
-				log.Info("Skipping resource: CRD not installed",
+			// Only skip if the error is specifically because the Kyverno CRD is not installed.
+			// Other errors (RBAC, timeout, invalid manifest) must be propagated.
+			if meta.IsNoMatchError(err) && gvk.Group == constant.KyvernoGroup {
+				log.Info("Skipping Kyverno resource: CRD not installed",
 					"kind", gvk.Kind,
 					"apiVersion", gvk.GroupVersion().String(),
 					"namespace", obj.GetNamespace(),


### PR DESCRIPTION
Fixes #6174
i noticed the integrationservice and namespacelister controllers were accidentally hiding real errors—like permission issues or timeouts—by assuming any Kyverno error meant the CRD wasn't installed. To fix this, i added a specific check (meta.IsNoMatchError) so the code now only skips the deployment if the CRD is actually missing. This ensures all other legitimate errors are properly reported instead of failing silently.

<img width="1917" height="520" alt="image" src="https://github.com/user-attachments/assets/3998ea73-30e9-42a1-b82b-a8030143df4a" />
