### PR TITLE
chore: track latest instead of konflux for release-policy

### DIFF
--- a/operator/docs/content/docs/guides/conforma-policy-configuration.md
+++ b/operator/docs/content/docs/guides/conforma-policy-configuration.md
@@ -171,7 +171,7 @@ spec:
   sources:
     - name: Release policies
       policy:
-        - oci::quay.io/conforma/release-policy:konflux
+        - oci::quay.io/conforma/release-policy:latest
       data:
         - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
         - github.com/release-engineering/rhtap-ec-policy//data

--- a/operator/pkg/manifests/enterprise-contract/manifests.yaml
+++ b/operator/pkg/manifests/enterprise-contract/manifests.yaml
@@ -405,4 +405,4 @@ spec:
     - github.com/redhat-appstudio/tsf-conforma-data//data?ref=1966f21842d507441a7a5e1c7de9071cf3f9ec53
     name: Default
     policy:
-    - oci::quay.io/conforma/release-policy:konflux@sha256:1b296a925b4021f4b4959ea289596925a8735540e554f3ba7754a651731a216f
+    - oci::quay.io/conforma/release-policy:latest@sha256:1b296a925b4021f4b4959ea289596925a8735540e554f3ba7754a651731a216f

--- a/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
+++ b/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
@@ -37,4 +37,4 @@ spec:
     - github.com/redhat-appstudio/tsf-conforma-data//data?ref=1966f21842d507441a7a5e1c7de9071cf3f9ec53
     name: Default
     policy:
-    - oci::quay.io/conforma/release-policy:konflux@sha256:1b296a925b4021f4b4959ea289596925a8735540e554f3ba7754a651731a216f
+    - oci::quay.io/conforma/release-policy:latest@sha256:1b296a925b4021f4b4959ea289596925a8735540e554f3ba7754a651731a216f

--- a/renovate.json
+++ b/renovate.json
@@ -147,10 +147,10 @@
         "operator/upstream-kustomizations/enterprise-contract/policies/.*\\.yaml$"
       ],
       "matchStrings": [
-        "- oci::(?<depName>quay\\.io/conforma/[^:]+):konflux@(?<currentDigest>sha256:[a-f0-9]{64})"
+        "- oci::(?<depName>quay\\.io/conforma/[^:]+):latest@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
       "datasourceTemplate": "docker",
-      "currentValueTemplate": "konflux"
+      "currentValueTemplate": "latest"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
For quay.io/conforma/release-policy, konflux is lagging behind latest. We currently see no reason not to track latest, so switching to that.