### PR TITLE
fix: use skills/ path in local-dev-setup skill scripts

### DIFF
--- a/skills/local-dev-setup/SKILL.md
+++ b/skills/local-dev-setup/SKILL.md
@@ -118,22 +118,24 @@ Use `block_until_ms: 0` for `make run` since it runs indefinitely. Poll the term
 
 ### Step 4: Apply the Konflux CR and Wait
 
-In a **separate** shell (the operator terminal is occupied), apply the CR using the shim script. It uses `scripts/resolve-konflux-cr.sh` to pick the right CR (defaults to the base CR; auto-selects `konflux-e2e.yaml` when Quay credentials are set):
+In a **separate** shell (the operator terminal is occupied), apply the CR using the shim script. It uses `scripts/resolve-konflux-cr.sh` to pick the right CR (defaults to the base CR; auto-selects `konflux-e2e.yaml` when Quay credentials are set).
+
+**Run these commands from the repository root** (use `working_directory` parameter pointing to the repo root, since the previous step leaves the shell in `operator/`):
 
 ```bash
-bash .cursor/skills/local-dev-setup/scripts/apply-konflux-cr.sh
+bash skills/local-dev-setup/scripts/apply-konflux-cr.sh
 ```
 
 To use a specific CR file:
 
 ```bash
-bash .cursor/skills/local-dev-setup/scripts/apply-konflux-cr.sh operator/config/samples/konflux_v1alpha1_konflux.yaml
+bash skills/local-dev-setup/scripts/apply-konflux-cr.sh operator/config/samples/konflux_v1alpha1_konflux.yaml
 ```
 
 Then wait for Konflux to become ready:
 
 ```bash
-bash .cursor/skills/local-dev-setup/scripts/wait-for-konflux.sh
+bash skills/local-dev-setup/scripts/wait-for-konflux.sh
 ```
 
 Both scripts are in the command allowlist and run without user confirmation.

--- a/skills/local-dev-setup/scripts/apply-konflux-cr.sh
+++ b/skills/local-dev-setup/scripts/apply-konflux-cr.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # deploy-local.sh). Pass an explicit path to override.
 #
 # Usage:
-#   bash .cursor/skills/local-dev-setup/scripts/apply-konflux-cr.sh [cr-path]
+#   bash skills/local-dev-setup/scripts/apply-konflux-cr.sh [cr-path]
 
 REPO_ROOT=$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)
 

--- a/skills/local-dev-setup/scripts/wait-for-konflux.sh
+++ b/skills/local-dev-setup/scripts/wait-for-konflux.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Wait for the Konflux CR to become Ready.
 #
 # Usage:
-#   bash .cursor/skills/local-dev-setup/scripts/wait-for-konflux.sh [timeout]
+#   bash skills/local-dev-setup/scripts/wait-for-konflux.sh [timeout]
 #
 # Default timeout: 15m
 


### PR DESCRIPTION
## Summary
- Replace `.cursor/skills/` with `skills/` in the local-dev-setup skill doc and helper scripts for clarity
- Add an explicit note to run the CR apply/wait commands from the repo root, since the previous step (`make install`/`make run`) leaves the shell in `operator/`

## Test plan
- [x] Verified the symlink `.cursor/skills -> ../skills` still resolves correctly
- [ ] Run the local-dev-setup skill end-to-end and confirm the apply/wait scripts execute without path errors


Made with [Cursor](https://cursor.com)