### PR TITLE
fix(KFLUXVNGD-874): Add verify-conforma logs to the error logs script

### DIFF
--- a/test/go-tests/pkg/utils/tekton/pipelineruns.go
+++ b/test/go-tests/pkg/utils/tekton/pipelineruns.go
@@ -22,6 +22,8 @@ import (
 
 const sslCertDir = "/var/run/secrets/kubernetes.io/serviceaccount"
 
+const verifyConformaTaskName = "verify-conforma"
+
 type PipelineRunGenerator interface {
 	Generate() (*pipeline.PipelineRun, error)
 }
@@ -254,6 +256,40 @@ func GetFailedPipelineRunLogs(c crclient.Client, ki kubernetes.Interface, pipeli
 		failMessage += "TaskRun status.conditions (no failed container logs available):\n" + d.TaskRunConditionsText
 	}
 	return failMessage, nil
+}
+
+// GetVerifyConformaLogs fetches logs from all step containers of the
+// verify-conforma task in a failed PipelineRun, using the steps reported in
+// the TaskRun status. Returns an empty string if the task is not found
+// (e.g. the pipeline failed before reaching it).
+func GetVerifyConformaLogs(c crclient.Client, ki kubernetes.Interface, pr *pipeline.PipelineRun) (string, error) {
+	for _, chr := range pr.Status.ChildReferences {
+		if chr.PipelineTaskName != verifyConformaTaskName {
+			continue
+		}
+		taskRun := &pipeline.TaskRun{}
+		if err := c.Get(context.Background(), types.NamespacedName{
+			Namespace: pr.Namespace, Name: chr.Name,
+		}, taskRun); err != nil {
+			return "", fmt.Errorf("failed to get %s TaskRun %s: %w", verifyConformaTaskName, chr.Name, err)
+		}
+		if taskRun.Status.PodName == "" {
+			return "", fmt.Errorf("%s TaskRun %s has no pod (task may not have started)", verifyConformaTaskName, chr.Name)
+		}
+		var out strings.Builder
+		for _, step := range taskRun.Status.Steps {
+			logs, err := utils.GetContainerLogs(ki, taskRun.Status.PodName, step.Container, pr.Namespace)
+			if err != nil {
+				out.WriteString(fmt.Sprintf("--- %s: (unavailable: %v)\n", step.Name, err))
+				continue
+			}
+			if logs != "" {
+				out.WriteString(fmt.Sprintf("--- %s:\n%s\n", step.Name, logs))
+			}
+		}
+		return out.String(), nil
+	}
+	return "", nil
 }
 
 func HasPipelineRunSucceeded(pr *pipeline.PipelineRun) bool {

--- a/test/go-tests/tests/conformance/conformance.go
+++ b/test/go-tests/tests/conformance/conformance.go
@@ -403,6 +403,17 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 							} else {
 								klog.Errorf("release PipelineRun %s/%s could not get failed logs: %v", pr.GetNamespace(), pr.GetName(), logErr)
 							}
+						// Fetch verify-conforma logs separately: they contain EC policy
+						// violation details that are not captured by the generic failed-task
+						// logs above, and are useful even when another task caused the failure.
+						if ecLogs, ecErr := tekton.GetVerifyConformaLogs(
+							fw.AsKubeAdmin.ReleaseController.KubeRest(),
+							fw.AsKubeAdmin.ReleaseController.KubeInterface(),
+							pr); ecErr == nil && ecLogs != "" {
+								klog.Errorf("release PipelineRun %s/%s verify-conforma EC policy details:\n%s", pr.GetNamespace(), pr.GetName(), ecLogs)
+							} else if ecErr != nil {
+								klog.Errorf("release PipelineRun %s/%s could not get verify-conforma logs: %v", pr.GetNamespace(), pr.GetName(), ecErr)
+							}
 							gomega.Expect(tekton.HasPipelineRunFailed(pr)).NotTo(gomega.BeTrue(), "PipelineRun %s/%s failed", pr.GetNamespace(), pr.GetName())
 						}
 						if !pr.IsDone() {


### PR DESCRIPTION
Add `verify-conforma` log collection to conformance test diagnostics. When a release PipelineRun fails in the conformance test, the verify-conforma task's step logs are now fetched and printed alongside the existing failed-task diagnostics.

These logs contain EC policy violation details
The new `GetVerifyConformaLogs` helper in the tekton package iterates all step containers of the `verify-conforma` TaskRun and aggregates their logs. It handles the case where the task was never reached (returns empty, no error), where its pod never started (returns a descriptive error), and where individual step logs are unavailable.
The task name is extracted into a named constant to avoid silent breakage if the pipeline task is ever renamed.

Assisted-By: Cursor