### PR TITLE
fix: reconcile on metadata changes to prevent ownership loss

### DIFF
--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
@@ -255,13 +255,13 @@ func (r *KonfluxBuildServiceReconciler) SetupWithManager(mgr ctrl.Manager) error
 		// Use predicates to filter out unnecessary updates and prevent reconcile loops
 		// Deployments: watch spec changes AND readiness status changes
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&corev1.ConfigMap{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.Role{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
+		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Secret{}).
+		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
 		Complete(r)
 }

--- a/operator/internal/controller/certmanager/konfluxcertmanager_controller.go
+++ b/operator/internal/controller/certmanager/konfluxcertmanager_controller.go
@@ -25,14 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
-	"github.com/konflux-ci/konflux-ci/operator/internal/predicate"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
 )
@@ -166,6 +164,6 @@ func (r *KonfluxCertManagerReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		For(&konfluxv1alpha1.KonfluxCertManager{}).
 		Named("konfluxcertmanager").
 		// Watch for changes to cert-manager resources
-		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
+		Owns(&corev1.Secret{}).
 		Complete(r)
 }

--- a/operator/internal/controller/defaulttenant/konfluxdefaulttenant_controller.go
+++ b/operator/internal/controller/defaulttenant/konfluxdefaulttenant_controller.go
@@ -156,9 +156,9 @@ func (r *KonfluxDefaultTenantReconciler) SetupWithManager(mgr ctrl.Manager) erro
 		For(&konfluxv1alpha1.KonfluxDefaultTenant{}).
 		Named("konfluxdefaulttenant").
 		// Watch Namespace, ConfigMap, ServiceAccount, and RoleBindings
-		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&corev1.ConfigMap{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.ServiceAccount{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
+		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Complete(r)
 }

--- a/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller.go
+++ b/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller.go
@@ -171,14 +171,14 @@ func (r *KonfluxEnterpriseContractReconciler) SetupWithManager(mgr ctrl.Manager)
 		// Use predicates to filter out unnecessary updates and prevent reconcile loops
 		// Deployments: watch spec changes AND readiness status changes
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&corev1.ConfigMap{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.Role{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
+		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Secret{}).
+		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
 		// Watch CRDs so that out-of-band deletion triggers reconcile and re-apply.
 		Watches(&apiextensionsv1.CustomResourceDefinition{},
 			handler.EnqueueRequestsFromMapFunc(crdMapFunc)).

--- a/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
+++ b/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
@@ -231,14 +231,14 @@ func (r *KonfluxImageControllerReconciler) SetupWithManager(mgr ctrl.Manager) er
 		// Use predicates to filter out unnecessary updates and prevent reconcile loops
 		// Deployments: watch spec changes AND readiness status changes
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&corev1.ConfigMap{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.Role{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
+		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Secret{}).
+		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
 		// Watch CRDs so that out-of-band deletion triggers reconcile and re-apply.
 		Watches(&apiextensionsv1.CustomResourceDefinition{},
 			handler.EnqueueRequestsFromMapFunc(crdMapFunc)).

--- a/operator/internal/controller/info/konfluxinfo_controller.go
+++ b/operator/internal/controller/info/konfluxinfo_controller.go
@@ -278,10 +278,10 @@ func (r *KonfluxInfoReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&konfluxv1alpha1.KonfluxInfo{}).
 		Named("konfluxinfo").
 		// Use predicates to filter out unnecessary updates and prevent reconcile loops
-		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.Role{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&corev1.ConfigMap{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
+		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
+		Owns(&corev1.ConfigMap{}).
 		WatchesRawSource(channelSource)
 
 	// Conditionally watch ClusterVersion only on OpenShift

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
@@ -262,14 +262,14 @@ func (r *KonfluxIntegrationServiceReconciler) SetupWithManager(mgr ctrl.Manager)
 		// Use predicates to filter out unnecessary updates and prevent reconcile loops
 		// Deployments: watch spec changes AND readiness status changes
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&corev1.ConfigMap{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.Role{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
+		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Secret{}).
+		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
 		// Watch CRDs so that out-of-band deletion triggers reconcile and re-apply.
 		Watches(&apiextensionsv1.CustomResourceDefinition{},
 			handler.EnqueueRequestsFromMapFunc(crdMapFunc)).

--- a/operator/internal/controller/internalregistry/konfluxinternalregistry_controller.go
+++ b/operator/internal/controller/internalregistry/konfluxinternalregistry_controller.go
@@ -174,7 +174,7 @@ func (r *KonfluxInternalRegistryReconciler) SetupWithManager(mgr ctrl.Manager) e
 		Named("konfluxinternalregistry").
 		// Watch for changes to registry resources
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
+		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		Complete(r)
 }

--- a/operator/internal/controller/konflux/konflux_controller.go
+++ b/operator/internal/controller/konflux/konflux_controller.go
@@ -765,7 +765,6 @@ func (r *KonfluxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch sub-CRs for status changes to aggregate conditions on the parent Konflux CR
 		// All resource management (Deployments, Services, etc.) is handled by component-specific reconcilers
 		// Watch KonfluxBuildService for any changes to copy conditions to Konflux CR
-		// No predicate needed - the For() GenerationChangedPredicate prevents self-triggering loops
 		Owns(&konfluxv1alpha1.KonfluxBuildService{}).
 		// Watch KonfluxIntegrationService for any changes to copy conditions to Konflux CR
 		Owns(&konfluxv1alpha1.KonfluxIntegrationService{}).
@@ -774,31 +773,22 @@ func (r *KonfluxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch KonfluxUI for any changes to copy conditions to Konflux CR
 		Owns(&konfluxv1alpha1.KonfluxUI{}).
 		// Watch KonfluxRBAC for any changes to copy conditions to Konflux CR
-		// No predicate needed - the For() GenerationChangedPredicate prevents self-triggering loops
 		Owns(&konfluxv1alpha1.KonfluxRBAC{}).
 		// Watch KonfluxInfo for any changes to copy conditions to Konflux CR
-		// No predicate needed - the For() GenerationChangedPredicate prevents self-triggering loops
 		Owns(&konfluxv1alpha1.KonfluxInfo{}).
 		// Watch KonfluxNamespaceLister for any changes to copy conditions to Konflux CR
-		// No predicate needed - the For() GenerationChangedPredicate prevents self-triggering loops
 		Owns(&konfluxv1alpha1.KonfluxNamespaceLister{}).
 		// Watch KonfluxEnterpriseContract for any changes to copy conditions to Konflux CR
-		// No predicate needed - the For() GenerationChangedPredicate prevents self-triggering loops
 		Owns(&konfluxv1alpha1.KonfluxEnterpriseContract{}).
 		// Watch KonfluxApplicationAPI for any changes to copy conditions to Konflux CR
-		// No predicate needed - the For() GenerationChangedPredicate prevents self-triggering loops
 		Owns(&konfluxv1alpha1.KonfluxApplicationAPI{}).
 		// Watch KonfluxImageController for any changes to copy conditions to Konflux CR
-		// No predicate needed - the For() GenerationChangedPredicate prevents self-triggering loops
 		Owns(&konfluxv1alpha1.KonfluxImageController{}).
 		// Watch KonfluxCertManager for any changes to copy conditions to Konflux CR
-		// No predicate needed - the For() GenerationChangedPredicate prevents self-triggering loops
 		Owns(&konfluxv1alpha1.KonfluxCertManager{}).
 		// Watch KonfluxInternalRegistry for any changes to copy conditions to Konflux CR
-		// No predicate needed - the For() GenerationChangedPredicate prevents self-triggering loops
 		Owns(&konfluxv1alpha1.KonfluxInternalRegistry{}).
 		// Watch KonfluxDefaultTenant for any changes to copy conditions to Konflux CR
-		// No predicate needed - the For() GenerationChangedPredicate prevents self-triggering loops
 		Owns(&konfluxv1alpha1.KonfluxDefaultTenant{}).
 		Owns(&konfluxv1alpha1.KonfluxSegmentBridge{}).
 		Complete(r)

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
@@ -212,13 +212,13 @@ func (r *KonfluxNamespaceListerReconciler) SetupWithManager(mgr ctrl.Manager) er
 		// Use predicates to filter out unnecessary updates and prevent reconcile loops
 		// Deployments: watch spec changes AND readiness status changes
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&corev1.ConfigMap{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.Role{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
+		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Secret{}).
+		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
 		Complete(r)
 }

--- a/operator/internal/controller/rbac/konfluxrbac_controller.go
+++ b/operator/internal/controller/rbac/konfluxrbac_controller.go
@@ -157,13 +157,13 @@ func (r *KonfluxRBACReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Use predicates to filter out unnecessary updates and prevent reconcile loops
 		// Deployments: watch spec changes AND readiness status changes
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&corev1.ConfigMap{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.Role{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
+		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Secret{}).
+		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
 		Complete(r)
 }

--- a/operator/internal/controller/releaseservice/konfluxreleaseservice_controller.go
+++ b/operator/internal/controller/releaseservice/konfluxreleaseservice_controller.go
@@ -214,14 +214,14 @@ func (r *KonfluxReleaseServiceReconciler) SetupWithManager(mgr ctrl.Manager) err
 		// Use predicates to filter out unnecessary updates and prevent reconcile loops
 		// Deployments: watch spec changes AND readiness status changes
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&corev1.ConfigMap{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.Role{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
+		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Secret{}).
+		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
 		// Watch CRDs so that out-of-band deletion triggers reconcile and re-apply.
 		Watches(&apiextensionsv1.CustomResourceDefinition{},
 			handler.EnqueueRequestsFromMapFunc(crdMapFunc)).

--- a/operator/internal/controller/segmentbridge/konfluxsegmentbridge_controller.go
+++ b/operator/internal/controller/segmentbridge/konfluxsegmentbridge_controller.go
@@ -217,11 +217,11 @@ func (r *KonfluxSegmentBridgeReconciler) SetupWithManager(mgr ctrl.Manager) erro
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&konfluxv1alpha1.KonfluxSegmentBridge{}).
 		Named("konfluxsegmentbridge").
-		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&corev1.ServiceAccount{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&batchv1.CronJob{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
+		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&corev1.Secret{}).
+		Owns(&batchv1.CronJob{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
 		Complete(r)
 }

--- a/operator/internal/controller/ui/konfluxui_controller.go
+++ b/operator/internal/controller/ui/konfluxui_controller.go
@@ -659,19 +659,19 @@ func (r *KonfluxUIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Use predicates to filter out unnecessary updates and prevent reconcile loops
 		// Deployments: watch spec changes AND readiness status changes
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&corev1.ConfigMap{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.LabelsOrAnnotationsChangedPredicate)).
-		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.Role{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
-		Owns(&networkingv1.Ingress{}, builder.WithPredicates(predicate.GenerationChangedPredicate)).
+		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Secret{}).
+		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
+		Owns(&networkingv1.Ingress{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		// Watch KonfluxSegmentBridge CR so Segment config changes trigger a UI reconcile
 		Watches(&konfluxv1alpha1.KonfluxSegmentBridge{},
 			handler.EnqueueRequestsFromMapFunc(r.mapSegmentBridgeToUI),
-			builder.WithPredicates(predicate.GenerationChangedPredicate)).
+			builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		Complete(r)
 }
 

--- a/operator/internal/predicate/predicate.go
+++ b/operator/internal/predicate/predicate.go
@@ -17,25 +17,43 @@ limitations under the License.
 package predicate
 
 import (
-	"reflect"
+	"maps"
 
 	appsv1 "k8s.io/api/apps/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 )
 
-// GenerationChangedPredicate filters out events where the generation hasn't changed
-// (i.e., status-only updates that shouldn't trigger reconciliation)
-var GenerationChangedPredicate = predicate.Funcs{
+// generationOrMetadataChanged returns true if the update is NOT a status-only change.
+// It detects spec changes (generation bump), ownerReference changes, and
+// label/annotation changes -- none of which are reflected in the generation
+// field alone.
+func generationOrMetadataChanged(oldObj, newObj client.Object) bool {
+	if oldObj.GetGeneration() != newObj.GetGeneration() {
+		return true
+	}
+	if !apiequality.Semantic.DeepEqual(oldObj.GetOwnerReferences(), newObj.GetOwnerReferences()) {
+		return true
+	}
+	if !maps.Equal(oldObj.GetLabels(), newObj.GetLabels()) {
+		return true
+	}
+	return !maps.Equal(oldObj.GetAnnotations(), newObj.GetAnnotations())
+}
+
+// IgnoreStatusUpdatesPredicate filters out status-only updates.
+// Reconciliation triggers on spec changes (generation bump), ownerReference
+// changes, and label/annotation changes.
+var IgnoreStatusUpdatesPredicate = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		if e.ObjectOld == nil || e.ObjectNew == nil {
 			return true
 		}
-		// Only reconcile if the generation changed (spec was modified)
-		// This filters out status-only updates
-		return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+		return generationOrMetadataChanged(e.ObjectOld, e.ObjectNew)
 	},
 	CreateFunc: func(e event.CreateEvent) bool {
 		return true
@@ -48,17 +66,15 @@ var GenerationChangedPredicate = predicate.Funcs{
 	},
 }
 
-// DeploymentReadinessPredicate triggers reconciliation when:
-// - Spec changes (generation changed)
-// - Readiness status changes (ReadyReplicas, AvailableReplicas, UnavailableReplicas)
-// This allows us to react to deployment health changes without polling
+// DeploymentReadinessPredicate extends IgnoreStatusUpdatesPredicate by also
+// triggering on deployment readiness status changes (ReadyReplicas,
+// AvailableReplicas, etc.) so we can react to health changes without polling.
 var DeploymentReadinessPredicate = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		if e.ObjectOld == nil || e.ObjectNew == nil {
 			return true
 		}
-		// Always reconcile on spec changes
-		if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+		if generationOrMetadataChanged(e.ObjectOld, e.ObjectNew) {
 			return true
 		}
 		// Check for meaningful status changes
@@ -85,41 +101,14 @@ var DeploymentReadinessPredicate = predicate.Funcs{
 	},
 }
 
-// LabelsOrAnnotationsChangedPredicate triggers reconciliation when labels or annotations change
-// Used for resources like ConfigMaps that don't have a generation field that changes on data updates
-var LabelsOrAnnotationsChangedPredicate = predicate.Funcs{
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		if e.ObjectOld == nil || e.ObjectNew == nil {
-			return true
-		}
-		// Check if generation changed
-		if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
-			return true
-		}
-		// Also check labels and annotations for resources without generation updates
-		return !reflect.DeepEqual(e.ObjectOld.GetLabels(), e.ObjectNew.GetLabels()) ||
-			!reflect.DeepEqual(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations())
-	},
-	CreateFunc: func(e event.CreateEvent) bool {
-		return true
-	},
-	DeleteFunc: func(e event.DeleteEvent) bool {
-		return true
-	},
-	GenericFunc: func(e event.GenericEvent) bool {
-		return true
-	},
-}
-
-// KonfluxUIIngressStatusChangedPredicate triggers reconciliation only when the Status.Ingress field changes in KonfluxUI CR.
-// This predicate filters out status updates that don't affect the ingress configuration.
+// KonfluxUIIngressStatusChangedPredicate extends IgnoreStatusUpdatesPredicate
+// by also triggering when the Status.Ingress field changes in KonfluxUI CR.
 var KonfluxUIIngressStatusChangedPredicate = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		if e.ObjectOld == nil || e.ObjectNew == nil {
 			return true
 		}
-		// Always reconcile on spec changes
-		if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+		if generationOrMetadataChanged(e.ObjectOld, e.ObjectNew) {
 			return true
 		}
 		// Check for ingress status changes

--- a/operator/internal/predicate/predicate_test.go
+++ b/operator/internal/predicate/predicate_test.go
@@ -20,11 +20,153 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 )
+
+var testOwnerRef = metav1.OwnerReference{
+	APIVersion: "konflux.konflux-ci.dev/v1alpha1",
+	Kind:       "KonfluxEnterpriseContract",
+	Name:       "test-owner",
+	UID:        "test-uid",
+}
+
+func TestIgnoreStatusUpdatesPredicate_UpdateFunc(t *testing.T) {
+	t.Run("nil objects should trigger reconciliation", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		e := event.UpdateEvent{}
+		g.Expect(IgnoreStatusUpdatesPredicate.UpdateFunc(e)).To(gomega.BeTrue())
+	})
+
+	tests := []struct {
+		name     string
+		old      *corev1.ConfigMap
+		new      *corev1.ConfigMap
+		expected bool
+	}{
+		{
+			name: "generation change triggers reconciliation",
+			old: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			},
+			new: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+			},
+			expected: true,
+		},
+		{
+			name: "status-only update does not trigger",
+			old: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation:      1,
+					OwnerReferences: []metav1.OwnerReference{testOwnerRef},
+					Labels:          map[string]string{"app": "test"},
+					Annotations:     map[string]string{"note": "ok"},
+				},
+			},
+			new: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation:      1,
+					OwnerReferences: []metav1.OwnerReference{testOwnerRef},
+					Labels:          map[string]string{"app": "test"},
+					Annotations:     map[string]string{"note": "ok"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "ownerReference removed triggers reconciliation",
+			old: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, OwnerReferences: []metav1.OwnerReference{testOwnerRef}},
+			},
+			new: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, OwnerReferences: []metav1.OwnerReference{}},
+			},
+			expected: true,
+		},
+		{
+			name: "ownerReference added triggers reconciliation",
+			old: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			},
+			new: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, OwnerReferences: []metav1.OwnerReference{testOwnerRef}},
+			},
+			expected: true,
+		},
+		{
+			name: "ownerReference modified triggers reconciliation",
+			old: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, OwnerReferences: []metav1.OwnerReference{testOwnerRef}},
+			},
+			new: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, OwnerReferences: []metav1.OwnerReference{
+					{APIVersion: "v1", Kind: "Other", Name: "other", UID: "other-uid"},
+				}},
+			},
+			expected: true,
+		},
+		{
+			name: "label change triggers reconciliation",
+			old: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, Labels: map[string]string{"app": "old"}},
+			},
+			new: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, Labels: map[string]string{"app": "new"}},
+			},
+			expected: true,
+		},
+		{
+			name: "annotation change triggers reconciliation",
+			old: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, Annotations: map[string]string{"note": "old"}},
+			},
+			new: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, Annotations: map[string]string{"note": "new"}},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			e := event.UpdateEvent{ObjectOld: tt.old, ObjectNew: tt.new}
+			g.Expect(IgnoreStatusUpdatesPredicate.UpdateFunc(e)).To(gomega.Equal(tt.expected))
+		})
+	}
+}
+
+func TestDeploymentReadinessPredicate_MetadataChange(t *testing.T) {
+	t.Run("ownerReference removed triggers reconciliation", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		e := event.UpdateEvent{
+			ObjectOld: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, OwnerReferences: []metav1.OwnerReference{testOwnerRef}},
+			},
+			ObjectNew: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			},
+		}
+		g.Expect(DeploymentReadinessPredicate.UpdateFunc(e)).To(gomega.BeTrue())
+	})
+	t.Run("label change triggers reconciliation", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		e := event.UpdateEvent{
+			ObjectOld: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, Labels: map[string]string{"app": "old"}},
+			},
+			ObjectNew: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, Labels: map[string]string{"app": "new"}},
+			},
+		}
+		g.Expect(DeploymentReadinessPredicate.UpdateFunc(e)).To(gomega.BeTrue())
+	})
+}
 
 func TestKonfluxUIIngressStatusChangedPredicate_UpdateFunc(t *testing.T) {
 	t.Run("nil objects should trigger reconciliation", func(t *testing.T) {
@@ -184,6 +326,30 @@ func TestKonfluxUIIngressStatusChangedPredicate_UpdateFunc(t *testing.T) {
 				},
 			},
 			expected: false,
+		},
+		{
+			name: "ownerReference removed should trigger reconciliation",
+			oldUI: &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, OwnerReferences: []metav1.OwnerReference{testOwnerRef}},
+				Status: konfluxv1alpha1.KonfluxUIStatus{
+					Ingress: &konfluxv1alpha1.IngressStatus{
+						Enabled:  true,
+						Hostname: "konflux.example.com",
+						URL:      "https://konflux.example.com",
+					},
+				},
+			},
+			newUI: &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: konfluxv1alpha1.KonfluxUIStatus{
+					Ingress: &konfluxv1alpha1.IngressStatus{
+						Enabled:  true,
+						Hostname: "konflux.example.com",
+						URL:      "https://konflux.example.com",
+					},
+				},
+			},
+			expected: true,
 		},
 	}
 


### PR DESCRIPTION
The GenerationChangedPredicate only checked .metadata.generation, which is only bumped on .spec changes. Metadata-only changes like removing an ownerReference, or modifying labels/annotations, were silently filtered out. This meant the operator could permanently lose ownership of its managed resources if someone removed the ownerReference.

Replace GenerationChangedPredicate and LabelsOrAnnotationsChangedPredicate with a unified IgnoreStatusUpdatesPredicate that triggers reconciliation on any non-status change: generation bumps, ownerReference changes, and label/annotation changes. Extract a shared specOrMetadataChanged helper used by all predicates including DeploymentReadinessPredicate and KonfluxUIIngressStatusChangedPredicate.

Remove predicates entirely from Owns() calls for resources that lack a /status subresource (ConfigMaps, Secrets, ServiceAccounts, Roles, RoleBindings, ClusterRoles, ClusterRoleBindings). These resources never produce status-only updates, so filtering is unnecessary and was preventing the operator from detecting content drift.

Assisted-By: Cursor