### PR TITLE
refactor(e2e): use setup-release.sh from operator ConfigMap for release setup

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -271,11 +271,6 @@ jobs:
           cd test/go-tests
           go test . ./pkg/...
 
-      - name: Set release catalog revision
-        if: matrix.test_scope == 'integration+e2e'
-        working-directory: ${{ github.workspace }}
-        run: grep 'RELEASE_SERVICE_CATALOG_REVISION=' test/e2e/release-service-catalog-revision | sed 's/^export //' >> $GITHUB_ENV
-
       - name: Set build pipeline bundle (min)
         if: matrix.test_scope == 'integration+e2e'
         working-directory: ${{ github.workspace }}
@@ -292,9 +287,7 @@ jobs:
           # Test framework reads GITHUB_TOKEN and MY_GITHUB_ORG (see pkg/clients/common/controller.go, e2e.env.template)
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           MY_GITHUB_ORG: ${{ secrets.GH_ORG }}
-          QUAY_DOCKERCONFIGJSON: ${{ secrets.QUAY_DOCKERCONFIGJSON }}
-          RELEASE_CATALOG_TA_QUAY_TOKEN: ${{ secrets.RELEASE_CATALOG_TA_QUAY_TOKEN }}
-          E2E_APPLICATIONS_NAMESPACE: user-ns2
+          E2E_APPLICATIONS_NAMESPACE: default-tenant
         run: |
           ./test/e2e/run-e2e.sh \
             -ginkgo.github-output \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,10 +150,10 @@ cp scripts/deploy-local.env.template scripts/deploy-local.env
 Create the E2E test configuration (only needed when running E2E tests):
 ```bash
 cp test/e2e/e2e.env.template test/e2e/e2e.env
-# Edit test/e2e/e2e.env with GH_ORG, GH_TOKEN, QUAY_DOCKERCONFIGJSON, etc.
+# Edit test/e2e/e2e.env with GH_ORG, GH_TOKEN, etc.
 ```
 
-See `test/e2e/e2e.env.template` for all E2E variables and descriptions. You do not need to set `RELEASE_SERVICE_CATALOG_REVISION` in `e2e.env`; it is read from `test/e2e/release-service-catalog-revision` when unset.
+See `test/e2e/e2e.env.template` for all E2E variables and descriptions. Release infrastructure (managed namespace, ImageRepositories, ReleasePlan, etc.) is set up automatically by `operator/hack/setup-release.sh`, which the test calls during `BeforeAll`. The release-service-catalog revision is embedded in the script as its default and tracked by Renovate.
 
 ## Running the test
 
@@ -170,6 +170,6 @@ source test/e2e/e2e.env
 
 The script deploys test resources and runs the conformance suite.
 
-Note: The deploy step uses `scripts/deploy-local.env` (GitHub App, Quay for image-controller, Smee). The E2E step uses `test/e2e/e2e.env` (GitHub/Quay for E2E flows only). They are separate so you never load deploy secrets into the shell where you only run tests.
+Note: The deploy step uses `scripts/deploy-local.env` (GitHub App, Quay for image-controller, Smee). The E2E step uses `test/e2e/e2e.env` (GitHub token for PaC flows). They are separate so you never load deploy secrets into the shell where you only run tests.
 
 The source code of the E2E tests is in this repo under `test/go-tests/tests/conformance/`.

--- a/operator/pkg/manifests/cli/manifests.yaml
+++ b/operator/pkg/manifests/cli/manifests.yaml
@@ -121,7 +121,9 @@ data:
     get imagerepository \"${name}\" -n \"${MANAGED_NS}\" -o jsonpath='{.status.state}'
     2>/dev/null || echo 'unknown')\"\n    echo \"  Message: $(kubectl get imagerepository
     \"${name}\" -n \"${MANAGED_NS}\" -o jsonpath='{.status.message}' 2>/dev/null ||
-    echo 'none')\"\n    return 1\n}\n\n# Parse arguments\nTENANT_NS=\"default-tenant\"\nMANAGED_NS=\"default-managed-tenant\"\nAPPLICATION=\"sample-component\"\nPRODUCT_VERSION=\"0.1\"\nCONFORMA_POLICY=\"default\"\nRELEASE_NAME=\"local-release\"\nCATALOG_REVISION=\"production\"\nIMAGE_NAME_PREFIX=\"\"\nCOMPONENTS=()\n\nwhile
+    echo 'none')\"\n    return 1\n}\n\n# Parse arguments\nTENANT_NS=\"default-tenant\"\nMANAGED_NS=\"default-managed-tenant\"\nAPPLICATION=\"sample-component\"\nPRODUCT_VERSION=\"0.1\"\nCONFORMA_POLICY=\"default\"\nRELEASE_NAME=\"local-release\"\n#
+    renovate: datasource=git-refs depName=https://github.com/konflux-ci/release-service-catalog
+    currentValue=development\nCATALOG_REVISION=\"2c240d6a1b551a1e152e299567175872bb10fb16\"\nIMAGE_NAME_PREFIX=\"\"\nCOMPONENTS=()\n\nwhile
     [[ $# -gt 0 ]]; do\n    case $1 in\n        -t|--tenant-namespace)\n            TENANT_NS=\"$2\"\n
     \           shift 2\n            ;;\n        -m|--managed-namespace)\n            MANAGED_NS=\"$2\"\n
     \           shift 2\n            ;;\n        -a|--application)\n            APPLICATION=\"$2\"\n
@@ -139,7 +141,7 @@ data:
     a unique image name prefix to avoid credential collisions between\n# concurrent
     CI runs that share the same Quay organization.\nif [[ -z \"${IMAGE_NAME_PREFIX}\"
     ]]; then\n    RANDOM_SUFFIX=$(od -An -tx1 -N3 /dev/urandom | tr -d ' ')\n    IMAGE_NAME_PREFIX=\"${MANAGED_NS}-${RANDOM_SUFFIX}\"\nfi\n\nIS_OPENSHIFT=false\nif
-    kubectl api-resources --api-group=config.openshift.io &>/dev/null; then\n    IS_OPENSHIFT=true\nfi\n\n#
+    kubectl api-resources --api-group=config.openshift.io &>/dev/null; then\n    IS_OPENSHIFT=true\nfi\n#
     Auto-detect components if none specified\nif [[ ${#COMPONENTS[@]} -eq 0 ]]; then\n
     \   echo \"\U0001F50D No components specified, auto-detecting from application
     '${APPLICATION}' in namespace '${TENANT_NS}'...\"\n    mapfile -t COMPONENTS <

--- a/operator/upstream-kustomizations/cli/setup-release.sh
+++ b/operator/upstream-kustomizations/cli/setup-release.sh
@@ -82,7 +82,8 @@ APPLICATION="sample-component"
 PRODUCT_VERSION="0.1"
 CONFORMA_POLICY="default"
 RELEASE_NAME="local-release"
-CATALOG_REVISION="production"
+# renovate: datasource=git-refs depName=https://github.com/konflux-ci/release-service-catalog currentValue=development
+CATALOG_REVISION="2c240d6a1b551a1e152e299567175872bb10fb16"
 IMAGE_NAME_PREFIX=""
 COMPONENTS=()
 
@@ -152,7 +153,6 @@ IS_OPENSHIFT=false
 if kubectl api-resources --api-group=config.openshift.io &>/dev/null; then
     IS_OPENSHIFT=true
 fi
-
 # Auto-detect components if none specified
 if [[ ${#COMPONENTS[@]} -eq 0 ]]; then
     echo "🔍 No components specified, auto-detecting from application '${APPLICATION}' in namespace '${TENANT_NS}'..."

--- a/renovate.json
+++ b/renovate.json
@@ -241,18 +241,18 @@
       "extractVersionTemplate": "^v?(?<version>.*)$"
     },
     {
-      "description": "Track release-service-catalog development branch SHA (single source of truth for E2E and workflows)",
+      "description": "Track release-service-catalog development branch SHA in setup-release.sh",
       "customType": "regex",
       "matchStringsStrategy": "combination",
-      "fileMatch": ["test/e2e/release-service-catalog-revision"],
+      "fileMatch": ["operator/upstream-kustomizations/cli/setup-release\\.sh$"],
       "matchStrings": [
-        "# renovate: datasource=git-refs depName=https://github.com/konflux-ci/release-service-catalog",
-        "RELEASE_SERVICE_CATALOG_REVISION=(?<currentDigest>[a-f0-9]{40})"
+        "# renovate: datasource=git-refs depName=https://github.com/konflux-ci/release-service-catalog currentValue=development",
+        "CATALOG_REVISION=\"(?<currentDigest>[a-f0-9]{40})\""
       ],
       "datasourceTemplate": "git-refs",
       "depNameTemplate": "https://github.com/konflux-ci/release-service-catalog",
       "currentValueTemplate": "development",
-      "autoReplaceStringTemplate": "RELEASE_SERVICE_CATALOG_REVISION={{newDigest}}"
+      "autoReplaceStringTemplate": "CATALOG_REVISION=\"{{newDigest}}\""
     },
     {
       "description": "Track cert-manager Helm chart in Update Third-Party Manifests workflow",

--- a/test/e2e/e2e.env.template
+++ b/test/e2e/e2e.env.template
@@ -7,8 +7,13 @@
 #   source test/e2e/e2e.env
 #   ./test/e2e/run-e2e.sh
 #
-# This template sources test/e2e/release-service-catalog-revision so the catalog revision
-# comes from the single tracked file (same as CI). Override by setting RELEASE_SERVICE_CATALOG_REVISION here.
+# Release infrastructure (managed namespace, ImageRepositories, ReleasePlan, etc.)
+# is created automatically by operator/hack/setup-release.sh, which the test calls
+# during BeforeAll. No Quay credentials are needed here -- image-controller handles them.
+#
+# The release-service-catalog revision is embedded in operator/hack/setup-release.sh as its default
+# (tracked by Renovate). The test calls setup-release.sh without overriding it, so local runs
+# match CI automatically.
 # The build pipeline bundle (docker-build-oci-ta-min) is set from operator/pkg/manifests/build-service/manifests.yaml
 # when unset, so local runs match CI without a prep script. Override with CUSTOM_DOCKER_BUILD_OCI_TA_MIN_PIPELINE_BUNDLE.
 #
@@ -28,31 +33,10 @@ export GH_TOKEN=""
 export GITHUB_TOKEN="${GH_TOKEN}"
 export MY_GITHUB_ORG="${GH_ORG}"
 
-# Quay.io credentials: full .dockerconfigjson content (single line or quoted).
-# Must be exported so the test process sees it; BeforeSuite then sets QUAY_TOKEN from this.
-export QUAY_DOCKERCONFIGJSON=""
-
-# Optional: Override release-service-catalog revision (default: loaded from release-service-catalog-revision below).
-# export RELEASE_SERVICE_CATALOG_REVISION=""
-
-# Load revision from the single tracked file (same as CI). Keep this line so your env does not drift.
-source test/e2e/release-service-catalog-revision
-
 # Required for running against kind/upstream (avoids OpenShift-only code paths like console route).
-# Use the same values as CI when testing against a local kind cluster.
-export E2E_APPLICATIONS_NAMESPACE=user-ns2
+# The test uses the operator-created default-tenant namespace.
+export E2E_APPLICATIONS_NAMESPACE=default-tenant
 export TEST_ENVIRONMENT=upstream
-
-# Optional: Quay token for release trusted-artifacts push (release-service-catalog).
-# Must be base64-encoded .dockerconfigjson (same as QUAY_DOCKERCONFIGJSON shape for quay.io).
-# Leave empty if not using trusted-artifacts in E2E.
-export RELEASE_CATALOG_TA_QUAY_TOKEN=""
-
-# Optional: OCI registry/repo URL for release trusted-artifacts (overrides catalog default).
-# Set to your own Quay (or other OCI) repo when running locally; CI uses the shared repo.
-# Example: quay.io/myuser/my-trusted-artifacts
-# When set, the test passes this as ReleasePlanAdmission.spec.pipeline.pipelineRef.ociStorage to the release pipeline.
-export RELEASE_TA_OCI_STORAGE=""
 
 # Optional: Override build pipeline bundle for docker-build-oci-ta-min (default: derived from operator manifest below).
 # Set CUSTOM_DOCKER_BUILD_OCI_TA_MIN_PIPELINE_BUNDLE before sourcing to use a different bundle.

--- a/test/e2e/release-service-catalog-revision
+++ b/test/e2e/release-service-catalog-revision
@@ -1,2 +1,0 @@
-# renovate: datasource=git-refs depName=https://github.com/konflux-ci/release-service-catalog
-export RELEASE_SERVICE_CATALOG_REVISION=ebc3e90406129ca56503d5cfb2c1ed903c41f85e

--- a/test/go-tests/pkg/utils/util.go
+++ b/test/go-tests/pkg/utils/util.go
@@ -88,30 +88,6 @@ func GetEnvOrFunc(key string, defaultFunc func() (string, error)) (string, error
 	return defaultFunc()
 }
 
-// GetReleaseServiceCatalogRevision returns RELEASE_SERVICE_CATALOG_REVISION from env, or from
-// test/e2e/release-service-catalog-revision (env-var file with one variable), or "development".
-func GetReleaseServiceCatalogRevision() string {
-	if v := os.Getenv("RELEASE_SERVICE_CATALOG_REVISION"); v != "" {
-		return v
-	}
-	for _, path := range []string{"../e2e/release-service-catalog-revision", "test/e2e/release-service-catalog-revision"} {
-		data, err := os.ReadFile(path)
-		if err != nil {
-			continue
-		}
-		for _, line := range strings.Split(string(data), "\n") {
-			line = strings.TrimSpace(line)
-			if strings.HasPrefix(line, "RELEASE_SERVICE_CATALOG_REVISION=") {
-				v := strings.TrimPrefix(line, "RELEASE_SERVICE_CATALOG_REVISION=")
-				v = strings.Trim(v, "\"'")
-				if v != "" {
-					return v
-				}
-			}
-		}
-	}
-	return "development"
-}
 
 func GetQuayIOOrganization() string {
 	return GetEnv(constants.QUAY_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe")

--- a/test/go-tests/tests/conformance/conformance.go
+++ b/test/go-tests/tests/conformance/conformance.go
@@ -2,7 +2,6 @@ package conformance
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -22,7 +21,6 @@ import (
 	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/utils/tekton"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	gomega "github.com/onsi/gomega"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
 	integrationv1beta2 "github.com/konflux-ci/integration-service/api/v1beta2"
 	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
@@ -32,14 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
-
-var _ = ginkgo.BeforeSuite(func() {
-	if os.Getenv("QUAY_TOKEN") == "" {
-		if qdc := os.Getenv("QUAY_DOCKERCONFIGJSON"); qdc != "" {
-			os.Setenv("QUAY_TOKEN", base64.StdEncoding.EncodeToString([]byte(qdc)))
-		}
-	}
-})
 
 var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamKonfluxTestLabel), func() {
 	defer ginkgo.GinkgoRecover()
@@ -78,28 +68,16 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				userNamespace = fw.UserNamespace
-				managedNamespace = userNamespace + "-managed"
+				managedNamespace = "default-managed-tenant"
 				klog.Info("conformance: namespaces ready", "user", userNamespace, "managed", managedNamespace)
 
 				componentName = fmt.Sprintf("%s-%s", appSpec.ComponentSpec.Name, util.GenerateRandomString(4))
 				pacBranchName = constants.PaCPullRequestBranchPrefix + componentName
 				componentRepositoryName = utils.ExtractGitRepositoryNameFromURL(appSpec.ComponentSpec.GitSourceUrl)
 
-				sharedSecret, secretErr := fw.AsKubeAdmin.CommonController.GetSecret(constants.QuayRepositorySecretNamespace, constants.QuayRepositorySecretName)
-				if secretErr != nil && k8sErrors.IsNotFound(secretErr) {
-					sharedSecret, secretErr = createE2EQuaySecret(fw.AsKubeAdmin.CommonController.CustomClient)
-				}
-				gomega.Expect(secretErr).ShouldNot(gomega.HaveOccurred(), "failed to get/create quay secret %s/%s", constants.QuayRepositorySecretNamespace, constants.QuayRepositorySecretName)
-
-				createReleaseConfig(fw.AsKubeAdmin, managedNamespace, userNamespace, appSpec.ComponentSpec.Name, appSpec.ApplicationName, sharedSecret.Data[".dockerconfigjson"], utils.GetEnv("RELEASE_TA_OCI_STORAGE", ""))
-
-				taToken := utils.GetEnv("RELEASE_CATALOG_TA_QUAY_TOKEN", "")
-				if taToken != "" {
-					_, err = fw.AsKubeAdmin.CommonController.CreateRegistryAuthSecret(releaseCatalogTAQuaySecret, managedNamespace, taToken)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					err = fw.AsKubeAdmin.CommonController.LinkSecretToServiceAccount(managedNamespace, releaseCatalogTAQuaySecret, "release-service-account", true)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				}
+				gomega.Expect(runSetupRelease(appSpec.ApplicationName, componentName, userNamespace, managedNamespace)).To(gomega.Succeed())
+				gomega.Expect(patchECPForE2E(fw.AsKubeAdmin, "default", managedNamespace)).To(gomega.Succeed())
+				gomega.Expect(grantIntegrationRunnerJobRBAC(userNamespace)).To(gomega.Succeed())
 
 				buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(appSpec.ComponentSpec.BuildPipelineType)
 			})
@@ -109,9 +87,6 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 					return
 				}
 				klog.Info("conformance: cleaning up")
-				// Fire-and-forget namespace deletion (don't wait for termination -- it can take minutes
-				// and the 30m test timeout includes cleanup time)
-				_ = fw.AsKubeAdmin.CommonController.KubeInterface().CoreV1().Namespaces().Delete(context.Background(), userNamespace, metav1.DeleteOptions{})
 				_ = fw.AsKubeAdmin.CommonController.KubeInterface().CoreV1().Namespaces().Delete(context.Background(), managedNamespace, metav1.DeleteOptions{})
 				cleanupWithRetry("delete PaC branch", func() error {
 					return fw.AsKubeAdmin.CommonController.GitHub.DeleteRef(componentRepositoryName, pacBranchName)

--- a/test/go-tests/tests/conformance/const.go
+++ b/test/go-tests/tests/conformance/const.go
@@ -13,7 +13,7 @@ const (
 	releaseTimeout              = time.Minute * 4
 
 	// Intervals
-	defaultPollingInterval = time.Second * 2
+	defaultPollingInterval  = time.Second * 2
 	snapshotPollingInterval = time.Second * 1
 	releasePollingInterval  = time.Second * 1
 

--- a/test/go-tests/tests/conformance/setup.go
+++ b/test/go-tests/tests/conformance/setup.go
@@ -2,185 +2,177 @@ package conformance
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"time"
 
 	ecp "github.com/conforma/crds/api/v1alpha1"
 	buildcontrollers "github.com/konflux-ci/build-service/controllers"
-	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 
-	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/clients/kube"
-	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/constants"
 	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/framework"
-	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/utils"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	gomega "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
 
-const (
-	releaseCatalogTAQuaySecret = "release-catalog-trusted-artifacts-quay-secret"
-)
-
-var (
-	relSvcCatalogURL      = utils.GetEnv("RELEASE_SERVICE_CATALOG_URL", "https://github.com/konflux-ci/release-service-catalog")
-	relSvcCatalogRevision = utils.GetReleaseServiceCatalogRevision()
-)
-
-func createReleaseConfig(hub *framework.ControllerHub, managedNamespace, userNamespace, componentName, appName string, secretData []byte, ociStorage string) {
-	if ociStorage == "" {
-		ociStorage = os.Getenv("RELEASE_TA_OCI_STORAGE")
-	}
-	if ociStorage != "" {
-		ginkgo.GinkgoWriter.Printf("RELEASE_TA_OCI_STORAGE=%q\n", ociStorage)
+// runSetupRelease downloads setup-release.sh from the ConfigMap shipped by the
+// operator (konflux-cli/setup-release) and executes it to create the managed
+// namespace, ImageRepositories, EnterpriseContractPolicy, ReleasePlanAdmission,
+// and ReleasePlan needed by the release flow.
+func runSetupRelease(appName, componentName, tenantNS, managedNS string) error {
+	scriptContent, err := downloadScriptFromConfigMap("konflux-cli", "setup-release", "setup-release.sh")
+	if err != nil {
+		return fmt.Errorf("download setup-release.sh from ConfigMap: %w", err)
 	}
 
-	klog.Info("conformance: creating release config", "managedNamespace", managedNamespace)
-
-	_, err := hub.CommonController.CreateTestNamespace(managedNamespace)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create managed namespace %s", managedNamespace)
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "release-pull-secret", Namespace: managedNamespace},
-		Data:       map[string][]byte{".dockerconfigjson": secretData},
-		Type:       corev1.SecretTypeDockerConfigJson,
+	tmpDir, err := os.MkdirTemp("", "setup-release-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
 	}
-	_, err = hub.CommonController.CreateSecret(managedNamespace, secret)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create release-pull-secret")
+	defer os.RemoveAll(tmpDir)
 
-	managedServiceAccount, err := hub.CommonController.CreateServiceAccount("release-service-account", managedNamespace, []corev1.ObjectReference{{Name: secret.Name}}, nil)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create release-service-account")
-
-	_, err = hub.ReleaseController.CreateReleasePipelineRoleBindingForServiceAccount(userNamespace, managedServiceAccount)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create role binding in %s", userNamespace)
-
-	_, err = hub.ReleaseController.CreateReleasePipelineRoleBindingForServiceAccount(managedNamespace, managedServiceAccount)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create role binding in %s", managedNamespace)
-
-	publicKey, err := hub.TektonController.GetTektonChainsPublicKey()
-	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get Tekton Chains public key")
-
-	err = hub.TektonController.CreateOrUpdateSigningSecret(publicKey, "cosign-public-key", managedNamespace)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create cosign-public-key secret")
-
-	_, err = hub.ReleaseController.CreateReleasePlan("source-releaseplan", userNamespace, appName, managedNamespace, "", nil, nil, nil)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan")
-
-	defaultEcPolicy, err := hub.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get default EC policy")
-
-	ecPolicyName := componentName + "-policy"
-	sources := make([]ecp.Source, len(defaultEcPolicy.Spec.Sources))
-	for i := range defaultEcPolicy.Spec.Sources {
-		defaultEcPolicy.Spec.Sources[i].DeepCopyInto(&sources[i])
-		if sources[i].Config == nil {
-			sources[i].Config = &ecp.SourceConfig{}
-		}
-		// By default, `skip-checks` is set to true in the build pipeline which disables all the
-		// tests/scans.
-		sources[i].Config.Exclude = append(
-			sources[i].Config.Exclude,
-			"cve",
-			"tasks.required_tasks_found:clair-scan",
-			"tasks.required_tasks_found:roxctl-scan",
-			"tasks.required_tasks_found:clamav-scan",
-			"tasks.required_tasks_found:tpa-scan",
-			"tasks.required_tasks_found:deprecated-image-check",
-			"tasks.required_tasks_found:rpms-signature-scan",
-			"tasks.required_tasks_found:sast-shell-check",
-			"tasks.required_tasks_found:sast-shell-check-oci-ta",
-			"tasks.required_tasks_found:sast-unicode-check",
-			"tasks.required_tasks_found:sast-unicode-check-oci-ta",
-			"test.test_data_found",
-		)
+	scriptPath := filepath.Join(tmpDir, "setup-release.sh")
+	if err := os.WriteFile(scriptPath, scriptContent, 0o755); err != nil {
+		return fmt.Errorf("write setup-release.sh: %w", err)
 	}
-	_, err = hub.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, managedNamespace, ecp.EnterpriseContractPolicySpec{
-		Description: "Red Hat's enterprise requirements",
-		PublicKey:   string(publicKey),
-		Sources:     sources,
-	})
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create EC policy %s", ecPolicyName)
 
-	_, err = hub.ReleaseController.CreateReleasePlanAdmission("demo", managedNamespace, "", userNamespace, ecPolicyName, "release-service-account", []string{appName}, false, &tektonutils.PipelineRef{
-		Resolver: "git",
-		Params: []tektonutils.Param{
-			{Name: "url", Value: relSvcCatalogURL},
-			{Name: "revision", Value: relSvcCatalogRevision},
-			{Name: "pathInRepo", Value: "pipelines/managed/e2e/e2e.yaml"},
-		},
-		OciStorage: ociStorage,
-	}, nil)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission")
-
-	_, err = hub.TektonController.CreatePVCInAccessMode("release-pvc", managedNamespace, corev1.ReadWriteOnce)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create release-pvc")
-
-	_, err = hub.CommonController.CreateRole("role-release-service-account", managedNamespace, map[string][]string{
-		"apiGroupsList": {""},
-		"roleResources": {"secrets"},
-		"roleVerbs":     {"get", "list", "watch"},
-	})
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Role")
-
-	_, err = hub.CommonController.CreateRoleBinding("role-release-service-account-binding", managedNamespace, "ServiceAccount", "release-service-account", managedNamespace, "Role", "role-release-service-account", "rbac.authorization.k8s.io")
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create RoleBinding")
-
-	klog.Info("conformance: release config created", "managedNamespace", managedNamespace)
+	args := []string{
+		"-t", tenantNS,
+		"-m", managedNS,
+		"-a", appName,
+		"-c", componentName,
+	}
+	klog.Infof("conformance: running setup-release.sh %v (from ConfigMap konflux-cli/setup-release)", args)
+	cmd := exec.Command(scriptPath, args...)
+	cmd.Stdout = ginkgo.GinkgoWriter
+	cmd.Stderr = ginkgo.GinkgoWriter
+	return cmd.Run()
 }
 
-func createE2EQuaySecret(k *kube.CustomClient) (*corev1.Secret, error) {
-	quayToken := os.Getenv("QUAY_TOKEN")
-	if quayToken == "" {
-		return nil, fmt.Errorf("QUAY_TOKEN env is not set")
+// e2eECPExclusions lists policy rules to exclude during E2E tests. The default
+// build pipeline sets skip-checks=true which disables security scans/tests, so
+// the corresponding required_tasks_found rules must be excluded to avoid EC
+// failures during the release.
+var e2eECPExclusions = []string{
+	"cve",
+	"tasks.required_tasks_found:clair-scan",
+	"tasks.required_tasks_found:roxctl-scan",
+	"tasks.required_tasks_found:clamav-scan",
+	"tasks.required_tasks_found:tpa-scan",
+	"tasks.required_tasks_found:deprecated-image-check",
+	"tasks.required_tasks_found:rpms-signature-scan",
+	"tasks.required_tasks_found:sast-shell-check",
+	"tasks.required_tasks_found:sast-shell-check-oci-ta",
+	"tasks.required_tasks_found:sast-unicode-check",
+	"tasks.required_tasks_found:sast-unicode-check-oci-ta",
+	"test.test_data_found",
+}
+
+// patchECPForE2E appends E2E-specific exclusions to the EnterpriseContractPolicy
+// in the managed namespace.
+func patchECPForE2E(hub *framework.ControllerHub, policyName, managedNS string) error {
+	klog.Infof("conformance: patching ECP %s/%s with E2E exclusions", managedNS, policyName)
+
+	policy, err := hub.TektonController.GetEnterpriseContractPolicy(policyName, managedNS)
+	if err != nil {
+		return fmt.Errorf("get ECP %s/%s: %w", managedNS, policyName, err)
 	}
 
-	decodedToken, err := base64.StdEncoding.DecodeString(quayToken)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode QUAY_TOKEN (must be base64): %v", err)
-	}
-
-	namespace := constants.QuayRepositorySecretNamespace
-	_, err = k.KubeInterface().CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
-	if err != nil {
-		if k8sErrors.IsNotFound(err) {
-			_, err = k.KubeInterface().CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{Name: namespace},
-			}, metav1.CreateOptions{})
-			if err != nil {
-				return nil, fmt.Errorf("error creating namespace %s: %v", namespace, err)
+	for i := range policy.Spec.Sources {
+		if policy.Spec.Sources[i].Config == nil {
+			policy.Spec.Sources[i].Config = &ecp.SourceConfig{}
+		}
+		seen := make(map[string]bool, len(policy.Spec.Sources[i].Config.Exclude))
+		for _, e := range policy.Spec.Sources[i].Config.Exclude {
+			seen[e] = true
+		}
+		for _, e := range e2eECPExclusions {
+			if !seen[e] {
+				policy.Spec.Sources[i].Config.Exclude = append(policy.Spec.Sources[i].Config.Exclude, e)
 			}
-		} else {
-			return nil, fmt.Errorf("error getting namespace %s: %v", namespace, err)
 		}
 	}
 
-	secretName := constants.QuayRepositorySecretName
-	secret, err := k.KubeInterface().CoreV1().Secrets(namespace).Get(context.Background(), secretName, metav1.GetOptions{})
-	if err != nil {
-		if k8sErrors.IsNotFound(err) {
-			secret, err = k.KubeInterface().CoreV1().Secrets(namespace).Create(context.Background(), &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: namespace},
-				Type:       corev1.SecretTypeDockerConfigJson,
-				Data:       map[string][]byte{corev1.DockerConfigJsonKey: decodedToken},
-			}, metav1.CreateOptions{})
-			if err != nil {
-				return nil, fmt.Errorf("error creating secret %s: %v", secretName, err)
-			}
-		} else {
-			secret.Data = map[string][]byte{corev1.DockerConfigJsonKey: decodedToken}
-			secret, err = k.KubeInterface().CoreV1().Secrets(namespace).Update(context.Background(), secret, metav1.UpdateOptions{})
-			if err != nil {
-				return nil, fmt.Errorf("error updating secret %s: %v", secretName, err)
-			}
-		}
-	}
+	return hub.TektonController.KubeRest().Update(context.Background(), policy)
+}
 
-	return secret, nil
+// resolveKubectl returns the path to kubectl or oc, preferring kubectl.
+// Go's exec.Command performs a direct binary lookup and cannot see the bash
+// function alias that run-e2e.sh sets up, so we need an explicit fallback.
+func resolveKubectl() string {
+	if p, err := exec.LookPath("kubectl"); err == nil {
+		return p
+	}
+	if p, err := exec.LookPath("oc"); err == nil {
+		return p
+	}
+	return "kubectl"
+}
+
+// downloadScriptFromConfigMap extracts a script from a ConfigMap using kubectl.
+func downloadScriptFromConfigMap(namespace, configMapName, key string) ([]byte, error) {
+	jsonpath := fmt.Sprintf("{.data.%s}", strings.ReplaceAll(key, ".", "\\."))
+	cmd := exec.Command(resolveKubectl(), "get", "configmap", configMapName,
+		"-n", namespace,
+		"-o", fmt.Sprintf("jsonpath=%s", jsonpath))
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("kubectl get configmap %s/%s: %s", namespace, configMapName, string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("kubectl get configmap %s/%s: %w", namespace, configMapName, err)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("ConfigMap %s/%s key %q is empty", namespace, configMapName, key)
+	}
+	return out, nil
+}
+
+// grantIntegrationRunnerJobRBAC creates a Role + RoleBinding so that the
+// konflux-integration-runner SA can manage Jobs and Pods in the tenant namespace.
+// TODO: remove once the integration test pipeline no longer creates/deletes Jobs
+// directly and instead runs the image via a Tekton task.
+func grantIntegrationRunnerJobRBAC(namespace string) error {
+	manifest := fmt.Sprintf(`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: integration-runner-jobs
+  namespace: %[1]s
+rules:
+- apiGroups: [""]
+  resources: [pods]
+  verbs: [get, list, watch, delete]
+- apiGroups: [""]
+  resources: [pods/log]
+  verbs: [get, list]
+- apiGroups: [batch]
+  resources: [jobs]
+  verbs: [create, delete, get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-runner-jobs
+  namespace: %[1]s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: integration-runner-jobs
+subjects:
+- kind: ServiceAccount
+  name: konflux-integration-runner
+  namespace: %[1]s
+`, namespace)
+
+	cmd := exec.Command(resolveKubectl(), "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(manifest)
+	cmd.Stdout = ginkgo.GinkgoWriter
+	cmd.Stderr = ginkgo.GinkgoWriter
+	return cmd.Run()
 }
 
 // dumpDiagnostics logs component build status, application status, PaC repository state,


### PR DESCRIPTION
Replace the hand-rolled release setup code in the conformance test with the operator-managed setup-release.sh script, downloaded at runtime from the konflux-cli/setup-release ConfigMap. This eliminates duplicated logic between the test and the operator, and ensures the e2e test always uses the exact script version deployed on the cluster.

- Remove inline release-setup helpers (createManagedNamespace, createReleasePlanAdmission, etc.) from setup.go and conformance.go.
- Download and execute setup-release.sh from the ConfigMap instead.
- Pin CATALOG_REVISION inside setup-release.sh with a Renovate comment so it is automatically updated.
- Delete the standalone test/e2e/release-service-catalog-revision file and the workflow steps that sourced it.
- Update Renovate custom manager to match the new location.
- Clean up e2e.env.template and CONTRIBUTING.md references.

Assisted-By: Cursor