### PR TITLE
chore(operator): pass version info via ldflags in make build and run targets

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -192,13 +192,17 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 
 ##@ Build
 
+GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
+LDFLAGS ?= -X github.com/konflux-ci/konflux-ci/operator/pkg/version.Version=$(VERSION) \
+           -X github.com/konflux-ci/konflux-ci/operator/pkg/version.GitCommit=$(GIT_COMMIT)
+
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager ./cmd/main.go
+	go build -ldflags "$(LDFLAGS)" -o bin/manager ./cmd/main.go
 
 .PHONY: run
 run: manifests generate fmt vet install-user-rbac ## Run a controller from your host.
-	go run ./cmd/main.go
+	go run -ldflags "$(LDFLAGS)" ./cmd/main.go
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.


### PR DESCRIPTION
The build and run Makefile targets now inject Version and GitCommit into the binary using -ldflags, matching what the Containerfile already does. This ensures the operator logs accurate version information during local development.

Assisted-By: Cursor