### PR TITLE
chore: add agent skill for debugging e2e test failures

### DIFF
--- a/.cursor/skills/debug-e2e-tests/SKILL.md
+++ b/.cursor/skills/debug-e2e-tests/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: debug-e2e-tests
+description: Debug failed Konflux e2e test runs by downloading logs and artifacts from GitHub Actions, analyzing test failures, and suggesting fixes. Use when the user asks to debug, investigate, or fix a failing e2e test, CI failure, or flaky test.
+---
+
+# Debug E2E Tests
+
+Debug failed e2e test runs from GitHub Actions. Downloads test logs and cluster artifacts, identifies root causes, and suggests fixes to this repo or upstream dependencies.
+
+**When this skill is activated, tell the user:** "Using the **debug-e2e-tests** skill to investigate this failure." Then show the checklist from the Workflow section below so the user can track progress.
+
+## Prerequisites
+
+- `gh` CLI authenticated with access to `konflux-ci/konflux-ci`
+- `tar` and `unzip` available (standard on Linux/macOS)
+
+## Workflow
+
+Copy this checklist and track progress:
+
+```
+- [ ] Step 1: Identify the failed run
+- [ ] Step 2: Download artifacts
+- [ ] Step 3: Analyze test output (JUnit + Ginkgo logs)
+- [ ] Step 4: Analyze cluster logs
+- [ ] Step 5: (Optional) Inspect the tested commit
+- [ ] Step 6: Determine root cause and suggest fix
+```
+
+### Step 1: Identify the Failed Run
+
+If the user provides a PR number, run ID, or branch name, use that. Otherwise, find recent failures:
+
+```bash
+# List recent failed e2e runs
+gh run list --repo konflux-ci/konflux-ci \
+  --workflow "Operator E2E Tests" \
+  --status failure --limit 10
+
+# For a specific PR
+gh run list --repo konflux-ci/konflux-ci \
+  --workflow "Operator E2E Tests" \
+  --branch <branch> --limit 5
+```
+
+Get the **run ID** from the output (first column).
+
+To see which jobs failed within a run:
+
+```bash
+gh run view <run-id> --repo konflux-ci/konflux-ci
+```
+
+The e2e workflow has these jobs:
+- **Run Operator E2E Tests (AMD64)** — main e2e on amd64
+- **Run Operator E2E Tests (ARM64)** — main e2e on arm64
+
+### Step 2: Download Artifacts
+
+Use the helper script to download and extract artifacts:
+
+```bash
+bash .cursor/skills/debug-e2e-tests/scripts/download-logs.sh <run-id> [arch]
+```
+
+- `arch` defaults to `amd64`. Use `arm64` if that's the failing job.
+- Artifacts are extracted to `/tmp/e2e-debug-<run-id>/`
+
+If the script is unavailable, download manually:
+
+```bash
+WORKDIR="/tmp/e2e-debug-<run-id>"
+mkdir -p "$WORKDIR" && cd "$WORKDIR"
+
+# Download artifacts (name is "logs-amd64" or "logs-arm64")
+gh run download <run-id> --repo konflux-ci/konflux-ci \
+  --name logs-amd64 --dir "$WORKDIR/logs"
+```
+
+Also download the raw job log for the failing job:
+
+```bash
+# Get job IDs
+gh api "repos/konflux-ci/konflux-ci/actions/runs/<run-id>/jobs" \
+  --jq '.jobs[] | select(.conclusion=="failure") | "\(.id) \(.name)"'
+
+# Download the full job log
+gh api "repos/konflux-ci/konflux-ci/actions/jobs/<job-id>/logs" > "$WORKDIR/job.log"
+```
+
+### Step 3: Analyze Test Output
+
+#### 3a. JUnit Report
+
+Check the JUnit XML first for a quick summary of which tests failed:
+
+```bash
+# The JUnit file is at:
+# logs/junit/junit-conformance-amd64.xml  (or arm64)
+```
+
+Look for `<testcase>` elements with `<failure>` children. Extract test names and failure messages.
+
+#### 3b. Ginkgo Output
+
+The raw job log (`job.log`) or stdout contains full Ginkgo output. Search for:
+
+- `[FAILED]` — Ginkgo failure markers
+- `FAIL!` — Go test failure
+- `Timed out` or `context deadline exceeded` — timeout failures
+- `Expected` / `to equal` / `to succeed` — Gomega assertion failures
+
+The test suite is `Konflux Conformance` under `test/go-tests/tests/conformance/`. Cross-reference the failing test name with the source files there to understand what the test was doing.
+
+### Step 4: Analyze Cluster Logs
+
+The `logs/` directory (from `generate-err-logs.sh`) contains the cluster state at test failure time. Read files in this priority order:
+
+| Priority | File | What to look for |
+|----------|------|------------------|
+| 1 | `operator-logs.log` | Operator crashes, reconcile errors, failed deployments |
+| 2 | `konflux-crs-status.log` | Konflux / sub-CR status conditions showing `Ready=False` |
+| 3 | `failed-pods-logs.log` | Container logs from pods with Warning events |
+| 4 | `failed-pods-definitions.yaml` | Pod specs showing image pull errors, resource limits, crash loops |
+| 5 | `failed-deployment-event-log.log` | Deployment rollout failures |
+| 6 | `pipelinerun-res.log` | PipelineRun status, failed tasks, error messages |
+| 7 | `taskrun-res.log` | TaskRun status, step container failures |
+| 8 | `cluster-resources.log` | Node pressure, pending pods, resource exhaustion |
+| 9 | `system-resources.log` | Host OOM, CPU saturation, disk full |
+
+For deeper analysis, check structured artifacts under `logs/artifacts/`:
+
+- `events.json` — all cluster events (search for Warning/error patterns)
+- `deployments.json` — deployment availability and conditions
+- `pipelineruns.json` / `taskruns.json` — Tekton resource details
+- `pods/<namespace>_<pod>.log` — individual pod logs from key namespaces
+- `repositories.json` — PipelinesAsCode Repository CRs and their status
+
+For details on log structure, see [reference.md](reference.md).
+
+#### 4a. "No PipelineRun found" failures — PaC webhook chain
+
+When the failure is **"no pipelinerun found for component …"**, read
+[pac-webhook-debugging.md](pac-webhook-debugging.md) for detailed guidance
+on tracing the PaC webhook delivery chain.
+
+### Step 5: Inspect the Tested Commit (Optional)
+
+This step is not always needed. Use it when the logs from Steps 3–4 suggest a regression in this repo's code (operator changes, kustomization updates, test modifications, deployment scripts) and you want to confirm by looking at the actual diff. Skip it when the root cause is already clear from the logs alone (e.g., an obvious infrastructure issue or upstream service crash).
+
+#### 5a. Get the head commit and base branch from the run
+
+```bash
+# Show the head SHA, branch, and associated PR for the run
+gh run view <run-id> --repo konflux-ci/konflux-ci --json headSha,headBranch \
+  --jq '"branch: \(.headBranch)\ncommit: \(.headSha)"'
+
+# Find the PR's base branch (don't assume main)
+gh pr list --repo konflux-ci/konflux-ci --head <branch> --json number,baseRefName \
+  --jq '.[0] | "PR #\(.number) → base: \(.baseRefName)"'
+```
+
+#### 5b. Check out and inspect the diff
+
+```bash
+# Fetch the branch and check it out
+git fetch origin <branch> <base-branch>
+git checkout <head-sha>
+
+# View the full diff against the base branch
+git diff origin/<base-branch>...<head-sha> --stat
+git diff origin/<base-branch>...<head-sha>
+
+# If the PR has multiple commits, review them individually
+git log --oneline origin/<base-branch>..<head-sha>
+```
+
+Scan the diff for changes to files related to the failure (e.g., kustomizations, operator code, test helpers, deployment scripts). Cross-reference with the error signals from Steps 3–4.
+
+#### 5c. Investigate git history for suspected regressions
+
+If a specific file or component looks suspicious, use git history to understand recent changes:
+
+```bash
+# Recent commits touching a suspect file
+git log --oneline -20 -- <file-path>
+
+# Show each change with diff
+git log -p -5 -- <file-path>
+
+# Compare the suspect file between two points
+git diff <known-good-sha> <head-sha> -- <file-path>
+```
+
+This is especially useful when the failure is new and the logs point to a particular controller, kustomization, or test file — tracing the history can pinpoint exactly which change introduced the regression.
+
+### Step 6: Determine Root Cause and Suggest Fix
+
+Classify the failure into one of these categories:
+
+#### A. Test code issue (fix in this repo)
+
+The test assertion is wrong, flaky, or the test setup is incomplete.
+- Fix location: `test/go-tests/tests/conformance/`
+- Also check: `test/e2e/run-e2e.sh`, `deploy-test-resources.sh`
+
+#### B. Operator issue (fix in this repo)
+
+The Konflux operator itself is broken — reconciliation failures, bad defaults, missing RBAC.
+- Fix location: `operator/` (controllers, API types, RBAC, kustomize overlays)
+
+#### C. Upstream dependency issue (fix in upstream repo)
+
+A Konflux microservice is broken. Identify which service from the logs, then map it to the upstream repo:
+
+| Service | Upstream Repo | Kustomization |
+|---------|---------------|---------------|
+| Build Service | `konflux-ci/build-service` | `operator/upstream-kustomizations/build-service/` |
+| Integration Service | `konflux-ci/integration-service` | `operator/upstream-kustomizations/integration/` |
+| Release Service | `konflux-ci/release-service` | `operator/upstream-kustomizations/release/` |
+| Image Controller | `konflux-ci/image-controller` | `operator/upstream-kustomizations/image-controller/` |
+| Application API (CRDs) | `redhat-appstudio/application-api` | `operator/upstream-kustomizations/application-api/` |
+| Enterprise Contract | `conforma/crds` | `operator/upstream-kustomizations/enterprise-contract/` |
+
+Check the pinned commit SHA in the kustomization to identify which upstream version is deployed, then inspect that repo for relevant issues or recent changes.
+
+#### D. Infrastructure / flaky failure
+
+Resource exhaustion, network issues, Kind cluster instability.
+- Check `system-resources.log` and `cluster-resources.log`
+- If the test passed on one arch but failed on another, likely infra-related
+- If the failure is intermittent across runs, likely flaky
+
+#### E. Cross-job interference (shared external state)
+
+When a failure looks flaky, check whether **parallel CI jobs are competing
+over shared external resources**. The AMD64 and ARM64 e2e jobs run on separate
+clusters but may share the same external services (Quay organization, GitHub
+repos, OCI registries). Multiple PRs or retries can also run concurrently.
+
+If two jobs create, modify, or depend on the **same external resource** (e.g.,
+same Quay repository path, same OCI artifact tag, same GitHub branch), one job
+can silently corrupt the other's state — overwriting images, rotating
+credentials, deleting data, or pushing conflicting artifacts.
+
+**How to check:**
+1. Compare the `BeforeAll` setup logs from both arches (in their JUnit XML
+   `<system-err>` blocks) — look for any external resource identifiers
+   (image URLs, repo paths, branch names, artifact names) that are identical.
+2. Check if the failure is non-deterministic: one arch passes while the other
+   fails, or results flip between re-runs with no code change.
+3. Check whether other PRs or workflow runs were active at the same time and
+   could have touched the same external resources.
+
+**Typical symptoms:** intermittent failures, "unauthorized" registry errors,
+wrong image content, unexpected data in pipeline results, one arch passes
+while the other fails, or tests that break only when CI is busy.
+
+**Fix:** ensure every concurrent job uses unique external resource names. See
+`operator/hack/setup-release.sh` `--image-name-prefix` (`-I`) for an example.
+
+### Output Format
+
+Present findings as:
+
+```markdown
+## E2E Failure Analysis
+
+**Run:** <link to run>
+**Failed job:** <job name>
+**Failed test(s):** <test name(s)>
+
+### Root Cause
+<Concise description of why the test failed>
+
+### Evidence
+<Key log excerpts that support the diagnosis>
+
+### Category
+<A/B/C/D from above>
+
+### Suggested Fix
+<Specific code changes or actions to resolve the issue>
+- File(s) to change: ...
+- If upstream: repo + what to fix
+```

--- a/.cursor/skills/debug-e2e-tests/pac-webhook-debugging.md
+++ b/.cursor/skills/debug-e2e-tests/pac-webhook-debugging.md
@@ -1,0 +1,78 @@
+# PaC Webhook Chain Debugging
+
+When the failure is **"no pipelinerun found for component …"**, the problem is
+almost always in the Pipelines-as-Code (PaC) webhook delivery or processing
+chain. The **push event** on the PaC branch is what triggers PaC to create a
+PipelineRun (not the `pull_request` event).
+
+## Webhook chain
+
+```
+GitHub App webhook → smee.io channel → gosmee client → smee sidecar (:8080) → PaC controller (:8180)
+```
+
+## Check each link
+
+### 1. Build-service logs
+
+File: `artifacts/pods/build-service_*.log`
+
+Confirm the PaC Repository was created and the PaC PR was opened:
+
+- `"Created PaC Repository object"` — when the Repository CR was created
+- `"Pipelines as Code configuration merge request:"` — the PaC PR URL
+
+Note the **timestamps** — you'll need them to correlate with the gosmee event
+log.
+
+### 2. Gosmee relay logs
+
+Location: **raw `job.log`** (not in the structured artifacts).
+
+Search for `"Pod 'gosmee-client-"` to find the gosmee pod's output section.
+The gosmee logs list every event relayed from the smee channel:
+
+```
+Fri, 20 Mar 2026 13:23:12 UTC INF ... push event replayed to http://localhost:8080, status: 202
+```
+
+What to check:
+
+- Were **push events** delivered **after** the PaC Repository was created?
+  Correlate gosmee replay timestamps with the build-service log.
+- Status `202` = the smee sidecar accepted the event (forwarded to PaC).
+- Status `200` = typically heartbeat/keepalive or events PaC doesn't act on.
+
+**Important:** The smee channel is **shared** between AMD64 and ARM64 jobs.
+Both gosmee clients receive **all** events from the channel. Push events from
+the other arch's PaC branch will also appear. Without the event payload you
+cannot distinguish which branch a push event belongs to — count and correlate
+timestamps with the build-service log.
+
+### 3. PaC controller logs
+
+File: `artifacts/pods/pipelines-as-code_*.log`
+
+These show whether PaC matched the event to a Repository, read `.tekton/`
+from the commit, and attempted to create a PipelineRun. Look for:
+
+- No matching Repository found (informer cache not yet synced after creation)
+- GitHub API errors reading the commit tree
+- Failures creating the PipelineRun resource
+
+### 4. PaC Repository status
+
+File: `artifacts/repositories.json`
+
+If the `status` field is empty or missing, PaC never successfully processed
+any event for that Repository.
+
+## Common root causes
+
+| Cause | Evidence |
+|-------|----------|
+| Push event arrived before Repository existed in PaC's informer cache | Build-service log shows Repository created *after* the gosmee push event timestamp |
+| Push event was from the other arch's branch (not the failing component) | Gosmee shows push events but none align with the failing component's timeline |
+| PaC couldn't read `.tekton/` from the commit | PaC controller logs show GitHub API errors |
+| Smee sidecar didn't forward to PaC | Gosmee shows 200 (not 202) for push events, or sidecar health checks failing |
+| GitHub didn't fire a webhook at all | No push events in the gosmee log after the PaC branch was pushed |

--- a/.cursor/skills/debug-e2e-tests/reference.md
+++ b/.cursor/skills/debug-e2e-tests/reference.md
@@ -1,0 +1,128 @@
+# Reference: E2E Debug Skill
+
+## Log Directory Structure
+
+After downloading artifacts from a failed run, the `logs/` directory contains:
+
+```
+logs/
+├── junit/
+│   └── junit-conformance-{amd64|arm64}.xml   # Ginkgo JUnit report
+├── artifacts/
+│   ├── namespaces.json
+│   ├── nodes.json
+│   ├── events.json                            # All cluster events (Warning = key signal)
+│   ├── configmaps.json
+│   ├── deployments.json
+│   ├── services.json
+│   ├── applications.json                      # AppStudio Application CRs
+│   ├── components.json                        # AppStudio Component CRs
+│   ├── snapshots.json
+│   ├── integrationtestscenarios.json
+│   ├── releaseplans.json
+│   ├── releaseplanadmissions.json
+│   ├── releases.json
+│   ├── enterprisecontractpolicies.json
+│   ├── pipelineruns.json                      # Tekton PipelineRuns (key for build/release failures)
+│   ├── taskruns.json                          # Tekton TaskRuns
+│   ├── pipelines.json
+│   ├── repositories.json                      # PipelinesAsCode Repository CRs
+│   └── pods/
+│       ├── build-service_<pod>.log
+│       ├── integration-service_<pod>.log
+│       ├── release-service_<pod>.log
+│       ├── application-service_<pod>.log
+│       └── pipelines-as-code_<pod>.log
+├── system-resources.log          # Host: memory, CPU, disk, load, top processes
+├── cluster-resources.log         # Nodes describe, pending pods, all pod status
+├── container-resources.log       # Docker/containerd stats
+├── operator-logs.log             # Konflux operator deployment + pod logs + events
+├── konflux-crs-status.log        # Konflux CR and all sub-CRs (KonfluxBuildService, etc.)
+├── kyverno-policy-pods.log       # Pods matching Kyverno policy labels
+├── kyverno-policy-pod-definitions.yaml
+├── failed-pods-definitions.yaml  # Full YAML of pods with Warning events
+├── failed-pods-logs.log          # Container logs from warning-event pods
+├── failed-deployment-event-log.log
+├── pipelinerun-res.log           # All PipelineRuns YAML
+└── taskrun-res.log               # All TaskRuns YAML
+```
+
+## Upstream Dependency Details
+
+### Pinned versions in kustomizations
+
+Each upstream service is pinned to a specific commit SHA in its kustomization file. The `ref=` query parameter on the GitHub URL and the `newTag:` in the `images:` block use the same SHA.
+
+Example from `operator/upstream-kustomizations/integration/core/kustomization.yaml`:
+```yaml
+resources:
+- https://github.com/konflux-ci/integration-service/config/default?ref=<SHA>
+images:
+- name: quay.io/konflux-ci/integration-service
+  newTag: <SHA>
+```
+
+### Finding the upstream commit
+
+To check what code is deployed when a test fails:
+
+```bash
+# Extract the pinned SHA for a service
+grep 'ref=' operator/upstream-kustomizations/<service>/core/kustomization.yaml
+
+# Then inspect that commit in the upstream repo
+gh browse --repo konflux-ci/<service> <SHA>
+
+# Or see recent commits after that SHA
+gh api "repos/konflux-ci/<service>/commits?sha=main&per_page=10" \
+  --jq '.[] | "\(.sha[:12]) \(.commit.message | split("\n")[0])"'
+```
+
+### Full upstream repo mapping
+
+| Kustomization path | Upstream repo | Container image |
+|--------------------|---------------|-----------------|
+| `build-service/core/` | `konflux-ci/build-service` | `quay.io/konflux-ci/build-service` |
+| `integration/core/` | `konflux-ci/integration-service` | `quay.io/konflux-ci/integration-service` |
+| `release/core/` | `konflux-ci/release-service` | `quay.io/konflux-ci/release-service` |
+| `image-controller/core/` | `konflux-ci/image-controller` | `quay.io/konflux-ci/image-controller` |
+| `application-api/` | `redhat-appstudio/application-api` | (CRDs only) |
+| `enterprise-contract/core/` | `conforma/crds` | (CRDs only) |
+| `release/internal-services/` | `redhat-appstudio/internal-services` | (CRDs only) |
+| `segment-bridge/` | `konflux-ci/segment-bridge` | `quay.io/konflux-ci/segment-bridge` |
+
+### Test code structure
+
+- **Suite**: `test/go-tests/tests/conformance/` — Ginkgo v2 + Gomega
+- **Entry point**: `test/e2e/run-e2e.sh` → `go test ./tests/conformance -ginkgo.vv`
+- **Framework helpers**: `test/go-tests/pkg/`
+- **Config/scenarios**: `test/go-tests/tests/conformance/config/scenarios.go`
+
+## CI Workflow Reference
+
+### Operator E2E Tests (`operator-test-e2e.yaml`)
+
+| Job | Purpose |
+|-----|---------|
+| `check-prerequisites` | Gate fork PRs |
+| `check-changes` | Path-filter to skip if no relevant changes |
+| `test` | Kind cluster + deploy + integration tests + e2e (matrix: amd64, arm64) |
+| `test-skip` | No-op jobs matching test names for consistent status checks |
+| `report-operator-e2e-status` | Update check runs for `/allow` dispatches |
+
+**Artifact names**: `logs-amd64`, `logs-arm64`
+
+### Common Failure Patterns
+
+| Pattern | Likely cause | Where to look |
+|---------|-------------|---------------|
+| `no pipelinerun found for component` | PaC webhook chain failure — push event not processed | See **PaC webhook chain** below |
+| `context deadline exceeded` in test | Test timeout — slow cluster or stuck reconciliation | `operator-logs.log`, `pipelineruns.json` |
+| `ImagePullBackOff` in pod logs | Bad image tag or registry issue | `failed-pods-definitions.yaml` |
+| `no matches for kind` in operator log | Missing CRDs — upstream kustomization issue | `operator-logs.log`, check CRD installation |
+| `admission webhook denied` | Kyverno policy blocking resource creation | `events.json`, `kyverno-policy-pods.log` |
+| `OOMKilled` in pod status | Container hit memory limit | `failed-pods-definitions.yaml`, `cluster-resources.log` |
+| Reconcile error loop in operator | Controller bug or bad CR spec | `operator-logs.log` |
+| PipelineRun stuck `Running` | Tekton task issue or missing resources | `pipelineruns.json`, `taskruns.json` |
+| Different result amd64 vs arm64 | Architecture-specific bug or resource limits | Compare both artifact sets |
+

--- a/.cursor/skills/debug-e2e-tests/scripts/download-logs.sh
+++ b/.cursor/skills/debug-e2e-tests/scripts/download-logs.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Download and extract e2e test artifacts from a GitHub Actions run.
+#
+# Usage: download-logs.sh <run-id> [arch]
+#   run-id  — GitHub Actions run ID
+#   arch    — amd64 (default) or arm64
+#
+# Output directory: /tmp/e2e-debug-<run-id>/
+
+set -euo pipefail
+
+REPO="konflux-ci/konflux-ci"
+
+run_id="${1:?Usage: download-logs.sh <run-id> [arch]}"
+arch="${2:-amd64}"
+workdir="/tmp/e2e-debug-${run_id}"
+
+mkdir -p "$workdir"
+echo "Downloading artifacts for run ${run_id} (${arch}) into ${workdir}..." >&2
+
+gh run download "$run_id" \
+  --repo "$REPO" \
+  --name "logs-${arch}" \
+  --dir "${workdir}/logs" 2>/dev/null || {
+    echo "Warning: could not download logs-${arch} artifact. It may have expired (90-day retention)." >&2
+  }
+
+echo "Downloading raw job log for the failing job..." >&2
+failing_job_id=$(
+  gh api "repos/${REPO}/actions/runs/${run_id}/jobs" \
+    --jq ".jobs[] | select(.conclusion==\"failure\" and (.name | test(\"${arch}\"; \"i\"))) | .id" \
+  | head -1
+) || {
+  echo "Warning: could not query jobs for run ${run_id}." >&2
+  failing_job_id=""
+}
+
+if [[ -n "$failing_job_id" ]]; then
+  gh api "repos/${REPO}/actions/jobs/${failing_job_id}/logs" \
+    > "${workdir}/job.log" 2>/dev/null || echo "Warning: could not download job log." >&2
+  echo "Job log saved to ${workdir}/job.log" >&2
+else
+  echo "No failing job found matching arch=${arch}. Trying any failed job..." >&2
+  failing_job_id=$(
+    gh api "repos/${REPO}/actions/runs/${run_id}/jobs" \
+      --jq '.jobs[] | select(.conclusion=="failure") | .id' \
+    | head -1
+  ) || {
+    echo "Warning: could not query jobs for run ${run_id}." >&2
+    failing_job_id=""
+  }
+  if [[ -n "$failing_job_id" ]]; then
+    gh api "repos/${REPO}/actions/jobs/${failing_job_id}/logs" \
+      > "${workdir}/job.log" 2>/dev/null || echo "Warning: could not download job log." >&2
+    echo "Job log saved to ${workdir}/job.log" >&2
+  else
+    echo "No failing jobs found in this run." >&2
+  fi
+fi
+
+echo "" >&2
+echo "=== Download complete ===" >&2
+echo "Artifacts directory: ${workdir}/logs/" >&2
+echo "Job log:             ${workdir}/job.log" >&2
+
+if [[ -d "${workdir}/logs" ]]; then
+  echo "" >&2
+  echo "Contents:" >&2
+  find "${workdir}/logs" -type f | head -30 >&2
+  total=$(find "${workdir}/logs" -type f | wc -l)
+  if (( total > 30 )); then
+    echo "... and $((total - 30)) more files" >&2
+  fi
+fi
+
+echo "" >&2
+echo "${workdir}"

--- a/.github/workflows/check-toc.yaml
+++ b/.github/workflows/check-toc.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Verify ToC
         run: |
-          find . -name "*.md" -not -path "./operator/docs/*" | while read -r file; do
+          find . -name "*.md" -not -path "./operator/docs/*" -not -path "./.cursor/*" | while read -r file; do
               npx markdown-toc $file -i
           done
           if [[ $(git status --porcelain) ]]; then


### PR DESCRIPTION
Add an Agent Skill that guides AI assistants through debugging failed Konflux e2e test runs from GitHub Actions. The skill covers downloading logs/artifacts, analyzing JUnit reports and Ginkgo output, inspecting cluster state, tracing PaC webhook delivery chains, and classifying root causes.

Agent Skills (https://claude.com/blog/skills) are a portable format for packaging domain expertise that AI coding assistants can load on demand. They are supported across different tools including Cursor and Claude Code. Skills are loaded automatically when the AI detects a relevant task, or can be invoked explicitly using a slash command.

Files added:
- SKILL.md: main skill with step-by-step debugging workflow
- reference.md: log structure, upstream repo mapping, failure patterns
- pac-webhook-debugging.md: PaC webhook chain tracing guide
- scripts/download-logs.sh: helper to fetch artifacts from GH Actions

Assisted-By: Cursor