### PR TITLE
fix: check IsNoMatchError before skipping Kyverno resources

### DIFF
--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -185,7 +186,7 @@ func (r *KonfluxIntegrationServiceReconciler) applyManifests(ctx context.Context
 		if err := tc.ApplyOwned(ctx, obj); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			// TODO: Remove this once we decide if we want to have a dependency on Kyverno
-			if gvk.Group == constant.KyvernoGroup {
+			if meta.IsNoMatchError(err) && gvk.Group == constant.KyvernoGroup {
 				log.Info("Skipping resource: CRD not installed",
 					"kind", gvk.Kind,
 					"apiVersion", gvk.GroupVersion().String(),

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
@@ -23,6 +23,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -164,7 +165,7 @@ func (r *KonfluxNamespaceListerReconciler) applyManifests(ctx context.Context, t
 		if err := tc.ApplyOwned(ctx, obj); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			// TODO: Remove this once we decide if we want to have a dependency on Kyverno
-			if gvk.Group == constant.KyvernoGroup {
+			if meta.IsNoMatchError(err) && gvk.Group == constant.KyvernoGroup {
 				log.Info("Skipping resource: CRD not installed",
 					"kind", gvk.Kind,
 					"apiVersion", gvk.GroupVersion().String(),


### PR DESCRIPTION
## Problem
The `integrationservice` and `namespacelister` controllers silently swallow 
all errors from the Kyverno API group — not just "CRD not installed" errors. 
This means real errors like RBAC failures or timeouts are never surfaced.

## Fix
Added `meta.IsNoMatchError(err)` check so only genuine "CRD not installed" 
errors are skipped. All other errors are now returned properly.

## Changes
- `operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go`
- `operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go`

Fixes #6174

> Note: This fix is minimal and non-invasive — it does not increase Kyverno 
> coupling and improves correctness regardless of the longer-term migration plan.