### PR TITLE
feat(customization): add WithRunAsUser container option

### DIFF
--- a/operator/pkg/customization/container.go
+++ b/operator/pkg/customization/container.go
@@ -108,6 +108,20 @@ func WithSecurityContext(sc *corev1.SecurityContext) ContainerOption {
 	}
 }
 
+// WithRunAsUser sets securityContext.runAsUser on the container, initializing
+// the SecurityContext if needed. Uses strategic merge so other SecurityContext
+// fields (e.g. runAsNonRoot, readOnlyRootFilesystem) from the base manifest
+// are preserved.
+func WithRunAsUser(uid int64) ContainerOption {
+	return func(c *corev1.Container, _ DeploymentContext) {
+		if c.SecurityContext == nil {
+			c.SecurityContext = &corev1.SecurityContext{}
+		}
+		u := uid
+		c.SecurityContext.RunAsUser = &u
+	}
+}
+
 // WithImage sets the container image.
 func WithImage(image string) ContainerOption {
 	return func(c *corev1.Container, _ DeploymentContext) {

--- a/operator/pkg/customization/container_test.go
+++ b/operator/pkg/customization/container_test.go
@@ -363,6 +363,28 @@ func TestWithVolumeMounts(t *testing.T) {
 	})
 }
 
+func TestWithRunAsUser(t *testing.T) {
+	ctx := DeploymentContext{Replicas: 1}
+
+	t.Run("sets runAsUser on nil security context", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		c := NewContainerOverlay(ctx, WithRunAsUser(1001))
+		g.Expect(c.SecurityContext).NotTo(gomega.BeNil())
+		g.Expect(*c.SecurityContext.RunAsUser).To(gomega.Equal(int64(1001)))
+	})
+
+	t.Run("preserves existing security context fields", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		runAsNonRoot := true
+		c := NewContainerOverlay(ctx,
+			WithSecurityContext(&corev1.SecurityContext{RunAsNonRoot: &runAsNonRoot}),
+			WithRunAsUser(1001),
+		)
+		g.Expect(*c.SecurityContext.RunAsUser).To(gomega.Equal(int64(1001)))
+		g.Expect(*c.SecurityContext.RunAsNonRoot).To(gomega.BeTrue())
+	})
+}
+
 func TestWithSecurityContext(t *testing.T) {
 	ctx := DeploymentContext{Replicas: 1}
 


### PR DESCRIPTION
## Summary

- Add `WithRunAsUser(uid int64) ContainerOption` to the customization package
- Ensures SecurityContext exists and sets runAsUser while preserving other fields
- Needed for non-OpenShift clusters where the Caddy image requires an explicit numeric UID

## Test plan

- [x] Unit tests added (`TestWithRunAsUser`)
- [ ] CI passes
