### PR TITLE
chore: remove some env vars from Tekton task

### DIFF
--- a/.tekton/tasks/deploy-konflux/README.md
+++ b/.tekton/tasks/deploy-konflux/README.md
@@ -17,7 +17,7 @@ This Task does **not** use Tekton `workspaces`. It clones `konflux-ci` into an `
 
 ## Required secrets / env sources
 
-Reads keys from Secret `konflux-operator-e2e-credentials` in the Task namespace:
+Reads keys from Secret `konflux-operator-e2e-credentials` in the Task namespace (for `deploy-prep` → `scripts/deploy-local.sh` / `deploy-secrets.sh`, matching `.github/workflows/operator-test-e2e.yaml` deploy step):
 
 - `GITHUB_APP_ID`
 - `GITHUB_PRIVATE_KEY`
@@ -25,10 +25,6 @@ Reads keys from Secret `konflux-operator-e2e-credentials` in the Task namespace:
 - `QUAY_TOKEN`
 - `QUAY_ORGANIZATION`
 - `SMEE_CHANNEL`
-- `GH_ORG`
-- `GH_TOKEN`
-- `QUAY_DOCKERCONFIGJSON`
-- `RELEASE_CATALOG_TA_QUAY_TOKEN`
 
 ## Steps / images
 

--- a/.tekton/tasks/deploy-konflux/task.yaml
+++ b/.tekton/tasks/deploy-konflux/task.yaml
@@ -162,26 +162,6 @@ spec:
             secretKeyRef:
               name: konflux-operator-e2e-credentials
               key: SMEE_CHANNEL
-        - name: GH_ORG
-          valueFrom:
-            secretKeyRef:
-              name: konflux-operator-e2e-credentials
-              key: GH_ORG
-        - name: GH_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: konflux-operator-e2e-credentials
-              key: GH_TOKEN
-        - name: QUAY_DOCKERCONFIGJSON
-          valueFrom:
-            secretKeyRef:
-              name: konflux-operator-e2e-credentials
-              key: QUAY_DOCKERCONFIGJSON
-        - name: RELEASE_CATALOG_TA_QUAY_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: konflux-operator-e2e-credentials
-              key: RELEASE_CATALOG_TA_QUAY_TOKEN
       script: |
         #!/bin/bash
         set -euo pipefail


### PR DESCRIPTION
Some env vars in the Tekton task for deploying Konflux are no longer needed. Removing them to clean up the task definition.

Assisted-by: Cursor