### PR TITLE
fix: bump docker-build-oci-ta-min bundle digest to latest one

### DIFF
--- a/konflux-ci/build-service/core/build-pipeline-config.yaml
+++ b/konflux-ci/build-service/core/build-pipeline-config.yaml
@@ -18,5 +18,5 @@ data:
     - name: tekton-bundle-builder-oci-ta
       bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder-oci-ta@sha256:f26d5fea5a12de33b9ca5454992afb4707120a5cf9ed076a6477c2cee55f141d
     - name: docker-build-oci-ta-min
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta-min@sha256:5596db15d773ea5892b0c6a3d701a19757fed875d20cc862b3bcfb9fcf32523b
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta-min@sha256:151372f879bc7e7bc2870e1134ed6d0c3aed6bea7ab40bfbf3903a855c0e0696
       description: minimal version of the docker-build-oci-ta pipeline, which requires less compute resources. In addition, it doesn't contain tasks which require user provided secrets.


### PR DESCRIPTION
bump docker-build-oci-ta-min bundle digest to latest one which contains [the fix](https://github.com/konflux-ci/build-definitions/pull/3486)
