### PR TITLE
ci: add manifest companion workflow for dependency bot PRs

### DIFF
--- a/.github/scripts/renovate-manifest-companion.sh
+++ b/.github/scripts/renovate-manifest-companion.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# From the current checkout (expected: Renovate PR head), rebuild all upstream
+# operator manifests and third-party Helm outputs, commit, push to a stable bot
+# branch, and open a PR to main if none exists.
+#
+# Usage:
+#   renovate-manifest-companion.sh [REPO_ROOT]
+#
+# Environment:
+#   SOURCE_PR              - Source dependency PR number (required in CI)
+#   GITHUB_REPOSITORY      - owner/repo (required for PR links)
+#   GH_TOKEN               - For git push and gh (optional locally)
+#
+# Chart versions for update-third-party-manifests.sh are read from
+# export-third-party-chart-env.sh (inline chart semver pins).
+#
+# Requires: kustomize, helm, yq, jq, git, gh on PATH (GitHub-hosted runners provide
+# the tools used by update-third-party-manifests / kustomize workflows without extra installs).
+set -euo pipefail
+
+REPO_ROOT="${1:-${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}}"
+REPO_ROOT="$(cd "${REPO_ROOT}" && pwd)"
+cd "${REPO_ROOT}"
+
+eval "$(bash "${REPO_ROOT}/.github/scripts/export-third-party-chart-env.sh" "${REPO_ROOT}")"
+
+SOURCE_PR="${SOURCE_PR:?SOURCE_PR (dependency bump PR number) is required}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+BRANCH="bot/manifest-companion-pr-${SOURCE_PR}"
+RENOVATE_PR_URL="https://github.com/${GITHUB_REPOSITORY}/pull/${SOURCE_PR}"
+
+if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  git config --local user.email "github-actions[bot]@users.noreply.github.com"
+  git config --local user.name "github-actions[bot]"
+  if [[ -n "${GH_TOKEN:-}" ]]; then
+    git config --local credential.helper store
+    echo "https://x-access-token:${GH_TOKEN}@github.com" >~/.git-credentials
+  fi
+fi
+
+echo "Creating/updating companion branch ${BRANCH} from $(git rev-parse --short HEAD)"
+git checkout -B "${BRANCH}"
+
+bash "${REPO_ROOT}/operator/pkg/manifests/rebuild-upstream-manifests.sh" "${REPO_ROOT}"
+
+export CERT_MANAGER_VERSION TRUST_MANAGER_VERSION
+bash "${REPO_ROOT}/.github/scripts/update-third-party-manifests.sh" "${REPO_ROOT}"
+
+git add \
+  operator/pkg/manifests \
+  dependencies/cert-manager/cert-manager.yaml \
+  dependencies/trust-manager/trust-manager.yaml \
+  operator/test/crds/cert-manager/cert-manager.crds.yaml
+
+if git diff --cached --quiet; then
+  echo "No manifest changes to commit; companion branch matches generators."
+  # Stale companion PRs: close if still open. Noop comment: one thread on the source
+  # PR, PATCH on repeat so the workflow run link stays current for troubleshooting.
+  NOOP_MARKER="<!-- konflux-manifest-companion-noop:${SOURCE_PR} -->"
+  if [[ -n "${GH_TOKEN:-}" ]]; then
+    # A prior run may have opened a companion PR; this head no longer needs a
+    # manifest-only commit. Close the open companion PR so it is not left stale
+    # against origin (we do not push the no-diff branch state here).
+    OPEN_COMPANION_PR="$(
+      gh pr list \
+        --repo "${GITHUB_REPOSITORY}" \
+        --head "${BRANCH}" \
+        --state open \
+        --json number \
+        --jq '.[0].number // empty' 2>/dev/null || true
+    )"
+    if [[ -n "${OPEN_COMPANION_PR}" ]]; then
+      echo "Closing stale companion PR #${OPEN_COMPANION_PR} (no manifest diff vs generators)."
+      gh pr close "${OPEN_COMPANION_PR}" \
+        --repo "${GITHUB_REPOSITORY}" \
+        --comment "Closed automatically: the latest manifest companion run found no rendered changes to commit for [PR #${SOURCE_PR}](${RENOVATE_PR_URL}); a separate companion PR is not needed. Merge the dependency PR to \`main\` when ready, or reopen if this close was mistaken." \
+        || true
+    fi
+    if [[ -n "${GITHUB_RUN_ID:-}" ]]; then
+      NOOP_RUN_LINK="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+    else
+      NOOP_RUN_LINK="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/actions"
+    fi
+    NOOP_BODY="${NOOP_MARKER}
+
+Manifest companion run found **no staged diff** after regenerating \`operator/pkg/manifests\` and third-party Helm outputs — a companion PR was not opened because rendered paths already match this branch.
+
+If you expected manifest changes, check the [workflow run logs](${NOOP_RUN_LINK}) and the rendering scripts (\`rebuild-upstream-manifests.sh\`, \`update-third-party-manifests.sh\`)."
+    NOOP_COMMENT_ID="$(
+      gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${SOURCE_PR}/comments" \
+        --jq ".[] | select(.body | contains(\"<!-- konflux-manifest-companion-noop:${SOURCE_PR} -->\")) | .id" 2>/dev/null | tail -n1 || true
+    )"
+    if [[ -n "${NOOP_COMMENT_ID}" ]]; then
+      jq -n --arg body "${NOOP_BODY}" '{body: $body}' \
+        | gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${NOOP_COMMENT_ID}" --input - || true
+    else
+      gh pr comment "${SOURCE_PR}" --repo "${GITHUB_REPOSITORY}" --body "${NOOP_BODY}" || true
+    fi
+  fi
+  exit 0
+fi
+
+git commit -m "chore: sync rendered manifests (companion to #${SOURCE_PR})
+
+Regenerated operator/pkg/manifests and Helm-rendered third-party files to match
+the dependency bump branch. Prefer merging this PR over #${SOURCE_PR} so rendered
+artifacts stay aligned with pins."
+
+git push origin "${BRANCH}" --force
+
+EXISTING="$(
+  gh pr list \
+    --repo "${GITHUB_REPOSITORY}" \
+    --head "${BRANCH}" \
+    --state open \
+    --json number \
+    --jq '.[0].number // empty' 2>/dev/null || true
+)"
+
+BODY_FILE="$(mktemp)"
+trap 'rm -f "${BODY_FILE}"' EXIT
+cat >"${BODY_FILE}" <<EOF
+## Manifest companion for PR #${SOURCE_PR}
+
+This branch is **[${BRANCH}](https://github.com/${GITHUB_REPOSITORY}/tree/${BRANCH})** — it starts from the head of [PR #${SOURCE_PR}](${RENOVATE_PR_URL}) and adds regenerated:
+
+- \`operator/pkg/manifests/*/manifests.yaml\` (from \`kustomize build\` on \`operator/upstream-kustomizations/*\`)
+- Third-party Helm outputs under \`dependencies/\` and envtest CRDs under \`operator/test/crds/cert-manager/\`
+
+**Merge this PR to \`main\`, not #${SOURCE_PR}**, so \`main\` always carries matching pins and rendered manifests.
+
+This PR is updated automatically when new commits are pushed to #${SOURCE_PR}.
+EOF
+
+COMPANION_PR=""
+if [[ -n "${EXISTING}" ]]; then
+  COMPANION_PR="${EXISTING}"
+  echo "Open companion PR already exists: #${COMPANION_PR}"
+  gh pr edit "${COMPANION_PR}" --repo "${GITHUB_REPOSITORY}" --body-file "${BODY_FILE}" || true
+else
+  gh pr create \
+    --repo "${GITHUB_REPOSITORY}" \
+    --base main \
+    --head "${BRANCH}" \
+    --title "chore: sync manifests (companion to #${SOURCE_PR})" \
+    --body-file "${BODY_FILE}"
+  COMPANION_PR="$(gh pr list --repo "${GITHUB_REPOSITORY}" --head "${BRANCH}" --json number --jq '.[0].number')"
+  if [[ -n "${COMPANION_PR}" ]]; then
+    gh pr edit "${COMPANION_PR}" --repo "${GITHUB_REPOSITORY}" --add-label "automated,dependencies" 2>/dev/null || true
+    echo "Created companion PR #${COMPANION_PR}"
+  fi
+fi
+
+# Cross-link on the source PR so its timeline shows the companion (body-only
+# links on the companion PR do not notify the source thread).
+NOTIFY_MARKER="<!-- konflux-manifest-companion-notify:${SOURCE_PR} -->"
+if [[ -n "${COMPANION_PR}" ]]; then
+  if ! gh pr view "${SOURCE_PR}" --repo "${GITHUB_REPOSITORY}" --json comments --jq -r '(.comments // [])[] | .body // empty' 2>/dev/null | grep -qF "${NOTIFY_MARKER}"; then
+    gh pr comment "${SOURCE_PR}" --repo "${GITHUB_REPOSITORY}" --body "${NOTIFY_MARKER}
+
+Manifest companion PR (regenerated \`operator/pkg/manifests\` and third-party Helm outputs for this branch): #${COMPANION_PR}
+
+**Prefer merging #${COMPANION_PR}** to \`main\` instead of this PR." || true
+  fi
+fi

--- a/.github/workflows/renovate-manifest-companion.yaml
+++ b/.github/workflows/renovate-manifest-companion.yaml
@@ -1,0 +1,98 @@
+name: Renovate manifest companion PR
+
+# When dependency automation (Renovate, MintMaker, etc.) updates upstream pins or
+# bumps third-party versions in .github/scripts/export-third-party-chart-env.sh,
+# open/update a bot branch and PR with regenerated manifests (do not push to the bot's PR branch).
+# kustomize, helm, and yq are expected on PATH (ubuntu-latest image).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      # Upstream digest/ref bumps (e.g. integration-service) live under here.
+      - "operator/upstream-kustomizations/**"
+      # MintMaker/Renovate bump Helm chart semvers here (see renovate.json customManagers).
+      - ".github/scripts/export-third-party-chart-env.sh"
+
+concurrency:
+  group: renovate-manifest-companion-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  companion:
+    name: Rebuild manifests and open companion PR
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["renovate[bot]","red-hat-konflux[bot]"]'), github.event.pull_request.user.login)
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.UPDATE_BOT_APP_ID }}
+          private-key: ${{ secrets.UPDATE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
+      - name: Checkout dependency PR head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+
+      # Refuse to run companion logic from the PR checkout unless the PR diff is
+      # limited to the same paths as the workflow trigger (defense in depth;
+      # keep this step inline so it is not replaced by PR-supplied script content).
+      - name: Verify PR diff allowlist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(
+            gh pr diff "${{ github.event.pull_request.number }}" \
+              --repo "${{ github.repository }}" \
+              --name-only | awk 'NF' | sort -u
+          )
+          disallowed=()
+          for file in "${files[@]}"; do
+            case "$file" in
+              operator/upstream-kustomizations/*) ;;
+              .github/scripts/export-third-party-chart-env.sh) ;;
+              *) disallowed+=("$file") ;;
+            esac
+          done
+          if ((${#disallowed[@]})); then
+            echo "::error::Refusing to run: PR changes files outside the manifest companion allowlist (only operator/upstream-kustomizations/** and .github/scripts/export-third-party-chart-env.sh)."
+            printf '%s\n' "${disallowed[@]}" | sed 's/^/  - /' >&2
+            exit 1
+          fi
+
+      - name: Run companion
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SOURCE_PR: ${{ github.event.pull_request.number }}
+        run: bash .github/scripts/renovate-manifest-companion.sh
+
+      - name: Notify on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_NAME: Renovate manifest companion PR
+        run: |
+          .github/scripts/create-or-update-issue.sh \
+            "⚠️ Renovate manifest companion PR workflow failed" \
+            "The workflow that rebuilds manifests and opens a companion PR for dependency automation has failed. See the workflow run logs."

--- a/operator/pkg/manifests/rebuild-upstream-manifests.sh
+++ b/operator/pkg/manifests/rebuild-upstream-manifests.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Rebuild operator/pkg/manifests/<component>/manifests.yaml for every top-level
+# component under operator/upstream-kustomizations (same layout as process-component.sh).
+#
+# Usage:
+#   rebuild-upstream-manifests.sh <workspace-root>
+#
+# Requires: kustomize on PATH.
+set -euo pipefail
+
+WORKSPACE_ROOT="${1:-}"
+if [[ -z "${WORKSPACE_ROOT}" ]]; then
+  echo "Usage: $0 <workspace-root>" >&2
+  exit 1
+fi
+WORKSPACE_ROOT="$(cd "${WORKSPACE_ROOT}" && pwd)"
+
+shopt -s nullglob
+mapfile -t component_dirs < <(
+  for dir in "${WORKSPACE_ROOT}/operator/upstream-kustomizations"/*; do
+    if [[ -d "${dir}" ]]; then
+      printf '%s\n' "${dir}"
+    fi
+  done | sort
+)
+
+for dir in "${component_dirs[@]}"; do
+  component="$(basename "${dir}")"
+  out_dir="${WORKSPACE_ROOT}/operator/pkg/manifests/${component}"
+  mkdir -p "${out_dir}"
+  echo "kustomize build -> operator/pkg/manifests/${component}/manifests.yaml"
+  kustomize build "${WORKSPACE_ROOT}/operator/upstream-kustomizations/${component}" \
+    > "${out_dir}/manifests.yaml"
+done


### PR DESCRIPTION
When MintMaker or Renovate update upstream kustomizations, trigger a workflow that uses this update and creates a PR that includes the updated kustomizations and any downstream rendered artifacts that need to be updated.

The idea is that we'll merge the companion PR, and Renovate will close the original PR once it becomes redundant.

Next step will be to introduce a CI workflow that will fail if any downstream rendered artifacts are not in sync with the upstream kustomizations, which will ensure that we don't merge the original PR.

Assisted-by: Cursor