### PR TITLE
fix(KFLUXVNGD-876): Envtest suites bypass SetupWithManager

### DIFF
--- a/operator/internal/controller/applicationapi/konfluxapplicationapi_controller_test.go
+++ b/operator/internal/controller/applicationapi/konfluxapplicationapi_controller_test.go
@@ -18,65 +18,38 @@ package applicationapi
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
 
 var _ = Describe("KonfluxApplicationAPI Controller", func() {
 	Context("When reconciling a resource", func() {
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name: CRName,
-		}
-		konfluxapplicationapi := &konfluxv1alpha1.KonfluxApplicationAPI{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxApplicationAPI")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxapplicationapi)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxApplicationAPI{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: CRName,
-					},
-					// TODO(user): Specify other spec details if needed.
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxApplicationAPI{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxApplicationAPI")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxApplicationAPIReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxApplicationAPI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxApplicationAPI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
 			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.KonfluxApplicationAPI{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+				readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/applicationapi/konfluxapplicationapi_controller_test.go
+++ b/operator/internal/controller/applicationapi/konfluxapplicationapi_controller_test.go
@@ -21,62 +21,34 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
 
 var _ = Describe("KonfluxApplicationAPI Controller", func() {
 	Context("When reconciling a resource", func() {
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name: CRName,
-		}
-		konfluxapplicationapi := &konfluxv1alpha1.KonfluxApplicationAPI{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxApplicationAPI")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxapplicationapi)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxApplicationAPI{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: CRName,
-					},
-					// TODO(user): Specify other spec details if needed.
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxApplicationAPI{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxApplicationAPI")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxApplicationAPIReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxApplicationAPI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxApplicationAPI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
 			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.KonfluxApplicationAPI{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+				readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/applicationapi/suite_test.go
+++ b/operator/internal/controller/applicationapi/suite_test.go
@@ -45,6 +45,14 @@ var _ = BeforeSuite(func() {
 	ctx = testEnv.Ctx
 	k8sClient = testEnv.K8sClient
 	objectStore = testEnv.ObjectStore
+
+	mgr := testutil.NewTestManager(testEnv)
+	Expect((&KonfluxApplicationAPIReconciler{
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ObjectStore: objectStore,
+	}).SetupWithManager(mgr)).To(Succeed())
+	testutil.StartManager(testEnv, mgr)
 })
 
 var _ = AfterSuite(func() {

--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
@@ -18,198 +18,138 @@ package buildservice
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	securityv1 "github.com/openshift/api/security/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 )
 
+const buildServiceNamespace = "build-service"
+
 var _ = Describe("KonfluxBuildService Controller", func() {
 	Context("When reconciling a resource", func() {
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      CRName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		konfluxbuildservice := &konfluxv1alpha1.KonfluxBuildService{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxBuildService")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxbuildservice)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxBuildService{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      CRName,
-						Namespace: "default",
-					},
-					Spec: konfluxv1alpha1.KonfluxBuildServiceSpec{},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxBuildService{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxBuildService")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxBuildServiceReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxBuildService{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
 			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			// Wait for the Deployment rather than Ready=True: UpdateComponentStatuses
+			// gates Ready=True on ReadyReplicas == Replicas, which never happens in
+			// envtest (no kubelet → pods never start). Deployment existence is
+			// sufficient proof that the full manifest-apply codepath completed.
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      buildControllerManagerDeploymentName,
+					Namespace: buildServiceNamespace,
+				}, &appsv1.Deployment{})).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 
 	Context("OpenShift SecurityContextConstraints", func() {
 		const sccName = "appstudio-pipelines-scc"
 
-		var (
-			ctx                  context.Context
-			buildService         *konfluxv1alpha1.KonfluxBuildService
-			reconciler           *KonfluxBuildServiceReconciler
-			openShiftClusterInfo *clusterinfo.Info
-			defaultClusterInfo   *clusterinfo.Info
-			typeNamespacedName   types.NamespacedName
-		)
+		var buildService *konfluxv1alpha1.KonfluxBuildService
 
-		sccExists := func(ctx context.Context) bool {
+		sccExists := func() bool {
 			scc := &securityv1.SecurityContextConstraints{}
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: sccName}, scc)
-			return err == nil
+			return k8sClient.Get(ctx, types.NamespacedName{Name: sccName}, scc) == nil
 		}
 
-		reconcileBuildService := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		// startManagerWithClusterInfo starts a per-test manager with the given ClusterInfo
+		// and registers a DeferCleanup to stop it when the It block finishes.
+		startManagerWithClusterInfo := func(clusterInfo *clusterinfo.Info) {
+			mgrCtx, mgrCancel := context.WithCancel(testEnv.Ctx)
+			DeferCleanup(mgrCancel)
+			mgr := testutil.NewTestManager(testEnv)
+			Expect((&KonfluxBuildServiceReconciler{
+				Client:      mgr.GetClient(),
+				Scheme:      mgr.GetScheme(),
+				ObjectStore: objectStore,
+				ClusterInfo: clusterInfo,
+			}).SetupWithManager(mgr)).To(Succeed())
+			testutil.StartManagerWithContext(mgrCtx, mgr)
 		}
 
 		BeforeEach(func() {
-			ctx = context.Background()
-			typeNamespacedName = types.NamespacedName{
-				Name:      CRName,
-				Namespace: "default",
+			buildService = &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
+			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+		})
 
-			By("cleaning up any existing SCC from previous tests")
-			existingSCC := &securityv1.SecurityContextConstraints{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: sccName,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingSCC)
+		AfterEach(func() {
+			testutil.DeleteAndWait(ctx, k8sClient, buildService)
+			testutil.DeleteAndWait(ctx, k8sClient, &securityv1.SecurityContextConstraints{
+				ObjectMeta: metav1.ObjectMeta{Name: sccName},
+			})
+		})
 
-			By("creating mock cluster info for OpenShift and non-OpenShift platforms")
-			var err error
-			openShiftClusterInfo, err = clusterinfo.DetectWithClient(&buildServiceMockDiscoveryClient{
+		It("Should create SCC when running on OpenShift", func() {
+			openShiftClusterInfo, err := clusterinfo.DetectWithClient(&buildServiceMockDiscoveryClient{
 				resources: map[string]*metav1.APIResourceList{
 					"config.openshift.io/v1": {
-						APIResources: []metav1.APIResource{
-							{Kind: "ClusterVersion"},
-						},
+						APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}},
 					},
 				},
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			defaultClusterInfo, err = clusterinfo.DetectWithClient(&buildServiceMockDiscoveryClient{
+			startManagerWithClusterInfo(openShiftClusterInfo)
+
+			By("verifying the SCC was created")
+			Eventually(sccExists).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(BeTrue())
+		})
+
+		It("Should NOT create SCC when NOT running on OpenShift", func() {
+			defaultClusterInfo, err := clusterinfo.DetectWithClient(&buildServiceMockDiscoveryClient{
 				resources:     map[string]*metav1.APIResourceList{},
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("creating the KonfluxBuildService resource")
-			buildService = &konfluxv1alpha1.KonfluxBuildService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      CRName,
-					Namespace: "default",
-				},
-				Spec: konfluxv1alpha1.KonfluxBuildServiceSpec{},
-			}
-			err = k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxBuildService{})
-			if errors.IsNotFound(err) {
-				Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
-			}
+			startManagerWithClusterInfo(defaultClusterInfo)
 
-			reconciler = &KonfluxBuildServiceReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-				ClusterInfo: nil, // Will be set in individual tests
-			}
-		})
-
-		AfterEach(func() {
-			By("cleaning up the SCC")
-			existingSCC := &securityv1.SecurityContextConstraints{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: sccName,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingSCC)
-
-			By("cleaning up KonfluxBuildService resource")
-			_ = k8sClient.Delete(ctx, buildService)
-		})
-
-		It("Should create SCC when running on OpenShift", func() {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
-
-			By("reconciling the resource")
-			reconcileBuildService(ctx)
-
-			By("verifying the SCC was created")
-			Expect(sccExists(ctx)).To(BeTrue())
-		})
-
-		It("Should NOT create SCC when NOT running on OpenShift", func() {
-			By("setting ClusterInfo to non-OpenShift")
-			reconciler.ClusterInfo = defaultClusterInfo
-
-			By("reconciling the resource")
-			reconcileBuildService(ctx)
-
-			By("verifying the SCC was NOT created")
-			Expect(sccExists(ctx)).To(BeFalse())
+			By("waiting for the controller to apply manifests and create the build-service Deployment, then verifying no SCC was created")
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      buildControllerManagerDeploymentName,
+					Namespace: buildServiceNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
+			Expect(sccExists()).To(BeFalse())
 		})
 
 		It("Should NOT create SCC when ClusterInfo is nil", func() {
-			By("keeping ClusterInfo as nil")
-			reconciler.ClusterInfo = nil
+			startManagerWithClusterInfo(nil)
 
-			By("reconciling the resource")
-			reconcileBuildService(ctx)
-
-			By("verifying the SCC was NOT created")
-			Expect(sccExists(ctx)).To(BeFalse())
+			By("waiting for the controller to apply manifests and create the build-service Deployment, then verifying no SCC was created")
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      buildControllerManagerDeploymentName,
+					Namespace: buildServiceNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
+			Expect(sccExists()).To(BeFalse())
 		})
 	})
 })

--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
@@ -22,194 +22,140 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	securityv1 "github.com/openshift/api/security/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 )
 
+const buildServiceNamespace = "build-service"
+
 var _ = Describe("KonfluxBuildService Controller", func() {
+	// startManagerWithClusterInfo starts a per-test manager with the given ClusterInfo
+	// and registers a DeferCleanup to stop it when the It block finishes.
+	// A per-test manager is used for every test (rather than a shared suite-level manager)
+	// because each test may wire the reconciler with a different ClusterInfo
+	// (e.g. OpenShift vs vanilla Kubernetes). Running a single manager for the whole
+	// suite while some tests also start their own would cause two managers to reconcile
+	// the same objects concurrently, leading to race conditions on status updates.
+	startManagerWithClusterInfo := func(clusterInfo *clusterinfo.Info) {
+		mgrCtx, mgrCancel := context.WithCancel(testEnv.Ctx)
+		DeferCleanup(mgrCancel)
+		mgr := testutil.NewTestManager(testEnv)
+		Expect((&KonfluxBuildServiceReconciler{
+			Client:      mgr.GetClient(),
+			Scheme:      mgr.GetScheme(),
+			ObjectStore: objectStore,
+			ClusterInfo: clusterInfo,
+		}).SetupWithManager(mgr)).To(Succeed())
+		testutil.StartManagerWithContext(mgrCtx, mgr)
+	}
+
 	Context("When reconciling a resource", func() {
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			startManagerWithClusterInfo(nil)
 
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      CRName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		konfluxbuildservice := &konfluxv1alpha1.KonfluxBuildService{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxBuildService")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxbuildservice)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxBuildService{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      CRName,
-						Namespace: "default",
-					},
-					Spec: konfluxv1alpha1.KonfluxBuildServiceSpec{},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxBuildService{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxBuildService")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxBuildServiceReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxBuildService{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
 			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			// Wait for the Deployment rather than Ready=True: UpdateComponentStatuses
+			// gates Ready=True on ReadyReplicas == Replicas, which never happens in
+			// envtest (no kubelet → pods never start). Deployment existence is
+			// sufficient proof that the full manifest-apply codepath completed.
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      buildControllerManagerDeploymentName,
+					Namespace: buildServiceNamespace,
+				}, &appsv1.Deployment{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 
 	Context("OpenShift SecurityContextConstraints", func() {
 		const sccName = "appstudio-pipelines-scc"
 
-		var (
-			ctx                  context.Context
-			buildService         *konfluxv1alpha1.KonfluxBuildService
-			reconciler           *KonfluxBuildServiceReconciler
-			openShiftClusterInfo *clusterinfo.Info
-			defaultClusterInfo   *clusterinfo.Info
-			typeNamespacedName   types.NamespacedName
-		)
+		var buildService *konfluxv1alpha1.KonfluxBuildService
 
-		sccExists := func(ctx context.Context) bool {
+		sccExists := func() bool {
 			scc := &securityv1.SecurityContextConstraints{}
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: sccName}, scc)
-			return err == nil
-		}
-
-		reconcileBuildService := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			return k8sClient.Get(ctx, types.NamespacedName{Name: sccName}, scc) == nil
 		}
 
 		BeforeEach(func() {
-			ctx = context.Background()
-			typeNamespacedName = types.NamespacedName{
-				Name:      CRName,
-				Namespace: "default",
+			buildService = &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
+			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+		})
 
-			By("cleaning up any existing SCC from previous tests")
-			existingSCC := &securityv1.SecurityContextConstraints{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: sccName,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingSCC)
+		AfterEach(func() {
+			testutil.DeleteAndWait(ctx, k8sClient, buildService)
+			testutil.DeleteAndWait(ctx, k8sClient, &securityv1.SecurityContextConstraints{
+				ObjectMeta: metav1.ObjectMeta{Name: sccName},
+			})
+		})
 
-			By("creating mock cluster info for OpenShift and non-OpenShift platforms")
-			var err error
-			openShiftClusterInfo, err = clusterinfo.DetectWithClient(&buildServiceMockDiscoveryClient{
+		It("Should create SCC when running on OpenShift", func() {
+			openShiftClusterInfo, err := clusterinfo.DetectWithClient(&buildServiceMockDiscoveryClient{
 				resources: map[string]*metav1.APIResourceList{
 					"config.openshift.io/v1": {
-						APIResources: []metav1.APIResource{
-							{Kind: "ClusterVersion"},
-						},
+						APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}},
 					},
 				},
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			defaultClusterInfo, err = clusterinfo.DetectWithClient(&buildServiceMockDiscoveryClient{
+			startManagerWithClusterInfo(openShiftClusterInfo)
+
+			By("verifying the SCC was created")
+			Eventually(sccExists).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(BeTrue())
+		})
+
+		It("Should NOT create SCC when NOT running on OpenShift", func() {
+			defaultClusterInfo, err := clusterinfo.DetectWithClient(&buildServiceMockDiscoveryClient{
 				resources:     map[string]*metav1.APIResourceList{},
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("creating the KonfluxBuildService resource")
-			buildService = &konfluxv1alpha1.KonfluxBuildService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      CRName,
-					Namespace: "default",
-				},
-				Spec: konfluxv1alpha1.KonfluxBuildServiceSpec{},
-			}
-			err = k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxBuildService{})
-			if errors.IsNotFound(err) {
-				Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
-			}
+			startManagerWithClusterInfo(defaultClusterInfo)
 
-			reconciler = &KonfluxBuildServiceReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-				ClusterInfo: nil, // Will be set in individual tests
-			}
-		})
-
-		AfterEach(func() {
-			By("cleaning up the SCC")
-			existingSCC := &securityv1.SecurityContextConstraints{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: sccName,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingSCC)
-
-			By("cleaning up KonfluxBuildService resource")
-			_ = k8sClient.Delete(ctx, buildService)
-		})
-
-		It("Should create SCC when running on OpenShift", func() {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
-
-			By("reconciling the resource")
-			reconcileBuildService(ctx)
-
-			By("verifying the SCC was created")
-			Expect(sccExists(ctx)).To(BeTrue())
-		})
-
-		It("Should NOT create SCC when NOT running on OpenShift", func() {
-			By("setting ClusterInfo to non-OpenShift")
-			reconciler.ClusterInfo = defaultClusterInfo
-
-			By("reconciling the resource")
-			reconcileBuildService(ctx)
-
-			By("verifying the SCC was NOT created")
-			Expect(sccExists(ctx)).To(BeFalse())
+			By("waiting for the controller to apply manifests and create the build-service Deployment, then verifying no SCC was created")
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      buildControllerManagerDeploymentName,
+					Namespace: buildServiceNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			Expect(sccExists()).To(BeFalse())
 		})
 
 		It("Should NOT create SCC when ClusterInfo is nil", func() {
-			By("keeping ClusterInfo as nil")
-			reconciler.ClusterInfo = nil
+			startManagerWithClusterInfo(nil)
 
-			By("reconciling the resource")
-			reconcileBuildService(ctx)
-
-			By("verifying the SCC was NOT created")
-			Expect(sccExists(ctx)).To(BeFalse())
+			By("waiting for the controller to apply manifests and create the build-service Deployment, then verifying no SCC was created")
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      buildControllerManagerDeploymentName,
+					Namespace: buildServiceNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			Expect(sccExists()).To(BeFalse())
 		})
 	})
 })

--- a/operator/internal/controller/buildservice/suite_test.go
+++ b/operator/internal/controller/buildservice/suite_test.go
@@ -45,6 +45,14 @@ var _ = BeforeSuite(func() {
 	ctx = testEnv.Ctx
 	k8sClient = testEnv.K8sClient
 	objectStore = testEnv.ObjectStore
+
+	mgr := testutil.NewTestManager(testEnv)
+	Expect((&KonfluxBuildServiceReconciler{
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ObjectStore: objectStore,
+	}).SetupWithManager(mgr)).To(Succeed())
+	testutil.StartManager(testEnv, mgr)
 })
 
 var _ = AfterSuite(func() {

--- a/operator/internal/controller/certmanager/konfluxcertmanager_controller_test.go
+++ b/operator/internal/controller/certmanager/konfluxcertmanager_controller_test.go
@@ -24,25 +24,24 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
 )
+
+const certManagerNamespace = "cert-manager"
 
 var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 	// "When the cert-manager namespace does not exist" runs first so the namespace
 	// has never been created by another test's BeforeEach.
 	Context("When the cert-manager namespace does not exist", func() {
-		ctx := context.Background()
-		typeNamespacedName := types.NamespacedName{Name: CRName}
-
 		It("should fail apply and report error when createClusterIssuer is enabled", func() {
 			By("creating the custom resource with createClusterIssuer enabled")
 			enabled := true
@@ -53,199 +52,78 @@ var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, resource)
+			})
 
-			reconciler := &KonfluxCertManagerReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			By("reconciling fails because the cert-manager namespace does not exist")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("cert-manager"))
-			Expect(err.Error()).To(ContainSubstring("not found"))
-
-			By("status reflects the apply failure")
-			updated := &konfluxv1alpha1.KonfluxCertManager{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
-			readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
-			Expect(readyCond).NotTo(BeNil())
-			Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
-			Expect(readyCond.Reason).To(Equal(condition.ReasonApplyFailed))
-			Expect(readyCond.Message).To(ContainSubstring("apply manifests"))
+			By("waiting for the controller to report the apply failure in status")
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.KonfluxCertManager{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+				readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(readyCond.Reason).To(Equal(condition.ReasonApplyFailed))
+				g.Expect(readyCond.Message).To(ContainSubstring("apply manifests"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 
 	Context("When reconciling a resource", func() {
-		ctx := context.Background()
+		// Simulate cert-manager being installed: the cert-manager namespace must exist
+		// before the controller can apply manifests. Run before each spec (idempotent).
+		BeforeEach(func() {
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: certManagerNamespace}}
+			Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, ns))).To(Succeed())
+		})
 
-		typeNamespacedName := types.NamespacedName{
-			Name: CRName,
+		// waitForReady is a shared helper that blocks until the CR reaches Ready=True.
+		waitForReady := func(g Gomega) {
+			updated := &konfluxv1alpha1.KonfluxCertManager{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+			readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+			g.Expect(readyCond).NotTo(BeNil())
+			g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
 		}
 
-		var reconciler *KonfluxCertManagerReconciler
-
-		BeforeEach(func() {
-			// Simulate cert-manager being installed: the cert-manager namespace must exist
-			// (the controller no longer creates it; whoever installs cert-manager creates it).
-			ns := &corev1.Namespace{}
-			ns.Name = "cert-manager"
-			getErr := k8sClient.Get(ctx, types.NamespacedName{Name: ns.Name}, ns)
-			if errors.IsNotFound(getErr) {
-				Expect(k8sClient.Create(ctx, ns)).To(Succeed())
-			} else {
-				Expect(getErr).NotTo(HaveOccurred())
-			}
-
-			// Ensure cleanup of any existing resource from previous test runs
-			resource := &konfluxv1alpha1.KonfluxCertManager{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup existing resource from previous test")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-				// Wait for the resource to be fully deleted
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxCertManager{})
-					return errors.IsNotFound(err)
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "Resource should be deleted before test starts")
-			}
-
-			reconciler = &KonfluxCertManagerReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-		})
-
-		AfterEach(func() {
-			// Cleanup the resource instance
-			resource := &konfluxv1alpha1.KonfluxCertManager{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup the specific resource instance KonfluxCertManager")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-				// Wait for the resource to be fully deleted
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxCertManager{})
-					return errors.IsNotFound(err)
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "Resource should be deleted")
-			}
-		})
-
-		It("should successfully reconcile with createClusterIssuer enabled (default)", func() {
-			By("creating the custom resource with createClusterIssuer unset (defaults to true)")
-			resource := &konfluxv1alpha1.KonfluxCertManager{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxCertManagerSpec{
-					// CreateClusterIssuer is nil, should default to true
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		Context("with createClusterIssuer unset (defaults to enabled)", func() {
+			It("should successfully reconcile the resource", func(ctx context.Context) {
+				Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxCertManager{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxCertManager{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
+				})
+				Eventually(waitForReady).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the status is ready")
-			updatedResource := &konfluxv1alpha1.KonfluxCertManager{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedResource)).To(Succeed())
-
-			// Check for Ready condition
-			conditions := updatedResource.Status.Conditions
-			Expect(conditions).NotTo(BeEmpty())
-
-			var readyCondition *metav1.Condition
-			for i := range conditions {
-				if conditions[i].Type == condition.TypeReady {
-					readyCondition = &conditions[i]
-					break
-				}
-			}
-			Expect(readyCondition).NotTo(BeNil(), "Ready condition should be present")
-			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
-			Expect(readyCondition.Message).To(ContainSubstring("Component ready"))
 		})
 
-		It("should successfully reconcile with createClusterIssuer explicitly enabled", func() {
-			By("creating the custom resource with createClusterIssuer=true")
-			enabled := true
-			resource := &konfluxv1alpha1.KonfluxCertManager{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxCertManagerSpec{
-					CreateClusterIssuer: &enabled,
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		Context("with createClusterIssuer explicitly enabled", func() {
+			It("should successfully reconcile the resource", func(ctx context.Context) {
+				enabled := true
+				Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxCertManager{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+					Spec:       konfluxv1alpha1.KonfluxCertManagerSpec{CreateClusterIssuer: &enabled},
+				})).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxCertManager{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
+				})
+				Eventually(waitForReady).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the status is ready")
-			updatedResource := &konfluxv1alpha1.KonfluxCertManager{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedResource)).To(Succeed())
-
-			conditions := updatedResource.Status.Conditions
-			Expect(conditions).NotTo(BeEmpty())
-
-			var readyCondition *metav1.Condition
-			for i := range conditions {
-				if conditions[i].Type == condition.TypeReady {
-					readyCondition = &conditions[i]
-					break
-				}
-			}
-			Expect(readyCondition).NotTo(BeNil())
-			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
 		})
 
-		It("should successfully reconcile with createClusterIssuer disabled", func() {
-			By("creating the custom resource with createClusterIssuer=false")
-			disabled := false
-			resource := &konfluxv1alpha1.KonfluxCertManager{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxCertManagerSpec{
-					CreateClusterIssuer: &disabled,
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		Context("with createClusterIssuer disabled", func() {
+			It("should successfully reconcile the resource", func(ctx context.Context) {
+				disabled := false
+				Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxCertManager{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+					Spec:       konfluxv1alpha1.KonfluxCertManagerSpec{CreateClusterIssuer: &disabled},
+				})).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxCertManager{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
+				})
+				Eventually(waitForReady).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the status is ready (no deployments to track)")
-			updatedResource := &konfluxv1alpha1.KonfluxCertManager{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedResource)).To(Succeed())
-
-			conditions := updatedResource.Status.Conditions
-			Expect(conditions).NotTo(BeEmpty())
-
-			var readyCondition *metav1.Condition
-			for i := range conditions {
-				if conditions[i].Type == condition.TypeReady {
-					readyCondition = &conditions[i]
-					break
-				}
-			}
-			Expect(readyCondition).NotTo(BeNil())
-			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
-			Expect(readyCondition.Message).To(ContainSubstring("Component ready"))
 		})
 	})
 

--- a/operator/internal/controller/certmanager/konfluxcertmanager_controller_test.go
+++ b/operator/internal/controller/certmanager/konfluxcertmanager_controller_test.go
@@ -19,30 +19,40 @@ package certmanager
 import (
 	"context"
 	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
 )
+
+const certManagerNamespace = "cert-manager"
+
+// clusterIssuerGVK is the GVK for cert-manager ClusterIssuer resources.
+var clusterIssuerGVK = schema.GroupVersionKind{Group: "cert-manager.io", Version: "v1", Kind: "ClusterIssuer"}
+
+// newClusterIssuer returns an unstructured object suitable for k8sClient.Get calls.
+func newClusterIssuer(name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(clusterIssuerGVK)
+	obj.SetName(name)
+	return obj
+}
 
 var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 	// "When the cert-manager namespace does not exist" runs first so the namespace
 	// has never been created by another test's BeforeEach.
 	Context("When the cert-manager namespace does not exist", func() {
-		ctx := context.Background()
-		typeNamespacedName := types.NamespacedName{Name: CRName}
-
 		It("should fail apply and report error when createClusterIssuer is enabled", func() {
 			By("creating the custom resource with createClusterIssuer enabled")
 			enabled := true
@@ -53,206 +63,101 @@ var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, resource)
+			})
 
-			reconciler := &KonfluxCertManagerReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			By("reconciling fails because the cert-manager namespace does not exist")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("cert-manager"))
-			Expect(err.Error()).To(ContainSubstring("not found"))
-
-			By("status reflects the apply failure")
-			updated := &konfluxv1alpha1.KonfluxCertManager{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
-			readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
-			Expect(readyCond).NotTo(BeNil())
-			Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
-			Expect(readyCond.Reason).To(Equal(condition.ReasonApplyFailed))
-			Expect(readyCond.Message).To(ContainSubstring("apply manifests"))
+			By("waiting for the controller to report the apply failure in status")
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.KonfluxCertManager{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+				readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(readyCond.Reason).To(Equal(condition.ReasonApplyFailed))
+				g.Expect(readyCond.Message).To(ContainSubstring("apply manifests"))
+				g.Expect(readyCond.Message).To(ContainSubstring("cert-manager"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 
 	Context("When reconciling a resource", func() {
-		ctx := context.Background()
+		// Simulate cert-manager being installed: the cert-manager namespace must exist
+		// before the controller can apply manifests. Run before each spec (idempotent).
+		BeforeEach(func() {
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: certManagerNamespace}}
+			Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, ns))).To(Succeed())
+		})
 
-		typeNamespacedName := types.NamespacedName{
-			Name: CRName,
+		// waitForReady is a shared helper that blocks until the CR reaches Ready=True.
+		waitForReady := func(g Gomega) {
+			updated := &konfluxv1alpha1.KonfluxCertManager{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+			readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+			g.Expect(readyCond).NotTo(BeNil())
+			g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
 		}
 
-		var reconciler *KonfluxCertManagerReconciler
-
-		BeforeEach(func() {
-			// Simulate cert-manager being installed: the cert-manager namespace must exist
-			// (the controller no longer creates it; whoever installs cert-manager creates it).
-			ns := &corev1.Namespace{}
-			ns.Name = "cert-manager"
-			getErr := k8sClient.Get(ctx, types.NamespacedName{Name: ns.Name}, ns)
-			if errors.IsNotFound(getErr) {
-				Expect(k8sClient.Create(ctx, ns)).To(Succeed())
-			} else {
-				Expect(getErr).NotTo(HaveOccurred())
-			}
-
-			// Ensure cleanup of any existing resource from previous test runs
-			resource := &konfluxv1alpha1.KonfluxCertManager{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup existing resource from previous test")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-				// Wait for the resource to be fully deleted
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxCertManager{})
-					return errors.IsNotFound(err)
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "Resource should be deleted before test starts")
-			}
-
-			reconciler = &KonfluxCertManagerReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
+		// Clean up after each spec. DeleteAndWait is a no-op when the object is already absent,
+		// so all deletions are safe to run unconditionally.
+		// ClusterIssuers are cleaned up explicitly because envtest has no GC controller, so
+		// OwnerReferences do not trigger cascading deletion.
+		AfterEach(func(ctx context.Context) {
+			testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxCertManager{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
+			testutil.DeleteAndWait(ctx, k8sClient, newClusterIssuer("self-signed-cluster-issuer"))
+			testutil.DeleteAndWait(ctx, k8sClient, newClusterIssuer("ca-issuer"))
 		})
 
-		AfterEach(func() {
-			// Cleanup the resource instance
-			resource := &konfluxv1alpha1.KonfluxCertManager{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup the specific resource instance KonfluxCertManager")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		Context("with createClusterIssuer unset (defaults to enabled)", func() {
+			It("should successfully reconcile the resource and create ClusterIssuers", func(ctx context.Context) {
+				Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxCertManager{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})).To(Succeed())
+				Eventually(waitForReady).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
-				// Wait for the resource to be fully deleted
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxCertManager{})
-					return errors.IsNotFound(err)
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "Resource should be deleted")
-			}
-		})
-
-		It("should successfully reconcile with createClusterIssuer enabled (default)", func() {
-			By("creating the custom resource with createClusterIssuer unset (defaults to true)")
-			resource := &konfluxv1alpha1.KonfluxCertManager{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxCertManagerSpec{
-					// CreateClusterIssuer is nil, should default to true
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+				By("verifying ClusterIssuers were created")
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "self-signed-cluster-issuer"}, newClusterIssuer("self-signed-cluster-issuer"))).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "ca-issuer"}, newClusterIssuer("ca-issuer"))).To(Succeed())
 			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the status is ready")
-			updatedResource := &konfluxv1alpha1.KonfluxCertManager{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedResource)).To(Succeed())
-
-			// Check for Ready condition
-			conditions := updatedResource.Status.Conditions
-			Expect(conditions).NotTo(BeEmpty())
-
-			var readyCondition *metav1.Condition
-			for i := range conditions {
-				if conditions[i].Type == condition.TypeReady {
-					readyCondition = &conditions[i]
-					break
-				}
-			}
-			Expect(readyCondition).NotTo(BeNil(), "Ready condition should be present")
-			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
-			Expect(readyCondition.Message).To(ContainSubstring("Component ready"))
 		})
 
-		It("should successfully reconcile with createClusterIssuer explicitly enabled", func() {
-			By("creating the custom resource with createClusterIssuer=true")
-			enabled := true
-			resource := &konfluxv1alpha1.KonfluxCertManager{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxCertManagerSpec{
-					CreateClusterIssuer: &enabled,
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		Context("with createClusterIssuer explicitly enabled", func() {
+			It("should successfully reconcile the resource and create ClusterIssuers", func(ctx context.Context) {
+				enabled := true
+				Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxCertManager{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+					Spec:       konfluxv1alpha1.KonfluxCertManagerSpec{CreateClusterIssuer: &enabled},
+				})).To(Succeed())
+				Eventually(waitForReady).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+				By("verifying ClusterIssuers were created")
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "self-signed-cluster-issuer"}, newClusterIssuer("self-signed-cluster-issuer"))).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "ca-issuer"}, newClusterIssuer("ca-issuer"))).To(Succeed())
 			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the status is ready")
-			updatedResource := &konfluxv1alpha1.KonfluxCertManager{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedResource)).To(Succeed())
-
-			conditions := updatedResource.Status.Conditions
-			Expect(conditions).NotTo(BeEmpty())
-
-			var readyCondition *metav1.Condition
-			for i := range conditions {
-				if conditions[i].Type == condition.TypeReady {
-					readyCondition = &conditions[i]
-					break
-				}
-			}
-			Expect(readyCondition).NotTo(BeNil())
-			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
 		})
 
-		It("should successfully reconcile with createClusterIssuer disabled", func() {
-			By("creating the custom resource with createClusterIssuer=false")
-			disabled := false
-			resource := &konfluxv1alpha1.KonfluxCertManager{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxCertManagerSpec{
-					CreateClusterIssuer: &disabled,
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		Context("with createClusterIssuer disabled", func() {
+			It("should successfully reconcile the resource and not create ClusterIssuers", func(ctx context.Context) {
+				disabled := false
+				Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxCertManager{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+					Spec:       konfluxv1alpha1.KonfluxCertManagerSpec{CreateClusterIssuer: &disabled},
+				})).To(Succeed())
+				Eventually(waitForReady).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+				By("verifying no ClusterIssuers were created")
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "self-signed-cluster-issuer"}, newClusterIssuer("self-signed-cluster-issuer"))).
+					To(MatchError(ContainSubstring("not found")))
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "ca-issuer"}, newClusterIssuer("ca-issuer"))).
+					To(MatchError(ContainSubstring("not found")))
 			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the status is ready (no deployments to track)")
-			updatedResource := &konfluxv1alpha1.KonfluxCertManager{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedResource)).To(Succeed())
-
-			conditions := updatedResource.Status.Conditions
-			Expect(conditions).NotTo(BeEmpty())
-
-			var readyCondition *metav1.Condition
-			for i := range conditions {
-				if conditions[i].Type == condition.TypeReady {
-					readyCondition = &conditions[i]
-					break
-				}
-			}
-			Expect(readyCondition).NotTo(BeNil())
-			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
-			Expect(readyCondition.Message).To(ContainSubstring("Component ready"))
 		})
 	})
 
 	Context("tracking.IsNoKindMatchError helper function", func() {
 		It("should correctly identify NoKindMatchError", func() {
 			noKindErr := &meta.NoKindMatchError{
-				GroupKind: schema.GroupKind{Group: "cert-manager.io", Kind: "ClusterIssuer"},
+				GroupKind: clusterIssuerGVK.GroupKind(),
 			}
 			Expect(tracking.IsNoKindMatchError(noKindErr)).To(BeTrue())
 

--- a/operator/internal/controller/certmanager/suite_test.go
+++ b/operator/internal/controller/certmanager/suite_test.go
@@ -45,6 +45,14 @@ var _ = BeforeSuite(func() {
 	ctx = testEnv.Ctx
 	k8sClient = testEnv.K8sClient
 	objectStore = testEnv.ObjectStore
+
+	mgr := testutil.NewTestManager(testEnv)
+	Expect((&KonfluxCertManagerReconciler{
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ObjectStore: objectStore,
+	}).SetupWithManager(mgr)).To(Succeed())
+	testutil.StartManager(testEnv, mgr)
 })
 
 var _ = AfterSuite(func() {

--- a/operator/internal/controller/cli/konfluxcli_controller_test.go
+++ b/operator/internal/controller/cli/konfluxcli_controller_test.go
@@ -18,12 +18,10 @@ package cli
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -32,102 +30,39 @@ import (
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
 
 var _ = Describe("KonfluxCLI Controller", func() {
 	Context("When reconciling a resource", func() {
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name: CRName,
-		}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxCLI")
-			resource := &konfluxv1alpha1.KonfluxCLI{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err != nil && errors.IsNotFound(err) {
-				resource = &konfluxv1alpha1.KonfluxCLI{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: CRName,
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			resource := &konfluxv1alpha1.KonfluxCLI{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup the specific resource instance KonfluxCLI")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxCLI{})
-					return errors.IsNotFound(err)
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "Resource should be deleted")
-			}
-		})
-
-		It("should successfully reconcile the resource", func() {
-			reconciler := &KonfluxCLIReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxCLI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxCLI{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 			})
-			Expect(err).NotTo(HaveOccurred())
-		})
 
-		It("should set Ready=True status after reconciliation", func() {
-			reconciler := &KonfluxCLIReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
+			// The CLI manifests contain no Deployments — only a Namespace, ConfigMaps, and
+			// RBAC resources — so Ready=True is a reliable sentinel that the full
+			// reconcile codepath ran successfully.
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.KonfluxCLI{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+				readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(readyCond.Message).To(ContainSubstring("Component ready"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the status is ready")
-			updated := &konfluxv1alpha1.KonfluxCLI{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
-
-			readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
-			Expect(readyCond).NotTo(BeNil(), "Ready condition should be present")
-			Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(readyCond.Message).To(ContainSubstring("Component ready"))
-		})
-
-		It("should create the CLI namespace and ConfigMaps", func() {
-			reconciler := &KonfluxCLIReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the konflux-cli namespace was created")
+			By("verifying the konflux-cli namespace was created")
 			ns := &corev1.Namespace{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-cli"}, ns)).To(Succeed())
 
-			By("Verifying the owner label is set on the namespace")
+			By("verifying the owner label is set on the namespace")
 			Expect(ns.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
 
-			By("Verifying the create-tenant ConfigMap was created")
+			By("verifying the create-tenant ConfigMap was created")
 			createTenantCM := &corev1.ConfigMap{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "create-tenant",
@@ -135,7 +70,7 @@ var _ = Describe("KonfluxCLI Controller", func() {
 			}, createTenantCM)).To(Succeed())
 			Expect(createTenantCM.Data).To(HaveKey("create-tenant.sh"))
 
-			By("Verifying the setup-release ConfigMap was created")
+			By("verifying the setup-release ConfigMap was created")
 			setupReleaseCM := &corev1.ConfigMap{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "setup-release",
@@ -143,15 +78,17 @@ var _ = Describe("KonfluxCLI Controller", func() {
 			}, setupReleaseCM)).To(Succeed())
 			Expect(setupReleaseCM.Data).To(HaveKey("setup-release.sh"))
 		})
-
-		It("should return no error when the CR does not exist", func() {
+		It("should return no error when the CR does not exist", func(ctx context.Context) {
+			// This is a unit-level guard: the controller must silently ignore
+			// reconcile requests for resources that no longer exist (e.g. deleted
+			// between the watch event and the actual reconcile). The manager flow
+			// cannot exercise this path directly, so we call Reconcile once with a
+			// name that was never created.
 			reconciler := &KonfluxCLIReconciler{
 				Client:      k8sClient,
 				Scheme:      k8sClient.Scheme(),
 				ObjectStore: objectStore,
 			}
-
-			By("Reconciling a non-existent resource")
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: "nonexistent"},
 			})

--- a/operator/internal/controller/cli/suite_test.go
+++ b/operator/internal/controller/cli/suite_test.go
@@ -45,6 +45,14 @@ var _ = BeforeSuite(func() {
 	ctx = testEnv.Ctx
 	k8sClient = testEnv.K8sClient
 	objectStore = testEnv.ObjectStore
+
+	mgr := testutil.NewTestManager(testEnv)
+	Expect((&KonfluxCLIReconciler{
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ObjectStore: objectStore,
+	}).SetupWithManager(mgr)).To(Succeed())
+	testutil.StartManager(testEnv, mgr)
 })
 
 var _ = AfterSuite(func() {

--- a/operator/internal/controller/defaulttenant/konfluxdefaulttenant_controller_test.go
+++ b/operator/internal/controller/defaulttenant/konfluxdefaulttenant_controller_test.go
@@ -17,181 +17,79 @@ limitations under the License.
 package defaulttenant
 
 import (
-	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
 
+const defaultTenantNamespace = "default-tenant"
+
 var _ = Describe("KonfluxDefaultTenant Controller", func() {
-	Context("When reconciling a resource", func() {
-		ctx := context.Background()
+	Context("When reconciling a resource", Ordered, func() {
+		BeforeAll(func() {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxDefaultTenant{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
 
-		typeNamespacedName := types.NamespacedName{
-			Name: CRName,
-		}
-
-		var reconciler *KonfluxDefaultTenantReconciler
-
-		BeforeEach(func() {
-			// Ensure cleanup of any existing resource from previous test runs
-			resource := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup existing resource from previous test")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-				// Wait for the resource to be fully deleted
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxDefaultTenant{})
-					return errors.IsNotFound(err)
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "Resource should be deleted before test starts")
-			}
-
-			reconciler = &KonfluxDefaultTenantReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.KonfluxDefaultTenant{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+				readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
-		AfterEach(func() {
-			// Cleanup the resource instance
-			resource := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup the specific resource instance KonfluxDefaultTenant")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-				// Wait for the resource to be fully deleted
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxDefaultTenant{})
-					return errors.IsNotFound(err)
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "Resource should be deleted")
-			}
-
-			// Cleanup created namespace
-			ns := &corev1.Namespace{}
-			if err := k8sClient.Get(ctx, types.NamespacedName{Name: "default-tenant"}, ns); err == nil {
-				Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
-			}
+		AfterAll(func() {
+			testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxDefaultTenant{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 		})
 
 		It("should successfully reconcile the resource", func() {
-			By("creating the custom resource")
-			resource := &konfluxv1alpha1.KonfluxDefaultTenant{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the status is ready")
-			updatedResource := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedResource)).To(Succeed())
-
-			// Check for Ready condition
-			conditions := updatedResource.Status.Conditions
-			Expect(conditions).NotTo(BeEmpty())
-
-			var readyCondition *metav1.Condition
-			for i := range conditions {
-				if conditions[i].Type == condition.TypeReady {
-					readyCondition = &conditions[i]
-					break
-				}
-			}
-			Expect(readyCondition).NotTo(BeNil(), "Ready condition should be present")
-			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
-			Expect(readyCondition.Message).To(ContainSubstring("Component ready"))
+			updated := &konfluxv1alpha1.KonfluxDefaultTenant{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+			readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+			Expect(readyCond).NotTo(BeNil())
+			Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
 		})
 
 		It("should create the default-tenant namespace", func() {
-			By("creating the custom resource")
-			resource := &konfluxv1alpha1.KonfluxDefaultTenant{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the default-tenant namespace was created")
 			ns := &corev1.Namespace{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: "default-tenant"}, ns)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: defaultTenantNamespace}, ns)).To(Succeed())
 			Expect(ns.Labels).To(HaveKeyWithValue("konflux-ci.dev/type", "tenant"))
 		})
 
 		It("should create the konflux-integration-runner ServiceAccount", func() {
-			By("creating the custom resource")
-			resource := &konfluxv1alpha1.KonfluxDefaultTenant{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the konflux-integration-runner ServiceAccount was created")
 			sa := &corev1.ServiceAccount{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-integration-runner", Namespace: "default-tenant"}, sa)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "konflux-integration-runner",
+				Namespace: defaultTenantNamespace,
+			}, sa)).To(Succeed())
 		})
 
 		It("should create the RoleBindings", func() {
-			By("creating the custom resource")
-			resource := &konfluxv1alpha1.KonfluxDefaultTenant{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the konflux-integration-runner RoleBinding was created")
 			rb := &rbacv1.RoleBinding{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-integration-runner", Namespace: "default-tenant"}, rb)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "konflux-integration-runner",
+				Namespace: defaultTenantNamespace,
+			}, rb)).To(Succeed())
 			Expect(rb.RoleRef.Name).To(Equal("konflux-integration-runner"))
 
-			By("Verifying the authenticated-konflux-maintainer RoleBinding was created")
 			rbAuth := &rbacv1.RoleBinding{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: "authenticated-konflux-maintainer", Namespace: "default-tenant"}, rbAuth)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "authenticated-konflux-maintainer",
+				Namespace: defaultTenantNamespace,
+			}, rbAuth)).To(Succeed())
 			Expect(rbAuth.RoleRef.Name).To(Equal("konflux-maintainer-user-actions"))
-			// Verify it grants access to all authenticated users
 			Expect(rbAuth.Subjects).To(HaveLen(1))
 			Expect(rbAuth.Subjects[0].Kind).To(Equal("Group"))
 			Expect(rbAuth.Subjects[0].Name).To(Equal("system:authenticated"))

--- a/operator/internal/controller/defaulttenant/konfluxdefaulttenant_controller_test.go
+++ b/operator/internal/controller/defaulttenant/konfluxdefaulttenant_controller_test.go
@@ -17,181 +17,77 @@ limitations under the License.
 package defaulttenant
 
 import (
-	"context"
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
 
+const defaultTenantNamespace = "default-tenant"
+
 var _ = Describe("KonfluxDefaultTenant Controller", func() {
-	Context("When reconciling a resource", func() {
-		ctx := context.Background()
+	Context("When reconciling a resource", Ordered, func() {
+		BeforeAll(func() {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxDefaultTenant{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
 
-		typeNamespacedName := types.NamespacedName{
-			Name: CRName,
-		}
-
-		var reconciler *KonfluxDefaultTenantReconciler
-
-		BeforeEach(func() {
-			// Ensure cleanup of any existing resource from previous test runs
-			resource := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup existing resource from previous test")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-				// Wait for the resource to be fully deleted
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxDefaultTenant{})
-					return errors.IsNotFound(err)
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "Resource should be deleted before test starts")
-			}
-
-			reconciler = &KonfluxDefaultTenantReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.KonfluxDefaultTenant{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+				readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
-		AfterEach(func() {
-			// Cleanup the resource instance
-			resource := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup the specific resource instance KonfluxDefaultTenant")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-				// Wait for the resource to be fully deleted
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxDefaultTenant{})
-					return errors.IsNotFound(err)
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "Resource should be deleted")
-			}
-
-			// Cleanup created namespace
-			ns := &corev1.Namespace{}
-			if err := k8sClient.Get(ctx, types.NamespacedName{Name: "default-tenant"}, ns); err == nil {
-				Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
-			}
+		AfterAll(func() {
+			testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxDefaultTenant{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 		})
 
 		It("should successfully reconcile the resource", func() {
-			By("creating the custom resource")
-			resource := &konfluxv1alpha1.KonfluxDefaultTenant{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the status is ready")
-			updatedResource := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedResource)).To(Succeed())
-
-			// Check for Ready condition
-			conditions := updatedResource.Status.Conditions
-			Expect(conditions).NotTo(BeEmpty())
-
-			var readyCondition *metav1.Condition
-			for i := range conditions {
-				if conditions[i].Type == condition.TypeReady {
-					readyCondition = &conditions[i]
-					break
-				}
-			}
-			Expect(readyCondition).NotTo(BeNil(), "Ready condition should be present")
-			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
-			Expect(readyCondition.Message).To(ContainSubstring("Component ready"))
+			updated := &konfluxv1alpha1.KonfluxDefaultTenant{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+			readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+			Expect(readyCond).NotTo(BeNil())
+			Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
 		})
 
 		It("should create the default-tenant namespace", func() {
-			By("creating the custom resource")
-			resource := &konfluxv1alpha1.KonfluxDefaultTenant{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the default-tenant namespace was created")
 			ns := &corev1.Namespace{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: "default-tenant"}, ns)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: defaultTenantNamespace}, ns)).To(Succeed())
 			Expect(ns.Labels).To(HaveKeyWithValue("konflux-ci.dev/type", "tenant"))
 		})
 
 		It("should create the konflux-integration-runner ServiceAccount", func() {
-			By("creating the custom resource")
-			resource := &konfluxv1alpha1.KonfluxDefaultTenant{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the konflux-integration-runner ServiceAccount was created")
 			sa := &corev1.ServiceAccount{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-integration-runner", Namespace: "default-tenant"}, sa)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "konflux-integration-runner",
+				Namespace: defaultTenantNamespace,
+			}, sa)).To(Succeed())
 		})
 
 		It("should create the RoleBindings", func() {
-			By("creating the custom resource")
-			resource := &konfluxv1alpha1.KonfluxDefaultTenant{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the konflux-integration-runner RoleBinding was created")
 			rb := &rbacv1.RoleBinding{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-integration-runner", Namespace: "default-tenant"}, rb)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "konflux-integration-runner",
+				Namespace: defaultTenantNamespace,
+			}, rb)).To(Succeed())
 			Expect(rb.RoleRef.Name).To(Equal("konflux-integration-runner"))
 
-			By("Verifying the authenticated-konflux-maintainer RoleBinding was created")
 			rbAuth := &rbacv1.RoleBinding{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: "authenticated-konflux-maintainer", Namespace: "default-tenant"}, rbAuth)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "authenticated-konflux-maintainer",
+				Namespace: defaultTenantNamespace,
+			}, rbAuth)).To(Succeed())
 			Expect(rbAuth.RoleRef.Name).To(Equal("konflux-maintainer-user-actions"))
-			// Verify it grants access to all authenticated users
 			Expect(rbAuth.Subjects).To(HaveLen(1))
 			Expect(rbAuth.Subjects[0].Kind).To(Equal("Group"))
 			Expect(rbAuth.Subjects[0].Name).To(Equal("system:authenticated"))

--- a/operator/internal/controller/defaulttenant/suite_test.go
+++ b/operator/internal/controller/defaulttenant/suite_test.go
@@ -45,6 +45,14 @@ var _ = BeforeSuite(func() {
 	ctx = testEnv.Ctx
 	k8sClient = testEnv.K8sClient
 	objectStore = testEnv.ObjectStore
+
+	mgr := testutil.NewTestManager(testEnv)
+	Expect((&KonfluxDefaultTenantReconciler{
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ObjectStore: objectStore,
+	}).SetupWithManager(mgr)).To(Succeed())
+	testutil.StartManager(testEnv, mgr)
 })
 
 var _ = AfterSuite(func() {

--- a/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
+++ b/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
@@ -22,67 +22,32 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
 
 var _ = Describe("KonfluxEnterpriseContract Controller", func() {
 	Context("When reconciling a resource", func() {
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxEnterpriseContract{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxEnterpriseContract{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
+			})
 
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      CRName,
-			Namespace: "default",
-		}
-		konfluxenterprisecontract := &konfluxv1alpha1.KonfluxEnterpriseContract{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxEnterpriseContract")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxenterprisecontract)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxEnterpriseContract{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      CRName,
-						Namespace: "default",
-					},
-					// TODO(user): Specify other spec details if needed.
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxEnterpriseContract{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxEnterpriseContract")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxEnterpriseContractReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			By("Waiting for reconciliation to succeed (CRD may need to establish first)")
-			Eventually(func() error {
-				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: typeNamespacedName,
-				})
-				return err
-			}).WithTimeout(15 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.KonfluxEnterpriseContract{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+				readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
+++ b/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
@@ -18,71 +18,45 @@ package enterprisecontract
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
 
 var _ = Describe("KonfluxEnterpriseContract Controller", func() {
 	Context("When reconciling a resource", func() {
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxEnterpriseContract{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxEnterpriseContract{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
+			})
 
-		ctx := context.Background()
+			// enterprise-contract manifests contain no Deployments, so Ready=True is
+			// the reliable sentinel that the full manifest-apply codepath ran.
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.KonfluxEnterpriseContract{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+				readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
-		typeNamespacedName := types.NamespacedName{
-			Name:      CRName,
-			Namespace: "default",
-		}
-		konfluxenterprisecontract := &konfluxv1alpha1.KonfluxEnterpriseContract{}
+			By("verifying the enterprise-contract namespace was created")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "enterprise-contract-service"}, &corev1.Namespace{})).To(Succeed())
 
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxEnterpriseContract")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxenterprisecontract)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxEnterpriseContract{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      CRName,
-						Namespace: "default",
-					},
-					// TODO(user): Specify other spec details if needed.
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxEnterpriseContract{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxEnterpriseContract")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxEnterpriseContractReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			By("Waiting for reconciliation to succeed (CRD may need to establish first)")
-			Eventually(func() error {
-				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: typeNamespacedName,
-				})
-				return err
-			}).WithTimeout(15 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+			By("verifying a representative ClusterRole was created")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "enterprisecontractpolicy-viewer-role"}, &rbacv1.ClusterRole{})).To(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/enterprisecontract/suite_test.go
+++ b/operator/internal/controller/enterprisecontract/suite_test.go
@@ -45,6 +45,14 @@ var _ = BeforeSuite(func() {
 	ctx = testEnv.Ctx
 	k8sClient = testEnv.K8sClient
 	objectStore = testEnv.ObjectStore
+
+	mgr := testutil.NewTestManager(testEnv)
+	Expect((&KonfluxEnterpriseContractReconciler{
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ObjectStore: objectStore,
+	}).SetupWithManager(mgr)).To(Succeed())
+	testutil.StartManager(testEnv, mgr)
 })
 
 var _ = AfterSuite(func() {

--- a/operator/internal/controller/imagecontroller/konfluximagecontroller_controller_test.go
+++ b/operator/internal/controller/imagecontroller/konfluximagecontroller_controller_test.go
@@ -18,250 +18,189 @@ package imagecontroller
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
 
+const imageControllerNamespace = "image-controller"
+
 var _ = Describe("KonfluxImageController Controller", func() {
 	Context("When reconciling a resource", func() {
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name: CRName,
-		}
-		konfluximagecontroller := &konfluxv1alpha1.KonfluxImageController{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxImageController")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluximagecontroller)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxImageController{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: CRName,
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			resource := &konfluxv1alpha1.KonfluxImageController{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxImageController")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxImageControllerReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxImageController{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxImageController{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 			})
-			Expect(err).NotTo(HaveOccurred())
+
+			// Wait for the Deployment rather than Ready=True: UpdateComponentStatuses
+			// gates Ready=True on ReadyReplicas == Replicas, which never happens in
+			// envtest (no kubelet → pods never start).
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      controllerManagerDeploymentName,
+					Namespace: imageControllerNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 
 	Context("Quay CA Bundle", func() {
-		var (
-			ctx                context.Context
-			imageController    *konfluxv1alpha1.KonfluxImageController
-			reconciler         *KonfluxImageControllerReconciler
-			typeNamespacedName types.NamespacedName
-		)
+		var imageController *konfluxv1alpha1.KonfluxImageController
 
-		reconcileImageController := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-		}
-
-		getManagerDeployment := func(ctx context.Context) *appsv1.Deployment {
-			deployment := &appsv1.Deployment{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
+		// waitForDeployment polls until the Deployment exists and returns it.
+		getDeployment := func(g Gomega) *appsv1.Deployment {
+			dep := &appsv1.Deployment{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
 				Name:      controllerManagerDeploymentName,
-				Namespace: "image-controller",
-			}, deployment)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-			return deployment
+				Namespace: imageControllerNamespace,
+			}, dep)).To(Succeed())
+			return dep
 		}
 
 		BeforeEach(func() {
-			ctx = context.Background()
-			typeNamespacedName = types.NamespacedName{
-				Name: CRName,
-			}
-
-			reconciler = &KonfluxImageControllerReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
 			imageController = &konfluxv1alpha1.KonfluxImageController{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxImageControllerSpec{},
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
+			Expect(k8sClient.Create(ctx, imageController)).To(Succeed())
 
-			err := k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxImageController{})
-			if errors.IsNotFound(err) {
-				Expect(k8sClient.Create(ctx, imageController)).To(Succeed())
-			}
+			// Same reasoning as BeforeAll above: wait for Deployment existence, not Ready=True.
+			Eventually(getDeployment).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Not(BeNil()))
 		})
 
 		AfterEach(func() {
-			_ = k8sClient.Delete(ctx, imageController)
+			testutil.DeleteAndWait(ctx, k8sClient, imageController)
 		})
 
 		It("should NOT set QUAY_ADDITIONAL_CA when QuayCABundle is not configured", func() {
-			By("reconciling without QuayCABundle")
-			reconcileImageController(ctx)
+			Eventually(func(g Gomega) {
+				dep := getDeployment(g)
+				managerContainer := testutil.FindContainer(dep.Spec.Template.Spec.Containers, managerContainerName)
+				g.Expect(managerContainer).NotTo(BeNil())
 
-			By("verifying deployment has no QUAY_ADDITIONAL_CA env var")
-			deployment := getManagerDeployment(ctx)
-			managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
-			Expect(managerContainer).NotTo(BeNil())
-
-			var envVar *string
-			for _, e := range managerContainer.Env {
-				if e.Name == quayAdditionalCAEnvVar {
-					envVar = &e.Value
-					break
+				for _, e := range managerContainer.Env {
+					g.Expect(e.Name).NotTo(Equal(quayAdditionalCAEnvVar), "QUAY_ADDITIONAL_CA should not be set")
 				}
-			}
-			Expect(envVar).To(BeNil(), "QUAY_ADDITIONAL_CA should not be set when QuayCABundle is not configured")
 
-			By("verifying quay-ca-bundle volume still exists from base manifests")
-			var caVolume bool
-			for _, v := range deployment.Spec.Template.Spec.Volumes {
-				if v.Name == quayCABundleVolumeName {
-					caVolume = true
-					Expect(v.ConfigMap).NotTo(BeNil())
-					Expect(v.ConfigMap.Name).To(Equal(defaultQuayCAConfigMapName))
-					break
+				var caVolume *corev1.Volume
+				for i := range dep.Spec.Template.Spec.Volumes {
+					if dep.Spec.Template.Spec.Volumes[i].Name == quayCABundleVolumeName {
+						caVolume = &dep.Spec.Template.Spec.Volumes[i]
+						break
+					}
 				}
-			}
-			Expect(caVolume).To(BeTrue(), "quay-ca-bundle volume should exist from base manifests")
+				g.Expect(caVolume).NotTo(BeNil(), "quay-ca-bundle volume should exist from base manifests")
+				g.Expect(caVolume.ConfigMap).NotTo(BeNil())
+				g.Expect(caVolume.ConfigMap.Name).To(Equal(defaultQuayCAConfigMapName))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("should set QUAY_ADDITIONAL_CA when QuayCABundle is configured", func() {
-			By("updating the CR with QuayCABundle spec")
-			err := k8sClient.Get(ctx, typeNamespacedName, imageController)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, imageController)).To(Succeed())
 			imageController.Spec.QuayCABundle = &konfluxv1alpha1.QuayCABundleSpec{
 				ConfigMapName: "quay-ca-bundle",
 				Key:           "quay-ca.crt",
 			}
 			Expect(k8sClient.Update(ctx, imageController)).To(Succeed())
 
-			By("reconciling the resource")
-			reconcileImageController(ctx)
-
-			By("verifying QUAY_ADDITIONAL_CA is set on the manager container")
-			deployment := getManagerDeployment(ctx)
-			managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
-			Expect(managerContainer).NotTo(BeNil())
-
-			var foundEnv bool
-			for _, e := range managerContainer.Env {
-				if e.Name == quayAdditionalCAEnvVar {
-					foundEnv = true
-					Expect(e.Value).To(Equal("/etc/ssl/certs/quay-ca/quay-ca.crt"))
-					break
+			Eventually(func(g Gomega) {
+				dep := getDeployment(g)
+				managerContainer := testutil.FindContainer(dep.Spec.Template.Spec.Containers, managerContainerName)
+				g.Expect(managerContainer).NotTo(BeNil())
+				var found bool
+				for _, e := range managerContainer.Env {
+					if e.Name == quayAdditionalCAEnvVar {
+						found = true
+						g.Expect(e.Value).To(Equal("/etc/ssl/certs/quay-ca/quay-ca.crt"))
+						break
+					}
 				}
-			}
-			Expect(foundEnv).To(BeTrue(), "QUAY_ADDITIONAL_CA should be set")
+				g.Expect(found).To(BeTrue(), "QUAY_ADDITIONAL_CA should be set")
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("should update ConfigMap volume name when custom ConfigMap is specified", func() {
-			By("creating CR with custom ConfigMap name")
-			err := k8sClient.Get(ctx, typeNamespacedName, imageController)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, imageController)).To(Succeed())
 			imageController.Spec.QuayCABundle = &konfluxv1alpha1.QuayCABundleSpec{
 				ConfigMapName: "my-custom-ca-bundle",
 				Key:           "ca.crt",
 			}
 			Expect(k8sClient.Update(ctx, imageController)).To(Succeed())
 
-			By("reconciling the resource")
-			reconcileImageController(ctx)
+			Eventually(func(g Gomega) {
+				dep := getDeployment(g)
 
-			By("verifying the ConfigMap volume name is updated")
-			deployment := getManagerDeployment(ctx)
-			var found bool
-			for _, v := range deployment.Spec.Template.Spec.Volumes {
-				if v.Name == quayCABundleVolumeName {
-					found = true
-					Expect(v.ConfigMap).NotTo(BeNil())
-					Expect(v.ConfigMap.Name).To(Equal("my-custom-ca-bundle"))
-					break
+				var caVolume *corev1.Volume
+				for i := range dep.Spec.Template.Spec.Volumes {
+					if dep.Spec.Template.Spec.Volumes[i].Name == quayCABundleVolumeName {
+						caVolume = &dep.Spec.Template.Spec.Volumes[i]
+						break
+					}
 				}
-			}
-			Expect(found).To(BeTrue(), "quay-ca-bundle volume should exist")
+				g.Expect(caVolume).NotTo(BeNil(), "quay-ca-bundle volume should exist")
+				g.Expect(caVolume.ConfigMap).NotTo(BeNil())
+				g.Expect(caVolume.ConfigMap.Name).To(Equal("my-custom-ca-bundle"))
 
-			By("verifying QUAY_ADDITIONAL_CA uses the correct key")
-			managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
-			Expect(managerContainer).NotTo(BeNil())
-			var foundEnv bool
-			for _, e := range managerContainer.Env {
-				if e.Name == quayAdditionalCAEnvVar {
-					foundEnv = true
-					Expect(e.Value).To(Equal("/etc/ssl/certs/quay-ca/ca.crt"))
-					break
+				managerContainer := testutil.FindContainer(dep.Spec.Template.Spec.Containers, managerContainerName)
+				g.Expect(managerContainer).NotTo(BeNil())
+				var found bool
+				for _, e := range managerContainer.Env {
+					if e.Name == quayAdditionalCAEnvVar {
+						found = true
+						g.Expect(e.Value).To(Equal("/etc/ssl/certs/quay-ca/ca.crt"))
+						break
+					}
 				}
-			}
-			Expect(foundEnv).To(BeTrue(), "QUAY_ADDITIONAL_CA should be set")
+				g.Expect(found).To(BeTrue(), "QUAY_ADDITIONAL_CA should be set with custom key")
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("should remove QUAY_ADDITIONAL_CA when QuayCABundle is removed", func() {
-			By("creating CR with QuayCABundle")
-			err := k8sClient.Get(ctx, typeNamespacedName, imageController)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, imageController)).To(Succeed())
 			imageController.Spec.QuayCABundle = &konfluxv1alpha1.QuayCABundleSpec{
 				ConfigMapName: "quay-ca-bundle",
 				Key:           "quay-ca.crt",
 			}
 			Expect(k8sClient.Update(ctx, imageController)).To(Succeed())
 
-			By("reconciling with QuayCABundle")
-			reconcileImageController(ctx)
+			// Wait for QUAY_ADDITIONAL_CA to appear first.
+			Eventually(func(g Gomega) {
+				dep := getDeployment(g)
+				managerContainer := testutil.FindContainer(dep.Spec.Template.Spec.Containers, managerContainerName)
+				g.Expect(managerContainer).NotTo(BeNil())
+				var found bool
+				for _, e := range managerContainer.Env {
+					if e.Name == quayAdditionalCAEnvVar {
+						found = true
+						break
+					}
+				}
+				g.Expect(found).To(BeTrue(), "QUAY_ADDITIONAL_CA should be set before removal")
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
-			By("removing QuayCABundle from the CR")
-			err = k8sClient.Get(ctx, typeNamespacedName, imageController)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, imageController)).To(Succeed())
 			imageController.Spec.QuayCABundle = nil
 			Expect(k8sClient.Update(ctx, imageController)).To(Succeed())
 
-			By("reconciling without QuayCABundle")
-			reconcileImageController(ctx)
-
-			By("verifying QUAY_ADDITIONAL_CA is no longer set")
-			deployment := getManagerDeployment(ctx)
-			managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
-			Expect(managerContainer).NotTo(BeNil())
-
-			for _, e := range managerContainer.Env {
-				Expect(e.Name).NotTo(Equal(quayAdditionalCAEnvVar),
-					"QUAY_ADDITIONAL_CA should not be present after removing QuayCABundle")
-			}
+			Eventually(func(g Gomega) {
+				dep := getDeployment(g)
+				managerContainer := testutil.FindContainer(dep.Spec.Template.Spec.Containers, managerContainerName)
+				g.Expect(managerContainer).NotTo(BeNil())
+				for _, e := range managerContainer.Env {
+					g.Expect(e.Name).NotTo(Equal(quayAdditionalCAEnvVar), "QUAY_ADDITIONAL_CA should not be present after removal")
+				}
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/imagecontroller/konfluximagecontroller_controller_test.go
+++ b/operator/internal/controller/imagecontroller/konfluximagecontroller_controller_test.go
@@ -22,246 +22,184 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
 
+const imageControllerNamespace = "image-controller"
+
 var _ = Describe("KonfluxImageController Controller", func() {
 	Context("When reconciling a resource", func() {
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name: CRName,
-		}
-		konfluximagecontroller := &konfluxv1alpha1.KonfluxImageController{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxImageController")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluximagecontroller)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxImageController{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: CRName,
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			resource := &konfluxv1alpha1.KonfluxImageController{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxImageController")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxImageControllerReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxImageController{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxImageController{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 			})
-			Expect(err).NotTo(HaveOccurred())
+
+			// Wait for the Deployment rather than Ready=True: UpdateComponentStatuses
+			// gates Ready=True on ReadyReplicas == Replicas, which never happens in
+			// envtest (no kubelet → pods never start).
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      controllerManagerDeploymentName,
+					Namespace: imageControllerNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 
 	Context("Quay CA Bundle", func() {
-		var (
-			ctx                context.Context
-			imageController    *konfluxv1alpha1.KonfluxImageController
-			reconciler         *KonfluxImageControllerReconciler
-			typeNamespacedName types.NamespacedName
-		)
+		var imageController *konfluxv1alpha1.KonfluxImageController
 
-		reconcileImageController := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-		}
-
-		getManagerDeployment := func(ctx context.Context) *appsv1.Deployment {
-			deployment := &appsv1.Deployment{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
+		// waitForDeployment polls until the Deployment exists and returns it.
+		getDeployment := func(g Gomega) *appsv1.Deployment {
+			dep := &appsv1.Deployment{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
 				Name:      controllerManagerDeploymentName,
-				Namespace: "image-controller",
-			}, deployment)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-			return deployment
+				Namespace: imageControllerNamespace,
+			}, dep)).To(Succeed())
+			return dep
 		}
 
 		BeforeEach(func() {
-			ctx = context.Background()
-			typeNamespacedName = types.NamespacedName{
-				Name: CRName,
-			}
-
-			reconciler = &KonfluxImageControllerReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
 			imageController = &konfluxv1alpha1.KonfluxImageController{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxImageControllerSpec{},
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
+			Expect(k8sClient.Create(ctx, imageController)).To(Succeed())
 
-			err := k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxImageController{})
-			if errors.IsNotFound(err) {
-				Expect(k8sClient.Create(ctx, imageController)).To(Succeed())
-			}
+			// Same reasoning as BeforeAll above: wait for Deployment existence, not Ready=True.
+			Eventually(getDeployment).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Not(BeNil()))
 		})
 
 		AfterEach(func() {
-			_ = k8sClient.Delete(ctx, imageController)
+			testutil.DeleteAndWait(ctx, k8sClient, imageController)
 		})
 
 		It("should NOT set QUAY_ADDITIONAL_CA when QuayCABundle is not configured", func() {
-			By("reconciling without QuayCABundle")
-			reconcileImageController(ctx)
+			Eventually(func(g Gomega) {
+				dep := getDeployment(g)
+				managerContainer := testutil.FindContainer(dep.Spec.Template.Spec.Containers, managerContainerName)
+				g.Expect(managerContainer).NotTo(BeNil())
 
-			By("verifying deployment has no QUAY_ADDITIONAL_CA env var")
-			deployment := getManagerDeployment(ctx)
-			managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
-			Expect(managerContainer).NotTo(BeNil())
-
-			var envVar *string
-			for _, e := range managerContainer.Env {
-				if e.Name == quayAdditionalCAEnvVar {
-					envVar = &e.Value
-					break
+				for _, e := range managerContainer.Env {
+					g.Expect(e.Name).NotTo(Equal(quayAdditionalCAEnvVar), "QUAY_ADDITIONAL_CA should not be set")
 				}
-			}
-			Expect(envVar).To(BeNil(), "QUAY_ADDITIONAL_CA should not be set when QuayCABundle is not configured")
 
-			By("verifying quay-ca-bundle volume still exists from base manifests")
-			var caVolume bool
-			for _, v := range deployment.Spec.Template.Spec.Volumes {
-				if v.Name == quayCABundleVolumeName {
-					caVolume = true
-					Expect(v.ConfigMap).NotTo(BeNil())
-					Expect(v.ConfigMap.Name).To(Equal(defaultQuayCAConfigMapName))
-					break
+				var caVolume *corev1.Volume
+				for i := range dep.Spec.Template.Spec.Volumes {
+					if dep.Spec.Template.Spec.Volumes[i].Name == quayCABundleVolumeName {
+						caVolume = &dep.Spec.Template.Spec.Volumes[i]
+						break
+					}
 				}
-			}
-			Expect(caVolume).To(BeTrue(), "quay-ca-bundle volume should exist from base manifests")
+				g.Expect(caVolume).NotTo(BeNil(), "quay-ca-bundle volume should exist from base manifests")
+				g.Expect(caVolume.ConfigMap).NotTo(BeNil())
+				g.Expect(caVolume.ConfigMap.Name).To(Equal(defaultQuayCAConfigMapName))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("should set QUAY_ADDITIONAL_CA when QuayCABundle is configured", func() {
-			By("updating the CR with QuayCABundle spec")
-			err := k8sClient.Get(ctx, typeNamespacedName, imageController)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, imageController)).To(Succeed())
 			imageController.Spec.QuayCABundle = &konfluxv1alpha1.QuayCABundleSpec{
 				ConfigMapName: "quay-ca-bundle",
 				Key:           "quay-ca.crt",
 			}
 			Expect(k8sClient.Update(ctx, imageController)).To(Succeed())
 
-			By("reconciling the resource")
-			reconcileImageController(ctx)
-
-			By("verifying QUAY_ADDITIONAL_CA is set on the manager container")
-			deployment := getManagerDeployment(ctx)
-			managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
-			Expect(managerContainer).NotTo(BeNil())
-
-			var foundEnv bool
-			for _, e := range managerContainer.Env {
-				if e.Name == quayAdditionalCAEnvVar {
-					foundEnv = true
-					Expect(e.Value).To(Equal("/etc/ssl/certs/quay-ca/quay-ca.crt"))
-					break
+			Eventually(func(g Gomega) {
+				dep := getDeployment(g)
+				managerContainer := testutil.FindContainer(dep.Spec.Template.Spec.Containers, managerContainerName)
+				g.Expect(managerContainer).NotTo(BeNil())
+				var found bool
+				for _, e := range managerContainer.Env {
+					if e.Name == quayAdditionalCAEnvVar {
+						found = true
+						g.Expect(e.Value).To(Equal("/etc/ssl/certs/quay-ca/quay-ca.crt"))
+						break
+					}
 				}
-			}
-			Expect(foundEnv).To(BeTrue(), "QUAY_ADDITIONAL_CA should be set")
+				g.Expect(found).To(BeTrue(), "QUAY_ADDITIONAL_CA should be set")
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("should update ConfigMap volume name when custom ConfigMap is specified", func() {
-			By("creating CR with custom ConfigMap name")
-			err := k8sClient.Get(ctx, typeNamespacedName, imageController)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, imageController)).To(Succeed())
 			imageController.Spec.QuayCABundle = &konfluxv1alpha1.QuayCABundleSpec{
 				ConfigMapName: "my-custom-ca-bundle",
 				Key:           "ca.crt",
 			}
 			Expect(k8sClient.Update(ctx, imageController)).To(Succeed())
 
-			By("reconciling the resource")
-			reconcileImageController(ctx)
+			Eventually(func(g Gomega) {
+				dep := getDeployment(g)
 
-			By("verifying the ConfigMap volume name is updated")
-			deployment := getManagerDeployment(ctx)
-			var found bool
-			for _, v := range deployment.Spec.Template.Spec.Volumes {
-				if v.Name == quayCABundleVolumeName {
-					found = true
-					Expect(v.ConfigMap).NotTo(BeNil())
-					Expect(v.ConfigMap.Name).To(Equal("my-custom-ca-bundle"))
-					break
+				var caVolume *corev1.Volume
+				for i := range dep.Spec.Template.Spec.Volumes {
+					if dep.Spec.Template.Spec.Volumes[i].Name == quayCABundleVolumeName {
+						caVolume = &dep.Spec.Template.Spec.Volumes[i]
+						break
+					}
 				}
-			}
-			Expect(found).To(BeTrue(), "quay-ca-bundle volume should exist")
+				g.Expect(caVolume).NotTo(BeNil(), "quay-ca-bundle volume should exist")
+				g.Expect(caVolume.ConfigMap).NotTo(BeNil())
+				g.Expect(caVolume.ConfigMap.Name).To(Equal("my-custom-ca-bundle"))
 
-			By("verifying QUAY_ADDITIONAL_CA uses the correct key")
-			managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
-			Expect(managerContainer).NotTo(BeNil())
-			var foundEnv bool
-			for _, e := range managerContainer.Env {
-				if e.Name == quayAdditionalCAEnvVar {
-					foundEnv = true
-					Expect(e.Value).To(Equal("/etc/ssl/certs/quay-ca/ca.crt"))
-					break
+				managerContainer := testutil.FindContainer(dep.Spec.Template.Spec.Containers, managerContainerName)
+				g.Expect(managerContainer).NotTo(BeNil())
+				var found bool
+				for _, e := range managerContainer.Env {
+					if e.Name == quayAdditionalCAEnvVar {
+						found = true
+						g.Expect(e.Value).To(Equal("/etc/ssl/certs/quay-ca/ca.crt"))
+						break
+					}
 				}
-			}
-			Expect(foundEnv).To(BeTrue(), "QUAY_ADDITIONAL_CA should be set")
+				g.Expect(found).To(BeTrue(), "QUAY_ADDITIONAL_CA should be set with custom key")
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("should remove QUAY_ADDITIONAL_CA when QuayCABundle is removed", func() {
-			By("creating CR with QuayCABundle")
-			err := k8sClient.Get(ctx, typeNamespacedName, imageController)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, imageController)).To(Succeed())
 			imageController.Spec.QuayCABundle = &konfluxv1alpha1.QuayCABundleSpec{
 				ConfigMapName: "quay-ca-bundle",
 				Key:           "quay-ca.crt",
 			}
 			Expect(k8sClient.Update(ctx, imageController)).To(Succeed())
 
-			By("reconciling with QuayCABundle")
-			reconcileImageController(ctx)
+			// Wait for QUAY_ADDITIONAL_CA to appear first.
+			Eventually(func(g Gomega) {
+				dep := getDeployment(g)
+				managerContainer := testutil.FindContainer(dep.Spec.Template.Spec.Containers, managerContainerName)
+				g.Expect(managerContainer).NotTo(BeNil())
+				var found bool
+				for _, e := range managerContainer.Env {
+					if e.Name == quayAdditionalCAEnvVar {
+						found = true
+						break
+					}
+				}
+				g.Expect(found).To(BeTrue(), "QUAY_ADDITIONAL_CA should be set before removal")
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
-			By("removing QuayCABundle from the CR")
-			err = k8sClient.Get(ctx, typeNamespacedName, imageController)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, imageController)).To(Succeed())
 			imageController.Spec.QuayCABundle = nil
 			Expect(k8sClient.Update(ctx, imageController)).To(Succeed())
 
-			By("reconciling without QuayCABundle")
-			reconcileImageController(ctx)
-
-			By("verifying QUAY_ADDITIONAL_CA is no longer set")
-			deployment := getManagerDeployment(ctx)
-			managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
-			Expect(managerContainer).NotTo(BeNil())
-
-			for _, e := range managerContainer.Env {
-				Expect(e.Name).NotTo(Equal(quayAdditionalCAEnvVar),
-					"QUAY_ADDITIONAL_CA should not be present after removing QuayCABundle")
-			}
+			Eventually(func(g Gomega) {
+				dep := getDeployment(g)
+				managerContainer := testutil.FindContainer(dep.Spec.Template.Spec.Containers, managerContainerName)
+				g.Expect(managerContainer).NotTo(BeNil())
+				for _, e := range managerContainer.Env {
+					g.Expect(e.Name).NotTo(Equal(quayAdditionalCAEnvVar), "QUAY_ADDITIONAL_CA should not be present after removal")
+				}
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/imagecontroller/suite_test.go
+++ b/operator/internal/controller/imagecontroller/suite_test.go
@@ -45,6 +45,14 @@ var _ = BeforeSuite(func() {
 	ctx = testEnv.Ctx
 	k8sClient = testEnv.K8sClient
 	objectStore = testEnv.ObjectStore
+
+	mgr := testutil.NewTestManager(testEnv)
+	Expect((&KonfluxImageControllerReconciler{
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ObjectStore: objectStore,
+	}).SetupWithManager(mgr)).To(Succeed())
+	testutil.StartManager(testEnv, mgr)
 })
 
 var _ = AfterSuite(func() {

--- a/operator/internal/controller/info/konfluxinfo_controller_test.go
+++ b/operator/internal/controller/info/konfluxinfo_controller_test.go
@@ -18,61 +18,36 @@ package info
 
 import (
 	"context"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
 
 var _ = Describe("KonfluxInfo Controller", func() {
 	Context("When reconciling a resource", func() {
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name: CRName,
-		}
-		konfluxinfo := &konfluxv1alpha1.KonfluxInfo{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxInfo")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxinfo)
-			if err != nil && apierrors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxInfo{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: CRName,
-					},
-					Spec: konfluxv1alpha1.KonfluxInfoSpec{},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			resource := &konfluxv1alpha1.KonfluxInfo{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup the specific resource instance KonfluxInfo")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-			}
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxInfoReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxInfo{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 			})
-			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.KonfluxInfo{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+				readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/info/konfluxinfo_controller_test.go
+++ b/operator/internal/controller/info/konfluxinfo_controller_test.go
@@ -19,60 +19,38 @@ package info
 import (
 	"context"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
 
 var _ = Describe("KonfluxInfo Controller", func() {
 	Context("When reconciling a resource", func() {
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name: CRName,
-		}
-		konfluxinfo := &konfluxv1alpha1.KonfluxInfo{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxInfo")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxinfo)
-			if err != nil && apierrors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxInfo{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: CRName,
-					},
-					Spec: konfluxv1alpha1.KonfluxInfoSpec{},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			resource := &konfluxv1alpha1.KonfluxInfo{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup the specific resource instance KonfluxInfo")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-			}
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxInfoReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxInfo{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 			})
-			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.KonfluxInfo{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+				readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the konflux-info namespace was created")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-info"}, &corev1.Namespace{})).To(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/info/suite_test.go
+++ b/operator/internal/controller/info/suite_test.go
@@ -45,6 +45,14 @@ var _ = BeforeSuite(func() {
 	ctx = testEnv.Ctx
 	k8sClient = testEnv.K8sClient
 	objectStore = testEnv.ObjectStore
+
+	mgr := testutil.NewTestManager(testEnv)
+	Expect((&KonfluxInfoReconciler{
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ObjectStore: objectStore,
+	}).SetupWithManager(mgr)).To(Succeed())
+	testutil.StartManager(testEnv, mgr)
 })
 
 var _ = AfterSuite(func() {

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_test.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_test.go
@@ -18,66 +18,40 @@ package integrationservice
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
+
+const integrationServiceNamespace = "integration-service"
 
 var _ = Describe("KonfluxIntegrationService Controller", func() {
 	Context("When reconciling a resource", func() {
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      CRName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		konfluxintegrationservice := &konfluxv1alpha1.KonfluxIntegrationService{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxIntegrationService")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxintegrationservice)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxIntegrationService{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      CRName,
-						Namespace: "default",
-					},
-					Spec: konfluxv1alpha1.KonfluxIntegrationServiceSpec{},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxIntegrationService{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxIntegrationService")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxIntegrationServiceReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxIntegrationService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxIntegrationService{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			// Wait for the Deployment rather than Ready=True: UpdateComponentStatuses
+			// gates Ready=True on ReadyReplicas == Replicas, which never happens in
+			// envtest (no kubelet → pods never start).
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "integration-service-controller-manager",
+					Namespace: integrationServiceNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_test.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_test.go
@@ -21,63 +21,36 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
+
+const integrationServiceNamespace = "integration-service"
 
 var _ = Describe("KonfluxIntegrationService Controller", func() {
 	Context("When reconciling a resource", func() {
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      CRName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		konfluxintegrationservice := &konfluxv1alpha1.KonfluxIntegrationService{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxIntegrationService")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxintegrationservice)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxIntegrationService{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      CRName,
-						Namespace: "default",
-					},
-					Spec: konfluxv1alpha1.KonfluxIntegrationServiceSpec{},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxIntegrationService{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxIntegrationService")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxIntegrationServiceReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxIntegrationService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxIntegrationService{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			// Wait for the Deployment rather than Ready=True: UpdateComponentStatuses
+			// gates Ready=True on ReadyReplicas == Replicas, which never happens in
+			// envtest (no kubelet → pods never start).
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "integration-service-controller-manager",
+					Namespace: integrationServiceNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/integrationservice/suite_test.go
+++ b/operator/internal/controller/integrationservice/suite_test.go
@@ -45,6 +45,14 @@ var _ = BeforeSuite(func() {
 	ctx = testEnv.Ctx
 	k8sClient = testEnv.K8sClient
 	objectStore = testEnv.ObjectStore
+
+	mgr := testutil.NewTestManager(testEnv)
+	Expect((&KonfluxIntegrationServiceReconciler{
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ObjectStore: objectStore,
+	}).SetupWithManager(mgr)).To(Succeed())
+	testutil.StartManager(testEnv, mgr)
 })
 
 var _ = AfterSuite(func() {

--- a/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
+++ b/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
@@ -17,139 +17,66 @@ limitations under the License.
 package internalregistry
 
 import (
-	"context"
 	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
 )
 
+const internalRegistryNamespace = "kind-registry"
+
 var _ = Describe("KonfluxInternalRegistry Controller", func() {
-	Context("When reconciling a resource", func() {
-		ctx := context.Background()
+	Context("When reconciling a resource", Ordered, func() {
+		BeforeAll(func() {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
 
-		typeNamespacedName := types.NamespacedName{
-			Name: CRName,
-		}
-
-		var reconciler *KonfluxInternalRegistryReconciler
-
-		BeforeEach(func() {
-			// Ensure cleanup of any existing resource from previous test runs
-			resource := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup existing resource from previous test")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-				// Wait for the resource to be fully deleted
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxInternalRegistry{})
-					return errors.IsNotFound(err)
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "Resource should be deleted before test starts")
-			}
-
-			reconciler = &KonfluxInternalRegistryReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
+			// Wait for Deployment existence as proof of successful reconciliation.
+			// Ready=True is not achievable in envtest (no kubelet → pods never start).
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "registry",
+					Namespace: internalRegistryNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
-		AfterEach(func() {
-			// Cleanup the resource instance
-			resource := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup the specific resource instance KonfluxInternalRegistry")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-				// Wait for the resource to be fully deleted
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxInternalRegistry{})
-					return errors.IsNotFound(err)
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "Resource should be deleted")
-			}
+		AfterAll(func() {
+			testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxInternalRegistry{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 		})
 
 		It("should successfully reconcile the resource", func() {
-			By("creating the custom resource")
-			resource := &konfluxv1alpha1.KonfluxInternalRegistry{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxInternalRegistrySpec{},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the status condition exists")
-			updatedResource := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedResource)).To(Succeed())
-
-			// Check for Ready condition - in test environment deployments may not be ready
-			// because Certificate CRD is not installed, so we just verify the condition exists
-			conditions := updatedResource.Status.Conditions
-			Expect(conditions).NotTo(BeEmpty())
-
-			var readyCondition *metav1.Condition
-			for i := range conditions {
-				if conditions[i].Type == condition.TypeReady {
-					readyCondition = &conditions[i]
-					break
-				}
-			}
-			Expect(readyCondition).NotTo(BeNil(), "Ready condition should be present")
-			// In test environment, deployment may not be ready due to missing Certificate Secret
-			// We verify reconcile completed without error, condition is set
+			updated := &konfluxv1alpha1.KonfluxInternalRegistry{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+			Expect(updated.Status.Conditions).NotTo(BeEmpty())
+			readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+			Expect(readyCond).NotTo(BeNil(), "Ready condition should be present")
 		})
 
 		It("should set ownership labels on applied resources", func() {
-			By("creating the custom resource")
-			resource := &konfluxv1alpha1.KonfluxInternalRegistry{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxInternalRegistrySpec{},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying ownership labels are set on the namespace")
 			namespace := &corev1.Namespace{}
-			Eventually(func() error {
-				return k8sClient.Get(ctx, types.NamespacedName{Name: "kind-registry"}, namespace)
-			}, 10*time.Second, 250*time.Millisecond).Should(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: internalRegistryNamespace}, namespace)).To(Succeed())
 
 			labels := namespace.GetLabels()
 			Expect(labels).NotTo(BeNil())
 			Expect(labels[constant.KonfluxOwnerLabel]).To(Equal(CRName))
 			Expect(labels[constant.KonfluxComponentLabel]).To(Equal("registry"))
 
-			By("Verifying owner reference is set on the namespace")
 			ownerRefs := namespace.GetOwnerReferences()
 			Expect(ownerRefs).NotTo(BeEmpty())
 			found := false

--- a/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
+++ b/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
@@ -17,139 +17,65 @@ limitations under the License.
 package internalregistry
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
 )
 
+const internalRegistryNamespace = "kind-registry"
+
 var _ = Describe("KonfluxInternalRegistry Controller", func() {
-	Context("When reconciling a resource", func() {
-		ctx := context.Background()
+	Context("When reconciling a resource", Ordered, func() {
+		BeforeAll(func() {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
 
-		typeNamespacedName := types.NamespacedName{
-			Name: CRName,
-		}
-
-		var reconciler *KonfluxInternalRegistryReconciler
-
-		BeforeEach(func() {
-			// Ensure cleanup of any existing resource from previous test runs
-			resource := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup existing resource from previous test")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-				// Wait for the resource to be fully deleted
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxInternalRegistry{})
-					return errors.IsNotFound(err)
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "Resource should be deleted before test starts")
-			}
-
-			reconciler = &KonfluxInternalRegistryReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
+			// Wait for Deployment existence as proof of successful reconciliation.
+			// Ready=True is not achievable in envtest (no kubelet → pods never start).
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "registry",
+					Namespace: internalRegistryNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
-		AfterEach(func() {
-			// Cleanup the resource instance
-			resource := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup the specific resource instance KonfluxInternalRegistry")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-				// Wait for the resource to be fully deleted
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, typeNamespacedName, &konfluxv1alpha1.KonfluxInternalRegistry{})
-					return errors.IsNotFound(err)
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "Resource should be deleted")
-			}
+		AfterAll(func() {
+			testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxInternalRegistry{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 		})
 
 		It("should successfully reconcile the resource", func() {
-			By("creating the custom resource")
-			resource := &konfluxv1alpha1.KonfluxInternalRegistry{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxInternalRegistrySpec{},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying the status condition exists")
-			updatedResource := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedResource)).To(Succeed())
-
-			// Check for Ready condition - in test environment deployments may not be ready
-			// because Certificate CRD is not installed, so we just verify the condition exists
-			conditions := updatedResource.Status.Conditions
-			Expect(conditions).NotTo(BeEmpty())
-
-			var readyCondition *metav1.Condition
-			for i := range conditions {
-				if conditions[i].Type == condition.TypeReady {
-					readyCondition = &conditions[i]
-					break
-				}
-			}
-			Expect(readyCondition).NotTo(BeNil(), "Ready condition should be present")
-			// In test environment, deployment may not be ready due to missing Certificate Secret
-			// We verify reconcile completed without error, condition is set
+			updated := &konfluxv1alpha1.KonfluxInternalRegistry{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+			Expect(updated.Status.Conditions).NotTo(BeEmpty())
+			readyCond := meta.FindStatusCondition(updated.Status.Conditions, condition.TypeReady)
+			Expect(readyCond).NotTo(BeNil(), "Ready condition should be present")
 		})
 
 		It("should set ownership labels on applied resources", func() {
-			By("creating the custom resource")
-			resource := &konfluxv1alpha1.KonfluxInternalRegistry{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxInternalRegistrySpec{},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Reconciling the created resource")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying ownership labels are set on the namespace")
 			namespace := &corev1.Namespace{}
-			Eventually(func() error {
-				return k8sClient.Get(ctx, types.NamespacedName{Name: "kind-registry"}, namespace)
-			}, 10*time.Second, 250*time.Millisecond).Should(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: internalRegistryNamespace}, namespace)).To(Succeed())
 
 			labels := namespace.GetLabels()
 			Expect(labels).NotTo(BeNil())
 			Expect(labels[constant.KonfluxOwnerLabel]).To(Equal(CRName))
 			Expect(labels[constant.KonfluxComponentLabel]).To(Equal("registry"))
 
-			By("Verifying owner reference is set on the namespace")
 			ownerRefs := namespace.GetOwnerReferences()
 			Expect(ownerRefs).NotTo(BeEmpty())
 			found := false

--- a/operator/internal/controller/internalregistry/suite_test.go
+++ b/operator/internal/controller/internalregistry/suite_test.go
@@ -45,6 +45,14 @@ var _ = BeforeSuite(func() {
 	ctx = testEnv.Ctx
 	k8sClient = testEnv.K8sClient
 	objectStore = testEnv.ObjectStore
+
+	mgr := testutil.NewTestManager(testEnv)
+	Expect((&KonfluxInternalRegistryReconciler{
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ObjectStore: objectStore,
+	}).SetupWithManager(mgr)).To(Succeed())
+	testutil.StartManager(testEnv, mgr)
 })
 
 var _ = AfterSuite(func() {

--- a/operator/internal/controller/konflux/konflux_controller_certmanager_test.go
+++ b/operator/internal/controller/konflux/konflux_controller_certmanager_test.go
@@ -19,293 +19,197 @@ package konflux
 import (
 	"context"
 	"errors"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 )
 
 var _ = Describe("Konflux Controller - Cert-Manager Dependency", func() {
+	// startManager creates a per-test manager with the given ClusterInfo
+	// and registers a DeferCleanup to cancel it after the test.
+	startManager := func(clusterInfo *clusterinfo.Info) {
+		mgr := testutil.NewTestManager(testEnv)
+		Expect((&KonfluxReconciler{
+			Client:      mgr.GetClient(),
+			Scheme:      mgr.GetScheme(),
+			ClusterInfo: clusterInfo,
+		}).SetupWithManager(mgr)).To(Succeed())
+		mgrCtx, cancel := context.WithCancel(testEnv.Ctx)
+		DeferCleanup(cancel)
+		testutil.StartManagerWithContext(mgrCtx, mgr)
+	}
+
 	Context("When cert-manager CRDs are not installed", func() {
-		var (
-			ctx                context.Context
-			reconciler         *KonfluxReconciler
-			fakeClient         client.Client
-			konflux            *konfluxv1alpha1.Konflux
-			typeNamespacedName types.NamespacedName
-		)
+		var clusterInfo *clusterinfo.Info
 
 		BeforeEach(func() {
-			ctx = context.Background()
-			scheme := runtime.NewScheme()
-			_ = konfluxv1alpha1.AddToScheme(scheme)
-
-			// Create a fake client WITHOUT cert-manager resources
-			fakeClient = fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithStatusSubresource(&konfluxv1alpha1.Konflux{}).
-				Build()
-
-			// Create clusterInfo without cert-manager resources
-			mockDiscoveryClient := &certManagerMockDiscoveryClient{
+			var err error
+			clusterInfo, err = clusterinfo.DetectWithClient(&certManagerMockDiscoveryClient{
 				hasCertManager: false,
-			}
-			clusterInfo, _ := clusterinfo.DetectWithClient(mockDiscoveryClient)
-
-			reconciler = &KonfluxReconciler{
-				Client:      fakeClient,
-				Scheme:      scheme,
-				ClusterInfo: clusterInfo,
-			}
-
-			konflux = &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-			}
-
-			typeNamespacedName = types.NamespacedName{
-				Name: CRName,
-			}
-
-			// Create the Konflux CR
-			Expect(fakeClient.Create(ctx, konflux)).To(Succeed())
-		})
-
-		AfterEach(func() {
-			// Cleanup
-			_ = fakeClient.Delete(ctx, konflux)
-		})
-
-		It("should set CertManagerAvailable and Ready conditions to False when cert-manager is missing", func() {
-			By("Reconciling the Konflux CR")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Fetching the updated Konflux CR")
-			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(fakeClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+			By("pre-cleaning any existing Konflux CR")
+			_ = k8sClient.Delete(ctx, &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})
+		})
 
-			By("Verifying CertManagerAvailable condition is False")
-			cond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeCertManagerAvailable)
-			Expect(cond).NotTo(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
-			Expect(cond.Reason).To(Equal(condition.ReasonCertManagerNotInstalled))
-			Expect(cond.Message).To(ContainSubstring("cert-manager CRDs are not installed"))
+		It("should set CertManagerAvailable and Ready conditions to False when cert-manager is missing", func(ctx context.Context) {
+			startManager(clusterInfo)
 
-			By("Verifying Ready condition is False")
-			readyCond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeReady)
-			Expect(readyCond).NotTo(BeNil())
-			Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
-			Expect(readyCond.Reason).To(Equal(condition.ReasonCertManagerNotInstalled))
-			Expect(readyCond.Message).To(ContainSubstring("cert-manager CRDs are not installed"))
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+
+				cond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeCertManagerAvailable)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(Equal(condition.ReasonCertManagerNotInstalled))
+				g.Expect(cond.Message).To(ContainSubstring("cert-manager CRDs are not installed"))
+
+				readyCond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(readyCond.Reason).To(Equal(condition.ReasonCertManagerNotInstalled))
+				g.Expect(readyCond.Message).To(ContainSubstring("cert-manager CRDs are not installed"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 
 	Context("When cert-manager CRDs are installed", func() {
-		var (
-			ctx                context.Context
-			reconciler         *KonfluxReconciler
-			fakeClient         client.Client
-			konflux            *konfluxv1alpha1.Konflux
-			typeNamespacedName types.NamespacedName
-		)
+		var clusterInfo *clusterinfo.Info
 
 		BeforeEach(func() {
-			ctx = context.Background()
-			scheme := runtime.NewScheme()
-			_ = konfluxv1alpha1.AddToScheme(scheme)
-
-			// Create a fake client WITH cert-manager resources
-			fakeClient = fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithStatusSubresource(&konfluxv1alpha1.Konflux{}).
-				Build()
-
-			// Create clusterInfo with cert-manager resources
-			mockDiscoveryClient := &certManagerMockDiscoveryClient{
+			var err error
+			clusterInfo, err = clusterinfo.DetectWithClient(&certManagerMockDiscoveryClient{
 				hasCertManager: true,
-			}
-			clusterInfo, _ := clusterinfo.DetectWithClient(mockDiscoveryClient)
-
-			reconciler = &KonfluxReconciler{
-				Client:      fakeClient,
-				Scheme:      scheme,
-				ClusterInfo: clusterInfo,
-			}
-
-			konflux = &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-			}
-
-			typeNamespacedName = types.NamespacedName{
-				Name: CRName,
-			}
-
-			// Create the Konflux CR
-			Expect(fakeClient.Create(ctx, konflux)).To(Succeed())
-		})
-
-		AfterEach(func() {
-			// Cleanup
-			_ = fakeClient.Delete(ctx, konflux)
-		})
-
-		It("should set CertManagerAvailable condition to True", func() {
-			By("Reconciling the Konflux CR")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Fetching the updated Konflux CR")
-			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(fakeClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
-
-			By("Verifying CertManagerAvailable condition is True")
-			cond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeCertManagerAvailable)
-			Expect(cond).NotTo(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal("CertManagerInstalled"))
-			Expect(cond.Message).To(ContainSubstring("cert-manager CRDs are installed"))
+			By("pre-cleaning any existing Konflux CR")
+			_ = k8sClient.Delete(ctx, &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})
 		})
 
-		It("should not override Ready condition when cert-manager is available", func() {
-			By("Reconciling the Konflux CR")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+		It("should set CertManagerAvailable condition to True", func(ctx context.Context) {
+			startManager(clusterInfo)
 
-			By("Fetching the updated Konflux CR")
-			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(fakeClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("Verifying Ready condition is not overridden by cert-manager check")
-			readyCond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeReady)
-			// Ready condition should be set based on sub-CR statuses, not cert-manager
-			// If cert-manager is available, it shouldn't force Ready to False
-			if readyCond != nil {
-				Expect(readyCond.Reason).NotTo(Equal(condition.ReasonCertManagerNotInstalled))
-			}
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+
+				cond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeCertManagerAvailable)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(cond.Reason).To(Equal("CertManagerInstalled"))
+				g.Expect(cond.Message).To(ContainSubstring("cert-manager CRDs are installed"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
+		})
+
+		It("should not override Ready condition when cert-manager is available", func(ctx context.Context) {
+			startManager(clusterInfo)
+
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			// Wait for CertManagerAvailable=True to confirm reconcile ran.
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+
+				cond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeCertManagerAvailable)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+
+				readyCond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)
+				if readyCond != nil {
+					g.Expect(readyCond.Reason).NotTo(Equal(condition.ReasonCertManagerNotInstalled))
+				}
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 
 	Context("When cert-manager check fails with an error", func() {
-		var (
-			ctx                context.Context
-			reconciler         *KonfluxReconciler
-			fakeClient         client.Client
-			konflux            *konfluxv1alpha1.Konflux
-			typeNamespacedName types.NamespacedName
-		)
+		var clusterInfo *clusterinfo.Info
 
 		BeforeEach(func() {
-			ctx = context.Background()
-			scheme := runtime.NewScheme()
-			_ = konfluxv1alpha1.AddToScheme(scheme)
-
-			// Create a fake client
-			fakeClient = fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithStatusSubresource(&konfluxv1alpha1.Konflux{}).
-				Build()
-
-			// Create clusterInfo that returns an error when checking cert-manager
-			// This simulates RBAC issues or network problems
-			mockDiscoveryClient := &certManagerMockDiscoveryClient{
+			var err error
+			clusterInfo, err = clusterinfo.DetectWithClient(&certManagerMockDiscoveryClient{
 				hasCertManager: false,
 				returnError:    true,
-			}
-			clusterInfo, _ := clusterinfo.DetectWithClient(mockDiscoveryClient)
-
-			reconciler = &KonfluxReconciler{
-				Client:      fakeClient,
-				Scheme:      scheme,
-				ClusterInfo: clusterInfo,
-			}
-
-			konflux = &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-			}
-
-			typeNamespacedName = types.NamespacedName{
-				Name: CRName,
-			}
-
-			// Create the Konflux CR
-			Expect(fakeClient.Create(ctx, konflux)).To(Succeed())
-		})
-
-		AfterEach(func() {
-			// Cleanup
-			_ = fakeClient.Delete(ctx, konflux)
-		})
-
-		It("should continue reconciliation and set CertManagerAvailable to Unknown", func() {
-			By("Reconciling the Konflux CR")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			// Reconciliation should continue even if cert-manager check fails
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Fetching the updated Konflux CR")
-			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(fakeClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
-
-			By("Verifying that CertManagerAvailable condition is set to Unknown")
-			cond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeCertManagerAvailable)
-			Expect(cond).NotTo(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
-			Expect(cond.Reason).To(Equal(condition.ReasonCertManagerInstallationCheckFailed))
-			Expect(cond.Message).To(ContainSubstring("simulated RBAC or network error"))
-		})
-
-		It("should allow Ready to be True when CertManagerAvailable is Unknown", func() {
-			By("Reconciling the Konflux CR")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Fetching the updated Konflux CR")
-			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(fakeClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+			By("pre-cleaning any existing Konflux CR")
+			_ = k8sClient.Delete(ctx, &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})
+		})
 
-			By("Verifying CertManagerAvailable is Unknown")
-			certManagerCond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeCertManagerAvailable)
-			Expect(certManagerCond).NotTo(BeNil())
-			Expect(certManagerCond.Status).To(Equal(metav1.ConditionUnknown))
+		It("should continue reconciliation and set CertManagerAvailable to Unknown", func(ctx context.Context) {
+			startManager(clusterInfo)
 
-			By("Verifying Ready condition is not overridden by Unknown CertManagerAvailable")
-			// Ready should be based on sub-CR statuses, not blocked by Unknown cert-manager status
-			readyCond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeReady)
-			// Ready condition should exist (set by SetAggregatedReadyCondition)
-			// It should NOT be False with CertManagerNotInstalled reason since cert-manager is Unknown, not False
-			if readyCond != nil {
-				Expect(readyCond.Reason).NotTo(Equal(condition.ReasonCertManagerNotInstalled))
-			}
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+
+				cond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeCertManagerAvailable)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+				g.Expect(cond.Reason).To(Equal(condition.ReasonCertManagerInstallationCheckFailed))
+				g.Expect(cond.Message).To(ContainSubstring("simulated RBAC or network error"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
+		})
+
+		It("should allow Ready to be True when CertManagerAvailable is Unknown", func(ctx context.Context) {
+			startManager(clusterInfo)
+
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			// Wait for CertManagerAvailable=Unknown to confirm reconcile ran.
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+
+				certManagerCond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeCertManagerAvailable)
+				g.Expect(certManagerCond).NotTo(BeNil())
+				g.Expect(certManagerCond.Status).To(Equal(metav1.ConditionUnknown))
+
+				readyCond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)
+				if readyCond != nil {
+					g.Expect(readyCond.Reason).NotTo(Equal(condition.ReasonCertManagerNotInstalled))
+				}
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/konflux/konflux_controller_certmanager_test.go
+++ b/operator/internal/controller/konflux/konflux_controller_certmanager_test.go
@@ -25,287 +25,193 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 )
 
 var _ = Describe("Konflux Controller - Cert-Manager Dependency", func() {
+	// startManager creates a per-test manager with the given ClusterInfo
+	// and registers a DeferCleanup to cancel it after the test.
+	// A per-test manager is required because each test wires the reconciler with a different
+	// ClusterInfo (e.g. cert-manager present vs absent), and a shared suite-level manager
+	// cannot be re-configured between tests.
+	startManager := func(clusterInfo *clusterinfo.Info) {
+		mgr := testutil.NewTestManager(testEnv)
+		Expect((&KonfluxReconciler{
+			Client:      mgr.GetClient(),
+			Scheme:      mgr.GetScheme(),
+			ClusterInfo: clusterInfo,
+		}).SetupWithManager(mgr)).To(Succeed())
+		mgrCtx, cancel := context.WithCancel(testEnv.Ctx)
+		DeferCleanup(cancel)
+		testutil.StartManagerWithContext(mgrCtx, mgr)
+	}
+
 	Context("When cert-manager CRDs are not installed", func() {
-		var (
-			ctx                context.Context
-			reconciler         *KonfluxReconciler
-			fakeClient         client.Client
-			konflux            *konfluxv1alpha1.Konflux
-			typeNamespacedName types.NamespacedName
-		)
+		var clusterInfo *clusterinfo.Info
 
 		BeforeEach(func() {
-			ctx = context.Background()
-			scheme := runtime.NewScheme()
-			_ = konfluxv1alpha1.AddToScheme(scheme)
-
-			// Create a fake client WITHOUT cert-manager resources
-			fakeClient = fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithStatusSubresource(&konfluxv1alpha1.Konflux{}).
-				Build()
-
-			// Create clusterInfo without cert-manager resources
-			mockDiscoveryClient := &certManagerMockDiscoveryClient{
+			var err error
+			clusterInfo, err = clusterinfo.DetectWithClient(&certManagerMockDiscoveryClient{
 				hasCertManager: false,
-			}
-			clusterInfo, _ := clusterinfo.DetectWithClient(mockDiscoveryClient)
-
-			reconciler = &KonfluxReconciler{
-				Client:      fakeClient,
-				Scheme:      scheme,
-				ClusterInfo: clusterInfo,
-			}
-
-			konflux = &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-			}
-
-			typeNamespacedName = types.NamespacedName{
-				Name: CRName,
-			}
-
-			// Create the Konflux CR
-			Expect(fakeClient.Create(ctx, konflux)).To(Succeed())
-		})
-
-		AfterEach(func() {
-			// Cleanup
-			_ = fakeClient.Delete(ctx, konflux)
-		})
-
-		It("should set CertManagerAvailable and Ready conditions to False when cert-manager is missing", func() {
-			By("Reconciling the Konflux CR")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Fetching the updated Konflux CR")
-			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(fakeClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+			By("pre-cleaning any existing Konflux CR")
+			testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})
+		})
 
-			By("Verifying CertManagerAvailable condition is False")
-			cond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeCertManagerAvailable)
-			Expect(cond).NotTo(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
-			Expect(cond.Reason).To(Equal(condition.ReasonCertManagerNotInstalled))
-			Expect(cond.Message).To(ContainSubstring("cert-manager CRDs are not installed"))
+		It("should set CertManagerAvailable and Ready conditions to False when cert-manager is missing", func(ctx context.Context) {
+			startManager(clusterInfo)
 
-			By("Verifying Ready condition is False")
-			readyCond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeReady)
-			Expect(readyCond).NotTo(BeNil())
-			Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
-			Expect(readyCond.Reason).To(Equal(condition.ReasonCertManagerNotInstalled))
-			Expect(readyCond.Message).To(ContainSubstring("cert-manager CRDs are not installed"))
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+
+				cond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeCertManagerAvailable)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(Equal(condition.ReasonCertManagerNotInstalled))
+				g.Expect(cond.Message).To(ContainSubstring("cert-manager CRDs are not installed"))
+
+				readyCond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(readyCond.Reason).To(Equal(condition.ReasonCertManagerNotInstalled))
+				g.Expect(readyCond.Message).To(ContainSubstring("cert-manager CRDs are not installed"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 
 	Context("When cert-manager CRDs are installed", func() {
-		var (
-			ctx                context.Context
-			reconciler         *KonfluxReconciler
-			fakeClient         client.Client
-			konflux            *konfluxv1alpha1.Konflux
-			typeNamespacedName types.NamespacedName
-		)
+		var clusterInfo *clusterinfo.Info
 
 		BeforeEach(func() {
-			ctx = context.Background()
-			scheme := runtime.NewScheme()
-			_ = konfluxv1alpha1.AddToScheme(scheme)
-
-			// Create a fake client WITH cert-manager resources
-			fakeClient = fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithStatusSubresource(&konfluxv1alpha1.Konflux{}).
-				Build()
-
-			// Create clusterInfo with cert-manager resources
-			mockDiscoveryClient := &certManagerMockDiscoveryClient{
+			var err error
+			clusterInfo, err = clusterinfo.DetectWithClient(&certManagerMockDiscoveryClient{
 				hasCertManager: true,
-			}
-			clusterInfo, _ := clusterinfo.DetectWithClient(mockDiscoveryClient)
-
-			reconciler = &KonfluxReconciler{
-				Client:      fakeClient,
-				Scheme:      scheme,
-				ClusterInfo: clusterInfo,
-			}
-
-			konflux = &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-			}
-
-			typeNamespacedName = types.NamespacedName{
-				Name: CRName,
-			}
-
-			// Create the Konflux CR
-			Expect(fakeClient.Create(ctx, konflux)).To(Succeed())
-		})
-
-		AfterEach(func() {
-			// Cleanup
-			_ = fakeClient.Delete(ctx, konflux)
-		})
-
-		It("should set CertManagerAvailable condition to True", func() {
-			By("Reconciling the Konflux CR")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Fetching the updated Konflux CR")
-			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(fakeClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
-
-			By("Verifying CertManagerAvailable condition is True")
-			cond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeCertManagerAvailable)
-			Expect(cond).NotTo(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal("CertManagerInstalled"))
-			Expect(cond.Message).To(ContainSubstring("cert-manager CRDs are installed"))
+			By("pre-cleaning any existing Konflux CR")
+			testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})
 		})
 
-		It("should not override Ready condition when cert-manager is available", func() {
-			By("Reconciling the Konflux CR")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+		It("should set CertManagerAvailable condition to True", func(ctx context.Context) {
+			startManager(clusterInfo)
 
-			By("Fetching the updated Konflux CR")
-			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(fakeClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("Verifying Ready condition is not overridden by cert-manager check")
-			readyCond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeReady)
-			// Ready condition should be set based on sub-CR statuses, not cert-manager
-			// If cert-manager is available, it shouldn't force Ready to False
-			if readyCond != nil {
-				Expect(readyCond.Reason).NotTo(Equal(condition.ReasonCertManagerNotInstalled))
-			}
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+
+				cond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeCertManagerAvailable)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(cond.Reason).To(Equal("CertManagerInstalled"))
+				g.Expect(cond.Message).To(ContainSubstring("cert-manager CRDs are installed"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("should not override Ready condition when cert-manager is available", func(ctx context.Context) {
+			startManager(clusterInfo)
+
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			// Wait for CertManagerAvailable=True to confirm reconcile ran.
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+
+				cond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeCertManagerAvailable)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+
+				readyCond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)
+				if readyCond != nil {
+					g.Expect(readyCond.Reason).NotTo(Equal(condition.ReasonCertManagerNotInstalled))
+				}
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 
 	Context("When cert-manager check fails with an error", func() {
-		var (
-			ctx                context.Context
-			reconciler         *KonfluxReconciler
-			fakeClient         client.Client
-			konflux            *konfluxv1alpha1.Konflux
-			typeNamespacedName types.NamespacedName
-		)
+		var clusterInfo *clusterinfo.Info
 
 		BeforeEach(func() {
-			ctx = context.Background()
-			scheme := runtime.NewScheme()
-			_ = konfluxv1alpha1.AddToScheme(scheme)
-
-			// Create a fake client
-			fakeClient = fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithStatusSubresource(&konfluxv1alpha1.Konflux{}).
-				Build()
-
-			// Create clusterInfo that returns an error when checking cert-manager
-			// This simulates RBAC issues or network problems
-			mockDiscoveryClient := &certManagerMockDiscoveryClient{
+			var err error
+			clusterInfo, err = clusterinfo.DetectWithClient(&certManagerMockDiscoveryClient{
 				hasCertManager: false,
 				returnError:    true,
-			}
-			clusterInfo, _ := clusterinfo.DetectWithClient(mockDiscoveryClient)
-
-			reconciler = &KonfluxReconciler{
-				Client:      fakeClient,
-				Scheme:      scheme,
-				ClusterInfo: clusterInfo,
-			}
-
-			konflux = &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-			}
-
-			typeNamespacedName = types.NamespacedName{
-				Name: CRName,
-			}
-
-			// Create the Konflux CR
-			Expect(fakeClient.Create(ctx, konflux)).To(Succeed())
-		})
-
-		AfterEach(func() {
-			// Cleanup
-			_ = fakeClient.Delete(ctx, konflux)
-		})
-
-		It("should continue reconciliation and set CertManagerAvailable to Unknown", func() {
-			By("Reconciling the Konflux CR")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			// Reconciliation should continue even if cert-manager check fails
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Fetching the updated Konflux CR")
-			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(fakeClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
-
-			By("Verifying that CertManagerAvailable condition is set to Unknown")
-			cond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeCertManagerAvailable)
-			Expect(cond).NotTo(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
-			Expect(cond.Reason).To(Equal(condition.ReasonCertManagerInstallationCheckFailed))
-			Expect(cond.Message).To(ContainSubstring("simulated RBAC or network error"))
-		})
-
-		It("should allow Ready to be True when CertManagerAvailable is Unknown", func() {
-			By("Reconciling the Konflux CR")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Fetching the updated Konflux CR")
-			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(fakeClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+			By("pre-cleaning any existing Konflux CR")
+			testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})
+		})
 
-			By("Verifying CertManagerAvailable is Unknown")
-			certManagerCond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeCertManagerAvailable)
-			Expect(certManagerCond).NotTo(BeNil())
-			Expect(certManagerCond.Status).To(Equal(metav1.ConditionUnknown))
+		It("should continue reconciliation and set CertManagerAvailable to Unknown", func(ctx context.Context) {
+			startManager(clusterInfo)
 
-			By("Verifying Ready condition is not overridden by Unknown CertManagerAvailable")
-			// Ready should be based on sub-CR statuses, not blocked by Unknown cert-manager status
-			readyCond := apimeta.FindStatusCondition(updatedKonflux.GetConditions(), constant.ConditionTypeReady)
-			// Ready condition should exist (set by SetAggregatedReadyCondition)
-			// It should NOT be False with CertManagerNotInstalled reason since cert-manager is Unknown, not False
-			if readyCond != nil {
-				Expect(readyCond.Reason).NotTo(Equal(condition.ReasonCertManagerNotInstalled))
-			}
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+
+				cond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeCertManagerAvailable)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+				g.Expect(cond.Reason).To(Equal(condition.ReasonCertManagerInstallationCheckFailed))
+				g.Expect(cond.Message).To(ContainSubstring("simulated RBAC or network error"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("should allow Ready to be True when CertManagerAvailable is Unknown", func(ctx context.Context) {
+			startManager(clusterInfo)
+
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			// Wait for CertManagerAvailable=Unknown to confirm reconcile ran.
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+
+				certManagerCond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeCertManagerAvailable)
+				g.Expect(certManagerCond).NotTo(BeNil())
+				g.Expect(certManagerCond.Status).To(Equal(metav1.ConditionUnknown))
+
+				readyCond := apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)
+				if readyCond != nil {
+					g.Expect(readyCond.Reason).NotTo(Equal(condition.ReasonCertManagerNotInstalled))
+				}
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/konflux/konflux_controller_test.go
+++ b/operator/internal/controller/konflux/konflux_controller_test.go
@@ -18,122 +18,115 @@ package konflux
 
 import (
 	"context"
-	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/applicationapi"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/buildservice"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/certmanager"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/defaulttenant"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/enterprisecontract"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/imagecontroller"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/info"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/integrationservice"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/internalregistry"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/namespacelister"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/rbac"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/releaseservice"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/segmentbridge"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
+	uictrl "github.com/konflux-ci/konflux-ci/operator/internal/controller/ui"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 )
 
 var _ = Describe("Konflux Controller", func() {
+	// startManager creates a per-test manager with the given ClusterInfo
+	// and registers a DeferCleanup to cancel it after the test.
+	startManager := func(clusterInfo *clusterinfo.Info) {
+		mgr := testutil.NewTestManager(testEnv)
+		Expect((&KonfluxReconciler{
+			Client:      mgr.GetClient(),
+			Scheme:      mgr.GetScheme(),
+			ClusterInfo: clusterInfo,
+		}).SetupWithManager(mgr)).To(Succeed())
+		mgrCtx, cancel := context.WithCancel(testEnv.Ctx)
+		DeferCleanup(cancel)
+		testutil.StartManagerWithContext(mgrCtx, mgr)
+	}
+
 	Context("When reconciling a resource", func() {
-		const resourceName = "konflux"
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
 
-		ctx := context.Background()
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-		typeNamespacedName := types.NamespacedName{
-			Name: resourceName,
-		}
-		konflux := &konfluxv1alpha1.Konflux{}
+			// The Ready condition is written only after the reconciler completes all apply/get/status steps
+			// without an early error return. Its presence (regardless of True/False) is therefore a reliable
+			// sentinel that the entire reconcile loop ran to completion. Ready=True is not expected here
+			// because the sub-controllers are not running in this test, so sub-CRs have no conditions yet.
+			//
+			// We also assert that every always-on sub-CR was created. This catches the case where both
+			// an applyKonflux* call and its corresponding Get are removed together — the Ready condition
+			// would still be set, but the sub-CR existence check would fail.
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+				g.Expect(apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)).NotTo(BeNil())
 
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind Konflux")
-			err := k8sClient.Get(ctx, typeNamespacedName, konflux)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.Konflux{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: resourceName,
-					},
-					// TODO(user): Specify other spec details if needed.
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
+				// Verify all always-on sub-CRs were created.
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: applicationapi.CRName}, &konfluxv1alpha1.KonfluxApplicationAPI{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: buildservice.CRName}, &konfluxv1alpha1.KonfluxBuildService{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: integrationservice.CRName}, &konfluxv1alpha1.KonfluxIntegrationService{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: releaseservice.CRName}, &konfluxv1alpha1.KonfluxReleaseService{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: uictrl.CRName}, &konfluxv1alpha1.KonfluxUI{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: rbac.CRName}, &konfluxv1alpha1.KonfluxRBAC{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: info.CRName}, &konfluxv1alpha1.KonfluxInfo{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespacelister.CRName}, &konfluxv1alpha1.KonfluxNamespaceLister{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: enterprisecontract.CRName}, &konfluxv1alpha1.KonfluxEnterpriseContract{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: certmanager.CRName}, &konfluxv1alpha1.KonfluxCertManager{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: defaulttenant.CRName}, &konfluxv1alpha1.KonfluxDefaultTenant{})).To(Succeed())
 
-		AfterEach(func() {
-			resource := &konfluxv1alpha1.Konflux{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup the specific resource instance Konflux")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-			}
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			clusterInfo := createTestClusterInfo()
-			controllerReconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+				// Verify optional sub-CRs are NOT created (disabled by default in empty spec).
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: imagecontroller.CRName}, &konfluxv1alpha1.KonfluxImageController{})).To(MatchError(ContainSubstring("not found")))
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: internalregistry.CRName}, &konfluxv1alpha1.KonfluxInternalRegistry{})).To(MatchError(ContainSubstring("not found")))
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, &konfluxv1alpha1.KonfluxSegmentBridge{})).To(MatchError(ContainSubstring("not found")))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 
 	Context("Konflux Name Validation (CEL)", func() {
 		const requiredKonfluxName = "konflux"
 
-		AfterEach(func(ctx context.Context) {
-			// Clean up any Konflux instances created during tests
-			konfluxList := &konfluxv1alpha1.KonfluxList{}
-			if err := k8sClient.List(ctx, konfluxList); err == nil {
-				for _, item := range konfluxList.Items {
-					if err := k8sClient.Delete(ctx, &item); err != nil && !errors.IsNotFound(err) {
-						_, _ = fmt.Fprintf(
-							GinkgoWriter,
-							"Failed to delete Konflux %q: %v\n",
-							item.GetName(),
-							err,
-						)
-					}
-				}
-			}
-		})
-
 		It("Should allow creation with the required name 'konflux'", func(ctx context.Context) {
 			By("creating a Konflux instance with the required name")
 			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: requiredKonfluxName,
-				},
-				Spec: konfluxv1alpha1.KonfluxSpec{},
+				ObjectMeta: metav1.ObjectMeta{Name: requiredKonfluxName},
 			}
-			err := k8sClient.Create(ctx, konflux)
-			Expect(err).NotTo(HaveOccurred(), "Creation with required name should be allowed")
+			Expect(k8sClient.Create(ctx, konflux)).To(Succeed(), "Creation with required name should be allowed")
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, konflux)
 
 			By("verifying the instance was created")
 			created := &konfluxv1alpha1.Konflux{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: requiredKonfluxName}, created)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: requiredKonfluxName}, created)).To(Succeed())
 			Expect(created.GetName()).To(Equal(requiredKonfluxName))
 		})
 
 		It("Should deny creation with a different name", func(ctx context.Context) {
 			By("attempting to create a Konflux instance with a different name")
 			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-konflux",
-				},
-				Spec: konfluxv1alpha1.KonfluxSpec{},
+				ObjectMeta: metav1.ObjectMeta{Name: "my-konflux"},
 			}
 			err := k8sClient.Create(ctx, konflux)
 			Expect(err).To(HaveOccurred(), "Creation with different name should be rejected")
@@ -143,615 +136,385 @@ var _ = Describe("Konflux Controller", func() {
 		It("Should allow updates to the instance with the required name", func(ctx context.Context) {
 			By("creating a Konflux instance with the required name")
 			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: requiredKonfluxName,
-				},
-				Spec: konfluxv1alpha1.KonfluxSpec{},
+				ObjectMeta: metav1.ObjectMeta{Name: requiredKonfluxName},
 			}
-			err := k8sClient.Create(ctx, konflux)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create Konflux instance")
+			Expect(k8sClient.Create(ctx, konflux)).To(Succeed(), "Failed to create Konflux instance")
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, konflux)
 
 			By("updating the instance")
-			// Get the latest version
 			updated := &konfluxv1alpha1.Konflux{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: requiredKonfluxName}, updated)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Add a label
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: requiredKonfluxName}, updated)).To(Succeed())
 			if updated.Labels == nil {
 				updated.Labels = make(map[string]string)
 			}
 			updated.Labels["test"] = "value"
-			err = k8sClient.Update(ctx, updated)
-			Expect(err).NotTo(HaveOccurred(), "Updates should be allowed")
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed(), "Updates should be allowed")
 		})
 	})
 
 	Context("InternalRegistry conditional enablement", func() {
 		const resourceName = "konflux"
-		ctx := context.Background()
 
-		typeNamespacedName := types.NamespacedName{
-			Name: resourceName,
-		}
-		registryTypeNamespacedName := types.NamespacedName{
-			Name: internalregistry.CRName,
-		}
+		It("should not create InternalRegistry CR when internalRegistry is omitted", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
 
-		AfterEach(func() {
-			// Cleanup Konflux CR
-			resource := &konfluxv1alpha1.Konflux{}
-			if err := k8sClient.Get(ctx, typeNamespacedName, resource); err == nil {
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-			}
-
-			// Cleanup InternalRegistry CR if it exists
-			registry := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			if err := k8sClient.Get(ctx, registryTypeNamespacedName, registry); err == nil {
-				Expect(k8sClient.Delete(ctx, registry)).To(Succeed())
-			}
-		})
-
-		It("should not create InternalRegistry CR when internalRegistry is omitted", func() {
 			By("creating Konflux CR without internalRegistry config")
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
-				Spec: konfluxv1alpha1.KonfluxSpec{
-					// internalRegistry is omitted (nil)
-				},
-			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: resourceName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for reconcile to complete")
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updated)).To(Succeed())
+				g.Expect(apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)).NotTo(BeNil())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
 			By("verifying InternalRegistry CR was not created")
 			registry := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			err = k8sClient.Get(ctx, registryTypeNamespacedName, registry)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: internalregistry.CRName}, registry)
 			Expect(errors.IsNotFound(err)).To(BeTrue(), "InternalRegistry CR should not exist when omitted")
 		})
 
-		It("should not create InternalRegistry CR when enabled is false", func() {
+		It("should not create InternalRegistry CR when enabled is false", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with internalRegistry.enabled=false")
 			disabled := false
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					InternalRegistry: &konfluxv1alpha1.InternalRegistryConfig{
-						Enabled: &disabled,
-					},
+					InternalRegistry: &konfluxv1alpha1.InternalRegistryConfig{Enabled: &disabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for reconcile to complete")
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updated)).To(Succeed())
+				g.Expect(apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)).NotTo(BeNil())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
 			By("verifying InternalRegistry CR was not created")
 			registry := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			err = k8sClient.Get(ctx, registryTypeNamespacedName, registry)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: internalregistry.CRName}, registry)
 			Expect(errors.IsNotFound(err)).To(BeTrue(), "InternalRegistry CR should not exist when enabled=false")
 		})
 
-		It("should create InternalRegistry CR when enabled is true", func() {
+		It("should create InternalRegistry CR when enabled is true", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with internalRegistry.enabled=true")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					InternalRegistry: &konfluxv1alpha1.InternalRegistryConfig{
-						Enabled: &enabled,
-					},
+					InternalRegistry: &konfluxv1alpha1.InternalRegistryConfig{Enabled: &enabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
-
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient,
+				&konfluxv1alpha1.KonfluxInternalRegistry{ObjectMeta: metav1.ObjectMeta{Name: internalregistry.CRName}})
 
 			By("verifying InternalRegistry CR was created")
 			registry := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			err = k8sClient.Get(ctx, registryTypeNamespacedName, registry)
-			Expect(err).NotTo(HaveOccurred(), "InternalRegistry CR should exist when enabled=true")
-			Expect(registry.Name).To(Equal(internalregistry.CRName))
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: internalregistry.CRName}, registry)).To(Succeed())
+				g.Expect(registry.Name).To(Equal(internalregistry.CRName))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
-		It("should delete InternalRegistry CR when enabled changes from true to false", func() {
+		It("should delete InternalRegistry CR when enabled changes from true to false", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with internalRegistry.enabled=true")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					InternalRegistry: &konfluxv1alpha1.InternalRegistryConfig{
-						Enabled: &enabled,
-					},
+					InternalRegistry: &konfluxv1alpha1.InternalRegistryConfig{Enabled: &enabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling to create the InternalRegistry CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("verifying InternalRegistry CR was created")
-			registry := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			err = k8sClient.Get(ctx, registryTypeNamespacedName, registry)
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for InternalRegistry CR to be created")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: internalregistry.CRName},
+					&konfluxv1alpha1.KonfluxInternalRegistry{})).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
 			By("updating Konflux CR to set enabled=false")
 			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updatedKonflux)).To(Succeed())
 			disabled := false
-			updatedKonflux.Spec.InternalRegistry = &konfluxv1alpha1.InternalRegistryConfig{
-				Enabled: &disabled,
-			}
+			updatedKonflux.Spec.InternalRegistry = &konfluxv1alpha1.InternalRegistryConfig{Enabled: &disabled}
 			Expect(k8sClient.Update(ctx, updatedKonflux)).To(Succeed())
 
-			By("reconciling again after disabling")
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("verifying InternalRegistry CR was deleted")
-			err = k8sClient.Get(ctx, registryTypeNamespacedName, registry)
-			Expect(errors.IsNotFound(err)).To(BeTrue(), "InternalRegistry CR should be deleted when enabled changes to false")
+			By("waiting for InternalRegistry CR to be deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: internalregistry.CRName},
+					&konfluxv1alpha1.KonfluxInternalRegistry{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "InternalRegistry CR should be deleted when enabled changes to false")
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 
 	Context("DefaultTenant conditional enablement", func() {
 		const resourceName = "konflux"
-		ctx := context.Background()
 
-		typeNamespacedName := types.NamespacedName{
-			Name: resourceName,
-		}
-		defaultTenantTypeNamespacedName := types.NamespacedName{
-			Name: defaulttenant.CRName,
-		}
+		It("should create DefaultTenant CR when defaultTenant is omitted (enabled by default)", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
 
-		AfterEach(func() {
-			// Cleanup Konflux CR
-			resource := &konfluxv1alpha1.Konflux{}
-			if err := k8sClient.Get(ctx, typeNamespacedName, resource); err == nil {
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-			}
-
-			// Cleanup DefaultTenant CR if it exists
-			tenant := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			if err := k8sClient.Get(ctx, defaultTenantTypeNamespacedName, tenant); err == nil {
-				Expect(k8sClient.Delete(ctx, tenant)).To(Succeed())
-			}
-		})
-
-		It("should create DefaultTenant CR when defaultTenant is omitted (enabled by default)", func() {
 			By("creating Konflux CR without defaultTenant config")
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
-				Spec: konfluxv1alpha1.KonfluxSpec{
-					// defaultTenant is omitted (nil) - should default to enabled
-				},
-			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
-
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: resourceName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient,
+				&konfluxv1alpha1.KonfluxDefaultTenant{ObjectMeta: metav1.ObjectMeta{Name: defaulttenant.CRName}})
 
 			By("verifying DefaultTenant CR was created (enabled by default)")
 			tenant := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			err = k8sClient.Get(ctx, defaultTenantTypeNamespacedName, tenant)
-			Expect(err).NotTo(HaveOccurred(), "DefaultTenant CR should exist when omitted (enabled by default)")
-			Expect(tenant.Name).To(Equal(defaulttenant.CRName))
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: defaulttenant.CRName}, tenant)).To(Succeed())
+				g.Expect(tenant.Name).To(Equal(defaulttenant.CRName))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
-		It("should create DefaultTenant CR when enabled is explicitly true", func() {
+		It("should create DefaultTenant CR when enabled is explicitly true", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with defaultTenant.enabled=true")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					DefaultTenant: &konfluxv1alpha1.DefaultTenantConfig{
-						Enabled: &enabled,
-					},
+					DefaultTenant: &konfluxv1alpha1.DefaultTenantConfig{Enabled: &enabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
-
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient,
+				&konfluxv1alpha1.KonfluxDefaultTenant{ObjectMeta: metav1.ObjectMeta{Name: defaulttenant.CRName}})
 
 			By("verifying DefaultTenant CR was created")
-			tenant := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			err = k8sClient.Get(ctx, defaultTenantTypeNamespacedName, tenant)
-			Expect(err).NotTo(HaveOccurred(), "DefaultTenant CR should exist when enabled=true")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: defaulttenant.CRName},
+					&konfluxv1alpha1.KonfluxDefaultTenant{})).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
-		It("should not create DefaultTenant CR when enabled is false", func() {
+		It("should not create DefaultTenant CR when enabled is false", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with defaultTenant.enabled=false")
 			disabled := false
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					DefaultTenant: &konfluxv1alpha1.DefaultTenantConfig{
-						Enabled: &disabled,
-					},
+					DefaultTenant: &konfluxv1alpha1.DefaultTenantConfig{Enabled: &disabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for reconcile to complete")
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updated)).To(Succeed())
+				g.Expect(apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)).NotTo(BeNil())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
 			By("verifying DefaultTenant CR was not created")
 			tenant := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			err = k8sClient.Get(ctx, defaultTenantTypeNamespacedName, tenant)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: defaulttenant.CRName}, tenant)
 			Expect(errors.IsNotFound(err)).To(BeTrue(), "DefaultTenant CR should not exist when enabled=false")
 		})
 
-		It("should delete DefaultTenant CR when enabled changes from true to false", func() {
+		It("should delete DefaultTenant CR when enabled changes from true to false", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with defaultTenant.enabled=true")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					DefaultTenant: &konfluxv1alpha1.DefaultTenantConfig{
-						Enabled: &enabled,
-					},
+					DefaultTenant: &konfluxv1alpha1.DefaultTenantConfig{Enabled: &enabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling to create the DefaultTenant CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("verifying DefaultTenant CR was created")
-			tenant := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			err = k8sClient.Get(ctx, defaultTenantTypeNamespacedName, tenant)
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for DefaultTenant CR to be created")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: defaulttenant.CRName},
+					&konfluxv1alpha1.KonfluxDefaultTenant{})).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
 			By("updating Konflux CR to set enabled=false")
 			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updatedKonflux)).To(Succeed())
 			disabled := false
-			updatedKonflux.Spec.DefaultTenant = &konfluxv1alpha1.DefaultTenantConfig{
-				Enabled: &disabled,
-			}
+			updatedKonflux.Spec.DefaultTenant = &konfluxv1alpha1.DefaultTenantConfig{Enabled: &disabled}
 			Expect(k8sClient.Update(ctx, updatedKonflux)).To(Succeed())
 
-			By("reconciling again after disabling")
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("verifying DefaultTenant CR was deleted")
-			err = k8sClient.Get(ctx, defaultTenantTypeNamespacedName, tenant)
-			Expect(errors.IsNotFound(err)).To(BeTrue(), "DefaultTenant CR should be deleted when enabled changes to false")
+			By("waiting for DefaultTenant CR to be deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: defaulttenant.CRName},
+					&konfluxv1alpha1.KonfluxDefaultTenant{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "DefaultTenant CR should be deleted when enabled changes to false")
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 
 	Context("SegmentBridge conditional enablement", func() {
 		const resourceName = "konflux"
-		ctx := context.Background()
 
-		typeNamespacedName := types.NamespacedName{
-			Name: resourceName,
-		}
-		segmentBridgeTypeNamespacedName := types.NamespacedName{
-			Name: segmentbridge.CRName,
-		}
+		It("should not create SegmentBridge CR when telemetry is omitted", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
 
-		AfterEach(func() {
-			resource := &konfluxv1alpha1.Konflux{}
-			if err := k8sClient.Get(ctx, typeNamespacedName, resource); err == nil {
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-			}
-
-			sb := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			if err := k8sClient.Get(ctx, segmentBridgeTypeNamespacedName, sb); err == nil {
-				Expect(k8sClient.Delete(ctx, sb)).To(Succeed())
-			}
-		})
-
-		It("should not create SegmentBridge CR when telemetry is omitted", func() {
 			By("creating Konflux CR without telemetry config")
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
-				Spec: konfluxv1alpha1.KonfluxSpec{},
-			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: resourceName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for reconcile to complete")
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updated)).To(Succeed())
+				g.Expect(apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)).NotTo(BeNil())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
 			By("verifying SegmentBridge CR was not created")
 			sb := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			err = k8sClient.Get(ctx, segmentBridgeTypeNamespacedName, sb)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, sb)
 			Expect(errors.IsNotFound(err)).To(BeTrue(), "SegmentBridge CR should not exist when telemetry is omitted")
 		})
 
-		It("should not create SegmentBridge CR when telemetry.enabled is false", func() {
+		It("should not create SegmentBridge CR when telemetry.enabled is false", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with telemetry.enabled=false")
 			disabled := false
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					Telemetry: &konfluxv1alpha1.TelemetryConfig{
-						Enabled: &disabled,
-					},
+					Telemetry: &konfluxv1alpha1.TelemetryConfig{Enabled: &disabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for reconcile to complete")
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updated)).To(Succeed())
+				g.Expect(apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)).NotTo(BeNil())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
 			By("verifying SegmentBridge CR was not created")
 			sb := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			err = k8sClient.Get(ctx, segmentBridgeTypeNamespacedName, sb)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, sb)
 			Expect(errors.IsNotFound(err)).To(BeTrue(), "SegmentBridge CR should not exist when telemetry.enabled=false")
 		})
 
-		It("should create SegmentBridge CR when telemetry.enabled is true", func() {
+		It("should create SegmentBridge CR when telemetry.enabled is true", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with telemetry.enabled=true")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					Telemetry: &konfluxv1alpha1.TelemetryConfig{
-						Enabled: &enabled,
-					},
+					Telemetry: &konfluxv1alpha1.TelemetryConfig{Enabled: &enabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
-
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient,
+				&konfluxv1alpha1.KonfluxSegmentBridge{ObjectMeta: metav1.ObjectMeta{Name: segmentbridge.CRName}})
 
 			By("verifying SegmentBridge CR was created")
 			sb := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			err = k8sClient.Get(ctx, segmentBridgeTypeNamespacedName, sb)
-			Expect(err).NotTo(HaveOccurred(), "SegmentBridge CR should exist when telemetry.enabled=true")
-			Expect(sb.Name).To(Equal(segmentbridge.CRName))
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, sb)).To(Succeed())
+				g.Expect(sb.Name).To(Equal(segmentbridge.CRName))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
-		It("should delete SegmentBridge CR when enabled changes from true to false", func() {
+		It("should delete SegmentBridge CR when enabled changes from true to false", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with telemetry.enabled=true")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					Telemetry: &konfluxv1alpha1.TelemetryConfig{
-						Enabled: &enabled,
-					},
+					Telemetry: &konfluxv1alpha1.TelemetryConfig{Enabled: &enabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling to create the SegmentBridge CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("verifying SegmentBridge CR was created")
-			sb := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			err = k8sClient.Get(ctx, segmentBridgeTypeNamespacedName, sb)
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for SegmentBridge CR to be created")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName},
+					&konfluxv1alpha1.KonfluxSegmentBridge{})).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
 			By("updating Konflux CR to set telemetry.enabled=false")
 			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updatedKonflux)).To(Succeed())
 			disabled := false
-			updatedKonflux.Spec.Telemetry = &konfluxv1alpha1.TelemetryConfig{
-				Enabled: &disabled,
-			}
+			updatedKonflux.Spec.Telemetry = &konfluxv1alpha1.TelemetryConfig{Enabled: &disabled}
 			Expect(k8sClient.Update(ctx, updatedKonflux)).To(Succeed())
 
-			By("reconciling again after disabling")
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("verifying SegmentBridge CR was deleted")
-			err = k8sClient.Get(ctx, segmentBridgeTypeNamespacedName, sb)
-			Expect(errors.IsNotFound(err)).To(BeTrue(), "SegmentBridge CR should be deleted when enabled changes to false")
+			By("waiting for SegmentBridge CR to be deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName},
+					&konfluxv1alpha1.KonfluxSegmentBridge{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "SegmentBridge CR should be deleted when enabled changes to false")
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 
 	Context("ImageController spec propagation", func() {
 		const resourceName = "konflux"
-		ctx := context.Background()
 
-		typeNamespacedName := types.NamespacedName{
-			Name: resourceName,
-		}
-		imageControllerNamespacedName := types.NamespacedName{
-			Name: imagecontroller.CRName,
-		}
+		It("should create ImageController CR with empty spec when no spec is provided", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
 
-		AfterEach(func() {
-			resource := &konfluxv1alpha1.Konflux{}
-			if err := k8sClient.Get(ctx, typeNamespacedName, resource); err == nil {
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-			}
-
-			ic := &konfluxv1alpha1.KonfluxImageController{}
-			if err := k8sClient.Get(ctx, imageControllerNamespacedName, ic); err == nil {
-				Expect(k8sClient.Delete(ctx, ic)).To(Succeed())
-			}
-		})
-
-		It("should create ImageController CR with empty spec when no spec is provided", func() {
 			By("creating Konflux CR with imageController.enabled=true but no spec")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					ImageController: &konfluxv1alpha1.ImageControllerConfig{
-						Enabled: &enabled,
-					},
+					ImageController: &konfluxv1alpha1.ImageControllerConfig{Enabled: &enabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
-
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient,
+				&konfluxv1alpha1.KonfluxImageController{ObjectMeta: metav1.ObjectMeta{Name: imagecontroller.CRName}})
 
 			By("verifying ImageController CR was created with empty spec")
 			ic := &konfluxv1alpha1.KonfluxImageController{}
-			err = k8sClient.Get(ctx, imageControllerNamespacedName, ic)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ic.Spec.QuayCABundle).To(BeNil())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: imagecontroller.CRName}, ic)).To(Succeed())
+				g.Expect(ic.Spec.QuayCABundle).To(BeNil())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
-		It("should propagate quayCABundle spec to ImageController CR", func() {
+		It("should propagate quayCABundle spec to ImageController CR", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with imageController.spec.quayCABundle")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
 					ImageController: &konfluxv1alpha1.ImageControllerConfig{
 						Enabled: &enabled,
@@ -764,36 +527,28 @@ var _ = Describe("Konflux Controller", func() {
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
-
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient,
+				&konfluxv1alpha1.KonfluxImageController{ObjectMeta: metav1.ObjectMeta{Name: imagecontroller.CRName}})
 
 			By("verifying ImageController CR has the quayCABundle spec")
 			ic := &konfluxv1alpha1.KonfluxImageController{}
-			err = k8sClient.Get(ctx, imageControllerNamespacedName, ic)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ic.Spec.QuayCABundle).NotTo(BeNil())
-			Expect(ic.Spec.QuayCABundle.ConfigMapName).To(Equal("my-ca-bundle"))
-			Expect(ic.Spec.QuayCABundle.Key).To(Equal("ca.crt"))
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: imagecontroller.CRName}, ic)).To(Succeed())
+				g.Expect(ic.Spec.QuayCABundle).NotTo(BeNil())
+				g.Expect(ic.Spec.QuayCABundle.ConfigMapName).To(Equal("my-ca-bundle"))
+				g.Expect(ic.Spec.QuayCABundle.Key).To(Equal("ca.crt"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
-		It("should update ImageController CR spec when Konflux CR spec changes", func() {
+		It("should update ImageController CR spec when Konflux CR spec changes", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with imageController.spec.quayCABundle")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
 					ImageController: &konfluxv1alpha1.ImageControllerConfig{
 						Enabled: &enabled,
@@ -806,37 +561,30 @@ var _ = Describe("Konflux Controller", func() {
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient,
+				&konfluxv1alpha1.KonfluxImageController{ObjectMeta: metav1.ObjectMeta{Name: imagecontroller.CRName}})
 
-			By("reconciling to create the ImageController CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for ImageController CR to be created with quayCABundle")
+			Eventually(func(g Gomega) {
+				ic := &konfluxv1alpha1.KonfluxImageController{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: imagecontroller.CRName}, ic)).To(Succeed())
+				g.Expect(ic.Spec.QuayCABundle).NotTo(BeNil())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
 			By("updating the Konflux CR to remove quayCABundle")
 			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updatedKonflux)).To(Succeed())
 			updatedKonflux.Spec.ImageController.Spec = nil
 			Expect(k8sClient.Update(ctx, updatedKonflux)).To(Succeed())
 
-			By("reconciling again after update")
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
 			By("verifying ImageController CR no longer has quayCABundle")
-			ic := &konfluxv1alpha1.KonfluxImageController{}
-			err = k8sClient.Get(ctx, imageControllerNamespacedName, ic)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ic.Spec.QuayCABundle).To(BeNil())
+			Eventually(func(g Gomega) {
+				ic := &konfluxv1alpha1.KonfluxImageController{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: imagecontroller.CRName}, ic)).To(Succeed())
+				g.Expect(ic.Spec.QuayCABundle).To(BeNil())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 })
@@ -847,8 +595,8 @@ func createTestClusterInfo() *clusterinfo.Info {
 		resources:     map[string]*metav1.APIResourceList{},
 		serverVersion: &version.Info{GitVersion: "v1.30.0"},
 	}
-	info, _ := clusterinfo.DetectWithClient(mockClient)
-	return info
+	clusterInfo, _ := clusterinfo.DetectWithClient(mockClient)
+	return clusterInfo
 }
 
 // testMockDiscoveryClient implements clusterinfo.DiscoveryClient for general testing

--- a/operator/internal/controller/konflux/konflux_controller_test.go
+++ b/operator/internal/controller/konflux/konflux_controller_test.go
@@ -18,122 +18,117 @@ package konflux
 
 import (
 	"context"
-	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/applicationapi"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/buildservice"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/certmanager"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/defaulttenant"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/enterprisecontract"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/imagecontroller"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/info"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/integrationservice"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/internalregistry"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/namespacelister"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/rbac"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/releaseservice"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/segmentbridge"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
+	uictrl "github.com/konflux-ci/konflux-ci/operator/internal/controller/ui"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 )
 
 var _ = Describe("Konflux Controller", func() {
+	// startManager creates a per-test manager with the given ClusterInfo
+	// and registers a DeferCleanup to cancel it after the test.
+	// A per-test manager is required because each test wires the reconciler with a different
+	// ClusterInfo (e.g. OpenShift vs vanilla Kubernetes), and a shared suite-level manager
+	// cannot be re-configured between tests.
+	startManager := func(clusterInfo *clusterinfo.Info) {
+		mgr := testutil.NewTestManager(testEnv)
+		Expect((&KonfluxReconciler{
+			Client:      mgr.GetClient(),
+			Scheme:      mgr.GetScheme(),
+			ClusterInfo: clusterInfo,
+		}).SetupWithManager(mgr)).To(Succeed())
+		mgrCtx, cancel := context.WithCancel(testEnv.Ctx)
+		DeferCleanup(cancel)
+		testutil.StartManagerWithContext(mgrCtx, mgr)
+	}
+
 	Context("When reconciling a resource", func() {
-		const resourceName = "konflux"
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
 
-		ctx := context.Background()
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-		typeNamespacedName := types.NamespacedName{
-			Name: resourceName,
-		}
-		konflux := &konfluxv1alpha1.Konflux{}
+			// The Ready condition is written only after the reconciler completes all apply/get/status steps
+			// without an early error return. Its presence (regardless of True/False) is therefore a reliable
+			// sentinel that the entire reconcile loop ran to completion. Ready=True is not expected here
+			// because the sub-controllers are not running in this test, so sub-CRs have no conditions yet.
+			//
+			// We also assert that every always-on sub-CR was created. This catches the case where both
+			// an applyKonflux* call and its corresponding Get are removed together — the Ready condition
+			// would still be set, but the sub-CR existence check would fail.
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+				g.Expect(apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)).NotTo(BeNil())
 
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind Konflux")
-			err := k8sClient.Get(ctx, typeNamespacedName, konflux)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.Konflux{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: resourceName,
-					},
-					// TODO(user): Specify other spec details if needed.
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
+				// Verify all always-on sub-CRs were created.
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: applicationapi.CRName}, &konfluxv1alpha1.KonfluxApplicationAPI{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: buildservice.CRName}, &konfluxv1alpha1.KonfluxBuildService{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: integrationservice.CRName}, &konfluxv1alpha1.KonfluxIntegrationService{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: releaseservice.CRName}, &konfluxv1alpha1.KonfluxReleaseService{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: uictrl.CRName}, &konfluxv1alpha1.KonfluxUI{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: rbac.CRName}, &konfluxv1alpha1.KonfluxRBAC{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: info.CRName}, &konfluxv1alpha1.KonfluxInfo{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespacelister.CRName}, &konfluxv1alpha1.KonfluxNamespaceLister{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: enterprisecontract.CRName}, &konfluxv1alpha1.KonfluxEnterpriseContract{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: certmanager.CRName}, &konfluxv1alpha1.KonfluxCertManager{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: defaulttenant.CRName}, &konfluxv1alpha1.KonfluxDefaultTenant{})).To(Succeed())
 
-		AfterEach(func() {
-			resource := &konfluxv1alpha1.Konflux{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				By("Cleanup the specific resource instance Konflux")
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-			}
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			clusterInfo := createTestClusterInfo()
-			controllerReconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+				// Verify optional sub-CRs are NOT created (disabled by default in empty spec).
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: imagecontroller.CRName}, &konfluxv1alpha1.KonfluxImageController{})).To(MatchError(ContainSubstring("not found")))
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: internalregistry.CRName}, &konfluxv1alpha1.KonfluxInternalRegistry{})).To(MatchError(ContainSubstring("not found")))
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, &konfluxv1alpha1.KonfluxSegmentBridge{})).To(MatchError(ContainSubstring("not found")))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 
 	Context("Konflux Name Validation (CEL)", func() {
 		const requiredKonfluxName = "konflux"
 
-		AfterEach(func(ctx context.Context) {
-			// Clean up any Konflux instances created during tests
-			konfluxList := &konfluxv1alpha1.KonfluxList{}
-			if err := k8sClient.List(ctx, konfluxList); err == nil {
-				for _, item := range konfluxList.Items {
-					if err := k8sClient.Delete(ctx, &item); err != nil && !errors.IsNotFound(err) {
-						_, _ = fmt.Fprintf(
-							GinkgoWriter,
-							"Failed to delete Konflux %q: %v\n",
-							item.GetName(),
-							err,
-						)
-					}
-				}
-			}
-		})
-
 		It("Should allow creation with the required name 'konflux'", func(ctx context.Context) {
 			By("creating a Konflux instance with the required name")
 			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: requiredKonfluxName,
-				},
-				Spec: konfluxv1alpha1.KonfluxSpec{},
+				ObjectMeta: metav1.ObjectMeta{Name: requiredKonfluxName},
 			}
-			err := k8sClient.Create(ctx, konflux)
-			Expect(err).NotTo(HaveOccurred(), "Creation with required name should be allowed")
+			Expect(k8sClient.Create(ctx, konflux)).To(Succeed(), "Creation with required name should be allowed")
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, konflux)
 
 			By("verifying the instance was created")
 			created := &konfluxv1alpha1.Konflux{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: requiredKonfluxName}, created)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: requiredKonfluxName}, created)).To(Succeed())
 			Expect(created.GetName()).To(Equal(requiredKonfluxName))
 		})
 
 		It("Should deny creation with a different name", func(ctx context.Context) {
 			By("attempting to create a Konflux instance with a different name")
 			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-konflux",
-				},
-				Spec: konfluxv1alpha1.KonfluxSpec{},
+				ObjectMeta: metav1.ObjectMeta{Name: "my-konflux"},
 			}
 			err := k8sClient.Create(ctx, konflux)
 			Expect(err).To(HaveOccurred(), "Creation with different name should be rejected")
@@ -143,615 +138,385 @@ var _ = Describe("Konflux Controller", func() {
 		It("Should allow updates to the instance with the required name", func(ctx context.Context) {
 			By("creating a Konflux instance with the required name")
 			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: requiredKonfluxName,
-				},
-				Spec: konfluxv1alpha1.KonfluxSpec{},
+				ObjectMeta: metav1.ObjectMeta{Name: requiredKonfluxName},
 			}
-			err := k8sClient.Create(ctx, konflux)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create Konflux instance")
+			Expect(k8sClient.Create(ctx, konflux)).To(Succeed(), "Failed to create Konflux instance")
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, konflux)
 
 			By("updating the instance")
-			// Get the latest version
 			updated := &konfluxv1alpha1.Konflux{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: requiredKonfluxName}, updated)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Add a label
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: requiredKonfluxName}, updated)).To(Succeed())
 			if updated.Labels == nil {
 				updated.Labels = make(map[string]string)
 			}
 			updated.Labels["test"] = "value"
-			err = k8sClient.Update(ctx, updated)
-			Expect(err).NotTo(HaveOccurred(), "Updates should be allowed")
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed(), "Updates should be allowed")
 		})
 	})
 
 	Context("InternalRegistry conditional enablement", func() {
 		const resourceName = "konflux"
-		ctx := context.Background()
 
-		typeNamespacedName := types.NamespacedName{
-			Name: resourceName,
-		}
-		registryTypeNamespacedName := types.NamespacedName{
-			Name: internalregistry.CRName,
-		}
+		It("should not create InternalRegistry CR when internalRegistry is omitted", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
 
-		AfterEach(func() {
-			// Cleanup Konflux CR
-			resource := &konfluxv1alpha1.Konflux{}
-			if err := k8sClient.Get(ctx, typeNamespacedName, resource); err == nil {
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-			}
-
-			// Cleanup InternalRegistry CR if it exists
-			registry := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			if err := k8sClient.Get(ctx, registryTypeNamespacedName, registry); err == nil {
-				Expect(k8sClient.Delete(ctx, registry)).To(Succeed())
-			}
-		})
-
-		It("should not create InternalRegistry CR when internalRegistry is omitted", func() {
 			By("creating Konflux CR without internalRegistry config")
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
-				Spec: konfluxv1alpha1.KonfluxSpec{
-					// internalRegistry is omitted (nil)
-				},
-			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: resourceName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for reconcile to complete")
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updated)).To(Succeed())
+				g.Expect(apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)).NotTo(BeNil())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("verifying InternalRegistry CR was not created")
 			registry := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			err = k8sClient.Get(ctx, registryTypeNamespacedName, registry)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: internalregistry.CRName}, registry)
 			Expect(errors.IsNotFound(err)).To(BeTrue(), "InternalRegistry CR should not exist when omitted")
 		})
 
-		It("should not create InternalRegistry CR when enabled is false", func() {
+		It("should not create InternalRegistry CR when enabled is false", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with internalRegistry.enabled=false")
 			disabled := false
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					InternalRegistry: &konfluxv1alpha1.InternalRegistryConfig{
-						Enabled: &disabled,
-					},
+					InternalRegistry: &konfluxv1alpha1.InternalRegistryConfig{Enabled: &disabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for reconcile to complete")
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updated)).To(Succeed())
+				g.Expect(apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)).NotTo(BeNil())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("verifying InternalRegistry CR was not created")
 			registry := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			err = k8sClient.Get(ctx, registryTypeNamespacedName, registry)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: internalregistry.CRName}, registry)
 			Expect(errors.IsNotFound(err)).To(BeTrue(), "InternalRegistry CR should not exist when enabled=false")
 		})
 
-		It("should create InternalRegistry CR when enabled is true", func() {
+		It("should create InternalRegistry CR when enabled is true", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with internalRegistry.enabled=true")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					InternalRegistry: &konfluxv1alpha1.InternalRegistryConfig{
-						Enabled: &enabled,
-					},
+					InternalRegistry: &konfluxv1alpha1.InternalRegistryConfig{Enabled: &enabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
-
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient,
+				&konfluxv1alpha1.KonfluxInternalRegistry{ObjectMeta: metav1.ObjectMeta{Name: internalregistry.CRName}})
 
 			By("verifying InternalRegistry CR was created")
 			registry := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			err = k8sClient.Get(ctx, registryTypeNamespacedName, registry)
-			Expect(err).NotTo(HaveOccurred(), "InternalRegistry CR should exist when enabled=true")
-			Expect(registry.Name).To(Equal(internalregistry.CRName))
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: internalregistry.CRName}, registry)).To(Succeed())
+				g.Expect(registry.Name).To(Equal(internalregistry.CRName))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
-		It("should delete InternalRegistry CR when enabled changes from true to false", func() {
+		It("should delete InternalRegistry CR when enabled changes from true to false", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with internalRegistry.enabled=true")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					InternalRegistry: &konfluxv1alpha1.InternalRegistryConfig{
-						Enabled: &enabled,
-					},
+					InternalRegistry: &konfluxv1alpha1.InternalRegistryConfig{Enabled: &enabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling to create the InternalRegistry CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("verifying InternalRegistry CR was created")
-			registry := &konfluxv1alpha1.KonfluxInternalRegistry{}
-			err = k8sClient.Get(ctx, registryTypeNamespacedName, registry)
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for InternalRegistry CR to be created")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: internalregistry.CRName},
+					&konfluxv1alpha1.KonfluxInternalRegistry{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("updating Konflux CR to set enabled=false")
 			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updatedKonflux)).To(Succeed())
 			disabled := false
-			updatedKonflux.Spec.InternalRegistry = &konfluxv1alpha1.InternalRegistryConfig{
-				Enabled: &disabled,
-			}
+			updatedKonflux.Spec.InternalRegistry = &konfluxv1alpha1.InternalRegistryConfig{Enabled: &disabled}
 			Expect(k8sClient.Update(ctx, updatedKonflux)).To(Succeed())
 
-			By("reconciling again after disabling")
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("verifying InternalRegistry CR was deleted")
-			err = k8sClient.Get(ctx, registryTypeNamespacedName, registry)
-			Expect(errors.IsNotFound(err)).To(BeTrue(), "InternalRegistry CR should be deleted when enabled changes to false")
+			By("waiting for InternalRegistry CR to be deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: internalregistry.CRName},
+					&konfluxv1alpha1.KonfluxInternalRegistry{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "InternalRegistry CR should be deleted when enabled changes to false")
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 
 	Context("DefaultTenant conditional enablement", func() {
 		const resourceName = "konflux"
-		ctx := context.Background()
 
-		typeNamespacedName := types.NamespacedName{
-			Name: resourceName,
-		}
-		defaultTenantTypeNamespacedName := types.NamespacedName{
-			Name: defaulttenant.CRName,
-		}
+		It("should create DefaultTenant CR when defaultTenant is omitted (enabled by default)", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
 
-		AfterEach(func() {
-			// Cleanup Konflux CR
-			resource := &konfluxv1alpha1.Konflux{}
-			if err := k8sClient.Get(ctx, typeNamespacedName, resource); err == nil {
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-			}
-
-			// Cleanup DefaultTenant CR if it exists
-			tenant := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			if err := k8sClient.Get(ctx, defaultTenantTypeNamespacedName, tenant); err == nil {
-				Expect(k8sClient.Delete(ctx, tenant)).To(Succeed())
-			}
-		})
-
-		It("should create DefaultTenant CR when defaultTenant is omitted (enabled by default)", func() {
 			By("creating Konflux CR without defaultTenant config")
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
-				Spec: konfluxv1alpha1.KonfluxSpec{
-					// defaultTenant is omitted (nil) - should default to enabled
-				},
-			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
-
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: resourceName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient,
+				&konfluxv1alpha1.KonfluxDefaultTenant{ObjectMeta: metav1.ObjectMeta{Name: defaulttenant.CRName}})
 
 			By("verifying DefaultTenant CR was created (enabled by default)")
 			tenant := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			err = k8sClient.Get(ctx, defaultTenantTypeNamespacedName, tenant)
-			Expect(err).NotTo(HaveOccurred(), "DefaultTenant CR should exist when omitted (enabled by default)")
-			Expect(tenant.Name).To(Equal(defaulttenant.CRName))
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: defaulttenant.CRName}, tenant)).To(Succeed())
+				g.Expect(tenant.Name).To(Equal(defaulttenant.CRName))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
-		It("should create DefaultTenant CR when enabled is explicitly true", func() {
+		It("should create DefaultTenant CR when enabled is explicitly true", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with defaultTenant.enabled=true")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					DefaultTenant: &konfluxv1alpha1.DefaultTenantConfig{
-						Enabled: &enabled,
-					},
+					DefaultTenant: &konfluxv1alpha1.DefaultTenantConfig{Enabled: &enabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
-
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient,
+				&konfluxv1alpha1.KonfluxDefaultTenant{ObjectMeta: metav1.ObjectMeta{Name: defaulttenant.CRName}})
 
 			By("verifying DefaultTenant CR was created")
-			tenant := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			err = k8sClient.Get(ctx, defaultTenantTypeNamespacedName, tenant)
-			Expect(err).NotTo(HaveOccurred(), "DefaultTenant CR should exist when enabled=true")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: defaulttenant.CRName},
+					&konfluxv1alpha1.KonfluxDefaultTenant{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
-		It("should not create DefaultTenant CR when enabled is false", func() {
+		It("should not create DefaultTenant CR when enabled is false", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with defaultTenant.enabled=false")
 			disabled := false
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					DefaultTenant: &konfluxv1alpha1.DefaultTenantConfig{
-						Enabled: &disabled,
-					},
+					DefaultTenant: &konfluxv1alpha1.DefaultTenantConfig{Enabled: &disabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for reconcile to complete")
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updated)).To(Succeed())
+				g.Expect(apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)).NotTo(BeNil())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("verifying DefaultTenant CR was not created")
 			tenant := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			err = k8sClient.Get(ctx, defaultTenantTypeNamespacedName, tenant)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: defaulttenant.CRName}, tenant)
 			Expect(errors.IsNotFound(err)).To(BeTrue(), "DefaultTenant CR should not exist when enabled=false")
 		})
 
-		It("should delete DefaultTenant CR when enabled changes from true to false", func() {
+		It("should delete DefaultTenant CR when enabled changes from true to false", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with defaultTenant.enabled=true")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					DefaultTenant: &konfluxv1alpha1.DefaultTenantConfig{
-						Enabled: &enabled,
-					},
+					DefaultTenant: &konfluxv1alpha1.DefaultTenantConfig{Enabled: &enabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling to create the DefaultTenant CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("verifying DefaultTenant CR was created")
-			tenant := &konfluxv1alpha1.KonfluxDefaultTenant{}
-			err = k8sClient.Get(ctx, defaultTenantTypeNamespacedName, tenant)
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for DefaultTenant CR to be created")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: defaulttenant.CRName},
+					&konfluxv1alpha1.KonfluxDefaultTenant{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("updating Konflux CR to set enabled=false")
 			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updatedKonflux)).To(Succeed())
 			disabled := false
-			updatedKonflux.Spec.DefaultTenant = &konfluxv1alpha1.DefaultTenantConfig{
-				Enabled: &disabled,
-			}
+			updatedKonflux.Spec.DefaultTenant = &konfluxv1alpha1.DefaultTenantConfig{Enabled: &disabled}
 			Expect(k8sClient.Update(ctx, updatedKonflux)).To(Succeed())
 
-			By("reconciling again after disabling")
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("verifying DefaultTenant CR was deleted")
-			err = k8sClient.Get(ctx, defaultTenantTypeNamespacedName, tenant)
-			Expect(errors.IsNotFound(err)).To(BeTrue(), "DefaultTenant CR should be deleted when enabled changes to false")
+			By("waiting for DefaultTenant CR to be deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: defaulttenant.CRName},
+					&konfluxv1alpha1.KonfluxDefaultTenant{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "DefaultTenant CR should be deleted when enabled changes to false")
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 
 	Context("SegmentBridge conditional enablement", func() {
 		const resourceName = "konflux"
-		ctx := context.Background()
 
-		typeNamespacedName := types.NamespacedName{
-			Name: resourceName,
-		}
-		segmentBridgeTypeNamespacedName := types.NamespacedName{
-			Name: segmentbridge.CRName,
-		}
+		It("should not create SegmentBridge CR when telemetry is omitted", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
 
-		AfterEach(func() {
-			resource := &konfluxv1alpha1.Konflux{}
-			if err := k8sClient.Get(ctx, typeNamespacedName, resource); err == nil {
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-			}
-
-			sb := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			if err := k8sClient.Get(ctx, segmentBridgeTypeNamespacedName, sb); err == nil {
-				Expect(k8sClient.Delete(ctx, sb)).To(Succeed())
-			}
-		})
-
-		It("should not create SegmentBridge CR when telemetry is omitted", func() {
 			By("creating Konflux CR without telemetry config")
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
-				Spec: konfluxv1alpha1.KonfluxSpec{},
-			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: resourceName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for reconcile to complete")
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updated)).To(Succeed())
+				g.Expect(apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)).NotTo(BeNil())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("verifying SegmentBridge CR was not created")
 			sb := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			err = k8sClient.Get(ctx, segmentBridgeTypeNamespacedName, sb)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, sb)
 			Expect(errors.IsNotFound(err)).To(BeTrue(), "SegmentBridge CR should not exist when telemetry is omitted")
 		})
 
-		It("should not create SegmentBridge CR when telemetry.enabled is false", func() {
+		It("should not create SegmentBridge CR when telemetry.enabled is false", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with telemetry.enabled=false")
 			disabled := false
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					Telemetry: &konfluxv1alpha1.TelemetryConfig{
-						Enabled: &disabled,
-					},
+					Telemetry: &konfluxv1alpha1.TelemetryConfig{Enabled: &disabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for reconcile to complete")
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updated)).To(Succeed())
+				g.Expect(apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)).NotTo(BeNil())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("verifying SegmentBridge CR was not created")
 			sb := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			err = k8sClient.Get(ctx, segmentBridgeTypeNamespacedName, sb)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, sb)
 			Expect(errors.IsNotFound(err)).To(BeTrue(), "SegmentBridge CR should not exist when telemetry.enabled=false")
 		})
 
-		It("should create SegmentBridge CR when telemetry.enabled is true", func() {
+		It("should create SegmentBridge CR when telemetry.enabled is true", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with telemetry.enabled=true")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					Telemetry: &konfluxv1alpha1.TelemetryConfig{
-						Enabled: &enabled,
-					},
+					Telemetry: &konfluxv1alpha1.TelemetryConfig{Enabled: &enabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
-
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient,
+				&konfluxv1alpha1.KonfluxSegmentBridge{ObjectMeta: metav1.ObjectMeta{Name: segmentbridge.CRName}})
 
 			By("verifying SegmentBridge CR was created")
 			sb := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			err = k8sClient.Get(ctx, segmentBridgeTypeNamespacedName, sb)
-			Expect(err).NotTo(HaveOccurred(), "SegmentBridge CR should exist when telemetry.enabled=true")
-			Expect(sb.Name).To(Equal(segmentbridge.CRName))
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, sb)).To(Succeed())
+				g.Expect(sb.Name).To(Equal(segmentbridge.CRName))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
-		It("should delete SegmentBridge CR when enabled changes from true to false", func() {
+		It("should delete SegmentBridge CR when enabled changes from true to false", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with telemetry.enabled=true")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					Telemetry: &konfluxv1alpha1.TelemetryConfig{
-						Enabled: &enabled,
-					},
+					Telemetry: &konfluxv1alpha1.TelemetryConfig{Enabled: &enabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
 
-			By("reconciling to create the SegmentBridge CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("verifying SegmentBridge CR was created")
-			sb := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			err = k8sClient.Get(ctx, segmentBridgeTypeNamespacedName, sb)
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for SegmentBridge CR to be created")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName},
+					&konfluxv1alpha1.KonfluxSegmentBridge{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("updating Konflux CR to set telemetry.enabled=false")
 			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updatedKonflux)).To(Succeed())
 			disabled := false
-			updatedKonflux.Spec.Telemetry = &konfluxv1alpha1.TelemetryConfig{
-				Enabled: &disabled,
-			}
+			updatedKonflux.Spec.Telemetry = &konfluxv1alpha1.TelemetryConfig{Enabled: &disabled}
 			Expect(k8sClient.Update(ctx, updatedKonflux)).To(Succeed())
 
-			By("reconciling again after disabling")
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("verifying SegmentBridge CR was deleted")
-			err = k8sClient.Get(ctx, segmentBridgeTypeNamespacedName, sb)
-			Expect(errors.IsNotFound(err)).To(BeTrue(), "SegmentBridge CR should be deleted when enabled changes to false")
+			By("waiting for SegmentBridge CR to be deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName},
+					&konfluxv1alpha1.KonfluxSegmentBridge{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "SegmentBridge CR should be deleted when enabled changes to false")
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 
 	Context("ImageController spec propagation", func() {
 		const resourceName = "konflux"
-		ctx := context.Background()
 
-		typeNamespacedName := types.NamespacedName{
-			Name: resourceName,
-		}
-		imageControllerNamespacedName := types.NamespacedName{
-			Name: imagecontroller.CRName,
-		}
+		It("should create ImageController CR with empty spec when no spec is provided", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
 
-		AfterEach(func() {
-			resource := &konfluxv1alpha1.Konflux{}
-			if err := k8sClient.Get(ctx, typeNamespacedName, resource); err == nil {
-				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-			}
-
-			ic := &konfluxv1alpha1.KonfluxImageController{}
-			if err := k8sClient.Get(ctx, imageControllerNamespacedName, ic); err == nil {
-				Expect(k8sClient.Delete(ctx, ic)).To(Succeed())
-			}
-		})
-
-		It("should create ImageController CR with empty spec when no spec is provided", func() {
 			By("creating Konflux CR with imageController.enabled=true but no spec")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
-					ImageController: &konfluxv1alpha1.ImageControllerConfig{
-						Enabled: &enabled,
-					},
+					ImageController: &konfluxv1alpha1.ImageControllerConfig{Enabled: &enabled},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
-
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient,
+				&konfluxv1alpha1.KonfluxImageController{ObjectMeta: metav1.ObjectMeta{Name: imagecontroller.CRName}})
 
 			By("verifying ImageController CR was created with empty spec")
 			ic := &konfluxv1alpha1.KonfluxImageController{}
-			err = k8sClient.Get(ctx, imageControllerNamespacedName, ic)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ic.Spec.QuayCABundle).To(BeNil())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: imagecontroller.CRName}, ic)).To(Succeed())
+				g.Expect(ic.Spec.QuayCABundle).To(BeNil())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
-		It("should propagate quayCABundle spec to ImageController CR", func() {
+		It("should propagate quayCABundle spec to ImageController CR", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with imageController.spec.quayCABundle")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
 					ImageController: &konfluxv1alpha1.ImageControllerConfig{
 						Enabled: &enabled,
@@ -764,36 +529,28 @@ var _ = Describe("Konflux Controller", func() {
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
-
-			By("reconciling the Konflux CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient,
+				&konfluxv1alpha1.KonfluxImageController{ObjectMeta: metav1.ObjectMeta{Name: imagecontroller.CRName}})
 
 			By("verifying ImageController CR has the quayCABundle spec")
 			ic := &konfluxv1alpha1.KonfluxImageController{}
-			err = k8sClient.Get(ctx, imageControllerNamespacedName, ic)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ic.Spec.QuayCABundle).NotTo(BeNil())
-			Expect(ic.Spec.QuayCABundle.ConfigMapName).To(Equal("my-ca-bundle"))
-			Expect(ic.Spec.QuayCABundle.Key).To(Equal("ca.crt"))
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: imagecontroller.CRName}, ic)).To(Succeed())
+				g.Expect(ic.Spec.QuayCABundle).NotTo(BeNil())
+				g.Expect(ic.Spec.QuayCABundle.ConfigMapName).To(Equal("my-ca-bundle"))
+				g.Expect(ic.Spec.QuayCABundle.Key).To(Equal("ca.crt"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
-		It("should update ImageController CR spec when Konflux CR spec changes", func() {
+		It("should update ImageController CR spec when Konflux CR spec changes", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
 			By("creating Konflux CR with imageController.spec.quayCABundle")
 			enabled := true
-			konflux := &konfluxv1alpha1.Konflux{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: resourceName,
-				},
+			cr := &konfluxv1alpha1.Konflux{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: konfluxv1alpha1.KonfluxSpec{
 					ImageController: &konfluxv1alpha1.ImageControllerConfig{
 						Enabled: &enabled,
@@ -806,37 +563,30 @@ var _ = Describe("Konflux Controller", func() {
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, konflux)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient,
+				&konfluxv1alpha1.KonfluxImageController{ObjectMeta: metav1.ObjectMeta{Name: imagecontroller.CRName}})
 
-			By("reconciling to create the ImageController CR")
-			clusterInfo := createTestClusterInfo()
-			reconciler := &KonfluxReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ClusterInfo: clusterInfo,
-			}
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+			By("waiting for ImageController CR to be created with quayCABundle")
+			Eventually(func(g Gomega) {
+				ic := &konfluxv1alpha1.KonfluxImageController{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: imagecontroller.CRName}, ic)).To(Succeed())
+				g.Expect(ic.Spec.QuayCABundle).NotTo(BeNil())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("updating the Konflux CR to remove quayCABundle")
 			updatedKonflux := &konfluxv1alpha1.Konflux{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedKonflux)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updatedKonflux)).To(Succeed())
 			updatedKonflux.Spec.ImageController.Spec = nil
 			Expect(k8sClient.Update(ctx, updatedKonflux)).To(Succeed())
 
-			By("reconciling again after update")
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
 			By("verifying ImageController CR no longer has quayCABundle")
-			ic := &konfluxv1alpha1.KonfluxImageController{}
-			err = k8sClient.Get(ctx, imageControllerNamespacedName, ic)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ic.Spec.QuayCABundle).To(BeNil())
+			Eventually(func(g Gomega) {
+				ic := &konfluxv1alpha1.KonfluxImageController{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: imagecontroller.CRName}, ic)).To(Succeed())
+				g.Expect(ic.Spec.QuayCABundle).To(BeNil())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 })
@@ -847,8 +597,8 @@ func createTestClusterInfo() *clusterinfo.Info {
 		resources:     map[string]*metav1.APIResourceList{},
 		serverVersion: &version.Info{GitVersion: "v1.30.0"},
 	}
-	info, _ := clusterinfo.DetectWithClient(mockClient)
-	return info
+	clusterInfo, _ := clusterinfo.DetectWithClient(mockClient)
+	return clusterInfo
 }
 
 // testMockDiscoveryClient implements clusterinfo.DiscoveryClient for general testing

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
@@ -18,67 +18,42 @@ package namespacelister
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
+
+const namespaceListerNamespace = "namespace-lister"
 
 var _ = Describe("KonfluxNamespaceLister Controller", func() {
 	Context("When reconciling a resource", func() {
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      CRName,
-			Namespace: "default",
-		}
-		konfluxnamespacelister := &konfluxv1alpha1.KonfluxNamespaceLister{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxNamespaceLister")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxnamespacelister)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxNamespaceLister{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      CRName,
-						Namespace: "default",
-					},
-					// TODO(user): Specify other spec details if needed.
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxNamespaceLister{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxNamespaceLister")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxNamespaceListerReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxNamespaceLister{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 			})
-			Expect(err).NotTo(HaveOccurred())
+
+			// Wait for the Deployment rather than Ready=True: UpdateComponentStatuses
+			// gates Ready=True on ReadyReplicas == Replicas, which never happens in
+			// envtest (no kubelet → pods never start).
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      namespaceListerNamespace,
+					Namespace: namespaceListerNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 })
@@ -95,7 +70,7 @@ var _ = Describe("applyNamespaceListerCustomizations", func() {
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
-								Name: "namespace-lister",
+								Name: namespaceListerNamespace,
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:    resource.MustParse("50m"),

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
@@ -23,62 +23,36 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
+
+const namespaceListerNamespace = "namespace-lister"
 
 var _ = Describe("KonfluxNamespaceLister Controller", func() {
 	Context("When reconciling a resource", func() {
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      CRName,
-			Namespace: "default",
-		}
-		konfluxnamespacelister := &konfluxv1alpha1.KonfluxNamespaceLister{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxNamespaceLister")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxnamespacelister)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxNamespaceLister{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      CRName,
-						Namespace: "default",
-					},
-					// TODO(user): Specify other spec details if needed.
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxNamespaceLister{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxNamespaceLister")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxNamespaceListerReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxNamespaceLister{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 			})
-			Expect(err).NotTo(HaveOccurred())
+
+			// Wait for the Deployment rather than Ready=True: UpdateComponentStatuses
+			// gates Ready=True on ReadyReplicas == Replicas, which never happens in
+			// envtest (no kubelet → pods never start).
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      namespaceListerNamespace,
+					Namespace: namespaceListerNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 })
@@ -95,7 +69,7 @@ var _ = Describe("applyNamespaceListerCustomizations", func() {
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
-								Name: "namespace-lister",
+								Name: namespaceListerNamespace,
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:    resource.MustParse("50m"),

--- a/operator/internal/controller/namespacelister/suite_test.go
+++ b/operator/internal/controller/namespacelister/suite_test.go
@@ -45,6 +45,14 @@ var _ = BeforeSuite(func() {
 	ctx = testEnv.Ctx
 	k8sClient = testEnv.K8sClient
 	objectStore = testEnv.ObjectStore
+
+	mgr := testutil.NewTestManager(testEnv)
+	Expect((&KonfluxNamespaceListerReconciler{
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ObjectStore: objectStore,
+	}).SetupWithManager(mgr)).To(Succeed())
+	testutil.StartManager(testEnv, mgr)
 })
 
 var _ = AfterSuite(func() {

--- a/operator/internal/controller/rbac/konfluxrbac_controller_test.go
+++ b/operator/internal/controller/rbac/konfluxrbac_controller_test.go
@@ -18,66 +18,35 @@ package rbac
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
 
 var _ = Describe("KonfluxRBAC Controller", func() {
 	Context("When reconciling a resource", func() {
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      CRName,
-			Namespace: "default",
-		}
-		konfluxrbac := &konfluxv1alpha1.KonfluxRBAC{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxRBAC")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxrbac)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxRBAC{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      CRName,
-						Namespace: "default",
-					},
-					// TODO(user): Specify other spec details if needed.
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxRBAC{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxRBAC")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxRBACReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxRBAC{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxRBAC{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			// The rbac manifests contain only ClusterRoles — no Deployments — so
+			// Ready=True is a reliable sentinel.
+			Eventually(func(g Gomega) {
+				cr := &konfluxv1alpha1.KonfluxRBAC{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, cr)).To(Succeed())
+				g.Expect(condition.IsConditionTrue(cr, condition.TypeReady)).To(BeTrue())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/rbac/konfluxrbac_controller_test.go
+++ b/operator/internal/controller/rbac/konfluxrbac_controller_test.go
@@ -21,63 +21,35 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
 
 var _ = Describe("KonfluxRBAC Controller", func() {
 	Context("When reconciling a resource", func() {
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      CRName,
-			Namespace: "default",
-		}
-		konfluxrbac := &konfluxv1alpha1.KonfluxRBAC{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxRBAC")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxrbac)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxRBAC{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      CRName,
-						Namespace: "default",
-					},
-					// TODO(user): Specify other spec details if needed.
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxRBAC{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxRBAC")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxRBACReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxRBAC{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxRBAC{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			// The rbac manifests contain only ClusterRoles — no Deployments — so
+			// Ready=True is a reliable sentinel.
+			Eventually(func(g Gomega) {
+				cr := &konfluxv1alpha1.KonfluxRBAC{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, cr)).To(Succeed())
+				g.Expect(condition.IsConditionTrue(cr, condition.TypeReady)).To(BeTrue())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying a representative ClusterRole was created")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-admin-user-actions-batch"}, &rbacv1.ClusterRole{})).To(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/rbac/suite_test.go
+++ b/operator/internal/controller/rbac/suite_test.go
@@ -45,6 +45,14 @@ var _ = BeforeSuite(func() {
 	ctx = testEnv.Ctx
 	k8sClient = testEnv.K8sClient
 	objectStore = testEnv.ObjectStore
+
+	mgr := testutil.NewTestManager(testEnv)
+	Expect((&KonfluxRBACReconciler{
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ObjectStore: objectStore,
+	}).SetupWithManager(mgr)).To(Succeed())
+	testutil.StartManager(testEnv, mgr)
 })
 
 var _ = AfterSuite(func() {

--- a/operator/internal/controller/releaseservice/konfluxreleaseservice_controller_test.go
+++ b/operator/internal/controller/releaseservice/konfluxreleaseservice_controller_test.go
@@ -18,67 +18,40 @@ package releaseservice
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
+
+const releaseServiceNamespace = "release-service"
 
 var _ = Describe("KonfluxReleaseService Controller", func() {
 	Context("When reconciling a resource", func() {
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      CRName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		konfluxreleaseservice := &konfluxv1alpha1.KonfluxReleaseService{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxReleaseService")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxreleaseservice)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxReleaseService{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      CRName,
-						Namespace: "default",
-					},
-					Spec: konfluxv1alpha1.KonfluxReleaseServiceSpec{},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxReleaseService{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxReleaseService")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxReleaseServiceReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxReleaseService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxReleaseService{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			// Wait for the Deployment rather than Ready=True: UpdateComponentStatuses
+			// gates Ready=True on ReadyReplicas == Replicas, which never happens in
+			// envtest (no kubelet → pods never start).
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      releaseControllerManagerDeploymentName,
+					Namespace: releaseServiceNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/releaseservice/konfluxreleaseservice_controller_test.go
+++ b/operator/internal/controller/releaseservice/konfluxreleaseservice_controller_test.go
@@ -21,64 +21,36 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
+
+const releaseServiceNamespace = "release-service"
 
 var _ = Describe("KonfluxReleaseService Controller", func() {
 	Context("When reconciling a resource", func() {
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      CRName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		konfluxreleaseservice := &konfluxv1alpha1.KonfluxReleaseService{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxReleaseService")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxreleaseservice)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxReleaseService{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      CRName,
-						Namespace: "default",
-					},
-					Spec: konfluxv1alpha1.KonfluxReleaseServiceSpec{},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxReleaseService{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxReleaseService")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxReleaseServiceReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				ObjectStore: objectStore,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxReleaseService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxReleaseService{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
 			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			// Wait for the Deployment rather than Ready=True: UpdateComponentStatuses
+			// gates Ready=True on ReadyReplicas == Replicas, which never happens in
+			// envtest (no kubelet → pods never start).
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      releaseControllerManagerDeploymentName,
+					Namespace: releaseServiceNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/releaseservice/suite_test.go
+++ b/operator/internal/controller/releaseservice/suite_test.go
@@ -45,6 +45,14 @@ var _ = BeforeSuite(func() {
 	ctx = testEnv.Ctx
 	k8sClient = testEnv.K8sClient
 	objectStore = testEnv.ObjectStore
+
+	mgr := testutil.NewTestManager(testEnv)
+	Expect((&KonfluxReleaseServiceReconciler{
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ObjectStore: objectStore,
+	}).SetupWithManager(mgr)).To(Succeed())
+	testutil.StartManager(testEnv, mgr)
 })
 
 var _ = AfterSuite(func() {

--- a/operator/internal/controller/segmentbridge/konfluxsegmentbridge_controller_test.go
+++ b/operator/internal/controller/segmentbridge/konfluxsegmentbridge_controller_test.go
@@ -18,6 +18,7 @@ package segmentbridge
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -27,9 +28,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 )
 
@@ -55,281 +57,190 @@ func (m *mockDiscoveryClient) ServerVersion() (*version.Info, error) {
 var _ clusterinfo.DiscoveryClient = (*mockDiscoveryClient)(nil)
 
 var _ = Describe("KonfluxSegmentBridge Controller", func() {
+	// startManager creates a per-test manager with the given reconciler configuration
+	// and registers a DeferCleanup to cancel it after the test.
+	startManager := func(getDefaultSegmentKey func() string, clusterInfo *clusterinfo.Info) {
+		mgr := testutil.NewTestManager(testEnv)
+		Expect((&KonfluxSegmentBridgeReconciler{
+			Client:               mgr.GetClient(),
+			Scheme:               mgr.GetScheme(),
+			ObjectStore:          objectStore,
+			GetDefaultSegmentKey: getDefaultSegmentKey,
+			ClusterInfo:          clusterInfo,
+		}).SetupWithManager(mgr)).To(Succeed())
+		mgrCtx, cancel := context.WithCancel(testEnv.Ctx)
+		DeferCleanup(cancel)
+		testutil.StartManagerWithContext(mgrCtx, mgr)
+	}
+
+	// createCR creates the KonfluxSegmentBridge CR and registers cleanup for both
+	// the CR and the Secret the controller will create.
+	createCR := func(ctx context.Context) {
+		Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxSegmentBridge{
+			ObjectMeta: metav1.ObjectMeta{Name: CRName},
+		})).To(Succeed())
+		DeferCleanup(func(ctx context.Context) {
+			testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxSegmentBridge{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})
+			_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      segmentBridgeSecretName,
+				Namespace: segmentBridgeNamespace,
+			}})
+		})
+	}
+
+	// waitForSecret polls until the Secret exists and the caller's check passes.
+	waitForSecret := func(ctx context.Context, check func(g Gomega, data map[string][]byte)) {
+		Eventually(func(g Gomega) {
+			secret := &corev1.Secret{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
+			}, secret)).To(Succeed())
+			check(g, secret.Data)
+		}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
+	}
+
 	Context("When reconciling a resource", func() {
+		Context("with no-op default segment key", func() {
+			BeforeEach(func() { startManager(noDefaultKey, nil) })
 
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name: CRName,
-		}
-		konfluxsegmentbridge := &konfluxv1alpha1.KonfluxSegmentBridge{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxSegmentBridge")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxsegmentbridge)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxSegmentBridge{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: CRName,
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxSegmentBridge")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Cleanup the segment-bridge-config secret if it exists")
-			secret := &corev1.Secret{}
-			err = k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)
-			if err == nil {
-				_ = k8sClient.Delete(ctx, secret)
-			}
-		})
-
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultKey,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+			It("should successfully reconcile the resource", func(ctx context.Context) {
+				createCR(ctx)
+				Eventually(func(g Gomega) {
+					cr := &konfluxv1alpha1.KonfluxSegmentBridge{}
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, cr)).To(Succeed())
+					g.Expect(cr.Status.Conditions).To(ContainElement(
+						HaveField("Type", condition.TypeReady),
+					))
+				}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 			})
-			Expect(err).NotTo(HaveOccurred())
+
+			It("should create Secret with empty segment fields when no write key is configured", func(ctx context.Context) {
+				createCR(ctx)
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
+					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(BeEmpty(), "write key should be empty")
+					g.Expect(string(data["SEGMENT_BATCH_API"])).To(Equal(
+						konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
+				})
+			})
+
+			It("should retain Secret with only TEKTON_RESULTS_API_ADDR when key becomes empty", func(ctx context.Context) {
+				createCR(ctx)
+
+				By("setting a temporary key on the CR")
+				resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, resource)).To(Succeed())
+				resource.Spec.SegmentKey = "temporary-key"
+				Expect(k8sClient.Update(ctx, resource)).To(Succeed())
+
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(Equal("temporary-key"))
+				})
+
+				By("removing the key from the CR")
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, resource)).To(Succeed())
+				resource.Spec.SegmentKey = ""
+				Expect(k8sClient.Update(ctx, resource)).To(Succeed())
+
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
+					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(BeEmpty(), "write key should be empty")
+					g.Expect(string(data["SEGMENT_BATCH_API"])).To(Equal(
+						konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
+				})
+			})
+
+			It("should create Secret with both SEGMENT_WRITE_KEY and SEGMENT_BATCH_API from inline CR fields", func(ctx context.Context) {
+				createCR(ctx)
+
+				resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, resource)).To(Succeed())
+				resource.Spec.SegmentKey = "test-write-key"
+				resource.Spec.SegmentAPIURL = "https://console.redhat.com/connections/api/v1"
+				Expect(k8sClient.Update(ctx, resource)).To(Succeed())
+
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(Equal("test-write-key"))
+					g.Expect(string(data["SEGMENT_BATCH_API"])).To(Equal("https://console.redhat.com/connections/api/v1/batch"))
+					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
+				})
+			})
+
+			It("should use default URL when only segmentKey is set", func(ctx context.Context) {
+				createCR(ctx)
+
+				resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, resource)).To(Succeed())
+				resource.Spec.SegmentKey = "default-key"
+				Expect(k8sClient.Update(ctx, resource)).To(Succeed())
+
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(Equal("default-key"))
+					g.Expect(string(data["SEGMENT_BATCH_API"])).To(Equal(
+						konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
+					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
+				})
+			})
 		})
 
-		It("should create Secret with empty segment fields when no write key is configured", func() {
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultKey,
-			}
+		Context("with build-time default key", func() {
+			BeforeEach(func() { startManager(staticKey("build-time-key"), nil) })
 
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+			It("should use build-time default key when CR key is empty", func(ctx context.Context) {
+				createCR(ctx)
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(Equal("build-time-key"))
+					g.Expect(string(data["SEGMENT_BATCH_API"])).To(Equal(
+						konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
+					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
+				})
 			})
-			Expect(err).NotTo(HaveOccurred())
 
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed(), "Secret should always be created")
+			It("should prefer CR inline key over build-time default", func(ctx context.Context) {
+				createCR(ctx)
 
-			Expect(string(secret.Data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
-			Expect(string(secret.Data["SEGMENT_WRITE_KEY"])).To(BeEmpty(), "write key should be empty")
-			Expect(string(secret.Data["SEGMENT_BATCH_API"])).To(Equal(
-				konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
+				resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, resource)).To(Succeed())
+				resource.Spec.SegmentKey = "cr-override-key"
+				Expect(k8sClient.Update(ctx, resource)).To(Succeed())
+
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(Equal("cr-override-key"))
+					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
+				})
+			})
 		})
 
-		It("should retain Secret with only TEKTON_RESULTS_API_ADDR when key becomes empty", func() {
-			By("First reconciling with a key to create the Secret")
-			resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
-			resource.Spec.SegmentKey = "temporary-key"
-			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
-
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultKey,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed(), "Secret should exist after reconciling with a key")
-			Expect(secret.Data).To(HaveKey("SEGMENT_WRITE_KEY"))
-
-			By("Removing the key and reconciling again")
-			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
-			resource.Spec.SegmentKey = ""
-			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
-
-			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed(), "Secret should still exist after key removal")
-
-			Expect(string(secret.Data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
-			Expect(string(secret.Data["SEGMENT_WRITE_KEY"])).To(BeEmpty(), "write key should be empty")
-			Expect(string(secret.Data["SEGMENT_BATCH_API"])).To(Equal(
-				konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
-		})
-
-		It("should create Secret with both SEGMENT_WRITE_KEY and SEGMENT_BATCH_API from inline CR fields", func() {
-			By("Updating the CR with inline segment config")
-			resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
-			resource.Spec.SegmentKey = "test-write-key"
-			resource.Spec.SegmentAPIURL = "https://console.redhat.com/connections/api/v1"
-			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
-
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultKey,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data["SEGMENT_WRITE_KEY"])).To(Equal("test-write-key"))
-			Expect(string(secret.Data["SEGMENT_BATCH_API"])).To(Equal("https://console.redhat.com/connections/api/v1/batch"))
-			Expect(string(secret.Data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
-		})
-
-		It("should use default URL when only segmentKey is set", func() {
-			By("Updating the CR with only a segment key")
-			resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
-			resource.Spec.SegmentKey = "default-key"
-			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
-
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultKey,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data["SEGMENT_WRITE_KEY"])).To(Equal("default-key"))
-			Expect(string(secret.Data["SEGMENT_BATCH_API"])).To(Equal(
-				konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
-			Expect(string(secret.Data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
-		})
-
-		It("should use build-time default key when CR key is empty", func() {
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: staticKey("build-time-key"),
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data["SEGMENT_WRITE_KEY"])).To(Equal("build-time-key"))
-			Expect(string(secret.Data["SEGMENT_BATCH_API"])).To(Equal(
-				konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
-			Expect(string(secret.Data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
-		})
-
-		It("should prefer CR inline key over build-time default", func() {
-			By("Updating the CR with an inline segment key")
-			resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
-			resource.Spec.SegmentKey = "cr-override-key"
-			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
-
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: staticKey("build-time-key"),
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data["SEGMENT_WRITE_KEY"])).To(Equal("cr-override-key"))
-			Expect(string(secret.Data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
-		})
-
-		It("should use OpenShift Tekton Results API address when running on OpenShift", func() {
-			By("Updating the CR with a segment key")
-			resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
-			resource.Spec.SegmentKey = "openshift-key"
-			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
-
-			openShiftClusterInfo, err := clusterinfo.DetectWithClient(&mockDiscoveryClient{
-				resources: map[string]*metav1.APIResourceList{
-					"config.openshift.io/v1": {
-						APIResources: []metav1.APIResource{
-							{Kind: "ClusterVersion"},
+		Context("on OpenShift", func() {
+			BeforeEach(func() {
+				openShiftClusterInfo, err := clusterinfo.DetectWithClient(&mockDiscoveryClient{
+					resources: map[string]*metav1.APIResourceList{
+						"config.openshift.io/v1": {
+							APIResources: []metav1.APIResource{
+								{Kind: "ClusterVersion"},
+							},
 						},
 					},
-				},
-				serverVersion: &version.Info{GitVersion: "v1.29.0"},
+					serverVersion: &version.Info{GitVersion: "v1.29.0"},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				startManager(noDefaultKey, openShiftClusterInfo)
 			})
-			Expect(err).NotTo(HaveOccurred())
 
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				ClusterInfo:          openShiftClusterInfo,
-				GetDefaultSegmentKey: noDefaultKey,
-			}
+			It("should use OpenShift Tekton Results API address when running on OpenShift", func(ctx context.Context) {
+				createCR(ctx)
 
-			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+				resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, resource)).To(Succeed())
+				resource.Spec.SegmentKey = "openshift-key"
+				Expect(k8sClient.Update(ctx, resource)).To(Succeed())
+
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrOpenShift))
+				})
 			})
-			Expect(err).NotTo(HaveOccurred())
-
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrOpenShift))
 		})
-
 	})
 })

--- a/operator/internal/controller/segmentbridge/konfluxsegmentbridge_controller_test.go
+++ b/operator/internal/controller/segmentbridge/konfluxsegmentbridge_controller_test.go
@@ -27,9 +27,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 )
 
@@ -55,281 +56,191 @@ func (m *mockDiscoveryClient) ServerVersion() (*version.Info, error) {
 var _ clusterinfo.DiscoveryClient = (*mockDiscoveryClient)(nil)
 
 var _ = Describe("KonfluxSegmentBridge Controller", func() {
+	// startManager creates a per-test manager with the given reconciler configuration
+	// and registers a DeferCleanup to cancel it after the test.
+	// A per-test manager is required because each test wires the reconciler with a different
+	// GetDefaultSegmentKey or ClusterInfo, and a shared suite-level manager cannot be
+	// re-configured between tests.
+	startManager := func(getDefaultSegmentKey func() string, clusterInfo *clusterinfo.Info) {
+		mgr := testutil.NewTestManager(testEnv)
+		Expect((&KonfluxSegmentBridgeReconciler{
+			Client:               mgr.GetClient(),
+			Scheme:               mgr.GetScheme(),
+			ObjectStore:          objectStore,
+			GetDefaultSegmentKey: getDefaultSegmentKey,
+			ClusterInfo:          clusterInfo,
+		}).SetupWithManager(mgr)).To(Succeed())
+		mgrCtx, cancel := context.WithCancel(testEnv.Ctx)
+		DeferCleanup(cancel)
+		testutil.StartManagerWithContext(mgrCtx, mgr)
+	}
+
+	// createCR creates the KonfluxSegmentBridge CR and registers cleanup for both
+	// the CR and the Secret the controller will create.
+	createCR := func(ctx context.Context) {
+		Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxSegmentBridge{
+			ObjectMeta: metav1.ObjectMeta{Name: CRName},
+		})).To(Succeed())
+		DeferCleanup(func(ctx context.Context) {
+			testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxSegmentBridge{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})
+			testutil.DeleteAndWait(ctx, k8sClient, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      segmentBridgeSecretName,
+				Namespace: segmentBridgeNamespace,
+			}})
+		})
+	}
+
+	// waitForSecret polls until the Secret exists and the caller's check passes.
+	waitForSecret := func(ctx context.Context, check func(g Gomega, data map[string][]byte)) {
+		Eventually(func(g Gomega) {
+			secret := &corev1.Secret{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
+			}, secret)).To(Succeed())
+			check(g, secret.Data)
+		}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+	}
+
 	Context("When reconciling a resource", func() {
+		Context("with no-op default segment key", func() {
+			BeforeEach(func() { startManager(noDefaultKey, nil) })
 
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name: CRName,
-		}
-		konfluxsegmentbridge := &konfluxv1alpha1.KonfluxSegmentBridge{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxSegmentBridge")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxsegmentbridge)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxSegmentBridge{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: CRName,
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxSegmentBridge")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Cleanup the segment-bridge-config secret if it exists")
-			secret := &corev1.Secret{}
-			err = k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)
-			if err == nil {
-				_ = k8sClient.Delete(ctx, secret)
-			}
-		})
-
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultKey,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+			It("should successfully reconcile the resource", func(ctx context.Context) {
+				createCR(ctx)
+				Eventually(func(g Gomega) {
+					cr := &konfluxv1alpha1.KonfluxSegmentBridge{}
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, cr)).To(Succeed())
+					g.Expect(condition.IsConditionTrue(cr, condition.TypeReady)).To(BeTrue())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 			})
-			Expect(err).NotTo(HaveOccurred())
+
+			It("should create Secret with empty segment fields when no write key is configured", func(ctx context.Context) {
+				createCR(ctx)
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
+					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(BeEmpty(), "write key should be empty")
+					g.Expect(string(data["SEGMENT_BATCH_API"])).To(Equal(
+						konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
+				})
+			})
+
+			It("should retain Secret with only TEKTON_RESULTS_API_ADDR when key becomes empty", func(ctx context.Context) {
+				createCR(ctx)
+
+				By("setting a temporary key on the CR")
+				resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, resource)).To(Succeed())
+				resource.Spec.SegmentKey = "temporary-key"
+				Expect(k8sClient.Update(ctx, resource)).To(Succeed())
+
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(Equal("temporary-key"))
+				})
+
+				By("removing the key from the CR")
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, resource)).To(Succeed())
+				resource.Spec.SegmentKey = ""
+				Expect(k8sClient.Update(ctx, resource)).To(Succeed())
+
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
+					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(BeEmpty(), "write key should be empty")
+					g.Expect(string(data["SEGMENT_BATCH_API"])).To(Equal(
+						konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
+				})
+			})
+
+			It("should create Secret with both SEGMENT_WRITE_KEY and SEGMENT_BATCH_API from inline CR fields", func(ctx context.Context) {
+				createCR(ctx)
+
+				resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, resource)).To(Succeed())
+				resource.Spec.SegmentKey = "test-write-key"
+				resource.Spec.SegmentAPIURL = "https://console.redhat.com/connections/api/v1"
+				Expect(k8sClient.Update(ctx, resource)).To(Succeed())
+
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(Equal("test-write-key"))
+					g.Expect(string(data["SEGMENT_BATCH_API"])).To(Equal("https://console.redhat.com/connections/api/v1/batch"))
+					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
+				})
+			})
+
+			It("should use default URL when only segmentKey is set", func(ctx context.Context) {
+				createCR(ctx)
+
+				resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, resource)).To(Succeed())
+				resource.Spec.SegmentKey = "default-key"
+				Expect(k8sClient.Update(ctx, resource)).To(Succeed())
+
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(Equal("default-key"))
+					g.Expect(string(data["SEGMENT_BATCH_API"])).To(Equal(
+						konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
+					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
+				})
+			})
 		})
 
-		It("should create Secret with empty segment fields when no write key is configured", func() {
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultKey,
-			}
+		Context("with build-time default key", func() {
+			BeforeEach(func() { startManager(staticKey("build-time-key"), nil) })
 
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+			It("should use build-time default key when CR key is empty", func(ctx context.Context) {
+				createCR(ctx)
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(Equal("build-time-key"))
+					g.Expect(string(data["SEGMENT_BATCH_API"])).To(Equal(
+						konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
+					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
+				})
 			})
-			Expect(err).NotTo(HaveOccurred())
 
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed(), "Secret should always be created")
+			It("should prefer CR inline key over build-time default", func(ctx context.Context) {
+				createCR(ctx)
 
-			Expect(string(secret.Data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
-			Expect(string(secret.Data["SEGMENT_WRITE_KEY"])).To(BeEmpty(), "write key should be empty")
-			Expect(string(secret.Data["SEGMENT_BATCH_API"])).To(Equal(
-				konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
+				resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, resource)).To(Succeed())
+				resource.Spec.SegmentKey = "cr-override-key"
+				Expect(k8sClient.Update(ctx, resource)).To(Succeed())
+
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(Equal("cr-override-key"))
+					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
+				})
+			})
 		})
 
-		It("should retain Secret with only TEKTON_RESULTS_API_ADDR when key becomes empty", func() {
-			By("First reconciling with a key to create the Secret")
-			resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
-			resource.Spec.SegmentKey = "temporary-key"
-			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
-
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultKey,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed(), "Secret should exist after reconciling with a key")
-			Expect(secret.Data).To(HaveKey("SEGMENT_WRITE_KEY"))
-
-			By("Removing the key and reconciling again")
-			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
-			resource.Spec.SegmentKey = ""
-			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
-
-			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed(), "Secret should still exist after key removal")
-
-			Expect(string(secret.Data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
-			Expect(string(secret.Data["SEGMENT_WRITE_KEY"])).To(BeEmpty(), "write key should be empty")
-			Expect(string(secret.Data["SEGMENT_BATCH_API"])).To(Equal(
-				konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
-		})
-
-		It("should create Secret with both SEGMENT_WRITE_KEY and SEGMENT_BATCH_API from inline CR fields", func() {
-			By("Updating the CR with inline segment config")
-			resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
-			resource.Spec.SegmentKey = "test-write-key"
-			resource.Spec.SegmentAPIURL = "https://console.redhat.com/connections/api/v1"
-			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
-
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultKey,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data["SEGMENT_WRITE_KEY"])).To(Equal("test-write-key"))
-			Expect(string(secret.Data["SEGMENT_BATCH_API"])).To(Equal("https://console.redhat.com/connections/api/v1/batch"))
-			Expect(string(secret.Data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
-		})
-
-		It("should use default URL when only segmentKey is set", func() {
-			By("Updating the CR with only a segment key")
-			resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
-			resource.Spec.SegmentKey = "default-key"
-			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
-
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultKey,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data["SEGMENT_WRITE_KEY"])).To(Equal("default-key"))
-			Expect(string(secret.Data["SEGMENT_BATCH_API"])).To(Equal(
-				konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
-			Expect(string(secret.Data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
-		})
-
-		It("should use build-time default key when CR key is empty", func() {
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: staticKey("build-time-key"),
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data["SEGMENT_WRITE_KEY"])).To(Equal("build-time-key"))
-			Expect(string(secret.Data["SEGMENT_BATCH_API"])).To(Equal(
-				konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
-			Expect(string(secret.Data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
-		})
-
-		It("should prefer CR inline key over build-time default", func() {
-			By("Updating the CR with an inline segment key")
-			resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
-			resource.Spec.SegmentKey = "cr-override-key"
-			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
-
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: staticKey("build-time-key"),
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data["SEGMENT_WRITE_KEY"])).To(Equal("cr-override-key"))
-			Expect(string(secret.Data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
-		})
-
-		It("should use OpenShift Tekton Results API address when running on OpenShift", func() {
-			By("Updating the CR with a segment key")
-			resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
-			resource.Spec.SegmentKey = "openshift-key"
-			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
-
-			openShiftClusterInfo, err := clusterinfo.DetectWithClient(&mockDiscoveryClient{
-				resources: map[string]*metav1.APIResourceList{
-					"config.openshift.io/v1": {
-						APIResources: []metav1.APIResource{
-							{Kind: "ClusterVersion"},
+		Context("on OpenShift", func() {
+			BeforeEach(func() {
+				openShiftClusterInfo, err := clusterinfo.DetectWithClient(&mockDiscoveryClient{
+					resources: map[string]*metav1.APIResourceList{
+						"config.openshift.io/v1": {
+							APIResources: []metav1.APIResource{
+								{Kind: "ClusterVersion"},
+							},
 						},
 					},
-				},
-				serverVersion: &version.Info{GitVersion: "v1.29.0"},
+					serverVersion: &version.Info{GitVersion: "v1.29.0"},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				startManager(noDefaultKey, openShiftClusterInfo)
 			})
-			Expect(err).NotTo(HaveOccurred())
 
-			controllerReconciler := &KonfluxSegmentBridgeReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				ClusterInfo:          openShiftClusterInfo,
-				GetDefaultSegmentKey: noDefaultKey,
-			}
+			It("should use OpenShift Tekton Results API address when running on OpenShift", func(ctx context.Context) {
+				createCR(ctx)
 
-			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+				resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, resource)).To(Succeed())
+				resource.Spec.SegmentKey = "openshift-key"
+				Expect(k8sClient.Update(ctx, resource)).To(Succeed())
+
+				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
+					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrOpenShift))
+				})
 			})
-			Expect(err).NotTo(HaveOccurred())
-
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: segmentBridgeSecretName, Namespace: segmentBridgeNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrOpenShift))
 		})
-
 	})
 })

--- a/operator/internal/controller/testutil/testutil.go
+++ b/operator/internal/controller/testutil/testutil.go
@@ -25,17 +25,23 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck // dot imports are standard for Ginkgo tests
 	. "github.com/onsi/gomega"    //nolint:staticcheck // dot imports are standard for Gomega matchers
 
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
@@ -52,6 +58,7 @@ type TestEnv struct {
 	Cfg         *rest.Config
 	K8sClient   client.Client
 	ObjectStore *manifests.ObjectStore
+	Manager     ctrl.Manager
 }
 
 var (
@@ -77,6 +84,9 @@ func SetupTestEnv(basePath string) *TestEnv {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = securityv1.Install(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = apiextensionsv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	objectStore, err := manifests.NewObjectStore(scheme.Scheme)
@@ -177,4 +187,78 @@ func FindContainer(containers []corev1.Container, name string) *corev1.Container
 		}
 	}
 	return nil
+}
+
+// NewTestManager creates a controller-runtime manager suitable for use in envtest suites.
+// Metrics server, health probes, and leader election are disabled so the manager
+// can be started without claiming ports or acquiring locks.
+// SkipNameValidation is set to true to prevent "controller already registered" panics
+// that can occur when the same controller name is registered across test runs in the
+// same process (consistent with the pattern used in notification-service).
+func NewTestManager(env *TestEnv) ctrl.Manager {
+	skipNameValidation := true
+	mgr, err := ctrl.NewManager(env.Cfg, ctrl.Options{
+		Scheme:                 scheme.Scheme,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+		LeaderElection:         false,
+		Controller: config.Controller{
+			SkipNameValidation: &skipNameValidation,
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	return mgr
+}
+
+// StartManager starts mgr in a goroutine tied to env.Ctx and blocks until the
+// informer cache has synced. Must be called after all SetupWithManager calls.
+//
+// Note: use the suite-level k8sClient (direct API server client) for test assertions,
+// not mgr.GetClient() (cache-backed). Asserting against the live API server state
+// avoids cache staleness and keeps test setup and assertions on the same client.
+// See: https://github.com/konflux-ci/notification-service/tree/main/internal/controller
+func StartManager(env *TestEnv, mgr ctrl.Manager) {
+	env.Manager = mgr
+	StartManagerWithContext(env.Ctx, mgr)
+}
+
+// DeleteAndWait deletes obj from the cluster if it exists and blocks until it is fully gone.
+// It is a no-op when the object is already absent. Any unexpected error fails the test immediately.
+func DeleteAndWait(ctx context.Context, c client.Client, obj client.Object) {
+	key := client.ObjectKeyFromObject(obj)
+	err := c.Get(ctx, key, obj)
+	if errors.IsNotFound(err) {
+		return
+	}
+	Expect(err).NotTo(HaveOccurred())
+	Expect(c.Delete(ctx, obj)).To(Succeed())
+	Eventually(func(g Gomega) {
+		err := c.Get(ctx, key, obj)
+		if errors.IsNotFound(err) {
+			return // object is gone: success
+		}
+		// Propagate unexpected errors (e.g. network failure, unauthorized) via the
+		// assertion rather than masking them as a generic timeout.
+		g.Expect(err).NotTo(HaveOccurred(), "unexpected error while waiting for deletion")
+		// err == nil: object still exists — fail the assertion to keep retrying.
+		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "object %s still exists, waiting for deletion", key)
+	}).WithTimeout(10 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
+}
+
+// StartManagerWithContext starts mgr in a goroutine tied to the provided context and
+// blocks until the informer cache has synced. Use this for per-test managers whose
+// lifecycle should be shorter than the suite (e.g. stop them via DeferCleanup when
+// different tests need different reconciler configurations).
+func StartManagerWithContext(ctx context.Context, mgr ctrl.Manager) {
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(ctx)).To(Succeed())
+	}()
+	// Use a dedicated timeout context for cache sync so that WaitForCacheSync —
+	// a blocking call — has a hard upper bound. The outer ctx has no deadline
+	// (it is a WithCancel of context.TODO()), so without this the call could
+	// block indefinitely and Eventually's timeout would never fire.
+	syncCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	Expect(mgr.GetCache().WaitForCacheSync(syncCtx)).To(BeTrue())
 }

--- a/operator/internal/controller/testutil/testutil.go
+++ b/operator/internal/controller/testutil/testutil.go
@@ -25,17 +25,23 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck // dot imports are standard for Ginkgo tests
 	. "github.com/onsi/gomega"    //nolint:staticcheck // dot imports are standard for Gomega matchers
 
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
@@ -53,6 +59,13 @@ type TestEnv struct {
 	K8sClient   client.Client
 	ObjectStore *manifests.ObjectStore
 }
+
+const (
+	// EventuallyTimeout is the default timeout for Eventually blocks in controller tests.
+	EventuallyTimeout = 30 * time.Second
+	// EventuallyPolling is the default polling interval for Eventually blocks in controller tests.
+	EventuallyPolling = time.Second
+)
 
 var (
 	sharedObjectStore     *manifests.ObjectStore
@@ -77,6 +90,9 @@ func SetupTestEnv(basePath string) *TestEnv {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = securityv1.Install(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = apiextensionsv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	objectStore, err := manifests.NewObjectStore(scheme.Scheme)
@@ -177,4 +193,77 @@ func FindContainer(containers []corev1.Container, name string) *corev1.Container
 		}
 	}
 	return nil
+}
+
+// NewTestManager creates a controller-runtime manager suitable for use in envtest suites.
+// Metrics server, health probes, and leader election are disabled so the manager
+// can be started without claiming ports or acquiring locks.
+// SkipNameValidation is set to true to prevent "controller already registered" panics
+// that can occur when the same controller name is registered across test runs in the
+// same process (consistent with the pattern used in notification-service).
+func NewTestManager(env *TestEnv) ctrl.Manager {
+	skipNameValidation := true
+	mgr, err := ctrl.NewManager(env.Cfg, ctrl.Options{
+		Scheme:                 scheme.Scheme,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+		LeaderElection:         false,
+		Controller: config.Controller{
+			SkipNameValidation: &skipNameValidation,
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	return mgr
+}
+
+// StartManager starts mgr in a goroutine tied to env.Ctx and blocks until the
+// informer cache has synced. Must be called after all SetupWithManager calls.
+//
+// Note: use the suite-level k8sClient (direct API server client) for test assertions,
+// not mgr.GetClient() (cache-backed). Asserting against the live API server state
+// avoids cache staleness and keeps test setup and assertions on the same client.
+// See: https://github.com/konflux-ci/notification-service/tree/main/internal/controller
+func StartManager(env *TestEnv, mgr ctrl.Manager) {
+	StartManagerWithContext(env.Ctx, mgr)
+}
+
+// DeleteAndWait deletes obj from the cluster if it exists and blocks until it is fully gone.
+// It is a no-op when the object is already absent. Any unexpected error fails the test immediately.
+func DeleteAndWait(ctx context.Context, c client.Client, obj client.Object) {
+	key := client.ObjectKeyFromObject(obj)
+	err := c.Get(ctx, key, obj)
+	if errors.IsNotFound(err) {
+		return
+	}
+	Expect(err).NotTo(HaveOccurred())
+	Expect(c.Delete(ctx, obj)).To(Succeed())
+	Eventually(func(g Gomega) {
+		err := c.Get(ctx, key, obj)
+		if errors.IsNotFound(err) {
+			return // object is gone: success
+		}
+		// Propagate unexpected errors (e.g. network failure, unauthorized) immediately
+		// rather than masking them as a generic timeout.
+		g.Expect(err).NotTo(HaveOccurred(), "unexpected error while waiting for deletion of %s", key)
+		// err == nil: object still exists — keep retrying.
+		g.Expect(false).To(BeTrue(), "object %s still exists, waiting for deletion", key)
+	}).WithTimeout(10 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
+}
+
+// StartManagerWithContext starts mgr in a goroutine tied to the provided context and
+// blocks until the informer cache has synced. Use this for per-test managers whose
+// lifecycle should be shorter than the suite (e.g. stop them via DeferCleanup when
+// different tests need different reconciler configurations).
+func StartManagerWithContext(ctx context.Context, mgr ctrl.Manager) {
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(ctx)).To(Succeed())
+	}()
+	// Use a dedicated timeout context for cache sync so that WaitForCacheSync —
+	// a blocking call — has a hard upper bound. The outer ctx has no deadline
+	// (it is a WithCancel of context.TODO()), so without this the call could
+	// block indefinitely and Eventually's timeout would never fire.
+	syncCtx, cancel := context.WithTimeout(ctx, EventuallyTimeout)
+	defer cancel()
+	Expect(mgr.GetCache().WaitForCacheSync(syncCtx)).To(BeTrue())
 }

--- a/operator/internal/controller/ui/konfluxui_controller_test.go
+++ b/operator/internal/controller/ui/konfluxui_controller_test.go
@@ -19,10 +19,12 @@ package ui
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	consolev1 "github.com/openshift/api/console/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -32,13 +34,11 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	consolev1 "github.com/openshift/api/console/v1"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/segmentbridge"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/consolelink"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/dex"
@@ -51,190 +51,115 @@ func noDefaultSegmentKey() string             { return "" }
 func staticSegmentKey(k string) func() string { return func() string { return k } }
 
 var _ = Describe("KonfluxUI Controller", func() {
+	// startManager creates a per-test manager with the given reconciler configuration
+	// and registers a DeferCleanup to cancel it after the test.
+	startManager := func(getDefaultSegmentKey func() string, clusterInfo *clusterinfo.Info) {
+		mgr := testutil.NewTestManager(testEnv)
+		Expect((&KonfluxUIReconciler{
+			Client:               mgr.GetClient(),
+			Scheme:               mgr.GetScheme(),
+			ObjectStore:          objectStore,
+			GetDefaultSegmentKey: getDefaultSegmentKey,
+			ClusterInfo:          clusterInfo,
+		}).SetupWithManager(mgr)).To(Succeed())
+		mgrCtx, cancel := context.WithCancel(testEnv.Ctx)
+		DeferCleanup(cancel)
+		testutil.StartManagerWithContext(mgrCtx, mgr)
+	}
+
+	// waitForReconcile blocks until both UI Deployments exist, proving the initial
+	// reconcile has completed. Used as a sentinel before synchronous absence checks.
+	waitForReconcile := func(ctx context.Context) {
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: proxyDeploymentName, Namespace: uiNamespace,
+			}, &appsv1.Deployment{})).To(Succeed())
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: dexDeploymentName, Namespace: uiNamespace,
+			}, &appsv1.Deployment{})).To(Succeed())
+		}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
+	}
+
 	Context("When reconciling a resource", func() {
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			startManager(noDefaultSegmentKey, nil)
 
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      CRName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		konfluxui := &konfluxv1alpha1.KonfluxUI{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxUI")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxui)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxUI{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      CRName,
-						Namespace: "default",
-					},
-					Spec: konfluxv1alpha1.KonfluxUISpec{},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxUI{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxUI")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxUIReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultSegmentKey,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				Spec:       konfluxv1alpha1.KonfluxUISpec{},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
 			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+			// Wait for the Deployment rather than Ready=True: UpdateComponentStatuses
+			// gates Ready=True on ReadyReplicas == Replicas, which never happens in
+			// envtest (no kubelet → pods never start).
+			waitForReconcile(ctx)
 		})
 	})
 
 	Context("ensureUISecrets", func() {
-		var ui *konfluxv1alpha1.KonfluxUI
-		var reconciler *KonfluxUIReconciler
-
-		// Helper: reconcile and expect success
-		reconcileUI := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: ui.Name},
-			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		cleanupSecrets := func(ctx context.Context) {
+			_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+			}})
+			_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: "oauth2-proxy-cookie-secret", Namespace: uiNamespace,
+			}})
 		}
 
 		BeforeEach(func(ctx context.Context) {
-			By("cleaning up any existing secrets from previous tests")
-			clientSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oauth2-proxy-client-secret",
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, clientSecret)
+			startManager(noDefaultSegmentKey, nil)
 
-			cookieSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oauth2-proxy-cookie-secret",
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, cookieSecret)
-
-			By("creating the KonfluxUI resource")
-			ui = &konfluxv1alpha1.KonfluxUI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxUISpec{},
-			}
-			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
-
-			reconciler = &KonfluxUIReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultSegmentKey,
-			}
-
-			By("creating the UI namespace")
-			uiNs := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: uiNamespace,
-				},
-			}
+			By("ensuring the UI namespace exists")
+			uiNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: uiNamespace}}
 			err := k8sClient.Create(ctx, uiNs)
 			if err != nil && !errors.IsAlreadyExists(err) {
 				Expect(err).NotTo(HaveOccurred())
 			}
-		})
 
-		AfterEach(func(ctx context.Context) {
-			By("cleaning up secrets")
-			clientSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oauth2-proxy-client-secret",
-					Namespace: uiNamespace,
-				},
-			}
-			err := k8sClient.Delete(ctx, clientSecret)
-			if err != nil && !errors.IsNotFound(err) {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to delete client secret: %v\n", err)
-			}
-
-			cookieSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oauth2-proxy-cookie-secret",
-					Namespace: uiNamespace,
-				},
-			}
-			err = k8sClient.Delete(ctx, cookieSecret)
-			if err != nil && !errors.IsNotFound(err) {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to delete cookie secret: %v\n", err)
-			}
-
-			By("cleaning up KonfluxUI resource")
-			err = k8sClient.Delete(ctx, ui)
-			if err != nil && !errors.IsNotFound(err) {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to delete KonfluxUI: %v\n", err)
-			}
+			By("pre-cleaning any leftover secrets")
+			cleanupSecrets(ctx)
 		})
 
 		It("Should preserve existing secret data when secret already exists with valid data", func(ctx context.Context) {
-			By("creating a secret with existing data")
+			By("creating the secret with existing data before the CR exists")
 			existingData := []byte("existing-secret-value")
-			secret := &corev1.Secret{
+			Expect(k8sClient.Create(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oauth2-proxy-client-secret",
-					Namespace: uiNamespace,
-					Labels: map[string]string{
-						constant.KonfluxOwnerLabel:     CRName,
-						constant.KonfluxComponentLabel: string(manifests.UI),
-					},
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "konflux.konflux-ci.dev/v1alpha1",
-							Kind:               "KonfluxUI",
-							Name:               ui.Name,
-							UID:                ui.UID,
-							Controller:         func() *bool { b := true; return &b }(),
-							BlockOwnerDeletion: func() *bool { b := true; return &b }(),
-						},
-					},
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
 				},
-				Data: map[string][]byte{
-					"client-secret": existingData,
-				},
-			}
-			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+				Data: map[string][]byte{"client-secret": existingData},
+			})).To(Succeed())
 
-			By("calling Reconcile")
-			reconcileUI(ctx)
+			By("creating the KonfluxUI CR to trigger reconcile")
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
+				cleanupSecrets(ctx)
+			})
 
-			By("verifying the secret data was preserved")
-			updatedSecret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-client-secret",
-				Namespace: uiNamespace,
-			}, updatedSecret)).To(Succeed())
-			Expect(updatedSecret.Data["client-secret"]).To(Equal(existingData))
+			By("verifying the secret data was preserved after reconcile")
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				// Owner reference being set proves reconcile ran
+				g.Expect(secret.OwnerReferences).NotTo(BeEmpty())
+				g.Expect(secret.Data["client-secret"]).To(Equal(existingData))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should update ownership labels and owner reference when secret exists but has incorrect ownership", func(ctx context.Context) {
-			By("creating a secret with incorrect ownership labels and no owner reference")
-			secret := &corev1.Secret{
+			By("creating the secret with wrong ownership before the CR exists")
+			Expect(k8sClient.Create(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "oauth2-proxy-client-secret",
 					Namespace: uiNamespace,
@@ -243,129 +168,160 @@ var _ = Describe("KonfluxUI Controller", func() {
 						constant.KonfluxComponentLabel: "wrong-component",
 					},
 				},
-				Data: map[string][]byte{
-					"client-secret": []byte("existing-value"),
-				},
-			}
-			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+				Data: map[string][]byte{"client-secret": []byte("existing-value")},
+			})).To(Succeed())
 
-			By("calling Reconcile")
-			reconcileUI(ctx)
+			By("creating the KonfluxUI CR to trigger reconcile")
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
+				cleanupSecrets(ctx)
+			})
 
-			By("verifying the ownership labels were updated")
-			updatedSecret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-client-secret",
-				Namespace: uiNamespace,
-			}, updatedSecret)).To(Succeed())
-			Expect(updatedSecret.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
-			Expect(updatedSecret.Labels).To(HaveKeyWithValue(constant.KonfluxComponentLabel, string(manifests.UI)))
-
-			By("verifying the owner reference was added")
-			Expect(updatedSecret.OwnerReferences).To(HaveLen(1))
-			Expect(updatedSecret.OwnerReferences[0].Name).To(Equal(CRName))
+			By("verifying the ownership labels and owner reference were corrected")
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(secret.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
+				g.Expect(secret.Labels).To(HaveKeyWithValue(constant.KonfluxComponentLabel, string(manifests.UI)))
+				g.Expect(secret.OwnerReferences).To(HaveLen(1))
+				g.Expect(secret.OwnerReferences[0].Name).To(Equal(CRName))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should regenerate secret data when secret exists but has empty data", func(ctx context.Context) {
-			By("creating a secret with empty data")
-			secret := &corev1.Secret{
+			By("creating the secret with empty data before the CR exists")
+			Expect(k8sClient.Create(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oauth2-proxy-client-secret",
-					Namespace: uiNamespace,
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
 				},
 				Data: map[string][]byte{},
-			}
-			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			})).To(Succeed())
 
-			By("calling Reconcile")
-			reconcileUI(ctx)
+			By("creating the KonfluxUI CR to trigger reconcile")
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
+				cleanupSecrets(ctx)
+			})
 
-			By("verifying the secret data was generated")
-			updatedSecret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-client-secret",
-				Namespace: uiNamespace,
-			}, updatedSecret)).To(Succeed())
-			Expect(updatedSecret.Data).To(HaveKey("client-secret"))
-			Expect(updatedSecret.Data["client-secret"]).ToNot(BeEmpty())
+			By("verifying the secret data was regenerated")
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(secret.Data).To(HaveKey("client-secret"))
+				g.Expect(secret.Data["client-secret"]).NotTo(BeEmpty())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should use URL-safe base64 encoding for client-secret", func(ctx context.Context) {
-			By("calling Reconcile")
-			reconcileUI(ctx)
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
+				cleanupSecrets(ctx)
+			})
 
-			By("verifying the client-secret uses URL-safe encoding")
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-client-secret",
-				Namespace: uiNamespace,
-			}, secret)).To(Succeed())
-
-			clientSecretValue := string(secret.Data["client-secret"])
-			By("verifying no padding characters (URL-safe uses RawURLEncoding)")
-			Expect(clientSecretValue).NotTo(ContainSubstring("="))
-			By("verifying it contains only URL-safe characters")
-			Expect(clientSecretValue).To(MatchRegexp("^[A-Za-z0-9_-]+$"))
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				clientSecretValue := string(secret.Data["client-secret"])
+				g.Expect(clientSecretValue).NotTo(BeEmpty())
+				g.Expect(clientSecretValue).NotTo(ContainSubstring("="), "URL-safe base64 should have no padding")
+				g.Expect(clientSecretValue).To(MatchRegexp("^[A-Za-z0-9_-]+$"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should use standard base64 encoding for cookie-secret", func(ctx context.Context) {
-			By("calling Reconcile")
-			reconcileUI(ctx)
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
+				cleanupSecrets(ctx)
+			})
 
-			By("verifying the cookie-secret uses standard encoding")
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-cookie-secret",
-				Namespace: uiNamespace,
-			}, secret)).To(Succeed())
-
-			cookieSecretValue := string(secret.Data["cookie-secret"])
-			By("verifying it contains standard base64 characters (may include + and /)")
-			Expect(cookieSecretValue).To(MatchRegexp("^[A-Za-z0-9+/]+=*$"))
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-cookie-secret", Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				cookieSecretValue := string(secret.Data["cookie-secret"])
+				g.Expect(cookieSecretValue).NotTo(BeEmpty())
+				g.Expect(cookieSecretValue).To(MatchRegexp("^[A-Za-z0-9+/]+=*$"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
-		It("Should create both secrets in a single call", func(ctx context.Context) {
-			By("calling Reconcile")
-			reconcileUI(ctx)
+		It("Should create both secrets in a single reconcile", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
+				cleanupSecrets(ctx)
+			})
 
-			By("verifying both secrets were created")
-			clientSecret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-client-secret",
-				Namespace: uiNamespace,
-			}, clientSecret)).To(Succeed())
-
-			cookieSecret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-cookie-secret",
-				Namespace: uiNamespace,
-			}, cookieSecret)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+				}, &corev1.Secret{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-cookie-secret", Namespace: uiNamespace,
+				}, &corev1.Secret{})).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
-		It("Should be idempotent when called multiple times", func(ctx context.Context) {
-			By("calling Reconcile first time")
-			reconcileUI(ctx)
+		It("Should be idempotent across multiple reconciles", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
+				cleanupSecrets(ctx)
+			})
 
-			By("getting the first secret value")
-			secret1 := &corev1.Secret{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-client-secret",
-				Namespace: uiNamespace,
-			}, secret1)
-			Expect(err).NotTo(HaveOccurred())
-			firstValue := secret1.Data["client-secret"]
+			By("waiting for the client-secret to be created")
+			var firstValue []byte
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(secret.Data["client-secret"]).NotTo(BeEmpty())
+				firstValue = secret.Data["client-secret"]
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
-			By("calling Reconcile second time")
-			reconcileUI(ctx)
-
-			By("verifying the secret value was not changed")
-			secret2 := &corev1.Secret{}
-			err = k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-client-secret",
-				Namespace: uiNamespace,
-			}, secret2)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(secret2.Data["client-secret"]).To(Equal(firstValue))
+			By("verifying the value is stable across subsequent reconciles")
+			Consistently(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(secret.Data["client-secret"]).To(Equal(firstValue))
+			}, 5*time.Second, time.Second).Should(Succeed())
 		})
 	})
 
@@ -441,277 +397,192 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 	Context("Ingress reconciliation via Reconcile", Serial, func() {
 		var ui *konfluxv1alpha1.KonfluxUI
-		var reconciler *KonfluxUIReconciler
 
-		// Helper: refresh UI from cluster
+		// refreshUI re-fetches the CR to get the latest ResourceVersion before updates.
 		refreshUI := func(ctx context.Context) {
-			ExpectWithOffset(1, k8sClient.Get(ctx, types.NamespacedName{Name: ui.Name}, ui)).To(Succeed())
+			ExpectWithOffset(1, k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 		}
 
-		// Helper: reconcile and expect success
-		reconcileUI := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: ui.Name},
-			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-		}
-
-		// Helper: get Ingress resource
-		getIngress := func(ctx context.Context) *networkingv1.Ingress {
-			ing := &networkingv1.Ingress{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      ingress.IngressName,
-				Namespace: uiNamespace,
-			}, ing)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-			return ing
-		}
-
-		// Helper: check if Ingress exists
-		ingressExists := func(ctx context.Context) bool {
-			ing := &networkingv1.Ingress{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      ingress.IngressName,
-				Namespace: uiNamespace,
-			}, ing)
-			return err == nil
-		}
-
-		// Helper: enable ingress with host and reconcile
-		enableIngressAndReconcile := func(ctx context.Context, host string) {
+		// enableIngress updates the CR to enable ingress; the manager reconciles automatically.
+		enableIngress := func(ctx context.Context, host string) {
 			refreshUI(ctx)
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{
 				Enabled: ptr.To(true),
 				Host:    host,
 			}
 			ExpectWithOffset(1, k8sClient.Update(ctx, ui)).To(Succeed())
-			reconcileUI(ctx)
 		}
 
 		BeforeEach(func(ctx context.Context) {
-			By("cleaning up any existing ingress from previous tests")
-			existingIngress := &networkingv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      ingress.IngressName,
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingIngress)
+			startManager(noDefaultSegmentKey, nil)
 
-			By("creating the KonfluxUI resource")
-			ui = &konfluxv1alpha1.KonfluxUI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxUISpec{},
-			}
+			By("pre-cleaning any existing Ingress")
+			_ = k8sClient.Delete(ctx, &networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{
+				Name: ingress.IngressName, Namespace: uiNamespace,
+			}})
+
+			ui = &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
-
-			reconciler = &KonfluxUIReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultSegmentKey,
-			}
-		})
-
-		AfterEach(func(ctx context.Context) {
-			By("cleaning up ingress")
-			existingIngress := &networkingv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      ingress.IngressName,
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingIngress)
-
-			By("cleaning up KonfluxUI resource")
-			_ = k8sClient.Delete(ctx, ui)
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, ui)
+				_ = k8sClient.Delete(ctx, &networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}})
+			})
 		})
 
 		It("Should create Ingress when ingress is enabled", func(ctx context.Context) {
-			enableIngressAndReconcile(ctx, "test.example.com")
+			enableIngress(ctx, "test.example.com")
 
-			By("verifying the Ingress was created")
-			ing := getIngress(ctx)
-			Expect(ing.Spec.Rules).To(HaveLen(1))
-			Expect(ing.Spec.Rules[0].Host).To(Equal("test.example.com"))
+			Eventually(func(g Gomega) {
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, ing)).To(Succeed())
+				g.Expect(ing.Spec.Rules).To(HaveLen(1))
+				g.Expect(ing.Spec.Rules[0].Host).To(Equal("test.example.com"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should delete Ingress when ingress spec is set to nil", func(ctx context.Context) {
-			By("first enabling ingress and reconciling to create the Ingress")
-			enableIngressAndReconcile(ctx, "test.example.com")
-			Expect(ingressExists(ctx)).To(BeTrue())
+			By("enabling ingress to create it first")
+			enableIngress(ctx, "test.example.com")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, &networkingv1.Ingress{})).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
-			By("disabling ingress by setting spec to nil")
+			By("setting ingress spec to nil")
 			refreshUI(ctx)
 			ui.Spec.Ingress = nil
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
-			reconcileUI(ctx)
 
-			By("verifying the Ingress was deleted")
-			Expect(ingressExists(ctx)).To(BeFalse())
+			Eventually(func(g Gomega) {
+				g.Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, &networkingv1.Ingress{}))).To(BeTrue())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should delete Ingress when Enabled is set to false", func(ctx context.Context) {
-			By("first enabling ingress and reconciling to create the Ingress")
-			enableIngressAndReconcile(ctx, "test.example.com")
-			Expect(ingressExists(ctx)).To(BeTrue())
+			By("enabling ingress to create it first")
+			enableIngress(ctx, "test.example.com")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, &networkingv1.Ingress{})).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
-			By("setting Enabled to false in the KonfluxUI spec")
+			By("setting Enabled to false")
 			refreshUI(ctx)
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{Enabled: ptr.To(false)}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
-			reconcileUI(ctx)
 
-			By("verifying the Ingress was deleted")
-			Expect(ingressExists(ctx)).To(BeFalse())
+			Eventually(func(g Gomega) {
+				g.Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, &networkingv1.Ingress{}))).To(BeTrue())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should not error when ingress is disabled and no Ingress exists", func(ctx context.Context) {
-			By("ensuring no Ingress exists")
-			Expect(ingressExists(ctx)).To(BeFalse())
+			By("waiting for initial reconcile to complete")
+			waitForReconcile(ctx)
 
-			By("reconciling with ingress disabled - should not error")
-			reconcileUI(ctx)
+			By("verifying no Ingress was created")
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: ingress.IngressName, Namespace: uiNamespace,
+			}, &networkingv1.Ingress{}))).To(BeTrue())
 		})
 
 		It("Should update Ingress when hostname changes", func(ctx context.Context) {
 			By("enabling ingress with initial hostname")
-			enableIngressAndReconcile(ctx, "initial.example.com")
-			Expect(getIngress(ctx).Spec.Rules[0].Host).To(Equal("initial.example.com"))
+			enableIngress(ctx, "initial.example.com")
+			Eventually(func(g Gomega) {
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, ing)).To(Succeed())
+				g.Expect(ing.Spec.Rules[0].Host).To(Equal("initial.example.com"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
 			By("updating to new hostname")
 			refreshUI(ctx)
 			ui.Spec.Ingress.Host = "updated.example.com"
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
-			reconcileUI(ctx)
 
-			By("verifying the Ingress was updated with new hostname")
-			Expect(getIngress(ctx).Spec.Rules[0].Host).To(Equal("updated.example.com"))
+			Eventually(func(g Gomega) {
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, ing)).To(Succeed())
+				g.Expect(ing.Spec.Rules[0].Host).To(Equal("updated.example.com"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should include OpenShift TLS annotations on created Ingress", func(ctx context.Context) {
-			enableIngressAndReconcile(ctx, "test.example.com")
+			enableIngress(ctx, "test.example.com")
 
-			By("verifying the Ingress has OpenShift TLS annotations")
-			ing := getIngress(ctx)
-			Expect(ing.Annotations).To(HaveKeyWithValue(
-				"route.openshift.io/destination-ca-certificate-secret", "ui-ca"))
-			Expect(ing.Annotations).To(HaveKeyWithValue(
-				"route.openshift.io/termination", "reencrypt"))
+			Eventually(func(g Gomega) {
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, ing)).To(Succeed())
+				g.Expect(ing.Annotations).To(HaveKeyWithValue(
+					"route.openshift.io/destination-ca-certificate-secret", "ui-ca"))
+				g.Expect(ing.Annotations).To(HaveKeyWithValue(
+					"route.openshift.io/termination", "reencrypt"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should set owner reference on created Ingress", func(ctx context.Context) {
-			enableIngressAndReconcile(ctx, "test.example.com")
+			enableIngress(ctx, "test.example.com")
 
-			By("verifying the Ingress has owner reference")
-			ing := getIngress(ctx)
-			Expect(ing.OwnerReferences).To(HaveLen(1))
-			Expect(ing.OwnerReferences[0].Name).To(Equal(CRName))
-			Expect(ing.OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
+			Eventually(func(g Gomega) {
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, ing)).To(Succeed())
+				g.Expect(ing.OwnerReferences).To(HaveLen(1))
+				g.Expect(ing.OwnerReferences[0].Name).To(Equal(CRName))
+				g.Expect(ing.OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should update KonfluxUI status with ingress information", func(ctx context.Context) {
-			enableIngressAndReconcile(ctx, "status-test.example.com")
+			enableIngress(ctx, "status-test.example.com")
 
-			By("verifying the KonfluxUI status has ingress information")
-			updatedUI := &konfluxv1alpha1.KonfluxUI{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ui.Name}, updatedUI)).To(Succeed())
-			Expect(updatedUI.Status.Ingress).NotTo(BeNil())
-			Expect(updatedUI.Status.Ingress.Enabled).To(BeTrue())
-			Expect(updatedUI.Status.Ingress.Hostname).To(Equal("status-test.example.com"))
-			Expect(updatedUI.Status.Ingress.URL).To(Equal("https://status-test.example.com"))
+			Eventually(func(g Gomega) {
+				updatedUI := &konfluxv1alpha1.KonfluxUI{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updatedUI)).To(Succeed())
+				g.Expect(updatedUI.Status.Ingress).NotTo(BeNil())
+				g.Expect(updatedUI.Status.Ingress.Enabled).To(BeTrue())
+				g.Expect(updatedUI.Status.Ingress.Hostname).To(Equal("status-test.example.com"))
+				g.Expect(updatedUI.Status.Ingress.URL).To(Equal("https://status-test.example.com"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 
 	Context("OpenShift OAuth reconciliation via Reconcile", Serial, func() {
-		var ui *konfluxv1alpha1.KonfluxUI
-		var reconciler *KonfluxUIReconciler
 		var openShiftClusterInfo *clusterinfo.Info
 		var defaultClusterInfo *clusterinfo.Info
 
-		// Helper: refresh UI from cluster
-		refreshUI := func(ctx context.Context) {
-			ExpectWithOffset(1, k8sClient.Get(ctx, types.NamespacedName{Name: ui.Name}, ui)).To(Succeed())
-		}
-
-		// Helper: reconcile and expect success
-		reconcileUI := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: ui.Name},
-			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-		}
-
-		// Helper: check if OpenShift OAuth ServiceAccount exists
-		serviceAccountExists := func(ctx context.Context) bool {
-			sa := &corev1.ServiceAccount{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      dex.DexClientServiceAccountName,
-				Namespace: uiNamespace,
-			}, sa)
-			return err == nil
-		}
-
-		// Helper: check if OpenShift OAuth Secret exists
-		secretExists := func(ctx context.Context) bool {
-			secret := &corev1.Secret{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      dex.DexClientSecretName,
-				Namespace: uiNamespace,
-			}, secret)
-			return err == nil
-		}
-
-		// Helper: get OpenShift OAuth ServiceAccount
-		getServiceAccount := func(ctx context.Context) *corev1.ServiceAccount {
-			sa := &corev1.ServiceAccount{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      dex.DexClientServiceAccountName,
-				Namespace: uiNamespace,
-			}, sa)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-			return sa
-		}
-
-		// Helper: get OpenShift OAuth Secret
-		getSecret := func(ctx context.Context) *corev1.Secret {
-			secret := &corev1.Secret{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      dex.DexClientSecretName,
-				Namespace: uiNamespace,
-			}, secret)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-			return secret
-		}
-
 		BeforeEach(func(ctx context.Context) {
-			By("cleaning up any existing OpenShift OAuth resources from previous tests")
-			existingSA := &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      dex.DexClientServiceAccountName,
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingSA)
+			By("pre-cleaning any existing OpenShift OAuth resources")
+			_ = k8sClient.Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+				Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+			}})
+			_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: dex.DexClientSecretName, Namespace: uiNamespace,
+			}})
 
-			existingSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      dex.DexClientSecretName,
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingSecret)
-
-			By("creating mock cluster info for OpenShift and non-OpenShift platforms")
+			By("building cluster info for OpenShift and non-OpenShift platforms")
 			var err error
 			openShiftClusterInfo, err = clusterinfo.DetectWithClient(&mockDiscoveryClient{
 				resources: map[string]*metav1.APIResourceList{
 					"config.openshift.io/v1": {
-						APIResources: []metav1.APIResource{
-							{Kind: "ClusterVersion"},
-						},
+						APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}},
 					},
 				},
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
@@ -723,12 +594,12 @@ var _ = Describe("KonfluxUI Controller", func() {
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
 			})
 			Expect(err).NotTo(HaveOccurred())
+		})
 
-			By("creating the KonfluxUI resource with ingress enabled")
-			ui = &konfluxv1alpha1.KonfluxUI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
+		// createCR creates the KonfluxUI CR with ingress enabled and registers DeferCleanup.
+		createCR := func(ctx context.Context) *konfluxv1alpha1.KonfluxUI {
+			ui := &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 				Spec: konfluxv1alpha1.KonfluxUISpec{
 					Ingress: &konfluxv1alpha1.IngressSpec{
 						Enabled: ptr.To(true),
@@ -737,98 +608,80 @@ var _ = Describe("KonfluxUI Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
-
-			reconciler = &KonfluxUIReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				ClusterInfo:          nil, // Will be set in individual tests
-				GetDefaultSegmentKey: noDefaultSegmentKey,
-			}
-		})
-
-		AfterEach(func(ctx context.Context) {
-			By("cleaning up OpenShift OAuth ServiceAccount")
-			existingSA := &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      dex.DexClientServiceAccountName,
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingSA)
-
-			By("cleaning up OpenShift OAuth Secret")
-			existingSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      dex.DexClientSecretName,
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingSecret)
-
-			By("cleaning up KonfluxUI resource")
-			_ = k8sClient.Delete(ctx, ui)
-		})
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, ui)
+				_ = k8sClient.Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+					Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+				}})
+				_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+					Name: dex.DexClientSecretName, Namespace: uiNamespace,
+				}})
+			})
+			return ui
+		}
 
 		It("Should create OpenShift OAuth resources when running on OpenShift (default behavior)", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+				}, sa)).To(Succeed())
+				g.Expect(sa.Annotations).To(HaveKeyWithValue(
+					"serviceaccounts.openshift.io/oauth-redirecturi.dex",
+					"https://openshift-test.example.com/idp/callback",
+				))
 
-			By("verifying the ServiceAccount was created")
-			Expect(serviceAccountExists(ctx)).To(BeTrue())
-			sa := getServiceAccount(ctx)
-			Expect(sa.Annotations).To(HaveKeyWithValue(
-				"serviceaccounts.openshift.io/oauth-redirecturi.dex",
-				"https://openshift-test.example.com/idp/callback",
-			))
-
-			By("verifying the Secret was created")
-			Expect(secretExists(ctx)).To(BeTrue())
-			secret := getSecret(ctx)
-			Expect(secret.Type).To(Equal(corev1.SecretTypeServiceAccountToken))
-			Expect(secret.Annotations).To(HaveKeyWithValue(
-				"kubernetes.io/service-account.name",
-				dex.DexClientServiceAccountName,
-			))
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientSecretName, Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(secret.Type).To(Equal(corev1.SecretTypeServiceAccountToken))
+				g.Expect(secret.Annotations).To(HaveKeyWithValue(
+					"kubernetes.io/service-account.name",
+					dex.DexClientServiceAccountName,
+				))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should NOT create OpenShift OAuth resources when NOT running on OpenShift", func(ctx context.Context) {
-			By("setting ClusterInfo to non-OpenShift")
-			reconciler.ClusterInfo = defaultClusterInfo
+			startManager(noDefaultSegmentKey, defaultClusterInfo)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
+			By("waiting for initial reconcile to complete")
+			waitForReconcile(ctx)
 
-			By("verifying the ServiceAccount was NOT created")
-			Expect(serviceAccountExists(ctx)).To(BeFalse())
-
-			By("verifying the Secret was NOT created")
-			Expect(secretExists(ctx)).To(BeFalse())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+			}, &corev1.ServiceAccount{}))).To(BeTrue())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: dex.DexClientSecretName, Namespace: uiNamespace,
+			}, &corev1.Secret{}))).To(BeTrue())
 		})
 
 		It("Should NOT create OpenShift OAuth resources when ClusterInfo is nil", func(ctx context.Context) {
-			By("keeping ClusterInfo as nil")
-			reconciler.ClusterInfo = nil
+			startManager(noDefaultSegmentKey, nil)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
+			By("waiting for initial reconcile to complete")
+			waitForReconcile(ctx)
 
-			By("verifying the ServiceAccount was NOT created")
-			Expect(serviceAccountExists(ctx)).To(BeFalse())
-
-			By("verifying the Secret was NOT created")
-			Expect(secretExists(ctx)).To(BeFalse())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+			}, &corev1.ServiceAccount{}))).To(BeTrue())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: dex.DexClientSecretName, Namespace: uiNamespace,
+			}, &corev1.Secret{}))).To(BeTrue())
 		})
 
 		It("Should NOT create OpenShift OAuth resources when explicitly disabled on OpenShift", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			ui := createCR(ctx)
 
-			By("explicitly disabling OpenShift login")
-			refreshUI(ctx)
+			By("disabling OpenShift login before first reconcile settles")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Dex = &konfluxv1alpha1.DexDeploymentSpec{
 				Config: &dex.DexParams{
 					ConfigureLoginWithOpenShift: ptr.To(false),
@@ -836,22 +689,23 @@ var _ = Describe("KonfluxUI Controller", func() {
 			}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
+			By("waiting for reconcile to complete")
+			waitForReconcile(ctx)
 
-			By("verifying the ServiceAccount was NOT created")
-			Expect(serviceAccountExists(ctx)).To(BeFalse())
-
-			By("verifying the Secret was NOT created")
-			Expect(secretExists(ctx)).To(BeFalse())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+			}, &corev1.ServiceAccount{}))).To(BeTrue())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: dex.DexClientSecretName, Namespace: uiNamespace,
+			}, &corev1.Secret{}))).To(BeTrue())
 		})
 
 		It("Should create OpenShift OAuth resources when explicitly enabled on OpenShift", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			ui := createCR(ctx)
 
 			By("explicitly enabling OpenShift login")
-			refreshUI(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Dex = &konfluxv1alpha1.DexDeploymentSpec{
 				Config: &dex.DexParams{
 					ConfigureLoginWithOpenShift: ptr.To(true),
@@ -859,27 +713,32 @@ var _ = Describe("KonfluxUI Controller", func() {
 			}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the ServiceAccount was created")
-			Expect(serviceAccountExists(ctx)).To(BeTrue())
-
-			By("verifying the Secret was created")
-			Expect(secretExists(ctx)).To(BeTrue())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+				}, &corev1.ServiceAccount{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientSecretName, Namespace: uiNamespace,
+				}, &corev1.Secret{})).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should delete OpenShift OAuth resources when disabled after being enabled", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			ui := createCR(ctx)
 
-			By("first reconciling to create the resources")
-			reconcileUI(ctx)
-			Expect(serviceAccountExists(ctx)).To(BeTrue())
-			Expect(secretExists(ctx)).To(BeTrue())
+			By("waiting for OAuth resources to be created")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+				}, &corev1.ServiceAccount{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientSecretName, Namespace: uiNamespace,
+				}, &corev1.Secret{})).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
 			By("disabling OpenShift login")
-			refreshUI(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Dex = &konfluxv1alpha1.DexDeploymentSpec{
 				Config: &dex.DexParams{
 					ConfigureLoginWithOpenShift: ptr.To(false),
@@ -887,131 +746,96 @@ var _ = Describe("KonfluxUI Controller", func() {
 			}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling again")
-			reconcileUI(ctx)
-
-			By("verifying the ServiceAccount was deleted")
-			Expect(serviceAccountExists(ctx)).To(BeFalse())
-
-			By("verifying the Secret was deleted")
-			Expect(secretExists(ctx)).To(BeFalse())
+			Eventually(func(g Gomega) {
+				g.Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+				}, &corev1.ServiceAccount{}))).To(BeTrue())
+				g.Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientSecretName, Namespace: uiNamespace,
+				}, &corev1.Secret{}))).To(BeTrue())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should set owner reference on OpenShift OAuth resources", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+				}, sa)).To(Succeed())
+				g.Expect(sa.OwnerReferences).To(HaveLen(1))
+				g.Expect(sa.OwnerReferences[0].Name).To(Equal(CRName))
+				g.Expect(sa.OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
 
-			By("verifying the ServiceAccount has owner reference")
-			sa := getServiceAccount(ctx)
-			Expect(sa.OwnerReferences).To(HaveLen(1))
-			Expect(sa.OwnerReferences[0].Name).To(Equal(CRName))
-			Expect(sa.OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
-
-			By("verifying the Secret has owner reference")
-			secret := getSecret(ctx)
-			Expect(secret.OwnerReferences).To(HaveLen(1))
-			Expect(secret.OwnerReferences[0].Name).To(Equal(CRName))
-			Expect(secret.OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientSecretName, Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(secret.OwnerReferences).To(HaveLen(1))
+				g.Expect(secret.OwnerReferences[0].Name).To(Equal(CRName))
+				g.Expect(secret.OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should use correct redirect URI format without port", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the redirect URI has correct format")
-			sa := getServiceAccount(ctx)
-			// The redirect URI should be the hostname followed by the Dex callback path
-			Expect(sa.Annotations["serviceaccounts.openshift.io/oauth-redirecturi.dex"]).To(
-				Equal("https://openshift-test.example.com/idp/callback"),
-			)
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+				}, sa)).To(Succeed())
+				g.Expect(sa.Annotations["serviceaccounts.openshift.io/oauth-redirecturi.dex"]).To(
+					Equal("https://openshift-test.example.com/idp/callback"),
+				)
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 
 	Context("NodePort Service configuration via Reconcile", Serial, func() {
 		var ui *konfluxv1alpha1.KonfluxUI
-		var reconciler *KonfluxUIReconciler
 
-		// Helper: refresh UI from cluster
-		refreshUI := func(ctx context.Context) {
-			ExpectWithOffset(1, k8sClient.Get(ctx, types.NamespacedName{Name: ui.Name}, ui)).To(Succeed())
-		}
+		BeforeEach(func(ctx context.Context) {
+			startManager(noDefaultSegmentKey, nil)
 
-		// Helper: reconcile and expect success
-		reconcileUI := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: ui.Name},
+			ui = &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, ui)
 			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-		}
+		})
 
-		// Helper: get proxy Service
-		getProxyService := func(ctx context.Context) *corev1.Service {
+		getProxySvc := func(ctx context.Context, g Gomega) *corev1.Service {
 			svc := &corev1.Service{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      proxyServiceName,
-				Namespace: uiNamespace,
-			}, svc)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: proxyServiceName, Namespace: uiNamespace,
+			}, svc)).To(Succeed())
 			return svc
 		}
 
-		BeforeEach(func(ctx context.Context) {
-			By("creating the KonfluxUI resource")
-			ui = &konfluxv1alpha1.KonfluxUI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxUISpec{},
-			}
-			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
-
-			reconciler = &KonfluxUIReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultSegmentKey,
-			}
-		})
-
-		AfterEach(func(ctx context.Context) {
-			By("cleaning up KonfluxUI resource")
-			_ = k8sClient.Delete(ctx, ui)
-		})
-
 		It("Should create proxy Service as ClusterIP by default", func(ctx context.Context) {
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the proxy Service is ClusterIP")
-			svc := getProxyService(ctx)
-			Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+			Eventually(func(g Gomega) {
+				g.Expect(getProxySvc(ctx, g).Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should create proxy Service as NodePort when nodePortService is configured", func(ctx context.Context) {
-			By("configuring nodePortService")
-			refreshUI(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{
 				NodePortService: &konfluxv1alpha1.NodePortServiceSpec{},
 			}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the proxy Service is NodePort")
-			svc := getProxyService(ctx)
-			Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			Eventually(func(g Gomega) {
+				g.Expect(getProxySvc(ctx, g).Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should set specific HTTPS NodePort when httpsPort is specified", func(ctx context.Context) {
-			By("configuring nodePortService with specific httpsPort")
-			refreshUI(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{
 				NodePortService: &konfluxv1alpha1.NodePortServiceSpec{
 					HTTPSPort: ptr.To(int32(30443)),
@@ -1019,31 +843,29 @@ var _ = Describe("KonfluxUI Controller", func() {
 			}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the proxy Service has the specified NodePort")
-			svc := getProxyService(ctx)
-			Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
-
-			var httpsPort *corev1.ServicePort
-			for i := range svc.Spec.Ports {
-				if svc.Spec.Ports[i].Name == "web-tls" {
-					httpsPort = &svc.Spec.Ports[i]
-					break
+			Eventually(func(g Gomega) {
+				svc := getProxySvc(ctx, g)
+				g.Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+				var httpsPort *corev1.ServicePort
+				for i := range svc.Spec.Ports {
+					if svc.Spec.Ports[i].Name == "web-tls" {
+						httpsPort = &svc.Spec.Ports[i]
+						break
+					}
 				}
-			}
-			Expect(httpsPort).NotTo(BeNil())
-			Expect(httpsPort.NodePort).To(Equal(int32(30443)))
+				g.Expect(httpsPort).NotTo(BeNil())
+				g.Expect(httpsPort.NodePort).To(Equal(int32(30443)))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should change proxy Service from ClusterIP to NodePort when nodePortService is added", func(ctx context.Context) {
-			By("reconciling without nodePortService")
-			reconcileUI(ctx)
-			Expect(getProxyService(ctx).Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+			By("waiting for initial ClusterIP service")
+			Eventually(func(g Gomega) {
+				g.Expect(getProxySvc(ctx, g).Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
-			By("adding nodePortService configuration")
-			refreshUI(ctx)
+			By("adding NodePort configuration")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{
 				NodePortService: &konfluxv1alpha1.NodePortServiceSpec{
 					HTTPSPort: ptr.To(int32(30444)),
@@ -1051,93 +873,49 @@ var _ = Describe("KonfluxUI Controller", func() {
 			}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling again")
-			reconcileUI(ctx)
-
-			By("verifying the proxy Service changed to NodePort")
-			svc := getProxyService(ctx)
-			Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			Eventually(func(g Gomega) {
+				g.Expect(getProxySvc(ctx, g).Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should change proxy Service from NodePort to ClusterIP when nodePortService is removed", func(ctx context.Context) {
-			By("configuring nodePortService and reconciling")
-			refreshUI(ctx)
+			By("configuring NodePort service")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{
 				NodePortService: &konfluxv1alpha1.NodePortServiceSpec{},
 			}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
-			reconcileUI(ctx)
-			Expect(getProxyService(ctx).Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			Eventually(func(g Gomega) {
+				g.Expect(getProxySvc(ctx, g).Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
-			By("removing nodePortService configuration")
-			refreshUI(ctx)
+			By("removing NodePort configuration")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress = nil
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling again")
-			reconcileUI(ctx)
-
-			By("verifying the proxy Service changed back to ClusterIP")
-			svc := getProxyService(ctx)
-			Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+			Eventually(func(g Gomega) {
+				g.Expect(getProxySvc(ctx, g).Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 
 	Context("ConsoleLink reconciliation via Reconcile", Serial, func() {
-		var ui *konfluxv1alpha1.KonfluxUI
-		var reconciler *KonfluxUIReconciler
 		var openShiftClusterInfo *clusterinfo.Info
 		var defaultClusterInfo *clusterinfo.Info
 
-		// Helper: refresh UI from cluster
-		refreshUI := func(ctx context.Context) {
-			ExpectWithOffset(1, k8sClient.Get(ctx, types.NamespacedName{Name: ui.Name}, ui)).To(Succeed())
-		}
-
-		// Helper: reconcile and expect success
-		reconcileUI := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: ui.Name},
-			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-		}
-
-		// Helper: check if ConsoleLink exists
-		consoleLinkExists := func(ctx context.Context) bool {
-			cl := &consolev1.ConsoleLink{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name: consolelink.ConsoleLinkName,
-			}, cl)
-			return err == nil
-		}
-
-		// Helper: get ConsoleLink resource
-		getConsoleLink := func(ctx context.Context) *consolev1.ConsoleLink {
-			cl := &consolev1.ConsoleLink{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name: consolelink.ConsoleLinkName,
-			}, cl)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-			return cl
-		}
-
 		BeforeEach(func(ctx context.Context) {
-			By("cleaning up any existing ConsoleLink from previous tests")
-			existingCL := &consolev1.ConsoleLink{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: consolelink.ConsoleLinkName,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingCL)
+			By("pre-cleaning any existing ConsoleLink")
+			_ = k8sClient.Delete(ctx, &consolev1.ConsoleLink{ObjectMeta: metav1.ObjectMeta{
+				Name: consolelink.ConsoleLinkName,
+			}})
 
-			By("creating mock cluster info for OpenShift and non-OpenShift platforms")
+			By("building cluster info for OpenShift and non-OpenShift platforms")
 			var err error
 			openShiftClusterInfo, err = clusterinfo.DetectWithClient(&mockDiscoveryClient{
 				resources: map[string]*metav1.APIResourceList{
 					"config.openshift.io/v1": {
-						APIResources: []metav1.APIResource{
-							{Kind: "ClusterVersion"},
-						},
+						APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}},
 					},
 				},
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
@@ -1149,12 +927,12 @@ var _ = Describe("KonfluxUI Controller", func() {
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
 			})
 			Expect(err).NotTo(HaveOccurred())
+		})
 
-			By("creating the KonfluxUI resource with ingress enabled")
-			ui = &konfluxv1alpha1.KonfluxUI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
+		// createCR creates a KonfluxUI CR with ingress enabled and registers DeferCleanup.
+		createCR := func(ctx context.Context) *konfluxv1alpha1.KonfluxUI {
+			ui := &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 				Spec: konfluxv1alpha1.KonfluxUISpec{
 					Ingress: &konfluxv1alpha1.IngressSpec{
 						Enabled: ptr.To(true),
@@ -1163,154 +941,136 @@ var _ = Describe("KonfluxUI Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
-
-			reconciler = &KonfluxUIReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				ClusterInfo:          nil, // Will be set in individual tests
-				GetDefaultSegmentKey: noDefaultSegmentKey,
-			}
-		})
-
-		AfterEach(func(ctx context.Context) {
-			By("cleaning up ConsoleLink")
-			existingCL := &consolev1.ConsoleLink{
-				ObjectMeta: metav1.ObjectMeta{
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, ui)
+				_ = k8sClient.Delete(ctx, &consolev1.ConsoleLink{ObjectMeta: metav1.ObjectMeta{
 					Name: consolelink.ConsoleLinkName,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingCL)
-
-			By("cleaning up KonfluxUI resource")
-			_ = k8sClient.Delete(ctx, ui)
-		})
+				}})
+			})
+			return ui
+		}
 
 		It("Should create ConsoleLink when ingress is enabled and running on OpenShift", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the ConsoleLink was created")
-			Expect(consoleLinkExists(ctx)).To(BeTrue())
-
-			By("verifying the ConsoleLink has correct configuration")
-			cl := getConsoleLink(ctx)
-			Expect(cl.Spec.Href).To(Equal("https://consolelink-test.example.com"))
-			Expect(cl.Spec.Text).To(Equal("Konflux Console"))
-			Expect(cl.Spec.Location).To(Equal(consolev1.ApplicationMenu))
-			Expect(cl.Spec.ApplicationMenu).NotTo(BeNil())
-			Expect(cl.Spec.ApplicationMenu.Section).To(Equal("Konflux"))
+			Eventually(func(g Gomega) {
+				cl := &consolev1.ConsoleLink{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: consolelink.ConsoleLinkName,
+				}, cl)).To(Succeed())
+				g.Expect(cl.Spec.Href).To(Equal("https://consolelink-test.example.com"))
+				g.Expect(cl.Spec.Text).To(Equal("Konflux Console"))
+				g.Expect(cl.Spec.Location).To(Equal(consolev1.ApplicationMenu))
+				g.Expect(cl.Spec.ApplicationMenu).NotTo(BeNil())
+				g.Expect(cl.Spec.ApplicationMenu.Section).To(Equal("Konflux"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should NOT create ConsoleLink when NOT running on OpenShift", func(ctx context.Context) {
-			By("setting ClusterInfo to non-OpenShift")
-			reconciler.ClusterInfo = defaultClusterInfo
+			startManager(noDefaultSegmentKey, defaultClusterInfo)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
+			By("waiting for initial reconcile to complete")
+			waitForReconcile(ctx)
 
-			By("verifying the ConsoleLink was NOT created")
-			Expect(consoleLinkExists(ctx)).To(BeFalse())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: consolelink.ConsoleLinkName,
+			}, &consolev1.ConsoleLink{}))).To(BeTrue())
 		})
 
 		It("Should NOT create ConsoleLink when ClusterInfo is nil", func(ctx context.Context) {
-			By("keeping ClusterInfo as nil")
-			reconciler.ClusterInfo = nil
+			startManager(noDefaultSegmentKey, nil)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
+			By("waiting for initial reconcile to complete")
+			waitForReconcile(ctx)
 
-			By("verifying the ConsoleLink was NOT created")
-			Expect(consoleLinkExists(ctx)).To(BeFalse())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: consolelink.ConsoleLinkName,
+			}, &consolev1.ConsoleLink{}))).To(BeTrue())
 		})
 
 		It("Should NOT create ConsoleLink when ingress is disabled on OpenShift", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			ui := createCR(ctx)
 
 			By("disabling ingress")
-			refreshUI(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{Enabled: ptr.To(false)}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the ConsoleLink was NOT created")
-			Expect(consoleLinkExists(ctx)).To(BeFalse())
+			Eventually(func(g Gomega) {
+				g.Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+					Name: consolelink.ConsoleLinkName,
+				}, &consolev1.ConsoleLink{}))).To(BeTrue())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should delete ConsoleLink when ingress is disabled", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			ui := createCR(ctx)
 
-			By("first reconciling to create the ConsoleLink")
-			reconcileUI(ctx)
-			Expect(consoleLinkExists(ctx)).To(BeTrue())
+			By("waiting for ConsoleLink to be created")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: consolelink.ConsoleLinkName,
+				}, &consolev1.ConsoleLink{})).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
 			By("disabling ingress")
-			refreshUI(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{Enabled: ptr.To(false)}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling again")
-			reconcileUI(ctx)
-
-			By("verifying the ConsoleLink was deleted")
-			Expect(consoleLinkExists(ctx)).To(BeFalse())
+			Eventually(func(g Gomega) {
+				g.Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+					Name: consolelink.ConsoleLinkName,
+				}, &consolev1.ConsoleLink{}))).To(BeTrue())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should update ConsoleLink when hostname changes", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			ui := createCR(ctx)
 
-			By("reconciling to create the ConsoleLink")
-			reconcileUI(ctx)
-			Expect(getConsoleLink(ctx).Spec.Href).To(Equal("https://consolelink-test.example.com"))
+			By("waiting for initial ConsoleLink")
+			Eventually(func(g Gomega) {
+				cl := &consolev1.ConsoleLink{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: consolelink.ConsoleLinkName,
+				}, cl)).To(Succeed())
+				g.Expect(cl.Spec.Href).To(Equal("https://consolelink-test.example.com"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
 			By("updating the hostname")
-			refreshUI(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress.Host = "updated-consolelink.example.com"
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling again")
-			reconcileUI(ctx)
-
-			By("verifying the ConsoleLink href was updated")
-			Expect(getConsoleLink(ctx).Spec.Href).To(Equal("https://updated-consolelink.example.com"))
+			Eventually(func(g Gomega) {
+				cl := &consolev1.ConsoleLink{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: consolelink.ConsoleLinkName,
+				}, cl)).To(Succeed())
+				g.Expect(cl.Spec.Href).To(Equal("https://updated-consolelink.example.com"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 
 	Context("Segment Secret reconciliation via Reconcile", Serial, func() {
-		var ui *konfluxv1alpha1.KonfluxUI
-		var reconciler *KonfluxUIReconciler
-		var segmentBridgeCR *konfluxv1alpha1.KonfluxSegmentBridge
-
-		// Helper: reconcile and expect success
-		reconcileUI := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: ui.Name},
-			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-		}
-
-		// Helper: build the expected hashed secret name for given data
+		// expectedSecretName computes the hashed secret name for a given write key and API URL.
 		expectedSecretName := func(writeKey, apiURL string) string {
-			s := hashedsecret.Build(segmentSecretBaseName, uiNamespace, map[string]string{
+			return hashedsecret.Build(segmentSecretBaseName, uiNamespace, map[string]string{
 				segmentKeyWriteKey: writeKey,
 				segmentKeyAPIURL:   apiURL,
-			})
-			return s.Name
+			}).Name
 		}
 
-		// Helper: list all Secrets in the UI namespace matching the segment base name prefix
+		// listSegmentSecrets returns all Secrets in uiNamespace whose name starts with the segment base name.
 		listSegmentSecrets := func(ctx context.Context) []corev1.Secret {
 			secretList := &corev1.SecretList{}
-			err := k8sClient.List(ctx, secretList, client.InNamespace(uiNamespace))
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			ExpectWithOffset(1, k8sClient.List(ctx, secretList, client.InNamespace(uiNamespace))).To(Succeed())
 			var result []corev1.Secret
 			for _, s := range secretList.Items {
 				if len(s.Name) > len(segmentSecretBaseName) && s.Name[:len(segmentSecretBaseName)] == segmentSecretBaseName {
@@ -1321,288 +1081,207 @@ var _ = Describe("KonfluxUI Controller", func() {
 		}
 
 		BeforeEach(func(ctx context.Context) {
-			By("cleaning up any existing segment secrets from previous tests")
+			By("pre-cleaning any existing segment secrets and Bridge CR")
 			for _, s := range listSegmentSecrets(ctx) {
-				_ = k8sClient.Delete(ctx, &s)
+				_ = k8sClient.Delete(ctx, &s) //nolint:gosec
 			}
+			_ = k8sClient.Delete(ctx, &konfluxv1alpha1.KonfluxSegmentBridge{ObjectMeta: metav1.ObjectMeta{
+				Name: segmentbridge.CRName,
+			}})
+		})
 
-			By("cleaning up any existing KonfluxSegmentBridge CR")
-			existingBridge := &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingBridge)
-
-			By("creating the KonfluxUI resource")
-			ui = &konfluxv1alpha1.KonfluxUI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxUISpec{},
-			}
+		// createUI creates the KonfluxUI CR and registers DeferCleanup for it and leftover secrets.
+		createUI := func(ctx context.Context) *konfluxv1alpha1.KonfluxUI {
+			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, ui)
+				for _, s := range listSegmentSecrets(ctx) {
+					_ = k8sClient.Delete(ctx, &s) //nolint:gosec
+				}
+			})
+			return ui
+		}
 
-			segmentBridgeCR = nil
-
-			reconciler = &KonfluxUIReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultSegmentKey,
-			}
-		})
-
-		AfterEach(func(ctx context.Context) {
-			By("cleaning up segment secrets")
-			for _, s := range listSegmentSecrets(ctx) {
-				_ = k8sClient.Delete(ctx, &s)
-			}
-
-			By("cleaning up KonfluxSegmentBridge CR")
-			if segmentBridgeCR != nil {
-				_ = k8sClient.Delete(ctx, segmentBridgeCR)
-			}
-
-			By("cleaning up KonfluxUI resource")
-			_ = k8sClient.Delete(ctx, ui)
-		})
+		// createBridgeCR creates a KonfluxSegmentBridge CR and registers DeferCleanup for it.
+		createBridgeCR := func(ctx context.Context) *konfluxv1alpha1.KonfluxSegmentBridge {
+			bridge := &konfluxv1alpha1.KonfluxSegmentBridge{ObjectMeta: metav1.ObjectMeta{Name: segmentbridge.CRName}}
+			Expect(k8sClient.Create(ctx, bridge)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, bridge)
+			return bridge
+		}
 
 		It("Should not create segment secret when KonfluxSegmentBridge CR does not exist", func(ctx context.Context) {
-			By("reconciling without a KonfluxSegmentBridge CR")
-			reconcileUI(ctx)
+			startManager(noDefaultSegmentKey, nil)
+			createUI(ctx)
 
-			By("verifying no segment secret was created")
+			By("waiting for initial reconcile to complete")
+			waitForReconcile(ctx)
+
 			Expect(listSegmentSecrets(ctx)).To(BeEmpty())
 		})
 
 		It("Should not create segment secret when no write key is configured", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR without a write key")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			bridge := createBridgeCR(ctx)
+			startManager(noDefaultSegmentKey, nil)
+			createUI(ctx)
 
-			By("reconciling with no default key either")
-			reconcileUI(ctx)
+			By("waiting for initial reconcile with empty Bridge key")
+			waitForReconcile(ctx)
 
-			By("verifying no segment secret was created")
+			_ = bridge
 			Expect(listSegmentSecrets(ctx)).To(BeEmpty())
 		})
 
 		It("Should create segment secret with CR write key and default API URL", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR with a write key")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			bridge := createBridgeCR(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = "test-write-key"
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			// Update to add segment key (default spec is empty)
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = "test-write-key"
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+			startManager(noDefaultSegmentKey, nil)
+			createUI(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the segment secret was created with correct data")
 			name := expectedSecretName("test-write-key", konfluxv1alpha1.DefaultSegmentAPIURL)
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      name,
-				Namespace: uiNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("test-write-key"))
-			Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal(konfluxv1alpha1.DefaultSegmentAPIURL))
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: name, Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("test-write-key"))
+				g.Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal(konfluxv1alpha1.DefaultSegmentAPIURL))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should create segment secret with CR write key and custom API URL", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR with a write key and custom API URL")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			bridge := createBridgeCR(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = "test-write-key"
+			bridge.Spec.SegmentAPIURL = "https://console.redhat.com/connections/api/v1"
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = "test-write-key"
-			segmentBridgeCR.Spec.SegmentAPIURL = "https://console.redhat.com/connections/api/v1"
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+			startManager(noDefaultSegmentKey, nil)
+			createUI(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the segment secret was created with custom API URL")
 			name := expectedSecretName("test-write-key", "https://console.redhat.com/connections/api/v1")
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      name,
-				Namespace: uiNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("test-write-key"))
-			Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal("https://console.redhat.com/connections/api/v1"))
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: name, Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("test-write-key"))
+				g.Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal("https://console.redhat.com/connections/api/v1"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should use build-time default key when CR key is empty", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR without a write key")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			createBridgeCR(ctx)
+			startManager(staticSegmentKey("build-time-key"), nil)
+			createUI(ctx)
 
-			By("configuring a build-time default key")
-			reconciler.GetDefaultSegmentKey = staticSegmentKey("build-time-key")
-
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the segment secret uses the build-time default key")
 			name := expectedSecretName("build-time-key", konfluxv1alpha1.DefaultSegmentAPIURL)
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      name,
-				Namespace: uiNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("build-time-key"))
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: name, Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("build-time-key"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should prefer CR key over build-time default", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR with a write key")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			bridge := createBridgeCR(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = "cr-override-key"
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = "cr-override-key"
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+			startManager(staticSegmentKey("build-time-key"), nil)
+			createUI(ctx)
 
-			By("configuring a build-time default key")
-			reconciler.GetDefaultSegmentKey = staticSegmentKey("build-time-key")
-
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the segment secret uses the CR key, not the build-time default")
 			name := expectedSecretName("cr-override-key", konfluxv1alpha1.DefaultSegmentAPIURL)
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      name,
-				Namespace: uiNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("cr-override-key"))
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: name, Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("cr-override-key"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should create a new secret and clean up old one when segment key changes", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR with an initial write key")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			bridge := createBridgeCR(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = "initial-key"
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = "initial-key"
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
-
-			By("reconciling to create the initial secret")
-			reconcileUI(ctx)
+			startManager(noDefaultSegmentKey, nil)
+			createUI(ctx)
 
 			initialName := expectedSecretName("initial-key", konfluxv1alpha1.DefaultSegmentAPIURL)
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      initialName,
-				Namespace: uiNamespace,
-			}, &corev1.Secret{})).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: initialName, Namespace: uiNamespace,
+				}, &corev1.Secret{})).To(Succeed())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
 			By("changing the segment key")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = "updated-key"
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = "updated-key"
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			By("reconciling again")
-			reconcileUI(ctx)
-
-			By("verifying the new secret was created")
 			updatedName := expectedSecretName("updated-key", konfluxv1alpha1.DefaultSegmentAPIURL)
 			Expect(updatedName).NotTo(Equal(initialName), "hash should differ for different keys")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      updatedName,
-				Namespace: uiNamespace,
-			}, &corev1.Secret{})).To(Succeed())
 
-			By("verifying the old secret was cleaned up")
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      initialName,
-				Namespace: uiNamespace,
-			}, &corev1.Secret{})
-			Expect(errors.IsNotFound(err)).To(BeTrue(), "old segment secret should be deleted")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: updatedName, Namespace: uiNamespace,
+				}, &corev1.Secret{})).To(Succeed())
+				g.Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+					Name: initialName, Namespace: uiNamespace,
+				}, &corev1.Secret{}))).To(BeTrue(), "old segment secret should be deleted")
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should clean up segment secret when key becomes empty", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR with a write key")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			bridge := createBridgeCR(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = "temporary-key"
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = "temporary-key"
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+			startManager(noDefaultSegmentKey, nil)
+			createUI(ctx)
 
-			By("reconciling to create the secret")
-			reconcileUI(ctx)
-			Expect(listSegmentSecrets(ctx)).To(HaveLen(1))
+			By("waiting for the secret to be created")
+			Eventually(func(g Gomega) {
+				g.Expect(listSegmentSecrets(ctx)).To(HaveLen(1))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 
 			By("removing the segment key")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = ""
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = ""
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			By("reconciling again")
-			reconcileUI(ctx)
-
-			By("verifying the secret was cleaned up")
-			Expect(listSegmentSecrets(ctx)).To(BeEmpty())
+			Eventually(func(g Gomega) {
+				g.Expect(listSegmentSecrets(ctx)).To(BeEmpty())
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 
 		It("Should set owner reference on created segment secret", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR with a write key")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			bridge := createBridgeCR(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = "owner-ref-test-key"
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = "owner-ref-test-key"
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+			startManager(noDefaultSegmentKey, nil)
+			createUI(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the secret has owner reference")
-			secrets := listSegmentSecrets(ctx)
-			Expect(secrets).To(HaveLen(1))
-			Expect(secrets[0].OwnerReferences).To(HaveLen(1))
-			Expect(secrets[0].OwnerReferences[0].Name).To(Equal(CRName))
-			Expect(secrets[0].OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
+			Eventually(func(g Gomega) {
+				secrets := listSegmentSecrets(ctx)
+				g.Expect(secrets).To(HaveLen(1))
+				g.Expect(secrets[0].OwnerReferences).To(HaveLen(1))
+				g.Expect(secrets[0].OwnerReferences[0].Name).To(Equal(CRName))
+				g.Expect(secrets[0].OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/ui/konfluxui_controller_test.go
+++ b/operator/internal/controller/ui/konfluxui_controller_test.go
@@ -19,10 +19,12 @@ package ui
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	consolev1 "github.com/openshift/api/console/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -32,13 +34,11 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	consolev1 "github.com/openshift/api/console/v1"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/segmentbridge"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/consolelink"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/dex"
@@ -51,190 +51,118 @@ func noDefaultSegmentKey() string             { return "" }
 func staticSegmentKey(k string) func() string { return func() string { return k } }
 
 var _ = Describe("KonfluxUI Controller", func() {
+	// startManager creates a per-test manager with the given reconciler configuration
+	// and registers a DeferCleanup to cancel it after the test.
+	// A per-test manager is required because each test wires the reconciler with a different
+	// GetDefaultSegmentKey or ClusterInfo, and a shared suite-level manager cannot be
+	// re-configured between tests.
+	startManager := func(getDefaultSegmentKey func() string, clusterInfo *clusterinfo.Info) {
+		mgr := testutil.NewTestManager(testEnv)
+		Expect((&KonfluxUIReconciler{
+			Client:               mgr.GetClient(),
+			Scheme:               mgr.GetScheme(),
+			ObjectStore:          objectStore,
+			GetDefaultSegmentKey: getDefaultSegmentKey,
+			ClusterInfo:          clusterInfo,
+		}).SetupWithManager(mgr)).To(Succeed())
+		mgrCtx, cancel := context.WithCancel(testEnv.Ctx)
+		DeferCleanup(cancel)
+		testutil.StartManagerWithContext(mgrCtx, mgr)
+	}
+
+	// waitForReconcile blocks until both UI Deployments exist, proving the initial
+	// reconcile has completed. Used as a sentinel before synchronous absence checks.
+	waitForReconcile := func(ctx context.Context) {
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: proxyDeploymentName, Namespace: uiNamespace,
+			}, &appsv1.Deployment{})).To(Succeed())
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: dexDeploymentName, Namespace: uiNamespace,
+			}, &appsv1.Deployment{})).To(Succeed())
+		}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+	}
+
 	Context("When reconciling a resource", func() {
+		It("should successfully reconcile the resource", func(ctx context.Context) {
+			startManager(noDefaultSegmentKey, nil)
 
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      CRName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		konfluxui := &konfluxv1alpha1.KonfluxUI{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind KonfluxUI")
-			err := k8sClient.Get(ctx, typeNamespacedName, konfluxui)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &konfluxv1alpha1.KonfluxUI{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      CRName,
-						Namespace: "default",
-					},
-					Spec: konfluxv1alpha1.KonfluxUISpec{},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &konfluxv1alpha1.KonfluxUI{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance KonfluxUI")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &KonfluxUIReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultSegmentKey,
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				Spec:       konfluxv1alpha1.KonfluxUISpec{},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
 			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+			// Wait for the Deployment rather than Ready=True: UpdateComponentStatuses
+			// gates Ready=True on ReadyReplicas == Replicas, which never happens in
+			// envtest (no kubelet → pods never start).
+			waitForReconcile(ctx)
 		})
 	})
 
 	Context("ensureUISecrets", func() {
-		var ui *konfluxv1alpha1.KonfluxUI
-		var reconciler *KonfluxUIReconciler
-
-		// Helper: reconcile and expect success
-		reconcileUI := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: ui.Name},
-			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		cleanupSecrets := func(ctx context.Context) {
+			_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+			}})
+			_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: "oauth2-proxy-cookie-secret", Namespace: uiNamespace,
+			}})
 		}
 
 		BeforeEach(func(ctx context.Context) {
-			By("cleaning up any existing secrets from previous tests")
-			clientSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oauth2-proxy-client-secret",
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, clientSecret)
+			startManager(noDefaultSegmentKey, nil)
 
-			cookieSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oauth2-proxy-cookie-secret",
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, cookieSecret)
-
-			By("creating the KonfluxUI resource")
-			ui = &konfluxv1alpha1.KonfluxUI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxUISpec{},
-			}
-			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
-
-			reconciler = &KonfluxUIReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultSegmentKey,
-			}
-
-			By("creating the UI namespace")
-			uiNs := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: uiNamespace,
-				},
-			}
+			By("ensuring the UI namespace exists")
+			uiNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: uiNamespace}}
 			err := k8sClient.Create(ctx, uiNs)
 			if err != nil && !errors.IsAlreadyExists(err) {
 				Expect(err).NotTo(HaveOccurred())
 			}
-		})
 
-		AfterEach(func(ctx context.Context) {
-			By("cleaning up secrets")
-			clientSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oauth2-proxy-client-secret",
-					Namespace: uiNamespace,
-				},
-			}
-			err := k8sClient.Delete(ctx, clientSecret)
-			if err != nil && !errors.IsNotFound(err) {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to delete client secret: %v\n", err)
-			}
-
-			cookieSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oauth2-proxy-cookie-secret",
-					Namespace: uiNamespace,
-				},
-			}
-			err = k8sClient.Delete(ctx, cookieSecret)
-			if err != nil && !errors.IsNotFound(err) {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to delete cookie secret: %v\n", err)
-			}
-
-			By("cleaning up KonfluxUI resource")
-			err = k8sClient.Delete(ctx, ui)
-			if err != nil && !errors.IsNotFound(err) {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to delete KonfluxUI: %v\n", err)
-			}
+			By("pre-cleaning any leftover secrets")
+			cleanupSecrets(ctx)
 		})
 
 		It("Should preserve existing secret data when secret already exists with valid data", func(ctx context.Context) {
-			By("creating a secret with existing data")
+			By("creating the secret with existing data before the CR exists")
 			existingData := []byte("existing-secret-value")
-			secret := &corev1.Secret{
+			Expect(k8sClient.Create(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oauth2-proxy-client-secret",
-					Namespace: uiNamespace,
-					Labels: map[string]string{
-						constant.KonfluxOwnerLabel:     CRName,
-						constant.KonfluxComponentLabel: string(manifests.UI),
-					},
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "konflux.konflux-ci.dev/v1alpha1",
-							Kind:               "KonfluxUI",
-							Name:               ui.Name,
-							UID:                ui.UID,
-							Controller:         func() *bool { b := true; return &b }(),
-							BlockOwnerDeletion: func() *bool { b := true; return &b }(),
-						},
-					},
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
 				},
-				Data: map[string][]byte{
-					"client-secret": existingData,
-				},
-			}
-			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+				Data: map[string][]byte{"client-secret": existingData},
+			})).To(Succeed())
 
-			By("calling Reconcile")
-			reconcileUI(ctx)
+			By("creating the KonfluxUI CR to trigger reconcile")
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
+				cleanupSecrets(ctx)
+			})
 
-			By("verifying the secret data was preserved")
-			updatedSecret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-client-secret",
-				Namespace: uiNamespace,
-			}, updatedSecret)).To(Succeed())
-			Expect(updatedSecret.Data["client-secret"]).To(Equal(existingData))
+			By("verifying the secret data was preserved after reconcile")
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				// Owner reference being set proves reconcile ran
+				g.Expect(secret.OwnerReferences).NotTo(BeEmpty())
+				g.Expect(secret.Data["client-secret"]).To(Equal(existingData))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should update ownership labels and owner reference when secret exists but has incorrect ownership", func(ctx context.Context) {
-			By("creating a secret with incorrect ownership labels and no owner reference")
-			secret := &corev1.Secret{
+			By("creating the secret with wrong ownership before the CR exists")
+			Expect(k8sClient.Create(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "oauth2-proxy-client-secret",
 					Namespace: uiNamespace,
@@ -243,129 +171,160 @@ var _ = Describe("KonfluxUI Controller", func() {
 						constant.KonfluxComponentLabel: "wrong-component",
 					},
 				},
-				Data: map[string][]byte{
-					"client-secret": []byte("existing-value"),
-				},
-			}
-			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+				Data: map[string][]byte{"client-secret": []byte("existing-value")},
+			})).To(Succeed())
 
-			By("calling Reconcile")
-			reconcileUI(ctx)
+			By("creating the KonfluxUI CR to trigger reconcile")
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
+				cleanupSecrets(ctx)
+			})
 
-			By("verifying the ownership labels were updated")
-			updatedSecret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-client-secret",
-				Namespace: uiNamespace,
-			}, updatedSecret)).To(Succeed())
-			Expect(updatedSecret.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
-			Expect(updatedSecret.Labels).To(HaveKeyWithValue(constant.KonfluxComponentLabel, string(manifests.UI)))
-
-			By("verifying the owner reference was added")
-			Expect(updatedSecret.OwnerReferences).To(HaveLen(1))
-			Expect(updatedSecret.OwnerReferences[0].Name).To(Equal(CRName))
+			By("verifying the ownership labels and owner reference were corrected")
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(secret.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
+				g.Expect(secret.Labels).To(HaveKeyWithValue(constant.KonfluxComponentLabel, string(manifests.UI)))
+				g.Expect(secret.OwnerReferences).To(HaveLen(1))
+				g.Expect(secret.OwnerReferences[0].Name).To(Equal(CRName))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should regenerate secret data when secret exists but has empty data", func(ctx context.Context) {
-			By("creating a secret with empty data")
-			secret := &corev1.Secret{
+			By("creating the secret with empty data before the CR exists")
+			Expect(k8sClient.Create(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oauth2-proxy-client-secret",
-					Namespace: uiNamespace,
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
 				},
 				Data: map[string][]byte{},
-			}
-			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			})).To(Succeed())
 
-			By("calling Reconcile")
-			reconcileUI(ctx)
+			By("creating the KonfluxUI CR to trigger reconcile")
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
+				cleanupSecrets(ctx)
+			})
 
-			By("verifying the secret data was generated")
-			updatedSecret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-client-secret",
-				Namespace: uiNamespace,
-			}, updatedSecret)).To(Succeed())
-			Expect(updatedSecret.Data).To(HaveKey("client-secret"))
-			Expect(updatedSecret.Data["client-secret"]).ToNot(BeEmpty())
+			By("verifying the secret data was regenerated")
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(secret.Data).To(HaveKey("client-secret"))
+				g.Expect(secret.Data["client-secret"]).NotTo(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should use URL-safe base64 encoding for client-secret", func(ctx context.Context) {
-			By("calling Reconcile")
-			reconcileUI(ctx)
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
+				cleanupSecrets(ctx)
+			})
 
-			By("verifying the client-secret uses URL-safe encoding")
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-client-secret",
-				Namespace: uiNamespace,
-			}, secret)).To(Succeed())
-
-			clientSecretValue := string(secret.Data["client-secret"])
-			By("verifying no padding characters (URL-safe uses RawURLEncoding)")
-			Expect(clientSecretValue).NotTo(ContainSubstring("="))
-			By("verifying it contains only URL-safe characters")
-			Expect(clientSecretValue).To(MatchRegexp("^[A-Za-z0-9_-]+$"))
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				clientSecretValue := string(secret.Data["client-secret"])
+				g.Expect(clientSecretValue).NotTo(BeEmpty())
+				g.Expect(clientSecretValue).NotTo(ContainSubstring("="), "URL-safe base64 should have no padding")
+				g.Expect(clientSecretValue).To(MatchRegexp("^[A-Za-z0-9_-]+$"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should use standard base64 encoding for cookie-secret", func(ctx context.Context) {
-			By("calling Reconcile")
-			reconcileUI(ctx)
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
+				cleanupSecrets(ctx)
+			})
 
-			By("verifying the cookie-secret uses standard encoding")
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-cookie-secret",
-				Namespace: uiNamespace,
-			}, secret)).To(Succeed())
-
-			cookieSecretValue := string(secret.Data["cookie-secret"])
-			By("verifying it contains standard base64 characters (may include + and /)")
-			Expect(cookieSecretValue).To(MatchRegexp("^[A-Za-z0-9+/]+=*$"))
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-cookie-secret", Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				cookieSecretValue := string(secret.Data["cookie-secret"])
+				g.Expect(cookieSecretValue).NotTo(BeEmpty())
+				g.Expect(cookieSecretValue).To(MatchRegexp("^[A-Za-z0-9+/]+=*$"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
-		It("Should create both secrets in a single call", func(ctx context.Context) {
-			By("calling Reconcile")
-			reconcileUI(ctx)
+		It("Should create both secrets in a single reconcile", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
+				cleanupSecrets(ctx)
+			})
 
-			By("verifying both secrets were created")
-			clientSecret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-client-secret",
-				Namespace: uiNamespace,
-			}, clientSecret)).To(Succeed())
-
-			cookieSecret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-cookie-secret",
-				Namespace: uiNamespace,
-			}, cookieSecret)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+				}, &corev1.Secret{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-cookie-secret", Namespace: uiNamespace,
+				}, &corev1.Secret{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
-		It("Should be idempotent when called multiple times", func(ctx context.Context) {
-			By("calling Reconcile first time")
-			reconcileUI(ctx)
+		It("Should be idempotent across multiple reconciles", func(ctx context.Context) {
+			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			})).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxUI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				})
+				cleanupSecrets(ctx)
+			})
 
-			By("getting the first secret value")
-			secret1 := &corev1.Secret{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-client-secret",
-				Namespace: uiNamespace,
-			}, secret1)
-			Expect(err).NotTo(HaveOccurred())
-			firstValue := secret1.Data["client-secret"]
+			By("waiting for the client-secret to be created")
+			var firstValue []byte
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(secret.Data["client-secret"]).NotTo(BeEmpty())
+				firstValue = secret.Data["client-secret"]
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
-			By("calling Reconcile second time")
-			reconcileUI(ctx)
-
-			By("verifying the secret value was not changed")
-			secret2 := &corev1.Secret{}
-			err = k8sClient.Get(ctx, types.NamespacedName{
-				Name:      "oauth2-proxy-client-secret",
-				Namespace: uiNamespace,
-			}, secret2)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(secret2.Data["client-secret"]).To(Equal(firstValue))
+			By("verifying the value is stable across subsequent reconciles")
+			Consistently(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: "oauth2-proxy-client-secret", Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(secret.Data["client-secret"]).To(Equal(firstValue))
+			}, 5*time.Second, time.Second).Should(Succeed())
 		})
 	})
 
@@ -441,277 +400,192 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 	Context("Ingress reconciliation via Reconcile", Serial, func() {
 		var ui *konfluxv1alpha1.KonfluxUI
-		var reconciler *KonfluxUIReconciler
 
-		// Helper: refresh UI from cluster
+		// refreshUI re-fetches the CR to get the latest ResourceVersion before updates.
 		refreshUI := func(ctx context.Context) {
-			ExpectWithOffset(1, k8sClient.Get(ctx, types.NamespacedName{Name: ui.Name}, ui)).To(Succeed())
+			ExpectWithOffset(1, k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 		}
 
-		// Helper: reconcile and expect success
-		reconcileUI := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: ui.Name},
-			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-		}
-
-		// Helper: get Ingress resource
-		getIngress := func(ctx context.Context) *networkingv1.Ingress {
-			ing := &networkingv1.Ingress{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      ingress.IngressName,
-				Namespace: uiNamespace,
-			}, ing)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-			return ing
-		}
-
-		// Helper: check if Ingress exists
-		ingressExists := func(ctx context.Context) bool {
-			ing := &networkingv1.Ingress{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      ingress.IngressName,
-				Namespace: uiNamespace,
-			}, ing)
-			return err == nil
-		}
-
-		// Helper: enable ingress with host and reconcile
-		enableIngressAndReconcile := func(ctx context.Context, host string) {
+		// enableIngress updates the CR to enable ingress; the manager reconciles automatically.
+		enableIngress := func(ctx context.Context, host string) {
 			refreshUI(ctx)
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{
 				Enabled: ptr.To(true),
 				Host:    host,
 			}
 			ExpectWithOffset(1, k8sClient.Update(ctx, ui)).To(Succeed())
-			reconcileUI(ctx)
 		}
 
 		BeforeEach(func(ctx context.Context) {
-			By("cleaning up any existing ingress from previous tests")
-			existingIngress := &networkingv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      ingress.IngressName,
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingIngress)
+			startManager(noDefaultSegmentKey, nil)
 
-			By("creating the KonfluxUI resource")
-			ui = &konfluxv1alpha1.KonfluxUI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxUISpec{},
-			}
+			By("pre-cleaning any existing Ingress")
+			_ = k8sClient.Delete(ctx, &networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{
+				Name: ingress.IngressName, Namespace: uiNamespace,
+			}})
+
+			ui = &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
-
-			reconciler = &KonfluxUIReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultSegmentKey,
-			}
-		})
-
-		AfterEach(func(ctx context.Context) {
-			By("cleaning up ingress")
-			existingIngress := &networkingv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      ingress.IngressName,
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingIngress)
-
-			By("cleaning up KonfluxUI resource")
-			_ = k8sClient.Delete(ctx, ui)
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, ui)
+				_ = k8sClient.Delete(ctx, &networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}})
+			})
 		})
 
 		It("Should create Ingress when ingress is enabled", func(ctx context.Context) {
-			enableIngressAndReconcile(ctx, "test.example.com")
+			enableIngress(ctx, "test.example.com")
 
-			By("verifying the Ingress was created")
-			ing := getIngress(ctx)
-			Expect(ing.Spec.Rules).To(HaveLen(1))
-			Expect(ing.Spec.Rules[0].Host).To(Equal("test.example.com"))
+			Eventually(func(g Gomega) {
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, ing)).To(Succeed())
+				g.Expect(ing.Spec.Rules).To(HaveLen(1))
+				g.Expect(ing.Spec.Rules[0].Host).To(Equal("test.example.com"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should delete Ingress when ingress spec is set to nil", func(ctx context.Context) {
-			By("first enabling ingress and reconciling to create the Ingress")
-			enableIngressAndReconcile(ctx, "test.example.com")
-			Expect(ingressExists(ctx)).To(BeTrue())
+			By("enabling ingress to create it first")
+			enableIngress(ctx, "test.example.com")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, &networkingv1.Ingress{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
-			By("disabling ingress by setting spec to nil")
+			By("setting ingress spec to nil")
 			refreshUI(ctx)
 			ui.Spec.Ingress = nil
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
-			reconcileUI(ctx)
 
-			By("verifying the Ingress was deleted")
-			Expect(ingressExists(ctx)).To(BeFalse())
+			Eventually(func(g Gomega) {
+				g.Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, &networkingv1.Ingress{}))).To(BeTrue())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should delete Ingress when Enabled is set to false", func(ctx context.Context) {
-			By("first enabling ingress and reconciling to create the Ingress")
-			enableIngressAndReconcile(ctx, "test.example.com")
-			Expect(ingressExists(ctx)).To(BeTrue())
+			By("enabling ingress to create it first")
+			enableIngress(ctx, "test.example.com")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, &networkingv1.Ingress{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
-			By("setting Enabled to false in the KonfluxUI spec")
+			By("setting Enabled to false")
 			refreshUI(ctx)
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{Enabled: ptr.To(false)}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
-			reconcileUI(ctx)
 
-			By("verifying the Ingress was deleted")
-			Expect(ingressExists(ctx)).To(BeFalse())
+			Eventually(func(g Gomega) {
+				g.Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, &networkingv1.Ingress{}))).To(BeTrue())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should not error when ingress is disabled and no Ingress exists", func(ctx context.Context) {
-			By("ensuring no Ingress exists")
-			Expect(ingressExists(ctx)).To(BeFalse())
+			By("waiting for initial reconcile to complete")
+			waitForReconcile(ctx)
 
-			By("reconciling with ingress disabled - should not error")
-			reconcileUI(ctx)
+			By("verifying no Ingress was created")
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: ingress.IngressName, Namespace: uiNamespace,
+			}, &networkingv1.Ingress{}))).To(BeTrue())
 		})
 
 		It("Should update Ingress when hostname changes", func(ctx context.Context) {
 			By("enabling ingress with initial hostname")
-			enableIngressAndReconcile(ctx, "initial.example.com")
-			Expect(getIngress(ctx).Spec.Rules[0].Host).To(Equal("initial.example.com"))
+			enableIngress(ctx, "initial.example.com")
+			Eventually(func(g Gomega) {
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, ing)).To(Succeed())
+				g.Expect(ing.Spec.Rules[0].Host).To(Equal("initial.example.com"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("updating to new hostname")
 			refreshUI(ctx)
 			ui.Spec.Ingress.Host = "updated.example.com"
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
-			reconcileUI(ctx)
 
-			By("verifying the Ingress was updated with new hostname")
-			Expect(getIngress(ctx).Spec.Rules[0].Host).To(Equal("updated.example.com"))
+			Eventually(func(g Gomega) {
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, ing)).To(Succeed())
+				g.Expect(ing.Spec.Rules[0].Host).To(Equal("updated.example.com"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should include OpenShift TLS annotations on created Ingress", func(ctx context.Context) {
-			enableIngressAndReconcile(ctx, "test.example.com")
+			enableIngress(ctx, "test.example.com")
 
-			By("verifying the Ingress has OpenShift TLS annotations")
-			ing := getIngress(ctx)
-			Expect(ing.Annotations).To(HaveKeyWithValue(
-				"route.openshift.io/destination-ca-certificate-secret", "ui-ca"))
-			Expect(ing.Annotations).To(HaveKeyWithValue(
-				"route.openshift.io/termination", "reencrypt"))
+			Eventually(func(g Gomega) {
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, ing)).To(Succeed())
+				g.Expect(ing.Annotations).To(HaveKeyWithValue(
+					"route.openshift.io/destination-ca-certificate-secret", "ui-ca"))
+				g.Expect(ing.Annotations).To(HaveKeyWithValue(
+					"route.openshift.io/termination", "reencrypt"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should set owner reference on created Ingress", func(ctx context.Context) {
-			enableIngressAndReconcile(ctx, "test.example.com")
+			enableIngress(ctx, "test.example.com")
 
-			By("verifying the Ingress has owner reference")
-			ing := getIngress(ctx)
-			Expect(ing.OwnerReferences).To(HaveLen(1))
-			Expect(ing.OwnerReferences[0].Name).To(Equal(CRName))
-			Expect(ing.OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
+			Eventually(func(g Gomega) {
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, ing)).To(Succeed())
+				g.Expect(ing.OwnerReferences).To(HaveLen(1))
+				g.Expect(ing.OwnerReferences[0].Name).To(Equal(CRName))
+				g.Expect(ing.OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should update KonfluxUI status with ingress information", func(ctx context.Context) {
-			enableIngressAndReconcile(ctx, "status-test.example.com")
+			enableIngress(ctx, "status-test.example.com")
 
-			By("verifying the KonfluxUI status has ingress information")
-			updatedUI := &konfluxv1alpha1.KonfluxUI{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ui.Name}, updatedUI)).To(Succeed())
-			Expect(updatedUI.Status.Ingress).NotTo(BeNil())
-			Expect(updatedUI.Status.Ingress.Enabled).To(BeTrue())
-			Expect(updatedUI.Status.Ingress.Hostname).To(Equal("status-test.example.com"))
-			Expect(updatedUI.Status.Ingress.URL).To(Equal("https://status-test.example.com"))
+			Eventually(func(g Gomega) {
+				updatedUI := &konfluxv1alpha1.KonfluxUI{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updatedUI)).To(Succeed())
+				g.Expect(updatedUI.Status.Ingress).NotTo(BeNil())
+				g.Expect(updatedUI.Status.Ingress.Enabled).To(BeTrue())
+				g.Expect(updatedUI.Status.Ingress.Hostname).To(Equal("status-test.example.com"))
+				g.Expect(updatedUI.Status.Ingress.URL).To(Equal("https://status-test.example.com"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 
 	Context("OpenShift OAuth reconciliation via Reconcile", Serial, func() {
-		var ui *konfluxv1alpha1.KonfluxUI
-		var reconciler *KonfluxUIReconciler
 		var openShiftClusterInfo *clusterinfo.Info
 		var defaultClusterInfo *clusterinfo.Info
 
-		// Helper: refresh UI from cluster
-		refreshUI := func(ctx context.Context) {
-			ExpectWithOffset(1, k8sClient.Get(ctx, types.NamespacedName{Name: ui.Name}, ui)).To(Succeed())
-		}
-
-		// Helper: reconcile and expect success
-		reconcileUI := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: ui.Name},
-			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-		}
-
-		// Helper: check if OpenShift OAuth ServiceAccount exists
-		serviceAccountExists := func(ctx context.Context) bool {
-			sa := &corev1.ServiceAccount{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      dex.DexClientServiceAccountName,
-				Namespace: uiNamespace,
-			}, sa)
-			return err == nil
-		}
-
-		// Helper: check if OpenShift OAuth Secret exists
-		secretExists := func(ctx context.Context) bool {
-			secret := &corev1.Secret{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      dex.DexClientSecretName,
-				Namespace: uiNamespace,
-			}, secret)
-			return err == nil
-		}
-
-		// Helper: get OpenShift OAuth ServiceAccount
-		getServiceAccount := func(ctx context.Context) *corev1.ServiceAccount {
-			sa := &corev1.ServiceAccount{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      dex.DexClientServiceAccountName,
-				Namespace: uiNamespace,
-			}, sa)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-			return sa
-		}
-
-		// Helper: get OpenShift OAuth Secret
-		getSecret := func(ctx context.Context) *corev1.Secret {
-			secret := &corev1.Secret{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      dex.DexClientSecretName,
-				Namespace: uiNamespace,
-			}, secret)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-			return secret
-		}
-
 		BeforeEach(func(ctx context.Context) {
-			By("cleaning up any existing OpenShift OAuth resources from previous tests")
-			existingSA := &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      dex.DexClientServiceAccountName,
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingSA)
+			By("pre-cleaning any existing OpenShift OAuth resources")
+			_ = k8sClient.Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+				Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+			}})
+			_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: dex.DexClientSecretName, Namespace: uiNamespace,
+			}})
 
-			existingSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      dex.DexClientSecretName,
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingSecret)
-
-			By("creating mock cluster info for OpenShift and non-OpenShift platforms")
+			By("building cluster info for OpenShift and non-OpenShift platforms")
 			var err error
 			openShiftClusterInfo, err = clusterinfo.DetectWithClient(&mockDiscoveryClient{
 				resources: map[string]*metav1.APIResourceList{
 					"config.openshift.io/v1": {
-						APIResources: []metav1.APIResource{
-							{Kind: "ClusterVersion"},
-						},
+						APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}},
 					},
 				},
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
@@ -723,12 +597,12 @@ var _ = Describe("KonfluxUI Controller", func() {
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
 			})
 			Expect(err).NotTo(HaveOccurred())
+		})
 
-			By("creating the KonfluxUI resource with ingress enabled")
-			ui = &konfluxv1alpha1.KonfluxUI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
+		// createCR creates the KonfluxUI CR with ingress enabled and registers DeferCleanup.
+		createCR := func(ctx context.Context) *konfluxv1alpha1.KonfluxUI {
+			ui := &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 				Spec: konfluxv1alpha1.KonfluxUISpec{
 					Ingress: &konfluxv1alpha1.IngressSpec{
 						Enabled: ptr.To(true),
@@ -737,98 +611,80 @@ var _ = Describe("KonfluxUI Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
-
-			reconciler = &KonfluxUIReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				ClusterInfo:          nil, // Will be set in individual tests
-				GetDefaultSegmentKey: noDefaultSegmentKey,
-			}
-		})
-
-		AfterEach(func(ctx context.Context) {
-			By("cleaning up OpenShift OAuth ServiceAccount")
-			existingSA := &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      dex.DexClientServiceAccountName,
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingSA)
-
-			By("cleaning up OpenShift OAuth Secret")
-			existingSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      dex.DexClientSecretName,
-					Namespace: uiNamespace,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingSecret)
-
-			By("cleaning up KonfluxUI resource")
-			_ = k8sClient.Delete(ctx, ui)
-		})
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, ui)
+				_ = k8sClient.Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+					Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+				}})
+				_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+					Name: dex.DexClientSecretName, Namespace: uiNamespace,
+				}})
+			})
+			return ui
+		}
 
 		It("Should create OpenShift OAuth resources when running on OpenShift (default behavior)", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+				}, sa)).To(Succeed())
+				g.Expect(sa.Annotations).To(HaveKeyWithValue(
+					"serviceaccounts.openshift.io/oauth-redirecturi.dex",
+					"https://openshift-test.example.com/idp/callback",
+				))
 
-			By("verifying the ServiceAccount was created")
-			Expect(serviceAccountExists(ctx)).To(BeTrue())
-			sa := getServiceAccount(ctx)
-			Expect(sa.Annotations).To(HaveKeyWithValue(
-				"serviceaccounts.openshift.io/oauth-redirecturi.dex",
-				"https://openshift-test.example.com/idp/callback",
-			))
-
-			By("verifying the Secret was created")
-			Expect(secretExists(ctx)).To(BeTrue())
-			secret := getSecret(ctx)
-			Expect(secret.Type).To(Equal(corev1.SecretTypeServiceAccountToken))
-			Expect(secret.Annotations).To(HaveKeyWithValue(
-				"kubernetes.io/service-account.name",
-				dex.DexClientServiceAccountName,
-			))
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientSecretName, Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(secret.Type).To(Equal(corev1.SecretTypeServiceAccountToken))
+				g.Expect(secret.Annotations).To(HaveKeyWithValue(
+					"kubernetes.io/service-account.name",
+					dex.DexClientServiceAccountName,
+				))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should NOT create OpenShift OAuth resources when NOT running on OpenShift", func(ctx context.Context) {
-			By("setting ClusterInfo to non-OpenShift")
-			reconciler.ClusterInfo = defaultClusterInfo
+			startManager(noDefaultSegmentKey, defaultClusterInfo)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
+			By("waiting for initial reconcile to complete")
+			waitForReconcile(ctx)
 
-			By("verifying the ServiceAccount was NOT created")
-			Expect(serviceAccountExists(ctx)).To(BeFalse())
-
-			By("verifying the Secret was NOT created")
-			Expect(secretExists(ctx)).To(BeFalse())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+			}, &corev1.ServiceAccount{}))).To(BeTrue())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: dex.DexClientSecretName, Namespace: uiNamespace,
+			}, &corev1.Secret{}))).To(BeTrue())
 		})
 
 		It("Should NOT create OpenShift OAuth resources when ClusterInfo is nil", func(ctx context.Context) {
-			By("keeping ClusterInfo as nil")
-			reconciler.ClusterInfo = nil
+			startManager(noDefaultSegmentKey, nil)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
+			By("waiting for initial reconcile to complete")
+			waitForReconcile(ctx)
 
-			By("verifying the ServiceAccount was NOT created")
-			Expect(serviceAccountExists(ctx)).To(BeFalse())
-
-			By("verifying the Secret was NOT created")
-			Expect(secretExists(ctx)).To(BeFalse())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+			}, &corev1.ServiceAccount{}))).To(BeTrue())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: dex.DexClientSecretName, Namespace: uiNamespace,
+			}, &corev1.Secret{}))).To(BeTrue())
 		})
 
 		It("Should NOT create OpenShift OAuth resources when explicitly disabled on OpenShift", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			ui := createCR(ctx)
 
-			By("explicitly disabling OpenShift login")
-			refreshUI(ctx)
+			By("disabling OpenShift login before first reconcile settles")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Dex = &konfluxv1alpha1.DexDeploymentSpec{
 				Config: &dex.DexParams{
 					ConfigureLoginWithOpenShift: ptr.To(false),
@@ -836,22 +692,23 @@ var _ = Describe("KonfluxUI Controller", func() {
 			}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
+			By("waiting for reconcile to complete")
+			waitForReconcile(ctx)
 
-			By("verifying the ServiceAccount was NOT created")
-			Expect(serviceAccountExists(ctx)).To(BeFalse())
-
-			By("verifying the Secret was NOT created")
-			Expect(secretExists(ctx)).To(BeFalse())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+			}, &corev1.ServiceAccount{}))).To(BeTrue())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: dex.DexClientSecretName, Namespace: uiNamespace,
+			}, &corev1.Secret{}))).To(BeTrue())
 		})
 
 		It("Should create OpenShift OAuth resources when explicitly enabled on OpenShift", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			ui := createCR(ctx)
 
 			By("explicitly enabling OpenShift login")
-			refreshUI(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Dex = &konfluxv1alpha1.DexDeploymentSpec{
 				Config: &dex.DexParams{
 					ConfigureLoginWithOpenShift: ptr.To(true),
@@ -859,27 +716,32 @@ var _ = Describe("KonfluxUI Controller", func() {
 			}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the ServiceAccount was created")
-			Expect(serviceAccountExists(ctx)).To(BeTrue())
-
-			By("verifying the Secret was created")
-			Expect(secretExists(ctx)).To(BeTrue())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+				}, &corev1.ServiceAccount{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientSecretName, Namespace: uiNamespace,
+				}, &corev1.Secret{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should delete OpenShift OAuth resources when disabled after being enabled", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			ui := createCR(ctx)
 
-			By("first reconciling to create the resources")
-			reconcileUI(ctx)
-			Expect(serviceAccountExists(ctx)).To(BeTrue())
-			Expect(secretExists(ctx)).To(BeTrue())
+			By("waiting for OAuth resources to be created")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+				}, &corev1.ServiceAccount{})).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientSecretName, Namespace: uiNamespace,
+				}, &corev1.Secret{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("disabling OpenShift login")
-			refreshUI(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Dex = &konfluxv1alpha1.DexDeploymentSpec{
 				Config: &dex.DexParams{
 					ConfigureLoginWithOpenShift: ptr.To(false),
@@ -887,131 +749,96 @@ var _ = Describe("KonfluxUI Controller", func() {
 			}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling again")
-			reconcileUI(ctx)
-
-			By("verifying the ServiceAccount was deleted")
-			Expect(serviceAccountExists(ctx)).To(BeFalse())
-
-			By("verifying the Secret was deleted")
-			Expect(secretExists(ctx)).To(BeFalse())
+			Eventually(func(g Gomega) {
+				g.Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+				}, &corev1.ServiceAccount{}))).To(BeTrue())
+				g.Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientSecretName, Namespace: uiNamespace,
+				}, &corev1.Secret{}))).To(BeTrue())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should set owner reference on OpenShift OAuth resources", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+				}, sa)).To(Succeed())
+				g.Expect(sa.OwnerReferences).To(HaveLen(1))
+				g.Expect(sa.OwnerReferences[0].Name).To(Equal(CRName))
+				g.Expect(sa.OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
 
-			By("verifying the ServiceAccount has owner reference")
-			sa := getServiceAccount(ctx)
-			Expect(sa.OwnerReferences).To(HaveLen(1))
-			Expect(sa.OwnerReferences[0].Name).To(Equal(CRName))
-			Expect(sa.OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
-
-			By("verifying the Secret has owner reference")
-			secret := getSecret(ctx)
-			Expect(secret.OwnerReferences).To(HaveLen(1))
-			Expect(secret.OwnerReferences[0].Name).To(Equal(CRName))
-			Expect(secret.OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientSecretName, Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(secret.OwnerReferences).To(HaveLen(1))
+				g.Expect(secret.OwnerReferences[0].Name).To(Equal(CRName))
+				g.Expect(secret.OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should use correct redirect URI format without port", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the redirect URI has correct format")
-			sa := getServiceAccount(ctx)
-			// The redirect URI should be the hostname followed by the Dex callback path
-			Expect(sa.Annotations["serviceaccounts.openshift.io/oauth-redirecturi.dex"]).To(
-				Equal("https://openshift-test.example.com/idp/callback"),
-			)
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: dex.DexClientServiceAccountName, Namespace: uiNamespace,
+				}, sa)).To(Succeed())
+				g.Expect(sa.Annotations["serviceaccounts.openshift.io/oauth-redirecturi.dex"]).To(
+					Equal("https://openshift-test.example.com/idp/callback"),
+				)
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 
 	Context("NodePort Service configuration via Reconcile", Serial, func() {
 		var ui *konfluxv1alpha1.KonfluxUI
-		var reconciler *KonfluxUIReconciler
 
-		// Helper: refresh UI from cluster
-		refreshUI := func(ctx context.Context) {
-			ExpectWithOffset(1, k8sClient.Get(ctx, types.NamespacedName{Name: ui.Name}, ui)).To(Succeed())
-		}
+		BeforeEach(func(ctx context.Context) {
+			startManager(noDefaultSegmentKey, nil)
 
-		// Helper: reconcile and expect success
-		reconcileUI := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: ui.Name},
+			ui = &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, ui)
 			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-		}
+		})
 
-		// Helper: get proxy Service
-		getProxyService := func(ctx context.Context) *corev1.Service {
+		getProxySvc := func(ctx context.Context, g Gomega) *corev1.Service {
 			svc := &corev1.Service{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      proxyServiceName,
-				Namespace: uiNamespace,
-			}, svc)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: proxyServiceName, Namespace: uiNamespace,
+			}, svc)).To(Succeed())
 			return svc
 		}
 
-		BeforeEach(func(ctx context.Context) {
-			By("creating the KonfluxUI resource")
-			ui = &konfluxv1alpha1.KonfluxUI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxUISpec{},
-			}
-			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
-
-			reconciler = &KonfluxUIReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultSegmentKey,
-			}
-		})
-
-		AfterEach(func(ctx context.Context) {
-			By("cleaning up KonfluxUI resource")
-			_ = k8sClient.Delete(ctx, ui)
-		})
-
 		It("Should create proxy Service as ClusterIP by default", func(ctx context.Context) {
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the proxy Service is ClusterIP")
-			svc := getProxyService(ctx)
-			Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+			Eventually(func(g Gomega) {
+				g.Expect(getProxySvc(ctx, g).Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should create proxy Service as NodePort when nodePortService is configured", func(ctx context.Context) {
-			By("configuring nodePortService")
-			refreshUI(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{
 				NodePortService: &konfluxv1alpha1.NodePortServiceSpec{},
 			}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the proxy Service is NodePort")
-			svc := getProxyService(ctx)
-			Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			Eventually(func(g Gomega) {
+				g.Expect(getProxySvc(ctx, g).Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should set specific HTTPS NodePort when httpsPort is specified", func(ctx context.Context) {
-			By("configuring nodePortService with specific httpsPort")
-			refreshUI(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{
 				NodePortService: &konfluxv1alpha1.NodePortServiceSpec{
 					HTTPSPort: ptr.To(int32(30443)),
@@ -1019,31 +846,29 @@ var _ = Describe("KonfluxUI Controller", func() {
 			}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the proxy Service has the specified NodePort")
-			svc := getProxyService(ctx)
-			Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
-
-			var httpsPort *corev1.ServicePort
-			for i := range svc.Spec.Ports {
-				if svc.Spec.Ports[i].Name == "web-tls" {
-					httpsPort = &svc.Spec.Ports[i]
-					break
+			Eventually(func(g Gomega) {
+				svc := getProxySvc(ctx, g)
+				g.Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+				var httpsPort *corev1.ServicePort
+				for i := range svc.Spec.Ports {
+					if svc.Spec.Ports[i].Name == "web-tls" {
+						httpsPort = &svc.Spec.Ports[i]
+						break
+					}
 				}
-			}
-			Expect(httpsPort).NotTo(BeNil())
-			Expect(httpsPort.NodePort).To(Equal(int32(30443)))
+				g.Expect(httpsPort).NotTo(BeNil())
+				g.Expect(httpsPort.NodePort).To(Equal(int32(30443)))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should change proxy Service from ClusterIP to NodePort when nodePortService is added", func(ctx context.Context) {
-			By("reconciling without nodePortService")
-			reconcileUI(ctx)
-			Expect(getProxyService(ctx).Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+			By("waiting for initial ClusterIP service")
+			Eventually(func(g Gomega) {
+				g.Expect(getProxySvc(ctx, g).Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
-			By("adding nodePortService configuration")
-			refreshUI(ctx)
+			By("adding NodePort configuration")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{
 				NodePortService: &konfluxv1alpha1.NodePortServiceSpec{
 					HTTPSPort: ptr.To(int32(30444)),
@@ -1051,93 +876,49 @@ var _ = Describe("KonfluxUI Controller", func() {
 			}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling again")
-			reconcileUI(ctx)
-
-			By("verifying the proxy Service changed to NodePort")
-			svc := getProxyService(ctx)
-			Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			Eventually(func(g Gomega) {
+				g.Expect(getProxySvc(ctx, g).Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should change proxy Service from NodePort to ClusterIP when nodePortService is removed", func(ctx context.Context) {
-			By("configuring nodePortService and reconciling")
-			refreshUI(ctx)
+			By("configuring NodePort service")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{
 				NodePortService: &konfluxv1alpha1.NodePortServiceSpec{},
 			}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
-			reconcileUI(ctx)
-			Expect(getProxyService(ctx).Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			Eventually(func(g Gomega) {
+				g.Expect(getProxySvc(ctx, g).Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
-			By("removing nodePortService configuration")
-			refreshUI(ctx)
+			By("removing NodePort configuration")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress = nil
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling again")
-			reconcileUI(ctx)
-
-			By("verifying the proxy Service changed back to ClusterIP")
-			svc := getProxyService(ctx)
-			Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+			Eventually(func(g Gomega) {
+				g.Expect(getProxySvc(ctx, g).Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 
 	Context("ConsoleLink reconciliation via Reconcile", Serial, func() {
-		var ui *konfluxv1alpha1.KonfluxUI
-		var reconciler *KonfluxUIReconciler
 		var openShiftClusterInfo *clusterinfo.Info
 		var defaultClusterInfo *clusterinfo.Info
 
-		// Helper: refresh UI from cluster
-		refreshUI := func(ctx context.Context) {
-			ExpectWithOffset(1, k8sClient.Get(ctx, types.NamespacedName{Name: ui.Name}, ui)).To(Succeed())
-		}
-
-		// Helper: reconcile and expect success
-		reconcileUI := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: ui.Name},
-			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-		}
-
-		// Helper: check if ConsoleLink exists
-		consoleLinkExists := func(ctx context.Context) bool {
-			cl := &consolev1.ConsoleLink{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name: consolelink.ConsoleLinkName,
-			}, cl)
-			return err == nil
-		}
-
-		// Helper: get ConsoleLink resource
-		getConsoleLink := func(ctx context.Context) *consolev1.ConsoleLink {
-			cl := &consolev1.ConsoleLink{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name: consolelink.ConsoleLinkName,
-			}, cl)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-			return cl
-		}
-
 		BeforeEach(func(ctx context.Context) {
-			By("cleaning up any existing ConsoleLink from previous tests")
-			existingCL := &consolev1.ConsoleLink{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: consolelink.ConsoleLinkName,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingCL)
+			By("pre-cleaning any existing ConsoleLink")
+			_ = k8sClient.Delete(ctx, &consolev1.ConsoleLink{ObjectMeta: metav1.ObjectMeta{
+				Name: consolelink.ConsoleLinkName,
+			}})
 
-			By("creating mock cluster info for OpenShift and non-OpenShift platforms")
+			By("building cluster info for OpenShift and non-OpenShift platforms")
 			var err error
 			openShiftClusterInfo, err = clusterinfo.DetectWithClient(&mockDiscoveryClient{
 				resources: map[string]*metav1.APIResourceList{
 					"config.openshift.io/v1": {
-						APIResources: []metav1.APIResource{
-							{Kind: "ClusterVersion"},
-						},
+						APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}},
 					},
 				},
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
@@ -1149,12 +930,12 @@ var _ = Describe("KonfluxUI Controller", func() {
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
 			})
 			Expect(err).NotTo(HaveOccurred())
+		})
 
-			By("creating the KonfluxUI resource with ingress enabled")
-			ui = &konfluxv1alpha1.KonfluxUI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
+		// createCR creates a KonfluxUI CR with ingress enabled and registers DeferCleanup.
+		createCR := func(ctx context.Context) *konfluxv1alpha1.KonfluxUI {
+			ui := &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 				Spec: konfluxv1alpha1.KonfluxUISpec{
 					Ingress: &konfluxv1alpha1.IngressSpec{
 						Enabled: ptr.To(true),
@@ -1163,154 +944,136 @@ var _ = Describe("KonfluxUI Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
-
-			reconciler = &KonfluxUIReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				ClusterInfo:          nil, // Will be set in individual tests
-				GetDefaultSegmentKey: noDefaultSegmentKey,
-			}
-		})
-
-		AfterEach(func(ctx context.Context) {
-			By("cleaning up ConsoleLink")
-			existingCL := &consolev1.ConsoleLink{
-				ObjectMeta: metav1.ObjectMeta{
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, ui)
+				_ = k8sClient.Delete(ctx, &consolev1.ConsoleLink{ObjectMeta: metav1.ObjectMeta{
 					Name: consolelink.ConsoleLinkName,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingCL)
-
-			By("cleaning up KonfluxUI resource")
-			_ = k8sClient.Delete(ctx, ui)
-		})
+				}})
+			})
+			return ui
+		}
 
 		It("Should create ConsoleLink when ingress is enabled and running on OpenShift", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the ConsoleLink was created")
-			Expect(consoleLinkExists(ctx)).To(BeTrue())
-
-			By("verifying the ConsoleLink has correct configuration")
-			cl := getConsoleLink(ctx)
-			Expect(cl.Spec.Href).To(Equal("https://consolelink-test.example.com"))
-			Expect(cl.Spec.Text).To(Equal("Konflux Console"))
-			Expect(cl.Spec.Location).To(Equal(consolev1.ApplicationMenu))
-			Expect(cl.Spec.ApplicationMenu).NotTo(BeNil())
-			Expect(cl.Spec.ApplicationMenu.Section).To(Equal("Konflux"))
+			Eventually(func(g Gomega) {
+				cl := &consolev1.ConsoleLink{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: consolelink.ConsoleLinkName,
+				}, cl)).To(Succeed())
+				g.Expect(cl.Spec.Href).To(Equal("https://consolelink-test.example.com"))
+				g.Expect(cl.Spec.Text).To(Equal("Konflux Console"))
+				g.Expect(cl.Spec.Location).To(Equal(consolev1.ApplicationMenu))
+				g.Expect(cl.Spec.ApplicationMenu).NotTo(BeNil())
+				g.Expect(cl.Spec.ApplicationMenu.Section).To(Equal("Konflux"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should NOT create ConsoleLink when NOT running on OpenShift", func(ctx context.Context) {
-			By("setting ClusterInfo to non-OpenShift")
-			reconciler.ClusterInfo = defaultClusterInfo
+			startManager(noDefaultSegmentKey, defaultClusterInfo)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
+			By("waiting for initial reconcile to complete")
+			waitForReconcile(ctx)
 
-			By("verifying the ConsoleLink was NOT created")
-			Expect(consoleLinkExists(ctx)).To(BeFalse())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: consolelink.ConsoleLinkName,
+			}, &consolev1.ConsoleLink{}))).To(BeTrue())
 		})
 
 		It("Should NOT create ConsoleLink when ClusterInfo is nil", func(ctx context.Context) {
-			By("keeping ClusterInfo as nil")
-			reconciler.ClusterInfo = nil
+			startManager(noDefaultSegmentKey, nil)
+			createCR(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
+			By("waiting for initial reconcile to complete")
+			waitForReconcile(ctx)
 
-			By("verifying the ConsoleLink was NOT created")
-			Expect(consoleLinkExists(ctx)).To(BeFalse())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: consolelink.ConsoleLinkName,
+			}, &consolev1.ConsoleLink{}))).To(BeTrue())
 		})
 
 		It("Should NOT create ConsoleLink when ingress is disabled on OpenShift", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			ui := createCR(ctx)
 
 			By("disabling ingress")
-			refreshUI(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{Enabled: ptr.To(false)}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the ConsoleLink was NOT created")
-			Expect(consoleLinkExists(ctx)).To(BeFalse())
+			Eventually(func(g Gomega) {
+				g.Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+					Name: consolelink.ConsoleLinkName,
+				}, &consolev1.ConsoleLink{}))).To(BeTrue())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should delete ConsoleLink when ingress is disabled", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			ui := createCR(ctx)
 
-			By("first reconciling to create the ConsoleLink")
-			reconcileUI(ctx)
-			Expect(consoleLinkExists(ctx)).To(BeTrue())
+			By("waiting for ConsoleLink to be created")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: consolelink.ConsoleLinkName,
+				}, &consolev1.ConsoleLink{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("disabling ingress")
-			refreshUI(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{Enabled: ptr.To(false)}
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling again")
-			reconcileUI(ctx)
-
-			By("verifying the ConsoleLink was deleted")
-			Expect(consoleLinkExists(ctx)).To(BeFalse())
+			Eventually(func(g Gomega) {
+				g.Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+					Name: consolelink.ConsoleLinkName,
+				}, &consolev1.ConsoleLink{}))).To(BeTrue())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should update ConsoleLink when hostname changes", func(ctx context.Context) {
-			By("setting ClusterInfo to OpenShift")
-			reconciler.ClusterInfo = openShiftClusterInfo
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			ui := createCR(ctx)
 
-			By("reconciling to create the ConsoleLink")
-			reconcileUI(ctx)
-			Expect(getConsoleLink(ctx).Spec.Href).To(Equal("https://consolelink-test.example.com"))
+			By("waiting for initial ConsoleLink")
+			Eventually(func(g Gomega) {
+				cl := &consolev1.ConsoleLink{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: consolelink.ConsoleLinkName,
+				}, cl)).To(Succeed())
+				g.Expect(cl.Spec.Href).To(Equal("https://consolelink-test.example.com"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("updating the hostname")
-			refreshUI(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
 			ui.Spec.Ingress.Host = "updated-consolelink.example.com"
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
-			By("reconciling again")
-			reconcileUI(ctx)
-
-			By("verifying the ConsoleLink href was updated")
-			Expect(getConsoleLink(ctx).Spec.Href).To(Equal("https://updated-consolelink.example.com"))
+			Eventually(func(g Gomega) {
+				cl := &consolev1.ConsoleLink{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: consolelink.ConsoleLinkName,
+				}, cl)).To(Succeed())
+				g.Expect(cl.Spec.Href).To(Equal("https://updated-consolelink.example.com"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 
 	Context("Segment Secret reconciliation via Reconcile", Serial, func() {
-		var ui *konfluxv1alpha1.KonfluxUI
-		var reconciler *KonfluxUIReconciler
-		var segmentBridgeCR *konfluxv1alpha1.KonfluxSegmentBridge
-
-		// Helper: reconcile and expect success
-		reconcileUI := func(ctx context.Context) {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: ui.Name},
-			})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-		}
-
-		// Helper: build the expected hashed secret name for given data
+		// expectedSecretName computes the hashed secret name for a given write key and API URL.
 		expectedSecretName := func(writeKey, apiURL string) string {
-			s := hashedsecret.Build(segmentSecretBaseName, uiNamespace, map[string]string{
+			return hashedsecret.Build(segmentSecretBaseName, uiNamespace, map[string]string{
 				segmentKeyWriteKey: writeKey,
 				segmentKeyAPIURL:   apiURL,
-			})
-			return s.Name
+			}).Name
 		}
 
-		// Helper: list all Secrets in the UI namespace matching the segment base name prefix
+		// listSegmentSecrets returns all Secrets in uiNamespace whose name starts with the segment base name.
 		listSegmentSecrets := func(ctx context.Context) []corev1.Secret {
 			secretList := &corev1.SecretList{}
-			err := k8sClient.List(ctx, secretList, client.InNamespace(uiNamespace))
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			ExpectWithOffset(1, k8sClient.List(ctx, secretList, client.InNamespace(uiNamespace))).To(Succeed())
 			var result []corev1.Secret
 			for _, s := range secretList.Items {
 				if len(s.Name) > len(segmentSecretBaseName) && s.Name[:len(segmentSecretBaseName)] == segmentSecretBaseName {
@@ -1321,288 +1084,207 @@ var _ = Describe("KonfluxUI Controller", func() {
 		}
 
 		BeforeEach(func(ctx context.Context) {
-			By("cleaning up any existing segment secrets from previous tests")
+			By("pre-cleaning any existing segment secrets and Bridge CR")
 			for _, s := range listSegmentSecrets(ctx) {
-				_ = k8sClient.Delete(ctx, &s)
+				_ = k8sClient.Delete(ctx, &s) //nolint:gosec
 			}
+			_ = k8sClient.Delete(ctx, &konfluxv1alpha1.KonfluxSegmentBridge{ObjectMeta: metav1.ObjectMeta{
+				Name: segmentbridge.CRName,
+			}})
+		})
 
-			By("cleaning up any existing KonfluxSegmentBridge CR")
-			existingBridge := &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			_ = k8sClient.Delete(ctx, existingBridge)
-
-			By("creating the KonfluxUI resource")
-			ui = &konfluxv1alpha1.KonfluxUI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: CRName,
-				},
-				Spec: konfluxv1alpha1.KonfluxUISpec{},
-			}
+		// createUI creates the KonfluxUI CR and registers DeferCleanup for it and leftover secrets.
+		createUI := func(ctx context.Context) *konfluxv1alpha1.KonfluxUI {
+			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				testutil.DeleteAndWait(ctx, k8sClient, ui)
+				for _, s := range listSegmentSecrets(ctx) {
+					_ = k8sClient.Delete(ctx, &s) //nolint:gosec
+				}
+			})
+			return ui
+		}
 
-			segmentBridgeCR = nil
-
-			reconciler = &KonfluxUIReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				ObjectStore:          objectStore,
-				GetDefaultSegmentKey: noDefaultSegmentKey,
-			}
-		})
-
-		AfterEach(func(ctx context.Context) {
-			By("cleaning up segment secrets")
-			for _, s := range listSegmentSecrets(ctx) {
-				_ = k8sClient.Delete(ctx, &s)
-			}
-
-			By("cleaning up KonfluxSegmentBridge CR")
-			if segmentBridgeCR != nil {
-				_ = k8sClient.Delete(ctx, segmentBridgeCR)
-			}
-
-			By("cleaning up KonfluxUI resource")
-			_ = k8sClient.Delete(ctx, ui)
-		})
+		// createBridgeCR creates a KonfluxSegmentBridge CR and registers DeferCleanup for it.
+		createBridgeCR := func(ctx context.Context) *konfluxv1alpha1.KonfluxSegmentBridge {
+			bridge := &konfluxv1alpha1.KonfluxSegmentBridge{ObjectMeta: metav1.ObjectMeta{Name: segmentbridge.CRName}}
+			Expect(k8sClient.Create(ctx, bridge)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, bridge)
+			return bridge
+		}
 
 		It("Should not create segment secret when KonfluxSegmentBridge CR does not exist", func(ctx context.Context) {
-			By("reconciling without a KonfluxSegmentBridge CR")
-			reconcileUI(ctx)
+			startManager(noDefaultSegmentKey, nil)
+			createUI(ctx)
 
-			By("verifying no segment secret was created")
+			By("waiting for initial reconcile to complete")
+			waitForReconcile(ctx)
+
 			Expect(listSegmentSecrets(ctx)).To(BeEmpty())
 		})
 
 		It("Should not create segment secret when no write key is configured", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR without a write key")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			bridge := createBridgeCR(ctx)
+			startManager(noDefaultSegmentKey, nil)
+			createUI(ctx)
 
-			By("reconciling with no default key either")
-			reconcileUI(ctx)
+			By("waiting for initial reconcile with empty Bridge key")
+			waitForReconcile(ctx)
 
-			By("verifying no segment secret was created")
+			_ = bridge
 			Expect(listSegmentSecrets(ctx)).To(BeEmpty())
 		})
 
 		It("Should create segment secret with CR write key and default API URL", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR with a write key")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			bridge := createBridgeCR(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = "test-write-key"
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			// Update to add segment key (default spec is empty)
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = "test-write-key"
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+			startManager(noDefaultSegmentKey, nil)
+			createUI(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the segment secret was created with correct data")
 			name := expectedSecretName("test-write-key", konfluxv1alpha1.DefaultSegmentAPIURL)
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      name,
-				Namespace: uiNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("test-write-key"))
-			Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal(konfluxv1alpha1.DefaultSegmentAPIURL))
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: name, Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("test-write-key"))
+				g.Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal(konfluxv1alpha1.DefaultSegmentAPIURL))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should create segment secret with CR write key and custom API URL", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR with a write key and custom API URL")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			bridge := createBridgeCR(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = "test-write-key"
+			bridge.Spec.SegmentAPIURL = "https://console.redhat.com/connections/api/v1"
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = "test-write-key"
-			segmentBridgeCR.Spec.SegmentAPIURL = "https://console.redhat.com/connections/api/v1"
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+			startManager(noDefaultSegmentKey, nil)
+			createUI(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the segment secret was created with custom API URL")
 			name := expectedSecretName("test-write-key", "https://console.redhat.com/connections/api/v1")
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      name,
-				Namespace: uiNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("test-write-key"))
-			Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal("https://console.redhat.com/connections/api/v1"))
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: name, Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("test-write-key"))
+				g.Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal("https://console.redhat.com/connections/api/v1"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should use build-time default key when CR key is empty", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR without a write key")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			createBridgeCR(ctx)
+			startManager(staticSegmentKey("build-time-key"), nil)
+			createUI(ctx)
 
-			By("configuring a build-time default key")
-			reconciler.GetDefaultSegmentKey = staticSegmentKey("build-time-key")
-
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the segment secret uses the build-time default key")
 			name := expectedSecretName("build-time-key", konfluxv1alpha1.DefaultSegmentAPIURL)
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      name,
-				Namespace: uiNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("build-time-key"))
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: name, Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("build-time-key"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should prefer CR key over build-time default", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR with a write key")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			bridge := createBridgeCR(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = "cr-override-key"
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = "cr-override-key"
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+			startManager(staticSegmentKey("build-time-key"), nil)
+			createUI(ctx)
 
-			By("configuring a build-time default key")
-			reconciler.GetDefaultSegmentKey = staticSegmentKey("build-time-key")
-
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the segment secret uses the CR key, not the build-time default")
 			name := expectedSecretName("cr-override-key", konfluxv1alpha1.DefaultSegmentAPIURL)
-			secret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      name,
-				Namespace: uiNamespace,
-			}, secret)).To(Succeed())
-
-			Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("cr-override-key"))
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: name, Namespace: uiNamespace,
+				}, secret)).To(Succeed())
+				g.Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("cr-override-key"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should create a new secret and clean up old one when segment key changes", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR with an initial write key")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			bridge := createBridgeCR(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = "initial-key"
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = "initial-key"
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
-
-			By("reconciling to create the initial secret")
-			reconcileUI(ctx)
+			startManager(noDefaultSegmentKey, nil)
+			createUI(ctx)
 
 			initialName := expectedSecretName("initial-key", konfluxv1alpha1.DefaultSegmentAPIURL)
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      initialName,
-				Namespace: uiNamespace,
-			}, &corev1.Secret{})).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: initialName, Namespace: uiNamespace,
+				}, &corev1.Secret{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("changing the segment key")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = "updated-key"
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = "updated-key"
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			By("reconciling again")
-			reconcileUI(ctx)
-
-			By("verifying the new secret was created")
 			updatedName := expectedSecretName("updated-key", konfluxv1alpha1.DefaultSegmentAPIURL)
 			Expect(updatedName).NotTo(Equal(initialName), "hash should differ for different keys")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      updatedName,
-				Namespace: uiNamespace,
-			}, &corev1.Secret{})).To(Succeed())
 
-			By("verifying the old secret was cleaned up")
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      initialName,
-				Namespace: uiNamespace,
-			}, &corev1.Secret{})
-			Expect(errors.IsNotFound(err)).To(BeTrue(), "old segment secret should be deleted")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: updatedName, Namespace: uiNamespace,
+				}, &corev1.Secret{})).To(Succeed())
+				g.Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+					Name: initialName, Namespace: uiNamespace,
+				}, &corev1.Secret{}))).To(BeTrue(), "old segment secret should be deleted")
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should clean up segment secret when key becomes empty", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR with a write key")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			bridge := createBridgeCR(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = "temporary-key"
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = "temporary-key"
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+			startManager(noDefaultSegmentKey, nil)
+			createUI(ctx)
 
-			By("reconciling to create the secret")
-			reconcileUI(ctx)
-			Expect(listSegmentSecrets(ctx)).To(HaveLen(1))
+			By("waiting for the secret to be created")
+			Eventually(func(g Gomega) {
+				g.Expect(listSegmentSecrets(ctx)).To(HaveLen(1))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("removing the segment key")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = ""
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = ""
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			By("reconciling again")
-			reconcileUI(ctx)
-
-			By("verifying the secret was cleaned up")
-			Expect(listSegmentSecrets(ctx)).To(BeEmpty())
+			Eventually(func(g Gomega) {
+				g.Expect(listSegmentSecrets(ctx)).To(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
 		It("Should set owner reference on created segment secret", func(ctx context.Context) {
-			By("creating a KonfluxSegmentBridge CR with a write key")
-			segmentBridgeCR = &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: segmentbridge.CRName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, segmentBridgeCR)).To(Succeed())
+			bridge := createBridgeCR(ctx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
+			bridge.Spec.SegmentKey = "owner-ref-test-key"
+			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, segmentBridgeCR)).To(Succeed())
-			segmentBridgeCR.Spec.SegmentKey = "owner-ref-test-key"
-			Expect(k8sClient.Update(ctx, segmentBridgeCR)).To(Succeed())
+			startManager(noDefaultSegmentKey, nil)
+			createUI(ctx)
 
-			By("reconciling the resource")
-			reconcileUI(ctx)
-
-			By("verifying the secret has owner reference")
-			secrets := listSegmentSecrets(ctx)
-			Expect(secrets).To(HaveLen(1))
-			Expect(secrets[0].OwnerReferences).To(HaveLen(1))
-			Expect(secrets[0].OwnerReferences[0].Name).To(Equal(CRName))
-			Expect(secrets[0].OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
+			Eventually(func(g Gomega) {
+				secrets := listSegmentSecrets(ctx)
+				g.Expect(secrets).To(HaveLen(1))
+				g.Expect(secrets[0].OwnerReferences).To(HaveLen(1))
+				g.Expect(secrets[0].OwnerReferences[0].Name).To(Equal(CRName))
+				g.Expect(secrets[0].OwnerReferences[0].Kind).To(Equal("KonfluxUI"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
Update the envtest suites to start a real controller manager
(via ctrl.NewManager + SetupWithManager + mgr.Start) so that edge-case
tests exercise the full event pipeline.

Remove all calls to reconcile and rely on the controller manager to do the work.

- Refactor `testutil` to add the infrastructure to start a real controller manager.
- Wire the manager in the BeforeSuite in `suite_test.go`.
- Update KonfluxApplicationAPIController test.
- Update KonfluxBuildServiceController test.
- Update KonfluxCertManagerController test.
- Update KonfluxDefaultTenantController test.
- Update KonfluxEnterpriseContractController test.
- Update KonfluxImageController test.
- Update KonfluxInfoController test.
- Update KonfluxIntegrationServiceController test.
- Update KonfluxInternalRegistryController test.
- Update KonfluxNamespaceListerController test.
- Update KonfluxRBACController test.
- Update KonfluxReleaseServiceController test.
- Update KonfluxSegmentBridgeController test.
- Update KonfluxUIController test.
- Update KonfluxController test.
- Update KonfluxCLIController test.

Assisted-By: Cursor
