### PR TITLE
chore(ci): centralize third-party chart pins and reuse runner kustomize

### DIFF
--- a/.github/scripts/export-third-party-chart-env.sh
+++ b/.github/scripts/export-third-party-chart-env.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Print shell `export` lines for CERT_MANAGER_VERSION and TRUST_MANAGER_VERSION
+# (Helm --version values with a leading v). Chart semver pins live in this script and
+# are updated by Renovate / MintMaker (see renovate.json customManagers).
+#
+# Usage (from repository root, or pass the full path to this script):
+#   eval "$(bash .github/scripts/export-third-party-chart-env.sh)"
+set -euo pipefail
+
+# renovate: datasource=helm depName=jetstack/cert-manager versioning=semver
+CERT_MANAGER_CHART_VERSION="1.19.4"
+# renovate: datasource=helm depName=jetstack/trust-manager versioning=semver
+TRUST_MANAGER_CHART_VERSION="0.21.0"
+
+cert="${CERT_MANAGER_CHART_VERSION}"
+trust="${TRUST_MANAGER_CHART_VERSION}"
+
+if [[ -z "${cert}" || -z "${trust}" ]]; then
+  echo "export-third-party-chart-env: chart versions are not set in ${BASH_SOURCE[0]}" >&2
+  exit 1
+fi
+
+[[ "${cert}" == v* ]] || cert="v${cert}"
+[[ "${trust}" == v* ]] || trust="v${trust}"
+
+printf 'export CERT_MANAGER_VERSION=%q\n' "${cert}"
+printf 'export TRUST_MANAGER_VERSION=%q\n' "${trust}"

--- a/.github/scripts/update-third-party-manifests.sh
+++ b/.github/scripts/update-third-party-manifests.sh
@@ -12,8 +12,9 @@ set -euo pipefail
 #   REPO_ROOT - Repository root (default: GITHUB_WORKSPACE or git rev-parse --show-toplevel)
 #
 # Environment:
-#   CERT_MANAGER_VERSION   - Required. cert-manager chart version.
-#   TRUST_MANAGER_VERSION  - Required. trust-manager chart version.
+#   CERT_MANAGER_VERSION   - Required. cert-manager chart version (use vX.Y.Z; from CI or
+#                             eval "$(bash .github/scripts/export-third-party-chart-env.sh)").
+#   TRUST_MANAGER_VERSION  - Required. trust-manager chart version (same pattern).
 #
 # Requires: helm, yq on PATH.
 

--- a/.github/workflows/update-third-party-manifests.yaml
+++ b/.github/workflows/update-third-party-manifests.yaml
@@ -1,13 +1,8 @@
 # Updates cert-manager and trust-manager manifests under dependencies/ using Helm.
 # Generates the same manifests we use today (resource limits, namespace, etc.).
+# Chart semver pins live in .github/scripts/export-third-party-chart-env.sh (Renovate/MintMaker).
 # Logic lives in .github/scripts/ so it can be run locally (e.g. ./.github/scripts/update-third-party-manifests.sh).
 name: Update Third-Party Manifests
-
-env:
-  # renovate: datasource=helm depName=jetstack/cert-manager versioning=semver
-  CERT_MANAGER_VERSION: "1.19.4"
-  # renovate: datasource=helm depName=jetstack/trust-manager versioning=semver
-  TRUST_MANAGER_VERSION: "0.21.0"
 
 on:
   schedule:
@@ -40,17 +35,18 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
+      - name: Load chart version env
+        run: |
+          eval "$(bash "${GITHUB_WORKSPACE}/.github/scripts/export-third-party-chart-env.sh")"
+          echo "CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION}" >> "${GITHUB_ENV}"
+          echo "TRUST_MANAGER_VERSION=${TRUST_MANAGER_VERSION}" >> "${GITHUB_ENV}"
+
       - name: Generate third-party manifests
-        env:
-          CERT_MANAGER_VERSION: "v${{ env.CERT_MANAGER_VERSION }}"
-          TRUST_MANAGER_VERSION: "v${{ env.TRUST_MANAGER_VERSION }}"
         run: .github/scripts/update-third-party-manifests.sh
 
       - name: Create or update PR if changed
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-          CERT_MANAGER_VERSION: "v${{ env.CERT_MANAGER_VERSION }}"
-          TRUST_MANAGER_VERSION: "v${{ env.TRUST_MANAGER_VERSION }}"
         run: .github/scripts/create-third-party-manifests-pr.sh
 
       - name: Notify on failure

--- a/.github/workflows/update-upstream-manifests.yaml
+++ b/.github/workflows/update-upstream-manifests.yaml
@@ -1,9 +1,5 @@
 name: Update Upstream Manifests
 
-env:
-  # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize
-  KUSTOMIZE_VERSION: "5.4.1"
-
 on:
   # Run on a schedule (daily at 2 AM UTC)
   schedule:
@@ -41,29 +37,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-
-      - name: Install Kustomize
-        run: |
-          KUSTOMIZE_VERSION="${{ env.KUSTOMIZE_VERSION }}"
-          ARCH="linux_amd64"
-
-          echo "Installing kustomize v${KUSTOMIZE_VERSION}..."
-
-          # Download and install kustomize
-          # Kustomize release tags use format: kustomize/v{VERSION}
-          # Download URL format: .../kustomize/v{VERSION}/kustomize_v{VERSION}_{ARCH}.tar.gz
-          RELEASE_TAG="kustomize/v${KUSTOMIZE_VERSION}"
-          DOWNLOAD_URL="https://github.com/kubernetes-sigs/kustomize/releases/download/${RELEASE_TAG}/kustomize_v${KUSTOMIZE_VERSION}_${ARCH}.tar.gz"
-
-          echo "Downloading from: ${DOWNLOAD_URL}"
-          curl -L -f -o kustomize.tar.gz "${DOWNLOAD_URL}"
-          tar -xzf kustomize.tar.gz
-          chmod +x kustomize
-          sudo mv kustomize /usr/local/bin/kustomize
-
-          # Verify installation
-          kustomize version
-          rm -f kustomize.tar.gz
 
       - name: Process all components
         id: process

--- a/renovate.json
+++ b/renovate.json
@@ -278,22 +278,26 @@
       "autoReplaceStringTemplate": "default: {{newDigest}}"
     },
     {
-      "description": "Track cert-manager Helm chart in Update Third-Party Manifests workflow",
+      "description": "Track cert-manager Helm chart version (export-third-party-chart-env.sh)",
       "customType": "regex",
-      "fileMatch": [".github/workflows/update-third-party-manifests.yaml"],
+      "matchStringsStrategy": "combination",
+      "fileMatch": ["^\\.github/scripts/export-third-party-chart-env\\.sh$"],
       "matchStrings": [
-        "# renovate: datasource=helm depName=jetstack/cert-manager versioning=semver\\s+CERT_MANAGER_VERSION:\\s*\"(?<currentValue>[^\"]+)\""
+        "# renovate: datasource=helm depName=jetstack/cert-manager versioning=semver",
+        "CERT_MANAGER_CHART_VERSION=\"(?<currentValue>[^\"]+)\""
       ],
       "datasourceTemplate": "helm",
       "depNameTemplate": "cert-manager",
       "extractVersionTemplate": "^v?(?<version>.*)$"
     },
     {
-      "description": "Track trust-manager Helm chart in Update Third-Party Manifests workflow",
+      "description": "Track trust-manager Helm chart version (export-third-party-chart-env.sh)",
       "customType": "regex",
-      "fileMatch": [".github/workflows/update-third-party-manifests.yaml"],
+      "matchStringsStrategy": "combination",
+      "fileMatch": ["^\\.github/scripts/export-third-party-chart-env\\.sh$"],
       "matchStrings": [
-        "# renovate: datasource=helm depName=jetstack/trust-manager versioning=semver\\s+TRUST_MANAGER_VERSION:\\s*\"(?<currentValue>[^\"]+)\""
+        "# renovate: datasource=helm depName=jetstack/trust-manager versioning=semver",
+        "TRUST_MANAGER_CHART_VERSION=\"(?<currentValue>[^\"]+)\""
       ],
       "datasourceTemplate": "helm",
       "depNameTemplate": "trust-manager",


### PR DESCRIPTION
This change moves the tracking and exporting of cert-manager and trust-manager versions to a standalone script. The reason for that is that a future PR will use the script from another workflow, and we want to avoid duplication of the pins.

We adjust renovate.json to track this file instead.

We also do additional cleanup of existing workflow before the next steps. Specifically, we don't need to install kustomize in the workflow, as we already assume it is available in the runner.

Assisted-by: Cursor