### PR TITLE
Legacy branch revert  bad commit from local: Remove default-imagepullbackoff-timeout from tekton config

### DIFF
--- a/dependencies/tekton-config/tekton-config.yml
+++ b/dependencies/tekton-config/tekton-config.yml
@@ -45,7 +45,6 @@ spec:
     disabled: false
   pipeline:
     default-service-account: default
-    default-imagepullbackoff-timeout: "10m"
     options:
       disabled: false
       deployments:


### PR DESCRIPTION
Revert bad commit from local: Removed default-imagepullbackoff-timeout setting from pipeline configuration.