### PR TITLE
feat(docs): add auto-generated llms.txt for LLM-friendly documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,14 +7,18 @@ on:
     paths:
       - 'operator/docs/**'
       - 'operator/hack/genref/**'
+      - 'operator/hack/generate-llms-txt.sh'
       - 'operator/api/**'
       - 'operator/config/samples/**'
+      - 'operator/Makefile'
   pull_request:
     paths:
       - 'operator/docs/**'
       - 'operator/hack/genref/**'
+      - 'operator/hack/generate-llms-txt.sh'
       - 'operator/api/**'
       - 'operator/config/samples/**'
+      - 'operator/Makefile'
   workflow_dispatch:
 
 permissions:

--- a/operator/.gitignore
+++ b/operator/.gitignore
@@ -39,6 +39,7 @@ docs/.hugo_build.lock
 docs/content/docs/reference/*.md
 !docs/content/docs/reference/_index.md
 docs/content/docs/examples.md
+docs/static/llms.txt
 
 # Temporary assets (if any)
 docs/assets/icons/*

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -115,6 +115,8 @@ generate-apiref: genref ## Generate API reference documentation in markdown form
 generate-docs: generate-apiref ## Generate all documentation (includes API reference).
 	@echo "Adding examples to homepage..."
 	@bash hack/genref/add-examples-to-github-pages.sh config/samples docs/content/docs/examples.md
+	@echo "Generating llms.txt..."
+	@bash hack/generate-llms-txt.sh docs/content/docs docs/static/llms.txt
 	@echo "Documentation generation complete"
 
 .PHONY: docs-serve

--- a/operator/docs/content/docs/guides/llms-txt.md
+++ b/operator/docs/content/docs/guides/llms-txt.md
@@ -1,0 +1,137 @@
+---
+title: "LLM-Friendly Documentation (llms.txt)"
+linkTitle: "LLM-Friendly Docs"
+weight: 11
+description: "How to use the Konflux Operator llms.txt file with MCP servers so AI coding assistants can access the documentation."
+---
+
+The Konflux Operator documentation publishes an [`llms.txt`](https://llmstxt.org/)
+file — a structured index that lets Large Language Models discover and consume the
+docs at inference time. The file is automatically generated from the Hugo content
+tree and stays in sync with documentation changes.
+
+**Published at:** <https://konflux-ci.dev/konflux-ci/llms.txt>
+
+## What is llms.txt?
+
+`llms.txt` is a lightweight specification for providing LLM-readable content on
+websites. It is a Markdown file with a title, description, and a list of links to
+documentation pages. AI coding assistants and MCP-enabled IDEs can read this file
+to find relevant documentation without scraping HTML.
+
+## Using with an MCP server (mcpdoc)
+
+[mcpdoc](https://github.com/langchain-ai/mcpdoc) is an open-source MCP server
+purpose-built for serving `llms.txt` files. It exposes two tools to MCP host
+applications (Cursor, Windsurf, Claude Code/Desktop):
+
+- **`list_doc_sources`** — lists available documentation sources
+- **`fetch_docs`** — fetches content from URLs found in the `llms.txt` file
+
+### Konflux llms.txt URL
+
+Use the following name and URL when configuring mcpdoc:
+
+| Name | URL |
+|------|-----|
+| `Konflux Operator And Administrator Documentation` | `https://konflux-ci.dev/konflux-ci/llms.txt` |
+
+### Quick start (Cursor example)
+
+Open **Cursor Settings > MCP** to edit your `~/.cursor/mcp.json`, then add:
+
+```json
+{
+  "mcpServers": {
+    "konflux-operator-docs": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "mcpdoc",
+        "mcpdoc",
+        "--urls",
+        "Konflux Operator And Administrator Documentation:https://konflux-ci.dev/konflux-ci/llms.txt",
+        "--transport",
+        "stdio"
+      ]
+    }
+  }
+}
+```
+
+For best results, add a rule to your Cursor **User Rules** (Settings > Rules):
+
+```text
+For ANY question about Konflux, the Konflux Operator, or Konflux administration,
+use the konflux-operator-docs MCP server:
+1. Call list_doc_sources to see available llms.txt files
+2. Call fetch_docs to read the llms.txt index
+3. Identify URLs relevant to the question
+4. Call fetch_docs on those URLs
+5. Use the retrieved content to answer
+```
+
+### Other IDEs and clients
+
+mcpdoc supports Cursor, Windsurf, Claude Code, and Claude Desktop. For setup
+instructions for each client, see the
+[mcpdoc Quickstart guide](https://github.com/langchain-ai/mcpdoc?tab=readme-ov-file#quickstart).
+The configuration is the same across clients — only the `--urls` value is
+Konflux-specific:
+
+```text
+Konflux Operator And Administrator Documentation:https://konflux-ci.dev/konflux-ci/llms.txt
+```
+
+### Testing with the MCP Inspector
+
+Start mcpdoc in SSE mode:
+
+```bash
+uvx --from mcpdoc mcpdoc \
+    --urls "Konflux Operator And Administrator Documentation:https://konflux-ci.dev/konflux-ci/llms.txt" \
+    --transport sse \
+    --port 8082 \
+    --host localhost
+```
+
+Then launch the [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector):
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+In the Inspector UI, set the transport to **SSE**, enter `http://localhost:8082/sse`,
+and click **Connect**. Use the **Tools** tab to call `list_doc_sources` and
+`fetch_docs`.
+
+### Testing with a local docs server
+
+When developing documentation locally, point mcpdoc at the local Hugo server
+instead of the production URL:
+
+```bash
+make docs-serve
+
+# In another terminal
+uvx --from mcpdoc mcpdoc \
+    --urls "Konflux Operator And Administrator Documentation:http://localhost:4000/konflux-ci/operator/llms.txt" \
+    --allowed-domains localhost raw.githubusercontent.com \
+    --transport sse \
+    --port 8082 \
+    --host localhost
+```
+
+{{< alert color="info" >}}
+When using a local `llms.txt` URL, you must pass `--allowed-domains` explicitly
+because mcpdoc only auto-allows the domain of the `llms.txt` URL itself. The
+documentation links inside `llms.txt` point to `raw.githubusercontent.com`, so
+that domain must be allowed as well.
+{{< /alert >}}
+
+## How llms.txt is generated
+
+The file is produced by `hack/generate-llms-txt.sh`, which scans the Hugo content
+tree and extracts title, description, and weight from each page's YAML frontmatter.
+It runs automatically as part of `make generate-docs`, so any changes to the
+documentation are reflected in `llms.txt` on the next build.

--- a/operator/hack/generate-llms-txt.sh
+++ b/operator/hack/generate-llms-txt.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Generates llms.txt for the Konflux Operator documentation.
+# Scans the Hugo content tree and produces a structured index
+# following the llms.txt specification (https://llmstxt.org/).
+#
+# Usage:
+#   generate-llms-txt.sh <content_dir> <output_file>
+#
+# Arguments:
+#   content_dir  - Path to Hugo content/docs/ directory
+#   output_file  - Output path for llms.txt (e.g., docs/static/llms.txt)
+#
+# Environment:
+#   RAW_GITHUB_BASE - Base URL for raw markdown links
+#                     (default: https://raw.githubusercontent.com/konflux-ci/konflux-ci/main/operator/docs/content/docs)
+
+set -euo pipefail
+
+CONTENT_DIR="${1:?Usage: generate-llms-txt.sh <content_dir> <output_file>}"
+OUTPUT_FILE="${2:?Usage: generate-llms-txt.sh <content_dir> <output_file>}"
+RAW_BASE="${RAW_GITHUB_BASE:-https://raw.githubusercontent.com/konflux-ci/konflux-ci/main/operator/docs/content/docs}"
+
+# Extract a YAML frontmatter field value from a markdown file.
+# Handles both quoted ("value") and unquoted (value) forms.
+get_frontmatter() {
+  local file="$1" field="$2"
+  sed -n '/^---$/,/^---$/p' "$file" \
+    | grep -E "^${field}:" \
+    | head -1 \
+    | sed "s/^${field}:[[:space:]]*//; s/^[\"']//; s/[\"'][[:space:]]*$//" \
+    || true
+}
+
+# Build a "weight|link line" for a single content file.
+# Outputs nothing if the file has no title.
+make_entry() {
+  local file="$1" indent="${2:-}"
+  local title description weight relpath url
+
+  title=$(get_frontmatter "$file" "title")
+  [ -z "$title" ] && return 0
+
+  description=$(get_frontmatter "$file" "description")
+  weight=$(get_frontmatter "$file" "weight")
+  weight="${weight:-999}"
+  relpath="${file#"$CONTENT_DIR"/}"
+  url="${RAW_BASE}/${relpath}"
+
+  if [ -n "$description" ]; then
+    printf '%s|%s- [%s](%s): %s\n' "$weight" "$indent" "$title" "$url" "$description"
+  else
+    printf '%s|%s- [%s](%s)\n' "$weight" "$indent" "$title" "$url"
+  fi
+}
+
+# Emit a sorted markdown link list for every non-index .md file in a directory.
+emit_section() {
+  local dir="$1"
+  local tmpfile
+  tmpfile=$(mktemp)
+
+  for file in "$dir"/*.md; do
+    [ -f "$file" ] || continue
+    [[ "$(basename "$file")" == "_index.md" ]] && continue
+    make_entry "$file" >> "$tmpfile"
+  done
+
+  if [ -s "$tmpfile" ]; then
+    sort -t'|' -k1 -n "$tmpfile" | cut -d'|' -f2-
+  fi
+  rm -f "$tmpfile"
+}
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+# Section ordering: directory name → display heading.
+# Add new sections here when the content tree grows.
+SECTION_DIRS=(  ""             "installation"  "guides"  "onboard"              "reference"    )
+SECTION_HDRS=("Docs"          "Installation"  "Guides"  "Onboarding Tutorial"  "API Reference")
+
+# Files to exclude from the main sections and place in Optional instead.
+OPTIONAL_FILES=("examples.md")
+
+is_optional() {
+  local base="$1"
+  for opt in "${OPTIONAL_FILES[@]}"; do
+    [[ "$base" == "$opt" ]] && return 0
+  done
+  return 1
+}
+
+{
+# --- Header (static project-level info) ---
+cat << 'HEADER'
+# Konflux Operator
+
+> The Konflux Operator is a Kubernetes-native operator that installs, configures, and manages the Konflux CI/CD platform from a single declarative Custom Resource. It deploys and wires together build controllers, release pipelines, policy engines, identity providers, ingress, and more. It works on any Kubernetes cluster: local Kind environments, OpenShift, EKS, GKE, or any conformant distribution.
+
+- Source code: https://github.com/konflux-ci/konflux-ci
+- Konflux project docs: https://konflux-ci.dev/docs/
+- Operator docs site: https://konflux-ci.dev/konflux-ci/docs/
+HEADER
+
+# --- Content sections ---
+for i in "${!SECTION_DIRS[@]}"; do
+  section_dir="${SECTION_DIRS[$i]}"
+  section_hdr="${SECTION_HDRS[$i]}"
+
+  if [ -z "$section_dir" ]; then
+    # Top-level pages (overview, troubleshooting, …) — skip _index.md and optional files
+    tmpfile=$(mktemp)
+    for file in "$CONTENT_DIR"/*.md; do
+      [ -f "$file" ] || continue
+      base=$(basename "$file")
+      [[ "$base" == "_index.md" ]] && continue
+      is_optional "$base" && continue
+      make_entry "$file" >> "$tmpfile"
+    done
+
+    if [ -s "$tmpfile" ]; then
+      printf '\n## %s\n\n' "$section_hdr"
+      sort -t'|' -k1 -n "$tmpfile" | cut -d'|' -f2-
+    fi
+    rm -f "$tmpfile"
+  else
+    dir="$CONTENT_DIR/$section_dir"
+    [ -d "$dir" ] || continue
+    section_entries=$(emit_section "$dir")
+    if [ -n "$section_entries" ]; then
+      printf '\n## %s\n\n' "$section_hdr"
+      printf '%s\n' "$section_entries"
+    fi
+  fi
+done
+
+# --- Optional section ---
+tmpfile=$(mktemp)
+for opt in "${OPTIONAL_FILES[@]}"; do
+  file="$CONTENT_DIR/$opt"
+  [ -f "$file" ] || continue
+  make_entry "$file" >> "$tmpfile"
+done
+
+if [ -s "$tmpfile" ]; then
+  printf '\n## Optional\n\n'
+  sort -t'|' -k1 -n "$tmpfile" | cut -d'|' -f2-
+fi
+rm -f "$tmpfile"
+
+} > "$OUTPUT_FILE"
+
+echo "Generated llms.txt: $OUTPUT_FILE"


### PR DESCRIPTION
Adds /llms.txt (https://llmstxt.org/) to the docs site so LLMs can discover and consume the operator documentation at inference time.

A generation script scans the Hugo content tree, reads frontmatter (title, description, weight), and produces a structured index with links to the raw markdown on GitHub. It runs as part of `make generate-docs`, keeping llms.txt in sync with doc changes automatically on every CI deploy and local build.

Assisted-By: Cursor
Made-with: Cursor