### PR TITLE
fix: watch EnterpriseContractPolicy resources for changes

### DIFF
--- a/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller.go
+++ b/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller.go
@@ -19,18 +19,24 @@ package enterprisecontract
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
@@ -63,11 +69,29 @@ var EnterpriseContractCleanupGVKs = []schema.GroupVersionKind{}
 // applied, so no allow list is needed (they're always tracked and never become orphans).
 var EnterpriseContractClusterScopedAllowList tracking.ClusterScopedAllowList = nil
 
+// ecPolicyGVK is the GroupVersionKind for the EnterpriseContractPolicy CRD
+// managed by this controller.
+var ecPolicyGVK = schema.GroupVersionKind{
+	Group:   "appstudio.redhat.com",
+	Version: "v1alpha1",
+	Kind:    "EnterpriseContractPolicy",
+}
+
 // KonfluxEnterpriseContractReconciler reconciles a KonfluxEnterpriseContract object
 type KonfluxEnterpriseContractReconciler struct {
 	client.Client
 	Scheme      *runtime.Scheme
 	ObjectStore *manifests.ObjectStore
+
+	// Fields for dynamic watch of EnterpriseContractPolicy resources.
+	// The CRD is deployed by this controller, so the watch cannot be
+	// registered at startup (the CRD does not exist yet). Instead, we
+	// start the watch on the first successful reconcile.
+	ctrl       controller.Controller
+	cache      cache.Cache
+	restMapper meta.RESTMapper
+	mu         sync.Mutex
+	watching   bool
 }
 
 // +kubebuilder:rbac:groups=konflux.konflux-ci.dev,resources=konfluxenterprisecontracts,verbs=get;list;watch;create;update;patch;delete
@@ -115,9 +139,14 @@ func (r *KonfluxEnterpriseContractReconciler) Reconcile(ctx context.Context, req
 		FieldManager:      FieldManager,
 	})
 
-	// Apply all embedded manifests
+	// Apply all embedded manifests (including the EnterpriseContractPolicy CRD and CRs)
 	if err := r.applyManifests(ctx, tc); err != nil {
 		return errHandler.HandleApplyError(ctx, err)
+	}
+
+	// Start watching EnterpriseContractPolicy CRs once the CRD has been applied.
+	if err := r.startECPolicyWatch(ctx); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// Cleanup orphaned resources
@@ -159,17 +188,57 @@ func (r *KonfluxEnterpriseContractReconciler) applyManifests(ctx context.Context
 	return nil
 }
 
+// startECPolicyWatch registers a dynamic watch for EnterpriseContractPolicy
+// CRs. The watch is deferred because this controller creates the ECP CRD
+// itself; registering the watch at startup would deadlock the manager
+// (WaitForCacheSync blocks until the informer syncs, but the CRD does not
+// exist until Reconcile runs). Instead, we start the watch after the first
+// successful manifest apply, when the CRD is guaranteed to exist.
+func (r *KonfluxEnterpriseContractReconciler) startECPolicyWatch(ctx context.Context) error {
+	if r.ctrl == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.watching {
+		return nil
+	}
+
+	log := logf.FromContext(ctx)
+
+	ecPolicy := &unstructured.Unstructured{}
+	ecPolicy.SetGroupVersionKind(ecPolicyGVK)
+
+	if err := r.ctrl.Watch(
+		source.Kind(
+			r.cache,
+			ecPolicy,
+			handler.TypedEnqueueRequestForOwner[*unstructured.Unstructured](
+				r.Scheme, r.restMapper,
+				&konfluxv1alpha1.KonfluxEnterpriseContract{}),
+		),
+	); err != nil {
+		log.Error(err, "Failed to start watch for EnterpriseContractPolicy, will retry next reconcile")
+		return nil
+	}
+
+	r.watching = true
+	log.Info("Started dynamic watch for EnterpriseContractPolicy resources")
+	return nil
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *KonfluxEnterpriseContractReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	crdMapFunc, err := crdhandler.MapCRDToRequest(r.ObjectStore, manifests.EnterpriseContract, CRName)
 	if err != nil {
 		return err
 	}
-	return ctrl.NewControllerManagedBy(mgr).
+
+	c, err := ctrl.NewControllerManagedBy(mgr).
 		For(&konfluxv1alpha1.KonfluxEnterpriseContract{}).
 		Named("konfluxenterprisecontract").
-		// Use predicates to filter out unnecessary updates and prevent reconcile loops
-		// Deployments: watch spec changes AND readiness status changes
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
 		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		Owns(&corev1.ConfigMap{}).
@@ -179,8 +248,18 @@ func (r *KonfluxEnterpriseContractReconciler) SetupWithManager(mgr ctrl.Manager)
 		Owns(&rbacv1.RoleBinding{}).
 		Owns(&rbacv1.ClusterRole{}).
 		Owns(&rbacv1.ClusterRoleBinding{}).
-		// Watch CRDs so that out-of-band deletion triggers reconcile and re-apply.
+		// EnterpriseContractPolicy is NOT watched here; its CRD is created by
+		// this controller, so the watch is started dynamically in Reconcile
+		// via startECPolicyWatch to avoid a startup deadlock.
 		Watches(&apiextensionsv1.CustomResourceDefinition{},
 			handler.EnqueueRequestsFromMapFunc(crdMapFunc)).
-		Complete(r)
+		Build(r)
+	if err != nil {
+		return err
+	}
+
+	r.ctrl = c
+	r.cache = mgr.GetCache()
+	r.restMapper = mgr.GetRESTMapper()
+	return nil
 }

--- a/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
+++ b/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
@@ -22,67 +22,123 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 )
 
+const (
+	ecPolicyNamespace = "enterprise-contract-service"
+	ecPolicyName      = "default"
+)
+
+// ecPolicyGVK is defined in the controller file.
+
+func newECPolicyObject() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(ecPolicyGVK)
+	obj.SetName(ecPolicyName)
+	obj.SetNamespace(ecPolicyNamespace)
+	return obj
+}
+
+func newECPolicyList() *unstructured.UnstructuredList {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(ecPolicyGVK)
+	return list
+}
+
+func reconcileEC(ctx context.Context) {
+	reconciler := &KonfluxEnterpriseContractReconciler{
+		Client:      k8sClient,
+		Scheme:      k8sClient.Scheme(),
+		ObjectStore: objectStore,
+	}
+	Eventually(func() error {
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: CRName},
+		})
+		return err
+	}).WithTimeout(15 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+}
+
 var _ = Describe("KonfluxEnterpriseContract Controller", func() {
 	Context("When reconciling a resource", func() {
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      CRName,
-			Namespace: "default",
-		}
-		konfluxenterprisecontract := &konfluxv1alpha1.KonfluxEnterpriseContract{}
+		var cr *konfluxv1alpha1.KonfluxEnterpriseContract
 
 		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxEnterpriseContract")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxenterprisecontract)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxEnterpriseContract{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      CRName,
-						Namespace: "default",
-					},
-					// TODO(user): Specify other spec details if needed.
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			By("creating the KonfluxEnterpriseContract CR")
+			cr = &konfluxv1alpha1.KonfluxEnterpriseContract{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: CRName,
+				},
 			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			By("running initial reconciliation")
+			reconcileEC(ctx)
 		})
 
 		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxEnterpriseContract{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxEnterpriseContract")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			By("cleaning up the KonfluxEnterpriseContract CR")
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
 		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxEnterpriseContractReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
 
-			By("Waiting for reconciliation to succeed (CRD may need to establish first)")
-			Eventually(func() error {
-				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: typeNamespacedName,
-				})
-				return err
-			}).WithTimeout(15 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		It("should create EnterpriseContractPolicy resources", func() {
+			policyList := newECPolicyList()
+			Expect(k8sClient.List(ctx, policyList, client.InNamespace(ecPolicyNamespace))).To(Succeed())
+			Expect(policyList.Items).NotTo(BeEmpty())
+		})
+
+		It("should restore an EnterpriseContractPolicy after it is modified", func() {
+			By("fetching the existing EnterpriseContractPolicy")
+			policy := newECPolicyObject()
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      ecPolicyName,
+				Namespace: ecPolicyNamespace,
+			}, policy)).To(Succeed())
+
+			spec, _, _ := unstructured.NestedMap(policy.Object, "spec")
+			originalDescription, _, _ := unstructured.NestedString(spec, "description")
+
+			By("modifying the EnterpriseContractPolicy spec")
+			Expect(unstructured.SetNestedField(policy.Object, "modified-by-test", "spec", "description")).To(Succeed())
+			Expect(k8sClient.Update(ctx, policy)).To(Succeed())
+
+			By("reconciling and verifying the controller restores the original spec")
+			reconcileEC(ctx)
+
+			updated := newECPolicyObject()
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      ecPolicyName,
+				Namespace: ecPolicyNamespace,
+			}, updated)).To(Succeed())
+			desc, _, _ := unstructured.NestedString(updated.Object, "spec", "description")
+			Expect(desc).To(Equal(originalDescription))
+		})
+
+		It("should re-create an EnterpriseContractPolicy after it is deleted", func() {
+			By("deleting the EnterpriseContractPolicy")
+			policy := newECPolicyObject()
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      ecPolicyName,
+				Namespace: ecPolicyNamespace,
+			}, policy)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
+
+			By("reconciling and verifying the controller re-creates it")
+			reconcileEC(ctx)
+
+			recreated := newECPolicyObject()
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      ecPolicyName,
+				Namespace: ecPolicyNamespace,
+			}, recreated)).To(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
The EnterpriseContract reconciler manages EnterpriseContractPolicy CRs
via server-side apply with ownerReferences, but changes to those CRs
did not trigger reconciliation.

A static Owns() watch is not possible here because this controller
creates the EnterpriseContractPolicy CRD itself; registering an
informer at startup would deadlock the manager (WaitForCacheSync
blocks, but the CRD does not exist until Reconcile runs).

Instead, use a dynamic watch: store the controller.Controller reference
from Build(), then call controller.Watch(source.Kind(...)) inside
Reconcile after the CRD has been applied. A mutex-guarded flag ensures
the watch is registered exactly once and retries on the next reconcile
if it fails.
    
    Assisted-By: Cursor