### PR TITLE
fix: exclude Clair from EC policy

### DIFF
--- a/operator/pkg/manifests/enterprise-contract/manifests.yaml
+++ b/operator/pkg/manifests/enterprise-contract/manifests.yaml
@@ -398,6 +398,7 @@ spec:
       - hermetic_task
       - source_image
       - rpm_repos
+      - cve.cve_results_found
       include:
       - '@redhat'
     data:

--- a/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
+++ b/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
@@ -30,6 +30,10 @@ spec:
         # https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/known_rpm_repositories.yml
         # However, it is not possible to include just that file in the rule data.
         - rpm_repos
+        # The minimal build pipeline we use does not include Clair scan for finding CVEs.
+        # The Clair scan task is also expected to be excluded from the the list of required
+        # tasks defined in `data` section.
+        - cve.cve_results_found
       include:
       - '@redhat'
     data:

--- a/test/go-tests/tests/conformance/setup.go
+++ b/test/go-tests/tests/conformance/setup.go
@@ -58,8 +58,6 @@ func runSetupRelease(appName, componentName, tenantNS, managedNS string) error {
 // failures during the release.
 var e2eECPExclusions = []string{
 	"cve",
-	"tasks.required_tasks_found:clair-scan",
-	"tasks.required_tasks_found:roxctl-scan",
 	"tasks.required_tasks_found:clamav-scan",
 	"tasks.required_tasks_found:tpa-scan",
 	"tasks.required_tasks_found:deprecated-image-check",


### PR DESCRIPTION
The EC policy had clair excluded from the list of required tasks, but cve.cve_results_found was still part of the policy, so as our minimal onboarding pipeline does not include Clair, EC would fail.

This change is addressing that gap by excluding cve.cve_results_found from the default EC policy.