### PR TITLE
fix: check if openshift

### DIFF
--- a/operator/pkg/manifests/cli/manifests.yaml
+++ b/operator/pkg/manifests/cli/manifests.yaml
@@ -83,9 +83,10 @@ data:
   setup-release.sh: "#!/bin/bash -e\n\n# Script to set up release resources for a
     Konflux application.\n# Creates a managed namespace with all required resources
     (EnterpriseContractPolicy,\n# ImageRepositories, ReleasePlanAdmission) and a ReleasePlan
-    in the tenant namespace.\n\nset -o pipefail\nset -eu\n\nWAIT_TIMEOUT=120  # seconds
-    to wait for ImageRepositories to become ready\nPOLL_INTERVAL=5   # seconds between
-    polls\n\nusage() {\n    cat <<EOF\nUsage: $(basename \"$0\") [OPTIONS]\n\nSet
+    in the tenant namespace.\n# Note: this script needs to be compatible with Bash
+    3.x to support both macOS and Linux.\n\nset -o pipefail\nset -eu\n\nWAIT_TIMEOUT=120
+    \ # seconds to wait for ImageRepositories to become ready\nPOLL_INTERVAL=5   #
+    seconds between polls\n\nusage() {\n    cat <<EOF\nUsage: $(basename \"$0\") [OPTIONS]\n\nSet
     up release resources for a Konflux application. Creates a managed namespace\nwith
     ImageRepositories, EnterpriseContractPolicy, and ReleasePlanAdmission,\nand a
     ReleasePlan in the tenant namespace.\n\nOptions:\n  -t, --tenant-namespace    Source
@@ -140,8 +141,11 @@ data:
     (after args parsing)\nPRODUCT_NAME=${PRODUCT_NAME:-$APPLICATION}\n\n# Generate
     a unique image name prefix to avoid credential collisions between\n# concurrent
     CI runs that share the same Quay organization.\nif [[ -z \"${IMAGE_NAME_PREFIX}\"
-    ]]; then\n    RANDOM_SUFFIX=$(od -An -tx1 -N3 /dev/urandom | tr -d ' ')\n    IMAGE_NAME_PREFIX=\"${MANAGED_NS}-${RANDOM_SUFFIX}\"\nfi\n\nIS_OPENSHIFT=false\nif
-    kubectl api-resources --api-group=config.openshift.io &>/dev/null; then\n    IS_OPENSHIFT=true\nfi\n#
+    ]]; then\n    RANDOM_SUFFIX=$(od -An -tx1 -N3 /dev/urandom | tr -d ' ')\n    IMAGE_NAME_PREFIX=\"${MANAGED_NS}-${RANDOM_SUFFIX}\"\nfi\n\n#
+    OpenShift registers config.openshift.io API resources. Without -o name, kubectl
+    still exits 0\n# when the group is absent (header-only table); -o name yields
+    no lines on vanilla k8s / Kind.\nIS_OPENSHIFT=false\nif [[ -n \"$(kubectl api-resources
+    --api-group=config.openshift.io -o name 2>/dev/null)\" ]]; then\n    IS_OPENSHIFT=true\nfi\n#
     Auto-detect components if none specified\nif [[ ${#COMPONENTS[@]} -eq 0 ]]; then\n
     \   echo \"\U0001F50D No components specified, auto-detecting from application
     '${APPLICATION}' in namespace '${TENANT_NS}'...\"\n    while IFS= read -r line;

--- a/operator/upstream-kustomizations/cli/setup-release.sh
+++ b/operator/upstream-kustomizations/cli/setup-release.sh
@@ -150,8 +150,10 @@ if [[ -z "${IMAGE_NAME_PREFIX}" ]]; then
     IMAGE_NAME_PREFIX="${MANAGED_NS}-${RANDOM_SUFFIX}"
 fi
 
+# OpenShift registers config.openshift.io API resources. Without -o name, kubectl still exits 0
+# when the group is absent (header-only table); -o name yields no lines on vanilla k8s / Kind.
 IS_OPENSHIFT=false
-if kubectl api-resources --api-group=config.openshift.io &>/dev/null; then
+if [[ -n "$(kubectl api-resources --api-group=config.openshift.io -o name 2>/dev/null)" ]]; then
     IS_OPENSHIFT=true
 fi
 # Auto-detect components if none specified


### PR DESCRIPTION
The check to see if running on openshift was assuming a certain kubctl command will exit with non-zero code if not openshift, but in reality it just returns no output and exits with 0.

This commit changes the behavior so it checks if the output is non-empty instead.

Assisted-by: Cursor

Closes: #6479