### PR TITLE
test: don't hang waiting for cleanup

### DIFF
--- a/test/go-tests/pkg/clients/github/git.go
+++ b/test/go-tests/pkg/clients/github/git.go
@@ -10,8 +10,8 @@ import (
 	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/utils"
 )
 
-func (c *Client) DeleteRef(repository, branchName string) error {
-	_, err := c.client.Git.DeleteRef(context.Background(), c.organization, repository, fmt.Sprintf(HEADS, branchName))
+func (c *Client) DeleteRef(ctx context.Context, repository, branchName string) error {
+	_, err := c.client.Git.DeleteRef(ctx, c.organization, repository, fmt.Sprintf(HEADS, branchName))
 	if err != nil {
 		return err
 	}

--- a/test/go-tests/pkg/clients/github/webhook.go
+++ b/test/go-tests/pkg/clients/github/webhook.go
@@ -11,8 +11,8 @@ type Webhook struct {
 	github.Hook
 }
 
-func (c *Client) ListRepoWebhooks(repository string) ([]*github.Hook, error) {
-	hooks, _, err := c.client.Repositories.ListHooks(context.Background(), c.organization, repository, &github.ListOptions{})
+func (c *Client) ListRepoWebhooks(ctx context.Context, repository string) ([]*github.Hook, error) {
+	hooks, _, err := c.client.Repositories.ListHooks(ctx, c.organization, repository, &github.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error when listing webhooks: %v", err)
 	}
@@ -36,8 +36,8 @@ func (c *Client) CreateWebhook(repository, url string) (int64, error) {
 	return hook.GetID(), err
 }
 
-func (c *Client) DeleteWebhook(repository string, ID int64) error {
-	_, err := c.client.Repositories.DeleteHook(context.Background(), c.organization, repository, ID)
+func (c *Client) DeleteWebhook(ctx context.Context, repository string, ID int64) error {
+	_, err := c.client.Repositories.DeleteHook(ctx, c.organization, repository, ID)
 	if err != nil {
 		return fmt.Errorf("error when deleting webhook: %v", err)
 	}

--- a/test/go-tests/pkg/utils/build/git.go
+++ b/test/go-tests/pkg/utils/build/git.go
@@ -1,13 +1,14 @@
 package build
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
 
-	ginkgo "github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 
 	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/clients/github"
 	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/constants"
@@ -83,16 +84,19 @@ func CreateCodebergBuildSecret(f *framework.Framework, secretName string, annota
 	return nil
 }
 
-func CleanupWebhooks(f *framework.Framework, repoName string) error {
-	hooks, err := f.AsKubeAdmin.CommonController.GitHub.ListRepoWebhooks(repoName)
+func CleanupWebhooks(ctx context.Context, f *framework.Framework, repoName string) error {
+	hooks, err := f.AsKubeAdmin.CommonController.GitHub.ListRepoWebhooks(ctx, repoName)
 	if err != nil {
 		return err
 	}
 	for _, h := range hooks {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		hookUrl := h.Config["url"].(string)
 		if strings.Contains(hookUrl, f.ClusterAppDomain) {
-			ginkgo.GinkgoWriter.Printf("removing webhook URL: %s\n", hookUrl)
-			err = f.AsKubeAdmin.CommonController.GitHub.DeleteWebhook(repoName, h.GetID())
+			klog.Infof("removing webhook URL: %s", hookUrl)
+			err = f.AsKubeAdmin.CommonController.GitHub.DeleteWebhook(ctx, repoName, h.GetID())
 			if err != nil {
 				return err
 			}

--- a/test/go-tests/tests/conformance/conformance.go
+++ b/test/go-tests/tests/conformance/conformance.go
@@ -31,6 +31,17 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// conformanceCleanupBudget returns the max wall time to wait for AfterAll cleanup.
+// Set E2E_CLEANUP_TIMEOUT to a Go duration (e.g. 90s, 1m30s); invalid or empty values use the default.
+func conformanceCleanupBudget() time.Duration {
+	if s := strings.TrimSpace(os.Getenv("E2E_CLEANUP_TIMEOUT")); s != "" {
+		if d, err := time.ParseDuration(s); err == nil && d > 0 {
+			return d
+		}
+	}
+	return conformanceCleanupMaxDuration
+}
+
 var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamKonfluxTestLabel), func() {
 	defer ginkgo.GinkgoRecover()
 
@@ -87,15 +98,19 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 					return
 				}
 				klog.Info("conformance: cleaning up")
-				_ = fw.AsKubeAdmin.CommonController.KubeInterface().CoreV1().Namespaces().Delete(context.Background(), managedNamespace, metav1.DeleteOptions{})
-				cleanupWithRetry("delete PaC branch", func() error {
-					return fw.AsKubeAdmin.CommonController.GitHub.DeleteRef(componentRepositoryName, pacBranchName)
+				budget := conformanceCleanupBudget()
+				ctx, cancel := context.WithTimeout(context.Background(), budget)
+				defer cancel()
+
+				_ = fw.AsKubeAdmin.CommonController.KubeInterface().CoreV1().Namespaces().Delete(ctx, managedNamespace, metav1.DeleteOptions{})
+				cleanupWithRetry(ctx, "delete PaC branch", func() error {
+					return fw.AsKubeAdmin.CommonController.GitHub.DeleteRef(ctx, componentRepositoryName, pacBranchName)
 				})
-				cleanupWithRetry("delete base branch", func() error {
-					return fw.AsKubeAdmin.CommonController.GitHub.DeleteRef(componentRepositoryName, componentNewBaseBranch)
+				cleanupWithRetry(ctx, "delete base branch", func() error {
+					return fw.AsKubeAdmin.CommonController.GitHub.DeleteRef(ctx, componentRepositoryName, componentNewBaseBranch)
 				})
-				cleanupWithRetry("cleanup webhooks", func() error {
-					return build.CleanupWebhooks(fw, componentRepositoryName)
+				cleanupWithRetry(ctx, "cleanup webhooks", func() error {
+					return build.CleanupWebhooks(ctx, fw, componentRepositoryName)
 				})
 			})
 

--- a/test/go-tests/tests/conformance/const.go
+++ b/test/go-tests/tests/conformance/const.go
@@ -12,6 +12,11 @@ const (
 	snapshotTimeout             = time.Minute * 4
 	releaseTimeout              = time.Minute * 4
 
+	// conformanceCleanupMaxDuration caps how long AfterAll waits for namespace + Git
+	// cleanup. After the budget, the suite still passes; override with E2E_CLEANUP_TIMEOUT
+	// (Go duration string, e.g. 90s, 2m).
+	conformanceCleanupMaxDuration = 2 * time.Minute
+
 	// Intervals
 	defaultPollingInterval  = time.Second * 2
 	snapshotPollingInterval = time.Second * 1

--- a/test/go-tests/tests/conformance/setup.go
+++ b/test/go-tests/tests/conformance/setup.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/framework"
 	ginkgo "github.com/onsi/ginkgo/v2"
-	gomega "github.com/onsi/gomega"
 	"k8s.io/klog/v2"
 )
 
@@ -212,14 +211,41 @@ func dumpDiagnostics(hub *framework.ControllerHub, componentName, appName, names
 	}
 }
 
-func cleanupWithRetry(description string, fn func() error) {
-	err := gomega.InterceptGomegaFailure(func() {
-		gomega.Eventually(fn).
-			WithTimeout(30 * time.Second).
-			WithPolling(5 * time.Second).
-			Should(gomega.Succeed())
-	})
-	if err != nil {
-		klog.Warningf("conformance cleanup: %s failed after retries: %v", description, err)
+// cleanupWithRetry runs fn until it returns nil, ctx is done, or a 30s per-step retry budget elapses.
+// fn should use ctx for outbound calls so they honor the overall cleanup deadline.
+func cleanupWithRetry(ctx context.Context, description string, fn func() error) {
+	const maxStep = 30 * time.Second
+	const poll = 5 * time.Second
+	stepStart := time.Now()
+	var lastErr error
+	for {
+		if err := ctx.Err(); err != nil {
+			if lastErr != nil {
+				klog.Warningf("conformance cleanup: %s stopped: %v (last attempt error: %v)", description, err, lastErr)
+			} else {
+				klog.Warningf("conformance cleanup: %s stopped: %v", description, err)
+			}
+			return
+		}
+		lastErr = fn()
+		if lastErr == nil {
+			return
+		}
+		stepElapsed := time.Since(stepStart)
+		if stepElapsed >= maxStep {
+			klog.Warningf("conformance cleanup: %s failed after retries: %v", description, lastErr)
+			return
+		}
+		remainingStep := maxStep - stepElapsed
+		d := poll
+		if remainingStep < d {
+			d = remainingStep
+		}
+		select {
+		case <-ctx.Done():
+			klog.Warningf("conformance cleanup: %s stopped: %v (last error: %v)", description, ctx.Err(), lastErr)
+			return
+		case <-time.After(d):
+		}
 	}
 }


### PR DESCRIPTION
When running e2e tests locally, the cleanup stage tends to hang. This commit makes it give up eventually, so the tests eventually finish even if cleanup hangs, not affecting the test results.

Assisted-by: Cursor