### PR TITLE
feat(KFLUXVNGD-966): add typed pipeline timeout fields to KonfluxIntegrationService

### DIFF
--- a/operator/api/v1alpha1/konfluxintegrationservice_types.go
+++ b/operator/api/v1alpha1/konfluxintegrationservice_types.go
@@ -25,6 +25,33 @@ type KonfluxIntegrationServiceSpec struct {
 	// IntegrationControllerManager defines customizations for the controller-manager deployment.
 	// +optional
 	IntegrationControllerManager *ControllerManagerDeploymentSpec `json:"integrationControllerManager,omitempty"`
+
+	// PipelineTimeout is the overall pipeline run timeout (e.g. "6h", "1h30m", "90m").
+	// Maps to the PIPELINE_TIMEOUT env var on the controller-manager container.
+	// Takes precedence over any PIPELINE_TIMEOUT entry in integrationControllerManager.manager.env.
+	// When omitted, the upstream integration-service default applies.
+	// +optional
+	// +kubebuilder:validation:Pattern=`^([0-9]+h)?([0-9]+m)?([0-9]+s)?$`
+	// +kubebuilder:validation:MinLength=2
+	PipelineTimeout string `json:"pipelineTimeout,omitempty"`
+
+	// TasksTimeout is the timeout for tasks within a pipeline run (e.g. "4h", "90m").
+	// Maps to the TASKS_TIMEOUT env var on the controller-manager container.
+	// Takes precedence over any TASKS_TIMEOUT entry in integrationControllerManager.manager.env.
+	// When omitted, the upstream integration-service default applies.
+	// +optional
+	// +kubebuilder:validation:Pattern=`^([0-9]+h)?([0-9]+m)?([0-9]+s)?$`
+	// +kubebuilder:validation:MinLength=2
+	TasksTimeout string `json:"tasksTimeout,omitempty"`
+
+	// FinallyTimeout is the timeout for finally tasks (e.g. "2h", "30m").
+	// Maps to the FINALLY_TIMEOUT env var on the controller-manager container.
+	// Takes precedence over any FINALLY_TIMEOUT entry in integrationControllerManager.manager.env.
+	// When omitted, the upstream integration-service default applies.
+	// +optional
+	// +kubebuilder:validation:Pattern=`^([0-9]+h)?([0-9]+m)?([0-9]+s)?$`
+	// +kubebuilder:validation:MinLength=2
+	FinallyTimeout string `json:"finallyTimeout,omitempty"`
 }
 
 // KonfluxIntegrationServiceStatus defines the observed state of KonfluxIntegrationService

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
@@ -655,6 +655,15 @@ spec:
                   spec:
                     description: Spec configures the integration-service component.
                     properties:
+                      finallyTimeout:
+                        description: |-
+                          FinallyTimeout is the timeout for finally tasks (e.g. "2h", "30m").
+                          Maps to the FINALLY_TIMEOUT env var on the controller-manager container.
+                          Takes precedence over any FINALLY_TIMEOUT entry in integrationControllerManager.manager.env.
+                          When omitted, the upstream integration-service default applies.
+                        minLength: 2
+                        pattern: ^([0-9]+h)?([0-9]+m)?([0-9]+s)?$
+                        type: string
                       integrationControllerManager:
                         description: IntegrationControllerManager defines customizations
                           for the controller-manager deployment.
@@ -896,6 +905,24 @@ spec:
                             minimum: 1
                             type: integer
                         type: object
+                      pipelineTimeout:
+                        description: |-
+                          PipelineTimeout is the overall pipeline run timeout (e.g. "6h", "1h30m", "90m").
+                          Maps to the PIPELINE_TIMEOUT env var on the controller-manager container.
+                          Takes precedence over any PIPELINE_TIMEOUT entry in integrationControllerManager.manager.env.
+                          When omitted, the upstream integration-service default applies.
+                        minLength: 2
+                        pattern: ^([0-9]+h)?([0-9]+m)?([0-9]+s)?$
+                        type: string
+                      tasksTimeout:
+                        description: |-
+                          TasksTimeout is the timeout for tasks within a pipeline run (e.g. "4h", "90m").
+                          Maps to the TASKS_TIMEOUT env var on the controller-manager container.
+                          Takes precedence over any TASKS_TIMEOUT entry in integrationControllerManager.manager.env.
+                          When omitted, the upstream integration-service default applies.
+                        minLength: 2
+                        pattern: ^([0-9]+h)?([0-9]+m)?([0-9]+s)?$
+                        type: string
                     type: object
                 type: object
               internalRegistry:

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxintegrationservices.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxintegrationservices.yaml
@@ -42,6 +42,15 @@ spec:
             description: KonfluxIntegrationServiceSpec defines the desired state of
               KonfluxIntegrationService
             properties:
+              finallyTimeout:
+                description: |-
+                  FinallyTimeout is the timeout for finally tasks (e.g. "2h", "30m").
+                  Maps to the FINALLY_TIMEOUT env var on the controller-manager container.
+                  Takes precedence over any FINALLY_TIMEOUT entry in integrationControllerManager.manager.env.
+                  When omitted, the upstream integration-service default applies.
+                minLength: 2
+                pattern: ^([0-9]+h)?([0-9]+m)?([0-9]+s)?$
+                type: string
               integrationControllerManager:
                 description: IntegrationControllerManager defines customizations for
                   the controller-manager deployment.
@@ -276,6 +285,24 @@ spec:
                     minimum: 1
                     type: integer
                 type: object
+              pipelineTimeout:
+                description: |-
+                  PipelineTimeout is the overall pipeline run timeout (e.g. "6h", "1h30m", "90m").
+                  Maps to the PIPELINE_TIMEOUT env var on the controller-manager container.
+                  Takes precedence over any PIPELINE_TIMEOUT entry in integrationControllerManager.manager.env.
+                  When omitted, the upstream integration-service default applies.
+                minLength: 2
+                pattern: ^([0-9]+h)?([0-9]+m)?([0-9]+s)?$
+                type: string
+              tasksTimeout:
+                description: |-
+                  TasksTimeout is the timeout for tasks within a pipeline run (e.g. "4h", "90m").
+                  Maps to the TASKS_TIMEOUT env var on the controller-manager container.
+                  Takes precedence over any TASKS_TIMEOUT entry in integrationControllerManager.manager.env.
+                  When omitted, the upstream integration-service default applies.
+                minLength: 2
+                pattern: ^([0-9]+h)?([0-9]+m)?([0-9]+s)?$
+                type: string
             type: object
           status:
             description: KonfluxIntegrationServiceStatus defines the observed state

--- a/operator/config/samples/konflux_v1alpha1_konfluxintegrationservice.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konfluxintegrationservice.yaml
@@ -8,6 +8,12 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: konflux-integration-service
 spec:
+  # Pipeline run timeouts. Each field maps to the corresponding env var on the
+  # controller-manager container. Omit to use the upstream integration-service defaults.
+  pipelineTimeout: "6h"
+  tasksTimeout: "4h"
+  finallyTimeout: "2h"
+
   integrationControllerManager:
     replicas: 3
     manager:
@@ -18,14 +24,16 @@ spec:
         limits:
           cpu: 512m
           memory: 1Gi
-      env:
-        - name: EXAMPLE_CUSTOM_CONFIG
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-config
-              key: custom-config
-        - name: EXAMPLE_SECRET_VALUE
-          valueFrom:
-            secretKeyRef:
-              name: integration-service-secret
-              key: secret-key
+      # For env vars beyond the typed timeout fields above, use manager.env directly.
+      # Supports plain values and valueFrom references (ConfigMap, Secret).
+      # env:
+      #   - name: EXAMPLE_CUSTOM_CONFIG
+      #     valueFrom:
+      #       configMapKeyRef:
+      #         name: integration-service-config
+      #         key: custom-config
+      #   - name: EXAMPLE_SECRET_VALUE
+      #     valueFrom:
+      #       secretKeyRef:
+      #         name: integration-service-secret
+      #         key: secret-key

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
@@ -59,6 +59,11 @@ const (
 
 	// Container names
 	managerContainerName = "manager"
+
+	// Env var names for pipeline run timeout configuration.
+	envPipelineTimeout = "PIPELINE_TIMEOUT"
+	envTasksTimeout    = "TASKS_TIMEOUT"
+	envFinallyTimeout  = "FINALLY_TIMEOUT"
 )
 
 // IntegrationServiceCleanupGVKs defines which resource types should be cleaned up when they are
@@ -211,7 +216,7 @@ func applyIntegrationServiceDeploymentCustomizations(deployment *appsv1.Deployme
 		if spec.IntegrationControllerManager != nil {
 			deployment.Spec.Replicas = &spec.IntegrationControllerManager.Replicas
 		}
-		if err := buildControllerManagerOverlay(spec.IntegrationControllerManager, consoleURL).ApplyToDeployment(deployment); err != nil {
+		if err := buildControllerManagerOverlay(spec.IntegrationControllerManager, consoleURL, spec).ApplyToDeployment(deployment); err != nil {
 			return err
 		}
 	}
@@ -219,16 +224,16 @@ func applyIntegrationServiceDeploymentCustomizations(deployment *appsv1.Deployme
 }
 
 // buildControllerManagerOverlay builds the pod overlay for the controller-manager deployment.
-func buildControllerManagerOverlay(spec *konfluxv1alpha1.ControllerManagerDeploymentSpec, consoleURL string) *customization.PodOverlay {
-	// Build console URL template for pipeline run links in the UI.
-	// Format: https://<host>/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}
+// Typed timeout fields (PipelineTimeout, TasksTimeout, FinallyTimeout) are applied last and
+// take precedence over any env entry with the same name in integrationControllerManager.manager.env.
+// When not set in the CRD, the upstream integration-service defaults apply.
+func buildControllerManagerOverlay(spec *konfluxv1alpha1.ControllerManagerDeploymentSpec, consoleURL string, integrationSpec konfluxv1alpha1.KonfluxIntegrationServiceSpec) *customization.PodOverlay {
 	consoleURLTemplate := ""
 	if consoleURL != "" {
 		consoleURLTemplate = fmt.Sprintf("%s/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}",
 			strings.TrimSuffix(consoleURL, "/"))
 	}
 
-	// Determine replicas and manager spec (default replicas to 1 if no spec)
 	replicas := int32(1)
 	var managerSpec *konfluxv1alpha1.ContainerSpec
 	if spec != nil {
@@ -243,6 +248,9 @@ func buildControllerManagerOverlay(spec *konfluxv1alpha1.ControllerManagerDeploy
 			customization.FromContainerSpec(managerSpec),
 			customization.WithLeaderElection(),
 			customization.WithEnvOverride("CONSOLE_URL", consoleURLTemplate),
+			customization.WithOptionalEnvOverride(envPipelineTimeout, integrationSpec.PipelineTimeout),
+			customization.WithOptionalEnvOverride(envTasksTimeout, integrationSpec.TasksTimeout),
+			customization.WithOptionalEnvOverride(envFinallyTimeout, integrationSpec.FinallyTimeout),
 		),
 	)
 }

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_customization_test.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_customization_test.go
@@ -58,14 +58,14 @@ func getIntegrationServiceDeployment(t *testing.T) *appsv1.Deployment {
 func TestBuildControllerManagerOverlay(t *testing.T) {
 	t.Run("nil spec returns empty overlay", func(t *testing.T) {
 		g := gomega.NewWithT(t)
-		overlay := buildControllerManagerOverlay(nil, "")
+		overlay := buildControllerManagerOverlay(nil, "", konfluxv1alpha1.KonfluxIntegrationServiceSpec{})
 		g.Expect(overlay).NotTo(gomega.BeNil())
 	})
 
 	t.Run("empty spec returns overlay without customizations", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 		spec := &konfluxv1alpha1.ControllerManagerDeploymentSpec{}
-		overlay := buildControllerManagerOverlay(spec, "")
+		overlay := buildControllerManagerOverlay(spec, "", konfluxv1alpha1.KonfluxIntegrationServiceSpec{})
 		g.Expect(overlay).NotTo(gomega.BeNil())
 	})
 
@@ -87,7 +87,7 @@ func TestBuildControllerManagerOverlay(t *testing.T) {
 		}
 
 		deployment := getIntegrationServiceDeployment(t)
-		overlay := buildControllerManagerOverlay(spec, "")
+		overlay := buildControllerManagerOverlay(spec, "", konfluxv1alpha1.KonfluxIntegrationServiceSpec{})
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -116,7 +116,7 @@ func TestBuildControllerManagerOverlay(t *testing.T) {
 		g.Expect(managerContainer).NotTo(gomega.BeNil(), "manager container must exist in controller-manager deployment")
 		originalImage := managerContainer.Image
 
-		overlay := buildControllerManagerOverlay(spec, "")
+		overlay := buildControllerManagerOverlay(spec, "", konfluxv1alpha1.KonfluxIntegrationServiceSpec{})
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -373,7 +373,7 @@ func TestBuildControllerManagerOverlay_ConsoleURL(t *testing.T) {
 		spec := &konfluxv1alpha1.ControllerManagerDeploymentSpec{}
 
 		deployment := getIntegrationServiceDeployment(t)
-		overlay := buildControllerManagerOverlay(spec, testConsoleURL)
+		overlay := buildControllerManagerOverlay(spec, testConsoleURL, konfluxv1alpha1.KonfluxIntegrationServiceSpec{})
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -389,7 +389,7 @@ func TestBuildControllerManagerOverlay_ConsoleURL(t *testing.T) {
 		g := gomega.NewWithT(t)
 
 		deployment := getIntegrationServiceDeployment(t)
-		overlay := buildControllerManagerOverlay(nil, testConsoleURL)
+		overlay := buildControllerManagerOverlay(nil, testConsoleURL, konfluxv1alpha1.KonfluxIntegrationServiceSpec{})
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -406,7 +406,7 @@ func TestBuildControllerManagerOverlay_ConsoleURL(t *testing.T) {
 		spec := &konfluxv1alpha1.ControllerManagerDeploymentSpec{}
 
 		deployment := getIntegrationServiceDeployment(t)
-		overlay := buildControllerManagerOverlay(spec, "")
+		overlay := buildControllerManagerOverlay(spec, "", konfluxv1alpha1.KonfluxIntegrationServiceSpec{})
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -432,7 +432,7 @@ func TestBuildControllerManagerOverlay_ConsoleURL(t *testing.T) {
 		}
 
 		deployment := getIntegrationServiceDeployment(t)
-		overlay := buildControllerManagerOverlay(spec, testConsoleURL)
+		overlay := buildControllerManagerOverlay(spec, testConsoleURL, konfluxv1alpha1.KonfluxIntegrationServiceSpec{})
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -461,7 +461,7 @@ func TestBuildControllerManagerOverlay_ConsoleURL(t *testing.T) {
 		}
 
 		deployment := getIntegrationServiceDeployment(t)
-		overlay := buildControllerManagerOverlay(spec, testConsoleURL)
+		overlay := buildControllerManagerOverlay(spec, testConsoleURL, konfluxv1alpha1.KonfluxIntegrationServiceSpec{})
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -492,7 +492,7 @@ func TestBuildControllerManagerOverlay_ConsoleURL(t *testing.T) {
 		}
 
 		deployment := getIntegrationServiceDeployment(t)
-		overlay := buildControllerManagerOverlay(spec, testConsoleURL)
+		overlay := buildControllerManagerOverlay(spec, testConsoleURL, konfluxv1alpha1.KonfluxIntegrationServiceSpec{})
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -522,7 +522,7 @@ func TestBuildControllerManagerOverlay_ConsoleURL(t *testing.T) {
 		}
 
 		deployment := getIntegrationServiceDeployment(t)
-		overlay := buildControllerManagerOverlay(spec, testConsoleURL)
+		overlay := buildControllerManagerOverlay(spec, testConsoleURL, konfluxv1alpha1.KonfluxIntegrationServiceSpec{})
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -547,7 +547,7 @@ func TestBuildControllerManagerOverlay_ConsoleURL(t *testing.T) {
 
 		// First, apply with old console URL
 		deployment := getIntegrationServiceDeployment(t)
-		overlay := buildControllerManagerOverlay(spec, oldConsoleURL)
+		overlay := buildControllerManagerOverlay(spec, oldConsoleURL, konfluxv1alpha1.KonfluxIntegrationServiceSpec{})
 		err := overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -560,7 +560,7 @@ func TestBuildControllerManagerOverlay_ConsoleURL(t *testing.T) {
 		g.Expect(envVar.Value).To(gomega.Equal(oldConsoleURLTemplate))
 
 		// Now apply with new console URL (simulating KonfluxUI ingress URL change)
-		overlay = buildControllerManagerOverlay(spec, testConsoleURL)
+		overlay = buildControllerManagerOverlay(spec, testConsoleURL, konfluxv1alpha1.KonfluxIntegrationServiceSpec{})
 		err = overlay.ApplyToDeployment(deployment)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -571,5 +571,139 @@ func TestBuildControllerManagerOverlay_ConsoleURL(t *testing.T) {
 		envVar = findEnvVar(managerContainer.Env, "CONSOLE_URL")
 		g.Expect(envVar).NotTo(gomega.BeNil())
 		g.Expect(envVar.Value).To(gomega.Equal(testConsoleURLTemplate))
+	})
+}
+
+func TestBuildControllerManagerOverlay_PipelineTimeouts(t *testing.T) {
+	t.Run("typed timeout fields are injected as env vars", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		integrationSpec := konfluxv1alpha1.KonfluxIntegrationServiceSpec{
+			PipelineTimeout: "6h",
+			TasksTimeout:    "4h",
+			FinallyTimeout:  "2h",
+		}
+		deployment := getIntegrationServiceDeployment(t)
+		g.Expect(applyIntegrationServiceDeploymentCustomizations(deployment, integrationSpec, "")).To(gomega.Succeed())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		pipelineTimeoutVar := findEnvVar(managerContainer.Env, envPipelineTimeout)
+		g.Expect(pipelineTimeoutVar).NotTo(gomega.BeNil())
+		g.Expect(pipelineTimeoutVar.Value).To(gomega.Equal("6h"))
+		tasksTimeoutVar := findEnvVar(managerContainer.Env, envTasksTimeout)
+		g.Expect(tasksTimeoutVar).NotTo(gomega.BeNil())
+		g.Expect(tasksTimeoutVar.Value).To(gomega.Equal("4h"))
+		finallyTimeoutVar := findEnvVar(managerContainer.Env, envFinallyTimeout)
+		g.Expect(finallyTimeoutVar).NotTo(gomega.BeNil())
+		g.Expect(finallyTimeoutVar.Value).To(gomega.Equal("2h"))
+	})
+
+	t.Run("typed CRD field overrides explicit manager.env entry", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		integrationSpec := konfluxv1alpha1.KonfluxIntegrationServiceSpec{
+			PipelineTimeout: "6h",
+			TasksTimeout:    "4h",
+			FinallyTimeout:  "2h",
+			IntegrationControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Manager: &konfluxv1alpha1.ContainerSpec{
+					Env: []corev1.EnvVar{
+						{Name: envPipelineTimeout, Value: "12h"},
+						{Name: envTasksTimeout, Value: "10h"},
+						{Name: envFinallyTimeout, Value: "8h"},
+					},
+				},
+			},
+		}
+		deployment := getIntegrationServiceDeployment(t)
+		g.Expect(applyIntegrationServiceDeploymentCustomizations(deployment, integrationSpec, "")).To(gomega.Succeed())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		pipelineTimeoutVar := findEnvVar(managerContainer.Env, envPipelineTimeout)
+		g.Expect(pipelineTimeoutVar).NotTo(gomega.BeNil())
+		g.Expect(pipelineTimeoutVar.Value).To(gomega.Equal("6h"))
+		tasksTimeoutVar := findEnvVar(managerContainer.Env, envTasksTimeout)
+		g.Expect(tasksTimeoutVar).NotTo(gomega.BeNil())
+		g.Expect(tasksTimeoutVar.Value).To(gomega.Equal("4h"))
+		finallyTimeoutVar := findEnvVar(managerContainer.Env, envFinallyTimeout)
+		g.Expect(finallyTimeoutVar).NotTo(gomega.BeNil())
+		g.Expect(finallyTimeoutVar.Value).To(gomega.Equal("2h"))
+	})
+
+	t.Run("empty timeout fields do not inject env vars", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		integrationSpec := konfluxv1alpha1.KonfluxIntegrationServiceSpec{}
+		deployment := getIntegrationServiceDeployment(t)
+		g.Expect(applyIntegrationServiceDeploymentCustomizations(deployment, integrationSpec, "")).To(gomega.Succeed())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(findEnvVar(managerContainer.Env, envPipelineTimeout)).To(gomega.BeNil())
+		g.Expect(findEnvVar(managerContainer.Env, envTasksTimeout)).To(gomega.BeNil())
+		g.Expect(findEnvVar(managerContainer.Env, envFinallyTimeout)).To(gomega.BeNil())
+	})
+
+	t.Run("manager.env values pass through when CRD timeout fields are not set", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		integrationSpec := konfluxv1alpha1.KonfluxIntegrationServiceSpec{
+			// PipelineTimeout, TasksTimeout, FinallyTimeout intentionally omitted
+			IntegrationControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Manager: &konfluxv1alpha1.ContainerSpec{
+					Env: []corev1.EnvVar{
+						{Name: envPipelineTimeout, Value: "8h"},
+						{Name: envTasksTimeout, Value: "5h"},
+						{Name: envFinallyTimeout, Value: "3h"},
+					},
+				},
+			},
+		}
+		deployment := getIntegrationServiceDeployment(t)
+		g.Expect(applyIntegrationServiceDeploymentCustomizations(deployment, integrationSpec, "")).To(gomega.Succeed())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		pipelineTimeoutVar := findEnvVar(managerContainer.Env, envPipelineTimeout)
+		g.Expect(pipelineTimeoutVar).NotTo(gomega.BeNil())
+		g.Expect(pipelineTimeoutVar.Value).To(gomega.Equal("8h"))
+		tasksTimeoutVar := findEnvVar(managerContainer.Env, envTasksTimeout)
+		g.Expect(tasksTimeoutVar).NotTo(gomega.BeNil())
+		g.Expect(tasksTimeoutVar.Value).To(gomega.Equal("5h"))
+		finallyTimeoutVar := findEnvVar(managerContainer.Env, envFinallyTimeout)
+		g.Expect(finallyTimeoutVar).NotTo(gomega.BeNil())
+		g.Expect(finallyTimeoutVar.Value).To(gomega.Equal("3h"))
+	})
+
+	t.Run("typed field wins for its var, manager.env pass-through for unset ones", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		integrationSpec := konfluxv1alpha1.KonfluxIntegrationServiceSpec{
+			PipelineTimeout: "6h", // typed field — should take precedence
+			// TasksTimeout and FinallyTimeout intentionally omitted — manager.env should pass through
+			IntegrationControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Manager: &konfluxv1alpha1.ContainerSpec{
+					Env: []corev1.EnvVar{
+						{Name: envPipelineTimeout, Value: "12h"}, // should be overridden by typed field
+						{Name: envTasksTimeout, Value: "5h"},     // should pass through unchanged
+						{Name: envFinallyTimeout, Value: "3h"},   // should pass through unchanged
+					},
+				},
+			},
+		}
+		deployment := getIntegrationServiceDeployment(t)
+		g.Expect(applyIntegrationServiceDeploymentCustomizations(deployment, integrationSpec, "")).To(gomega.Succeed())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+
+		pipelineTimeoutVar := findEnvVar(managerContainer.Env, envPipelineTimeout)
+		g.Expect(pipelineTimeoutVar).NotTo(gomega.BeNil())
+		g.Expect(pipelineTimeoutVar.Value).To(gomega.Equal("6h"))
+
+		tasksTimeoutVar := findEnvVar(managerContainer.Env, envTasksTimeout)
+		g.Expect(tasksTimeoutVar).NotTo(gomega.BeNil())
+		g.Expect(tasksTimeoutVar.Value).To(gomega.Equal("5h"))
+
+		finallyTimeoutVar := findEnvVar(managerContainer.Env, envFinallyTimeout)
+		g.Expect(finallyTimeoutVar).NotTo(gomega.BeNil())
+		g.Expect(finallyTimeoutVar.Value).To(gomega.Equal("3h"))
 	})
 }

--- a/operator/pkg/customization/container.go
+++ b/operator/pkg/customization/container.go
@@ -115,6 +115,16 @@ func WithImage(image string) ContainerOption {
 	}
 }
 
+// WithOptionalEnvOverride is like WithEnvOverride but is a no-op when value is empty,
+// leaving any existing variable (or the upstream manifest default) in place.
+// Use this when a CRD field should set an env var only when explicitly provided.
+func WithOptionalEnvOverride(name, value string) ContainerOption {
+	if value == "" {
+		return func(_ *corev1.Container, _ DeploymentContext) {}
+	}
+	return WithEnvOverride(name, value)
+}
+
 // --- Context-aware options ---
 
 // WithLeaderElection adds --leader-elect=true if replicas > 1.

--- a/operator/pkg/customization/container_test.go
+++ b/operator/pkg/customization/container_test.go
@@ -276,6 +276,46 @@ func TestWithEnvOverride(t *testing.T) {
 	})
 }
 
+func TestWithOptionalEnvOverride(t *testing.T) {
+	ctx := DeploymentContext{Replicas: 1}
+
+	t.Run("adds environment variable when value is non-empty", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		c := NewContainerOverlay(ctx, WithOptionalEnvOverride("VAR1", "value1"))
+		g.Expect(c.Env).To(gomega.HaveLen(1))
+		g.Expect(c.Env[0].Name).To(gomega.Equal("VAR1"))
+		g.Expect(c.Env[0].Value).To(gomega.Equal("value1"))
+	})
+
+	t.Run("is a no-op when value is empty", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		c := NewContainerOverlay(ctx, WithOptionalEnvOverride("VAR1", ""))
+		g.Expect(c.Env).To(gomega.BeEmpty())
+	})
+
+	t.Run("overrides existing variable when value is non-empty", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		c := NewContainerOverlay(ctx,
+			WithEnv(corev1.EnvVar{Name: "VAR1", Value: "original"}),
+			WithOptionalEnvOverride("VAR1", "override"),
+		)
+		g.Expect(c.Env).To(gomega.HaveLen(1))
+		g.Expect(c.Env[0].Name).To(gomega.Equal("VAR1"))
+		g.Expect(c.Env[0].Value).To(gomega.Equal("override"))
+	})
+
+	t.Run("leaves existing variable untouched when value is empty", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		c := NewContainerOverlay(ctx,
+			WithEnv(corev1.EnvVar{Name: "VAR1", Value: "original"}),
+			WithOptionalEnvOverride("VAR1", ""),
+		)
+		g.Expect(c.Env).To(gomega.HaveLen(1))
+		g.Expect(c.Env[0].Name).To(gomega.Equal("VAR1"))
+		g.Expect(c.Env[0].Value).To(gomega.Equal("original"))
+	})
+}
+
 func TestWithResources(t *testing.T) {
 	ctx := DeploymentContext{Replicas: 1}
 


### PR DESCRIPTION
Promote PIPELINE_TIMEOUT, TASKS_TIMEOUT, and FINALLY_TIMEOUT from
generic env var examples to first-class typed fields on
KonfluxIntegrationServiceSpec.

Previously, users could only set these via the unvalidated
integrationControllerManager.manager.env list, which provided no
schema validation and required knowledge of the exact env var names.

Changes:
- Add PipelineTimeout, TasksTimeout, FinallyTimeout string fields to
  KonfluxIntegrationServiceSpec, each validated against a duration
  pattern (e.g. "6h", "4h30m").
- Map the fields to their corresponding env vars (PIPELINE_TIMEOUT,
  TASKS_TIMEOUT, FINALLY_TIMEOUT) on the controller-manager container
  via withTimeoutField(), applied after FromContainerSpec so CRD fields
  take precedence over any same-named entry in manager.env.
- When a field is omitted, no env var is injected and the upstream
  integration-service default applies. Values supplied via manager.env
  still pass through when the typed fields are not set.
- Update the KonfluxIntegrationService sample YAML to show the new
  fields alongside the integrationControllerManager customization block.
- Regenerate CRDs and deepcopy to reflect the new API fields.
- Add TestBuildControllerManagerOverlay_PipelineTimeouts covering:
  injection, CRD-wins-over-manager.env precedence, empty fields
  (no injection), and manager.env pass-through.

Assisted-by: Cursor