### PR TITLE
feat(KFLUXVNGD-981): add logEncoder CRD field for zap log encoding

### DIFF
--- a/operator/api/v1alpha1/konfluxbuildservice_types.go
+++ b/operator/api/v1alpha1/konfluxbuildservice_types.go
@@ -29,6 +29,14 @@ type KonfluxBuildServiceSpec struct {
 	// +optional
 	BuildControllerManager *ControllerManagerDeploymentSpec `json:"buildControllerManager,omitempty"`
 
+	// LogEncoder sets the log encoding format for the build-service controller.
+	// "json" produces structured JSON logs (upstream default), "console" produces
+	// human-readable output useful for development and debugging.
+	// When not set, the upstream default (json) is used.
+	// +optional
+	// +kubebuilder:validation:Enum=json;console
+	LogEncoder string `json:"logEncoder,omitempty"`
+
 	// WebhookURLs maps repository URL prefixes to externally-reachable webhook URLs.
 	// When configured, the build-service uses these URLs instead of the default PaC webhook
 	// URL when setting up webhooks for git repositories.

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxbuildservices.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxbuildservices.yaml
@@ -275,6 +275,16 @@ spec:
                     minimum: 1
                     type: integer
                 type: object
+              logEncoder:
+                description: |-
+                  LogEncoder sets the log encoding format for the build-service controller.
+                  "json" produces structured JSON logs (upstream default), "console" produces
+                  human-readable output useful for development and debugging.
+                  When not set, the upstream default (json) is used.
+                enum:
+                - json
+                - console
+                type: string
               pipelineConfig:
                 description: |-
                   PipelineConfig controls the contents of the build-pipeline-config ConfigMap.

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
@@ -300,6 +300,16 @@ spec:
                             minimum: 1
                             type: integer
                         type: object
+                      logEncoder:
+                        description: |-
+                          LogEncoder sets the log encoding format for the build-service controller.
+                          "json" produces structured JSON logs (upstream default), "console" produces
+                          human-readable output useful for development and debugging.
+                          When not set, the upstream default (json) is used.
+                        enum:
+                        - json
+                        - console
+                        type: string
                       pipelineConfig:
                         description: |-
                           PipelineConfig controls the contents of the build-pipeline-config ConfigMap.

--- a/operator/config/samples/konflux_v1alpha1_konfluxbuildservice.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konfluxbuildservice.yaml
@@ -18,6 +18,10 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: konflux-build-service
 spec:
+  # logEncoder: console  # Use human-readable logs (default: json)
+  # webhookURLs:  # Map repository URL prefixes to external webhook URLs (e.g. Smee proxies)
+  #   https://github.com: "https://smee.example.com/github-hook"
+  #   https://gitlab.com: "https://smee.example.com/gitlab-hook"
   # pipelineConfig:
   #   # removeDefaults: true  # Discard all operator-provided default pipelines
   #   pipelines:

--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
@@ -67,6 +67,9 @@ const (
 	pacWebhookURLEnvName      = "PAC_WEBHOOK_URL"
 	pacWebhookURLNonOpenShift = "http://pipelines-as-code-controller.pipelines-as-code.svc.cluster.local:8180"
 
+	// zapEncoderArg is the CLI flag that controls log encoding format.
+	zapEncoderArg = "--zap-encoder"
+
 	// Webhook config constants for the optional per-provider webhook URL mapping.
 	// The volume, mount, and arg are baked into the manifest with optional: true.
 	// The operator only needs to create the ConfigMap and update the volume reference.
@@ -276,6 +279,10 @@ func buildBuildControllerManagerOverlay(spec konfluxv1alpha1.KonfluxBuildService
 	// The volume, mount, and arg are already in the manifest with optional: true.
 	if webhookConfigMapName != "" {
 		podOpts = append(podOpts, customization.WithConfigMapVolumeUpdate(webhookConfigVolName, webhookConfigMapName))
+	}
+
+	if spec.LogEncoder != "" {
+		containerOpts = append(containerOpts, customization.WithArgs(zapEncoderArg+"="+spec.LogEncoder))
 	}
 
 	if spec.BuildControllerManager == nil {

--- a/operator/internal/controller/buildservice/konfluxbuildservice_customization_test.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_customization_test.go
@@ -141,6 +141,96 @@ func TestBuildBuildControllerManagerOverlay(t *testing.T) {
 		g.Expect(managerContainer).NotTo(gomega.BeNil())
 		g.Expect(managerContainer.Image).To(gomega.Equal(originalImage))
 	})
+
+	t.Run("logEncoder=console appends zap-encoder arg", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			LogEncoder: "console",
+		}
+
+		deployment := getBuildServiceDeployment(t)
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		baseArgCount := len(managerContainer.Args)
+
+		overlay := buildBuildControllerManagerOverlay(spec, nil, "")
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer = testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(managerContainer.Args).To(gomega.HaveLen(baseArgCount + 1))
+		g.Expect(managerContainer.Args).To(gomega.ContainElement("--zap-encoder=console"))
+	})
+
+	t.Run("logEncoder=json appends zap-encoder arg", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			LogEncoder: "json",
+		}
+
+		deployment := getBuildServiceDeployment(t)
+		overlay := buildBuildControllerManagerOverlay(spec, nil, "")
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(managerContainer.Args).To(gomega.ContainElement("--zap-encoder=json"))
+	})
+
+	t.Run("empty logEncoder does not add zap-encoder arg", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{}
+
+		deployment := getBuildServiceDeployment(t)
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		baseArgs := make([]string, len(managerContainer.Args))
+		copy(baseArgs, managerContainer.Args)
+
+		overlay := buildBuildControllerManagerOverlay(spec, nil, "")
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer = testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(managerContainer.Args).To(gomega.Equal(baseArgs))
+	})
+
+	t.Run("logEncoder with buildControllerManager preserves base args and adds zap-encoder", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			LogEncoder: "console",
+			BuildControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Manager: &konfluxv1alpha1.ContainerSpec{
+					Resources: &corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("500m"),
+						},
+					},
+				},
+			},
+		}
+
+		deployment := getBuildServiceDeployment(t)
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		baseArgs := make([]string, len(managerContainer.Args))
+		copy(baseArgs, managerContainer.Args)
+
+		overlay := buildBuildControllerManagerOverlay(spec, nil, "")
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer = testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		for _, arg := range baseArgs {
+			g.Expect(managerContainer.Args).To(gomega.ContainElement(arg))
+		}
+		g.Expect(managerContainer.Args).To(gomega.ContainElement("--zap-encoder=console"))
+		g.Expect(managerContainer.Resources.Limits.Cpu().String()).To(gomega.Equal("500m"))
+	})
 }
 
 func TestApplyBuildServiceDeploymentCustomizations(t *testing.T) {


### PR DESCRIPTION
Bridge the `--zap-encoder` configuration gap between `infra-deployments`
and the operator. The development environment uses --zap-encoder=console
for human-readable logs, but there was no way to set this through the CRD.

Add a logEncoder field to KonfluxBuildServiceSpec with enum validation
(json, console). When set, the controller appends --zap-encoder=<value>
to the build-service manager container args via WithArgs.

Validated on a local Kind cluster against infra-deployments manifests for
development, staging, and all 8 production clusters.

NOTE:
This PR is based on https://github.com/konflux-ci/konflux-ci/pull/6866 and should be rebased once it will merged

Assisted-by: Cursor
