### PR TITLE
chore: realign rendered manifests and add verify CI

### DIFF
--- a/.github/path-filters/verify-manifests-in-sync.txt
+++ b/.github/path-filters/verify-manifests-in-sync.txt
@@ -1,0 +1,14 @@
+operator/upstream-kustomizations/**
+operator/pkg/manifests/**
+dependencies/**
+operator/test/crds/cert-manager/**
+.github/workflows/verify-manifests-in-sync.yaml
+.github/path-filters/verify-manifests-in-sync.txt
+.github/scripts/verify-manifests-in-sync.sh
+.github/scripts/export-third-party-chart-env.sh
+operator/pkg/manifests/rebuild-upstream-manifests.sh
+.github/workflows/update-upstream-manifests.yaml
+.github/workflows/update-third-party-manifests.yaml
+.github/scripts/update-third-party-manifests.sh
+.github/workflows/renovate-manifest-companion.yaml
+.github/scripts/renovate-manifest-companion.sh

--- a/.github/scripts/verify-manifests-in-sync.sh
+++ b/.github/scripts/verify-manifests-in-sync.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Fail if rendered upstream operator manifests or third-party Helm outputs are
+# out of date relative to operator/upstream-kustomizations and pinned chart versions.
+#
+# Usage:
+#   verify-manifests-in-sync.sh [REPO_ROOT]
+#
+# Chart versions come from export-third-party-chart-env.sh (same pins as the scheduled update workflow).
+#
+# Requires: kustomize, helm, yq on PATH (same expectation as other workflows that
+# invoke kustomize / update-third-party-manifests.sh without installing tools).
+set -euo pipefail
+
+REPO_ROOT="${1:-${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}}"
+REPO_ROOT="$(cd "${REPO_ROOT}" && pwd)"
+cd "${REPO_ROOT}"
+
+eval "$(bash "${REPO_ROOT}/.github/scripts/export-third-party-chart-env.sh" "${REPO_ROOT}")"
+
+fail=false
+
+echo "== Verifying upstream kustomize outputs =="
+shopt -s nullglob
+for dir in "${REPO_ROOT}/operator/upstream-kustomizations"/*; do
+  [[ -d "${dir}" ]] || continue
+  component="$(basename "${dir}")"
+  committed="${REPO_ROOT}/operator/pkg/manifests/${component}/manifests.yaml"
+  if [[ ! -f "${committed}" ]]; then
+    echo "❌ Missing committed manifest: ${committed}" >&2
+    fail=true
+    continue
+  fi
+  tmp="$(mktemp)"
+  if ! kustomize build "${REPO_ROOT}/operator/upstream-kustomizations/${component}" >"${tmp}" 2>/tmp/kustomize.err; then
+    echo "❌ kustomize build failed for ${component}" >&2
+    cat /tmp/kustomize.err >&2 || true
+    rm -f "${tmp}" /tmp/kustomize.err
+    fail=true
+    continue
+  fi
+  rm -f /tmp/kustomize.err
+  if ! diff -u "${committed}" "${tmp}" >/tmp/diff.out 2>&1; then
+    echo "❌ Upstream manifest drift for component: ${component}" >&2
+    head -n 80 /tmp/diff.out >&2 || cat /tmp/diff.out >&2
+    fail=true
+  else
+    echo "  OK ${component}"
+  fi
+  rm -f "${tmp}"
+done
+
+echo "== Verifying third-party Helm outputs =="
+export CERT_MANAGER_VERSION TRUST_MANAGER_VERSION
+bash "${REPO_ROOT}/.github/scripts/update-third-party-manifests.sh" "${REPO_ROOT}"
+
+third_paths=(
+  "dependencies/cert-manager/cert-manager.yaml"
+  "dependencies/trust-manager/trust-manager.yaml"
+  "operator/test/crds/cert-manager/cert-manager.crds.yaml"
+)
+if ! git diff --exit-code -- "${third_paths[@]}" 2>/dev/null; then
+  echo "❌ Third-party manifest drift (regenerate with update-third-party-manifests.sh and commit)." >&2
+  git --no-pager diff -- "${third_paths[@]}" >&2 || true
+  fail=true
+else
+  echo "  OK third-party manifests"
+fi
+
+if [[ "${fail}" == true ]]; then
+  echo "" >&2
+  echo "FAIL: One or more generated manifests are out of sync." >&2
+  exit 1
+fi
+
+echo "PASS: upstream kustomize outputs and third-party manifests match the tree."

--- a/.github/workflows/verify-manifests-in-sync.yaml
+++ b/.github/workflows/verify-manifests-in-sync.yaml
@@ -1,0 +1,43 @@
+name: Verify rendered manifests in sync
+
+# kustomize, helm, and yq are expected on PATH (ubuntu-latest / ubuntu-slim images).
+# cert-manager / trust-manager chart pins are defined in .github/scripts/export-third-party-chart-env.sh
+# (Renovate/MintMaker per renovate.json).
+
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+jobs:
+  check-changes:
+    name: Check for relevant changes
+    runs-on: ubuntu-slim
+    outputs:
+      manifests: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Check for changes
+        uses: tj-actions/changed-files@v47
+        id: changed-files
+        with:
+          files_from_source_file: .github/path-filters/verify-manifests-in-sync.txt
+
+  verify-manifests:
+    name: Verify upstream and third-party rendered manifests
+    runs-on: ubuntu-latest
+    needs: [check-changes]
+    if: needs.check-changes.outputs.manifests == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Verify manifests
+        working-directory: ${{ github.workspace }}
+        run: bash .github/scripts/verify-manifests-in-sync.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Contributing Guidelines
 - [Using KubeLinter](#using-kubelinter)
 - [Operator Development](#operator-development)
 - [CI/CD and Testing](#cicd-and-testing)
+  * [Operator rendered manifests](#operator-rendered-manifests)
   * [Automated E2E Tests](#automated-e2e-tests)
   * [OpenShift CI Periodic Tests](#openshift-ci-periodic-tests)
   * [ARM64 Testing](#arm64-testing)
@@ -111,6 +112,25 @@ For building and running the operator from source, see the
 Kind cluster, use `OPERATOR_INSTALL_METHOD=build` with `deploy-local.sh`.
 
 # CI/CD and Testing
+
+## Operator rendered manifests
+
+Pinned upstream components live under `operator/upstream-kustomizations/`. The
+operator bundles pre-rendered YAML under `operator/pkg/manifests/<component>/`.
+Those files must match `kustomize build` for the same pins; CI enforces that via
+`.github/workflows/verify-manifests-in-sync.yaml`.
+
+Helm-rendered **cert-manager** and **trust-manager** manifests under
+`dependencies/` (and extracted envtest CRDs) must match the chart versions in
+`.github/scripts/export-third-party-chart-env.sh`, which MintMaker/Renovate
+updates alongside the scheduled update workflow.
+
+When **MintMaker** or **Renovate** opens a PR that only bumps digests or chart
+versions, a **companion PR** may be opened automatically
+(`.github/workflows/renovate-manifest-companion.yaml`) that includes the matching
+rendered output. **Prefer merging the companion PR** (or a single PR that
+includes both pins and regenerated files) so `main` never carries mismatched
+pins and manifests.
 
 ## Automated E2E Tests
 

--- a/operator/upstream-kustomizations/build-service/core/build-pipeline-config.yaml
+++ b/operator/upstream-kustomizations/build-service/core/build-pipeline-config.yaml
@@ -8,15 +8,15 @@ data:
     default-pipeline-name: docker-build-oci-ta-min
     pipelines:
     - name: fbc-builder
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-fbc-builder@sha256:9f69085c4eaaedf85595f068b23459263d84a586d18346933163974b64c60056
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-fbc-builder@sha256:02e88dffd4e79369261fc131a2b5f6b8e2de06da6c85fd88ddc845decabedc97
     - name: docker-build
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build@sha256:6063d9dc6c62d1833cf5f22e9b2a85629587431b9d642e9c02899b7dba74fd4f
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build@sha256:a6202e4fd1f04b7196d6b6ec5c58153f10a333be090ba5b653bf14beed495a87
     - name: docker-build-oci-ta
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta@sha256:8aaf1b0ee8895445866bfc2b11924b2bf3bd731d826168d14188c891656ab902
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta@sha256:32966794fb9f4c0bd00045bfe7aa6c7f0c6f87db90dc915c87e4723fa10fcc5e
     - name: tekton-bundle-builder
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder@sha256:4579fe14d9cbc3353db48e376503a3623e9211afc432a02a669529e811da9504
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder@sha256:ce7dd91414f74832630764f06291fd6c85bc87669fecaa86d2a7e7353bdb3999
     - name: tekton-bundle-builder-oci-ta
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder-oci-ta@sha256:5efe5a4cad5d48d5af02e7172f30e852ee538bbcd02f6229842f3dff3bf6c650
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder-oci-ta@sha256:1fc35a293443fb288bc8c5c403dfc00bdf01019a0644ab41cf4d1a1ed24d7f80
     - name: docker-build-oci-ta-min
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta-min@sha256:1c1e3054056d41e0405f200466a2a6c193580ac5670781ceeaa39ae8dee74935
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta-min@sha256:a30a7d7df6fe9c702854c23ea0ace4b8ac6b3be736a96d8d014dea79f2fc36c5
       description: minimal version of the docker-build-oci-ta pipeline, which requires less compute resources. In addition, it doesn't contain tasks which require user provided secrets.

--- a/operator/upstream-kustomizations/build-service/core/kustomization.yaml
+++ b/operator/upstream-kustomizations/build-service/core/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/konflux-ci/build-service/config/default?ref=e7edaf5412f4c614185277f3afc7d7bd0f63fa92
+  - https://github.com/konflux-ci/build-service/config/default?ref=211140a26c96e8f028a0595fb779ea13210ed5c8
   - build-pipeline-config.yaml
   - build-config-rolebinding.yaml
   - appstudio-pipelines-runner.yaml
@@ -13,7 +13,7 @@ namespace: build-service
 images:
   - name: quay.io/konflux-ci/build-service
     newName: quay.io/konflux-ci/build-service
-    newTag: e7edaf5412f4c614185277f3afc7d7bd0f63fa92
+    newTag: 211140a26c96e8f028a0595fb779ea13210ed5c8
 
 patches:
   - target:

--- a/operator/upstream-kustomizations/cli/setup-release.sh
+++ b/operator/upstream-kustomizations/cli/setup-release.sh
@@ -84,7 +84,7 @@ PRODUCT_VERSION="0.1"
 CONFORMA_POLICY="default"
 RELEASE_NAME="local-release"
 # renovate: datasource=git-refs depName=https://github.com/konflux-ci/release-service-catalog currentValue=development
-CATALOG_REVISION="19d04c4ac787256f5a335257ffba1730acaa44c6"
+CATALOG_REVISION="afd702735b986e357feaf241ceb3d9cda5686fd0"
 IMAGE_NAME_PREFIX=""
 COMPONENTS=()
 

--- a/operator/upstream-kustomizations/integration/core/kustomization.yaml
+++ b/operator/upstream-kustomizations/integration/core/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/integration-service/config/default?ref=97f400b4cec8611d5bc0c5a79938dba08507c165
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=97f400b4cec8611d5bc0c5a79938dba08507c165
+- https://github.com/konflux-ci/integration-service/config/default?ref=ef2610ecd344292fb85e01321f7b613c7e621ec5
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=ef2610ecd344292fb85e01321f7b613c7e621ec5
 - konflux-integration-runner.yaml
 - kyverno-background-controller-binding.yaml
 - bootstrap-namespace.yaml
@@ -12,7 +12,7 @@ namespace: integration-service
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: 97f400b4cec8611d5bc0c5a79938dba08507c165
+  newTag: ef2610ecd344292fb85e01321f7b613c7e621ec5
 
 patches:
   - target:


### PR DESCRIPTION
Verify in CI that upstream and third-party rendered manifests are in
sync with upstream pointers.

To allow this to pass, realign the upstream manifests to the current
rendered artifacts.

Closes: #6759