### PR TITLE
integrationservice: handle KonfluxUI read errors without clearing CONSOLE_URL

### DIFF
--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -127,15 +128,11 @@ func (r *KonfluxIntegrationServiceReconciler) Reconcile(ctx context.Context, req
 		FieldManager:      FieldManager,
 	})
 
-	// Fetch KonfluxUI to get console URL
-	konfluxUI := &konfluxv1alpha1.KonfluxUI{}
-	consoleURL := ""
-	if err := r.Get(ctx, types.NamespacedName{Name: ui.CRName}, konfluxUI); err != nil {
-		// Log warning but don't fail - URL might not be available yet
-		log.Info("KonfluxUI not found, console URL will not be set", "error", err)
-	} else if konfluxUI.Status.Ingress != nil && konfluxUI.Status.Ingress.URL != "" {
-		consoleURL = konfluxUI.Status.Ingress.URL
-		log.Info("Found console URL from KonfluxUI", "url", consoleURL)
+	// Fetch KonfluxUI to get console URL. Non-NotFound read errors must fail reconcile
+	// so we don't accidentally overwrite CONSOLE_URL with an empty value.
+	consoleURL, err := getConsoleURLFromKonfluxUI(ctx, r.Client)
+	if err != nil {
+		return errHandler.HandleWithReason(ctx, err, condition.ReasonSubCRStatusFailed, "get KonfluxUI status for console URL")
 	}
 
 	// Apply all embedded manifests
@@ -162,6 +159,27 @@ func (r *KonfluxIntegrationServiceReconciler) Reconcile(ctx context.Context, req
 
 	log.Info("Successfully reconciled KonfluxIntegrationService")
 	return ctrl.Result{}, nil
+}
+
+func getConsoleURLFromKonfluxUI(ctx context.Context, c client.Client) (string, error) {
+	log := logf.FromContext(ctx)
+	konfluxUI := &konfluxv1alpha1.KonfluxUI{}
+
+	if err := c.Get(ctx, types.NamespacedName{Name: ui.CRName}, konfluxUI); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("KonfluxUI not found, console URL will not be set")
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to get KonfluxUI: %w", err)
+	}
+
+	if konfluxUI.Status.Ingress != nil && konfluxUI.Status.Ingress.URL != "" {
+		consoleURL := konfluxUI.Status.Ingress.URL
+		log.Info("Found console URL from KonfluxUI", "url", consoleURL)
+		return consoleURL, nil
+	}
+
+	return "", nil
 }
 
 // applyManifests loads and applies all embedded manifests to the cluster using the tracking client.

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_consoleurl_test.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_consoleurl_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integrationservice
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/ui"
+)
+
+type failingKonfluxUIGetClient struct {
+	client.Client
+	err error
+}
+
+func (c *failingKonfluxUIGetClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*konfluxv1alpha1.KonfluxUI); ok && key.Name == ui.CRName {
+		return c.err
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func TestGetConsoleURLFromKonfluxUI(t *testing.T) {
+	t.Run("returns URL when KonfluxUI ingress is set", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		s := runtime.NewScheme()
+		err := konfluxv1alpha1.AddToScheme(s)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		konfluxUI := &konfluxv1alpha1.KonfluxUI{
+			ObjectMeta: metav1.ObjectMeta{Name: ui.CRName},
+			Status: konfluxv1alpha1.KonfluxUIStatus{
+				Ingress: &konfluxv1alpha1.IngressStatus{URL: testConsoleURL},
+			},
+		}
+
+		c := fake.NewClientBuilder().WithScheme(s).WithObjects(konfluxUI).Build()
+
+		consoleURL, err := getConsoleURLFromKonfluxUI(context.Background(), c)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(consoleURL).To(gomega.Equal(testConsoleURL))
+	})
+
+	t.Run("returns empty URL when KonfluxUI is not found", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		s := runtime.NewScheme()
+		err := konfluxv1alpha1.AddToScheme(s)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		c := fake.NewClientBuilder().WithScheme(s).Build()
+
+		consoleURL, err := getConsoleURLFromKonfluxUI(context.Background(), c)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(consoleURL).To(gomega.BeEmpty())
+	})
+
+	t.Run("returns error on non-NotFound KonfluxUI get failures", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		s := runtime.NewScheme()
+		err := konfluxv1alpha1.AddToScheme(s)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		baseClient := fake.NewClientBuilder().WithScheme(s).Build()
+		getErr := apierrors.NewForbidden(
+			schema.GroupResource{Group: "konflux.konflux-ci.dev", Resource: "konfluxuis"},
+			ui.CRName,
+			errors.New("rbac denied"),
+		)
+		c := &failingKonfluxUIGetClient{Client: baseClient, err: getErr}
+
+		consoleURL, err := getConsoleURLFromKonfluxUI(context.Background(), c)
+		g.Expect(err).To(gomega.HaveOccurred())
+		g.Expect(err.Error()).To(gomega.ContainSubstring("failed to get KonfluxUI"))
+		g.Expect(apierrors.IsForbidden(err)).To(gomega.BeTrue())
+		g.Expect(consoleURL).To(gomega.BeEmpty())
+	})
+}


### PR DESCRIPTION
## Summary
- treat only NotFound when reading the KonfluxUI singleton as optional
- return reconcile error for non-NotFound KonfluxUI read failures
- keep CONSOLE_URL stable by avoiding the degraded apply path on transient read failures
- add focused unit tests for URL present, NotFound, and non-NotFound error cases

## Why
When KonfluxUI read errors were all handled like NotFound, transient API/RBAC/transport failures could lead to an empty console URL being written into CONSOLE_URL during reconcile.

## Testing
- go test ./internal/controller/integrationservice -run TestGetConsoleURLFromKonfluxUI -count=1
- go test ./internal/controller/integrationservice -run TestBuildControllerManagerOverlay_ConsoleURL -count=1

Fixes #6295