### PR TITLE
chore(ci): run manifest updater workflows weekly

### DIFF
--- a/.github/workflows/update-third-party-manifests.yaml
+++ b/.github/workflows/update-third-party-manifests.yaml
@@ -5,8 +5,9 @@
 name: Update Third-Party Manifests
 
 on:
+  # Weekly (Mondays 03:00 UTC); Renovate/MintMaker cover day-to-day updates.
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '0 3 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update-upstream-manifests.yaml
+++ b/.github/workflows/update-upstream-manifests.yaml
@@ -1,9 +1,9 @@
 name: Update Upstream Manifests
 
 on:
-  # Run on a schedule (daily at 2 AM UTC)
+  # Weekly (Mondays 02:00 UTC); Renovate companion PRs cover day-to-day updates.
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 2 * * 1'
   # Allow manual triggering
   workflow_dispatch:
 

--- a/skills/update-upstream-deps/SKILL.md
+++ b/skills/update-upstream-deps/SKILL.md
@@ -26,9 +26,9 @@ Other components (cli, ui, registry, namespace-lister, etc.) have local-only con
 
 ## Update Methods
 
-### Automated (daily)
+### Automated (weekly)
 
-`.github/workflows/update-upstream-manifests.yaml` runs at 2:00 UTC.
+`.github/workflows/update-upstream-manifests.yaml` runs weekly on Mondays at 02:00 UTC; use `workflow_dispatch` for an on-demand run.
 
 Renovate also proposes ref/tag bumps via `renovate.json`.
 


### PR DESCRIPTION
Reduce scheduled frequency of update-upstream-manifests and update-third-party-manifests from daily to weekly (Mondays UTC), per #6824. Renovate and companion PRs remain the primary update path; workflows stay as a periodic safety net. workflow_dispatch unchanged.

Assisted-by: Cursor

Closes: #6824