### PR TITLE
feat(KFLUXVNGD-966): add pacWebhookInsecureSSL CRD field to disable TLS verification

### DIFF
--- a/operator/api/v1alpha1/konfluxbuildservice_types.go
+++ b/operator/api/v1alpha1/konfluxbuildservice_types.go
@@ -29,6 +29,17 @@ type KonfluxBuildServiceSpec struct {
 	// +optional
 	BuildControllerManager *ControllerManagerDeploymentSpec `json:"buildControllerManager,omitempty"`
 
+	// PACWebhookInsecureSSL controls TLS certificate verification when the build-service
+	// configures webhooks on git providers.
+	// When set to true, sets PAC_WEBHOOK_INSECURE_SSL=1 on the controller
+	// (use only in development or test environments with self-signed certificates).
+	// When set to false, forces PAC_WEBHOOK_INSECURE_SSL off, overriding any
+	// value in buildControllerManager.manager.env.
+	// When omitted, the upstream default applies and PAC_WEBHOOK_INSECURE_SSL
+	// in buildControllerManager.manager.env (if set) takes effect.
+	// +optional
+	PACWebhookInsecureSSL *bool `json:"pacWebhookInsecureSSL,omitempty"`
+
 	// LogEncoder sets the log encoding format for the build-service controller.
 	// "json" produces structured JSON logs (upstream default), "console" produces
 	// human-readable output useful for development and debugging.

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -665,6 +665,11 @@ func (in *KonfluxBuildServiceSpec) DeepCopyInto(out *KonfluxBuildServiceSpec) {
 		*out = new(ControllerManagerDeploymentSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PACWebhookInsecureSSL != nil {
+		in, out := &in.PACWebhookInsecureSSL, &out.PACWebhookInsecureSSL
+		*out = new(bool)
+		**out = **in
+	}
 	if in.WebhookURLs != nil {
 		in, out := &in.WebhookURLs, &out.WebhookURLs
 		*out = make(map[string]string, len(*in))

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxbuildservices.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxbuildservices.yaml
@@ -285,6 +285,17 @@ spec:
                 - json
                 - console
                 type: string
+              pacWebhookInsecureSSL:
+                description: |-
+                  PACWebhookInsecureSSL controls TLS certificate verification when the build-service
+                  configures webhooks on git providers.
+                  When set to true, sets PAC_WEBHOOK_INSECURE_SSL=1 on the controller
+                  (use only in development or test environments with self-signed certificates).
+                  When set to false, forces PAC_WEBHOOK_INSECURE_SSL off, overriding any
+                  value in buildControllerManager.manager.env.
+                  When omitted, the upstream default applies and PAC_WEBHOOK_INSECURE_SSL
+                  in buildControllerManager.manager.env (if set) takes effect.
+                type: boolean
               pipelineConfig:
                 description: |-
                   PipelineConfig controls the contents of the build-pipeline-config ConfigMap.

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
@@ -310,6 +310,17 @@ spec:
                         - json
                         - console
                         type: string
+                      pacWebhookInsecureSSL:
+                        description: |-
+                          PACWebhookInsecureSSL controls TLS certificate verification when the build-service
+                          configures webhooks on git providers.
+                          When set to true, sets PAC_WEBHOOK_INSECURE_SSL=1 on the controller
+                          (use only in development or test environments with self-signed certificates).
+                          When set to false, forces PAC_WEBHOOK_INSECURE_SSL off, overriding any
+                          value in buildControllerManager.manager.env.
+                          When omitted, the upstream default applies and PAC_WEBHOOK_INSECURE_SSL
+                          in buildControllerManager.manager.env (if set) takes effect.
+                        type: boolean
                       pipelineConfig:
                         description: |-
                           PipelineConfig controls the contents of the build-pipeline-config ConfigMap.

--- a/operator/config/samples/konflux-e2e.yaml
+++ b/operator/config/samples/konflux-e2e.yaml
@@ -87,14 +87,12 @@ spec:
               memory: 256Mi
   buildService:
     spec:
+      # Skip TLS verification for PaC webhook URLs — the e2e environment
+      # exposes Pipelines-as-Code via a route with a self-signed certificate.
+      pacWebhookInsecureSSL: true
       buildControllerManager:
         replicas: 1
         manager:
-          # Skip TLS verification for PaC webhook URLs — the OpenShift e2e
-          # environment exposes Pipelines-as-Code via a route with a self-signed certificate.
-          env:
-            - name: PAC_WEBHOOK_INSECURE_SSL
-              value: "1"
           resources:
             requests:
               cpu: 30m

--- a/operator/config/samples/konflux_v1alpha1_konfluxbuildservice.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konfluxbuildservice.yaml
@@ -18,6 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: konflux-build-service
 spec:
+  # pacWebhookInsecureSSL: true  # Skip TLS verification for webhooks (dev/test only)
   # logEncoder: console  # Use human-readable logs (default: json)
   # webhookURLs:  # Map repository URL prefixes to external webhook URLs (e.g. Smee proxies)
   #   https://github.com: "https://smee.example.com/github-hook"

--- a/operator/docs/content/docs/guides/webhook-url-configuration.md
+++ b/operator/docs/content/docs/guides/webhook-url-configuration.md
@@ -140,18 +140,13 @@ The webhook endpoint may use a self-signed certificate, which is common in test
 or development environments. When the build-service configures webhooks on the
 git provider, TLS verification will fail against such certificates.
 
-To skip TLS verification, set the `PAC_WEBHOOK_INSECURE_SSL` environment
-variable:
+To skip TLS verification, set `pacWebhookInsecureSSL` to `true`:
 
 ```yaml
 spec:
   buildService:
     spec:
-      buildControllerManager:
-        manager:
-          env:
-            - name: PAC_WEBHOOK_INSECURE_SSL
-              value: "1"
+      pacWebhookInsecureSSL: true
 ```
 
 > **Warning:** Only use this in test or development environments. Production

--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
@@ -260,7 +260,8 @@ func applyBuildServiceDeploymentCustomizations(deployment *appsv1.Deployment, sp
 // On OpenShift, PAC_WEBHOOK_URL is never set — the build-service auto-discovers the PaC Route.
 // When webhookConfigMapName is non-empty, the webhook-config volume (baked into the manifest
 // with optional: true) is updated to reference the hashed ConfigMap.
-// User-provided env vars from the CR spec always take precedence.
+// Typed CRD fields (e.g. pacWebhookInsecureSSL) take precedence over
+// user-provided env vars in buildControllerManager.manager.env.
 func buildBuildControllerManagerOverlay(spec konfluxv1alpha1.KonfluxBuildServiceSpec, clusterInfo *clusterinfo.Info, webhookConfigMapName string) *customization.PodOverlay {
 	var containerOpts []customization.ContainerOption
 	var podOpts []customization.PodOverlayOption
@@ -285,20 +286,28 @@ func buildBuildControllerManagerOverlay(spec konfluxv1alpha1.KonfluxBuildService
 		containerOpts = append(containerOpts, customization.WithArgs(zapEncoderArg+"="+spec.LogEncoder))
 	}
 
-	if spec.BuildControllerManager == nil {
-		podOpts = append(podOpts,
-			customization.WithContainerOpts(buildManagerContainerName, customization.DeploymentContext{}, containerOpts...),
-		)
-		return customization.NewPodOverlay(podOpts...)
+	var deployCtx customization.DeploymentContext
+	var managerSpec *konfluxv1alpha1.ContainerSpec
+	if spec.BuildControllerManager != nil {
+		managerSpec = spec.BuildControllerManager.Manager
+		deployCtx = customization.DeploymentContext{Replicas: spec.BuildControllerManager.Replicas}
 	}
 
 	containerOpts = append(containerOpts,
-		customization.FromContainerSpec(spec.BuildControllerManager.Manager),
+		customization.FromContainerSpec(managerSpec),
 		customization.WithLeaderElection(),
 	)
 
+	if spec.PACWebhookInsecureSSL != nil {
+		if *spec.PACWebhookInsecureSSL {
+			containerOpts = append(containerOpts, customization.WithEnvOverride("PAC_WEBHOOK_INSECURE_SSL", "1"))
+		} else {
+			containerOpts = append(containerOpts, customization.WithoutEnv("PAC_WEBHOOK_INSECURE_SSL"))
+		}
+	}
+
 	podOpts = append(podOpts,
-		customization.WithContainerBuilder(buildManagerContainerName, containerOpts...)(customization.DeploymentContext{Replicas: spec.BuildControllerManager.Replicas}),
+		customization.WithContainerOpts(buildManagerContainerName, deployCtx, containerOpts...),
 	)
 	return customization.NewPodOverlay(podOpts...)
 }

--- a/operator/internal/controller/buildservice/konfluxbuildservice_customization_test.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_customization_test.go
@@ -60,19 +60,23 @@ func getBuildServiceDeployment(t *testing.T) *appsv1.Deployment {
 	return nil
 }
 
-// findPaCWebhookURLEnvValue returns the last PAC_WEBHOOK_URL env var value.
-// Returns the value and whether the env var was found. Checks the last match
-// to match Kubernetes behavior where later env entries override earlier ones.
-func findPaCWebhookURLEnvValue(envs []corev1.EnvVar) (string, bool) {
+// findEnvValue returns the last value of the named env var.
+// Checks the last match to match Kubernetes behavior where later entries override earlier ones.
+func findEnvValue(envs []corev1.EnvVar, name string) (string, bool) {
 	var value string
 	var found bool
 	for _, env := range envs {
-		if env.Name == pacWebhookURLEnvName {
+		if env.Name == name {
 			value = env.Value
 			found = true
 		}
 	}
 	return value, found
+}
+
+// findPaCWebhookURLEnvValue returns the last PAC_WEBHOOK_URL env var value.
+func findPaCWebhookURLEnvValue(envs []corev1.EnvVar) (string, bool) {
+	return findEnvValue(envs, pacWebhookURLEnvName)
 }
 
 func TestBuildBuildControllerManagerOverlay(t *testing.T) {
@@ -230,6 +234,159 @@ func TestBuildBuildControllerManagerOverlay(t *testing.T) {
 		}
 		g.Expect(managerContainer.Args).To(gomega.ContainElement("--zap-encoder=console"))
 		g.Expect(managerContainer.Resources.Limits.Cpu().String()).To(gomega.Equal("500m"))
+	})
+
+	t.Run("pacWebhookInsecureSSL=true injects PAC_WEBHOOK_INSECURE_SSL env", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			PACWebhookInsecureSSL: boolPtr(true),
+		}
+
+		deployment := getBuildServiceDeployment(t)
+		overlay := buildBuildControllerManagerOverlay(spec, nil, "")
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		val, found := findEnvValue(managerContainer.Env, "PAC_WEBHOOK_INSECURE_SSL")
+		g.Expect(found).To(gomega.BeTrue())
+		g.Expect(val).To(gomega.Equal("1"))
+	})
+
+	t.Run("pacWebhookInsecureSSL omitted does not inject PAC_WEBHOOK_INSECURE_SSL env", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{}
+
+		deployment := getBuildServiceDeployment(t)
+		overlay := buildBuildControllerManagerOverlay(spec, nil, "")
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		_, found := findEnvValue(managerContainer.Env, "PAC_WEBHOOK_INSECURE_SSL")
+		g.Expect(found).To(gomega.BeFalse())
+	})
+
+	t.Run("pacWebhookInsecureSSL=false removes PAC_WEBHOOK_INSECURE_SSL env", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			PACWebhookInsecureSSL: boolPtr(false),
+		}
+
+		deployment := getBuildServiceDeployment(t)
+		overlay := buildBuildControllerManagerOverlay(spec, nil, "")
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		_, found := findEnvValue(managerContainer.Env, "PAC_WEBHOOK_INSECURE_SSL")
+		g.Expect(found).To(gomega.BeFalse(), "explicit false should remove the env var entirely")
+	})
+
+	t.Run("pacWebhookInsecureSSL with logEncoder and resources", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			PACWebhookInsecureSSL: boolPtr(true),
+			LogEncoder:            "console",
+			BuildControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Manager: &konfluxv1alpha1.ContainerSpec{
+					Resources: &corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("500m"),
+						},
+					},
+				},
+			},
+		}
+
+		deployment := getBuildServiceDeployment(t)
+		overlay := buildBuildControllerManagerOverlay(spec, nil, "")
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		val, found := findEnvValue(managerContainer.Env, "PAC_WEBHOOK_INSECURE_SSL")
+		g.Expect(found).To(gomega.BeTrue())
+		g.Expect(val).To(gomega.Equal("1"))
+		g.Expect(managerContainer.Args).To(gomega.ContainElement("--zap-encoder=console"))
+		g.Expect(managerContainer.Resources.Limits.Cpu().String()).To(gomega.Equal("500m"))
+	})
+
+	t.Run("pacWebhookInsecureSSL=true takes precedence over manager.env", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			PACWebhookInsecureSSL: boolPtr(true),
+			BuildControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Manager: &konfluxv1alpha1.ContainerSpec{
+					Env: []corev1.EnvVar{
+						{Name: "PAC_WEBHOOK_INSECURE_SSL", Value: "0"},
+					},
+				},
+			},
+		}
+
+		deployment := getBuildServiceDeployment(t)
+		overlay := buildBuildControllerManagerOverlay(spec, nil, "")
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		val, found := findEnvValue(managerContainer.Env, "PAC_WEBHOOK_INSECURE_SSL")
+		g.Expect(found).To(gomega.BeTrue())
+		g.Expect(val).To(gomega.Equal("1"), "typed CRD field should take precedence over manager.env")
+	})
+
+	t.Run("pacWebhookInsecureSSL=false takes precedence over manager.env", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			PACWebhookInsecureSSL: boolPtr(false),
+			BuildControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Manager: &konfluxv1alpha1.ContainerSpec{
+					Env: []corev1.EnvVar{
+						{Name: "PAC_WEBHOOK_INSECURE_SSL", Value: "1"},
+					},
+				},
+			},
+		}
+
+		deployment := getBuildServiceDeployment(t)
+		overlay := buildBuildControllerManagerOverlay(spec, nil, "")
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		_, found := findEnvValue(managerContainer.Env, "PAC_WEBHOOK_INSECURE_SSL")
+		g.Expect(found).To(gomega.BeFalse(), "explicit false should remove env var even if set in manager.env")
+	})
+
+	t.Run("pacWebhookInsecureSSL omitted lets manager.env pass through", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			BuildControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Manager: &konfluxv1alpha1.ContainerSpec{
+					Env: []corev1.EnvVar{
+						{Name: "PAC_WEBHOOK_INSECURE_SSL", Value: "1"},
+					},
+				},
+			},
+		}
+
+		deployment := getBuildServiceDeployment(t)
+		overlay := buildBuildControllerManagerOverlay(spec, nil, "")
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		val, found := findEnvValue(managerContainer.Env, "PAC_WEBHOOK_INSECURE_SSL")
+		g.Expect(found).To(gomega.BeTrue())
+		g.Expect(val).To(gomega.Equal("1"), "env var should pass through when typed field is omitted")
 	})
 }
 
@@ -794,3 +951,5 @@ func TestApplyBuildServiceDeploymentCustomizations_ResourceMerging(t *testing.T)
 		g.Expect(managerContainer.Resources.Requests.Cpu().String()).To(gomega.Equal("100m"))
 	})
 }
+
+func boolPtr(b bool) *bool { return &b }

--- a/operator/pkg/customization/container.go
+++ b/operator/pkg/customization/container.go
@@ -87,6 +87,20 @@ func WithEnvOverride(name, value string) ContainerOption {
 	}
 }
 
+// WithoutEnv removes an environment variable by name.
+// If the variable does not exist, this is a no-op.
+func WithoutEnv(name string) ContainerOption {
+	return func(c *corev1.Container, _ DeploymentContext) {
+		filtered := make([]corev1.EnvVar, 0, len(c.Env))
+		for _, env := range c.Env {
+			if env.Name != name {
+				filtered = append(filtered, env)
+			}
+		}
+		c.Env = filtered
+	}
+}
+
 // WithResources sets resource requirements for the container.
 func WithResources(resources corev1.ResourceRequirements) ContainerOption {
 	return func(c *corev1.Container, _ DeploymentContext) {

--- a/operator/pkg/customization/container_test.go
+++ b/operator/pkg/customization/container_test.go
@@ -276,6 +276,37 @@ func TestWithEnvOverride(t *testing.T) {
 	})
 }
 
+func TestWithoutEnv(t *testing.T) {
+	ctx := DeploymentContext{Replicas: 1}
+
+	t.Run("removes existing variable", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		c := NewContainerOverlay(ctx,
+			WithEnv(corev1.EnvVar{Name: "KEEP", Value: "a"}),
+			WithEnv(corev1.EnvVar{Name: "REMOVE", Value: "b"}),
+			WithoutEnv("REMOVE"),
+		)
+		g.Expect(c.Env).To(gomega.HaveLen(1))
+		g.Expect(c.Env[0].Name).To(gomega.Equal("KEEP"))
+	})
+
+	t.Run("no-op when variable does not exist", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		c := NewContainerOverlay(ctx,
+			WithEnv(corev1.EnvVar{Name: "KEEP", Value: "a"}),
+			WithoutEnv("NONEXISTENT"),
+		)
+		g.Expect(c.Env).To(gomega.HaveLen(1))
+		g.Expect(c.Env[0].Name).To(gomega.Equal("KEEP"))
+	})
+
+	t.Run("no-op on empty env list", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		c := NewContainerOverlay(ctx, WithoutEnv("VAR1"))
+		g.Expect(c.Env).To(gomega.BeEmpty())
+	})
+}
+
 func TestWithOptionalEnvOverride(t *testing.T) {
 	ctx := DeploymentContext{Replicas: 1}
 


### PR DESCRIPTION
Add a typed *bool field to KonfluxBuildServiceSpec that controls the
PAC_WEBHOOK_INSECURE_SSL environment variable with three-state semantics:

- true: injects PAC_WEBHOOK_INSECURE_SSL=1, overrides manager.env
- false: removes PAC_WEBHOOK_INSECURE_SSL, overrides manager.env
- omitted (nil): defers to upstream default or manager.env value

Using *bool instead of bool lets the operator distinguish "explicitly false"
from "not set", so the typed field always takes precedence when the user expresses intent in either direction.

Refactored buildBuildControllerManagerOverlay to extract nullable fields upfront
and build a single linear option chain - no early return, no duplication.
Typed CRD fields are applied after FromContainerSpec so they always win over same-named entries in manager.env.

Added WithoutEnv container option to cleanly remove env vars (used for the explicit-false case), with unit tests.

Updated the e2e sample CR and webhook URL documentation to use the new field instead of the raw env var.

Assisted-by: Cursor