### PR TITLE
chore: exclude stream release-0.0

### DIFF
--- a/.github/excluded-release-branches.yaml
+++ b/.github/excluded-release-branches.yaml
@@ -2,5 +2,5 @@
 # Only release-x.y branches are considered; list here the ones to skip.
 # Example: add "release-0.0" to stop auto-tagging and verification for that branch.
 excluded:
-  - release-999.999
+  - release-0.0
   - release-888.888


### PR DESCRIPTION
This stream was mainly used for testing the release process and is no longer needed. Also, the auto-tagging script was updated so is will only generate releases if the branch was updated, but that change was not backported to the release-0.0 branch, so we're still getting releases there, which also slows down the release process for other streams.