### PR TITLE
fix: regenerate build manifest

### DIFF
--- a/operator/pkg/manifests/build-service/manifests.yaml
+++ b/operator/pkg/manifests/build-service/manifests.yaml
@@ -392,7 +392,6 @@ metadata:
   name: build-service-controller-manager
   namespace: build-service
 spec:
-  progressDeadlineSeconds: 2147483647
   replicas: 1
   selector:
     matchLabels:
@@ -441,10 +440,6 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
         volumeMounts:
-        - mountPath: /etc/ssl/certs/ca-custom-bundle.crt
-          name: trusted-ca
-          readOnly: true
-          subPath: ca-bundle.crt
         - mountPath: /mnt
           name: webhook-config
           readOnly: true
@@ -455,13 +450,6 @@ spec:
       serviceAccountName: build-service-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
-      - configMap:
-          items:
-          - key: ca-bundle.crt
-            path: ca-bundle.crt
-          name: trusted-ca
-          optional: true
-        name: trusted-ca
       - configMap:
           items:
           - key: webhook-config.json


### PR DESCRIPTION
While patching a failing automated PR for build-service it seems as we only propagated some of the changes in the upstream kusotmizations but not all. This commit regenerates the build manifest with the latest changes.

Assisted-by: Cursor