### PR TITLE
chore: update build and conforma

### DIFF
--- a/operator/pkg/manifests/build-service/manifests.yaml
+++ b/operator/pkg/manifests/build-service/manifests.yaml
@@ -344,7 +344,7 @@ data:
     default-pipeline-name: docker-build-oci-ta-min
     pipelines:
     - name: docker-build-oci-ta-min
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta-min@sha256:1f9d86b8429e6ed287f35ae7cd10927d53295fd5cd7ee446fd42317fa74b9aad
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta-min@sha256:0295b7b8a84a42745b6739af16b894477005b9bdbd8a899b8463af5730270611
       description: minimal version of the docker-build-oci-ta pipeline, which requires less compute resources. In addition, it doesn't contain tasks which require user provided secrets.
 kind: ConfigMap
 metadata:

--- a/operator/pkg/manifests/enterprise-contract/manifests.yaml
+++ b/operator/pkg/manifests/enterprise-contract/manifests.yaml
@@ -370,7 +370,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  verify_ec_task_bundle: quay.io/enterprise-contract/ec-task-bundle@sha256:4b657f5bf6144625093a5a58eeb3352816f5bf4196a53a915b4f109764460cc8
+  verify_ec_task_bundle: quay.io/enterprise-contract/ec-task-bundle@sha256:c9aef67023cec2bef31d93f2161920d4205722eda1b4876f2d46cdbb4d6db7c5
   verify_ec_task_git_pathInRepo: tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
   verify_ec_task_git_revision: b1ede77ff694522a917dea2b4bde14b2cc1839f2
   verify_ec_task_git_url: https://github.com/enterprise-contract/ec-cli.git
@@ -401,8 +401,8 @@ spec:
       include:
       - '@redhat'
     data:
-    - github.com/konflux-ci/konflux-operator-trusted-sources//data?ref=95b1ba6bd85fa2117c544f4adb446f9b74a870e3
+    - github.com/konflux-ci/konflux-operator-trusted-sources//data?ref=631d23a6fe1a9f8623d73b84958417de5c13343f
     - github.com/redhat-appstudio/tsf-conforma-data//data?ref=1966f21842d507441a7a5e1c7de9071cf3f9ec53
     name: Default
     policy:
-    - oci::quay.io/conforma/release-policy:konflux@sha256:1b296a925b4021f4b4959ea289596925a8735540e554f3ba7754a651731a216f
+    - oci::quay.io/conforma/release-policy:latest@sha256:2d9f3d23e85132ab3488a268ab47e27ce0a4aeeb02a34b2f3eeab194d9864e87

--- a/operator/upstream-kustomizations/build-service/core/build-pipeline-config.yaml
+++ b/operator/upstream-kustomizations/build-service/core/build-pipeline-config.yaml
@@ -8,5 +8,5 @@ data:
     default-pipeline-name: docker-build-oci-ta-min
     pipelines:
     - name: docker-build-oci-ta-min
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta-min@sha256:1f9d86b8429e6ed287f35ae7cd10927d53295fd5cd7ee446fd42317fa74b9aad
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta-min@sha256:0295b7b8a84a42745b6739af16b894477005b9bdbd8a899b8463af5730270611
       description: minimal version of the docker-build-oci-ta pipeline, which requires less compute resources. In addition, it doesn't contain tasks which require user provided secrets.

--- a/operator/upstream-kustomizations/build-service/core/kustomization.yaml
+++ b/operator/upstream-kustomizations/build-service/core/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/konflux-ci/build-service/config/default?ref=a7b6e5004856a04ea7e07c3217e9e7fa23546bdd
+  - https://github.com/konflux-ci/build-service/config/default?ref=ca44d2b8386e0af3ce29d2dc2d639a4e8fae3199
   - build-pipeline-config.yaml
   - build-config-rolebinding.yaml
   - appstudio-pipelines-runner.yaml
@@ -13,7 +13,7 @@ namespace: build-service
 images:
   - name: quay.io/konflux-ci/build-service
     newName: quay.io/konflux-ci/build-service
-    newTag: a7b6e5004856a04ea7e07c3217e9e7fa23546bdd
+    newTag: ca44d2b8386e0af3ce29d2dc2d639a4e8fae3199
 
 patches:
   - target:

--- a/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
+++ b/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
@@ -33,8 +33,8 @@ spec:
       include:
       - '@redhat'
     data:
-    - github.com/konflux-ci/konflux-operator-trusted-sources//data?ref=95b1ba6bd85fa2117c544f4adb446f9b74a870e3
+    - github.com/konflux-ci/konflux-operator-trusted-sources//data?ref=631d23a6fe1a9f8623d73b84958417de5c13343f
     - github.com/redhat-appstudio/tsf-conforma-data//data?ref=1966f21842d507441a7a5e1c7de9071cf3f9ec53
     name: Default
     policy:
-    - oci::quay.io/conforma/release-policy:konflux@sha256:1b296a925b4021f4b4959ea289596925a8735540e554f3ba7754a651731a216f
+    - oci::quay.io/conforma/release-policy:latest@sha256:2d9f3d23e85132ab3488a268ab47e27ce0a4aeeb02a34b2f3eeab194d9864e87


### PR DESCRIPTION
With this, the build pipeline will drop the use of Clair scan

Assisted-by: Cursor