### PR TITLE
(docs): Update broken links

### DIFF
--- a/operator/docs/content/docs/guides/github-secrets.md
+++ b/operator/docs/content/docs/guides/github-secrets.md
@@ -12,7 +12,7 @@ and deploy its credentials as secrets in the cluster.
 ## Creating a GitHub App
 
 Create a GitHub App following the
-[Pipelines-as-Code documentation](https://pipelinesascode.com/docs/install/github_apps/#manual-setup).
+[Pipelines-as-Code documentation](https://pipelinesascode.com/docs/providers/github-app/#manual-setup).
 
 {{% alert color="info" %}}
 That tutorial asks you to generate and set a **Webhook secret** when creating the App.

--- a/operator/docs/content/docs/troubleshooting.md
+++ b/operator/docs/content/docs/troubleshooting.md
@@ -211,7 +211,7 @@ allowing webhooks that has no secret"
 ```
 
 Go to your GitHub App settings and verify a webhook secret is configured. See
-[Pipelines as Code documentation](https://pipelinesascode.com/docs/install/github_apps/#manual-setup)
+[Pipelines-as-Code documentation](https://pipelinesascode.com/docs/providers/github-app/#manual-setup)
 for instructions.
 
 ### Unable to create Application with Component using the Konflux UI


### PR DESCRIPTION
The old one gave 404 error and the updated ones point to existing steps how to set up  GitHub App manually.