### PR TITLE
feat: provide konflux CR as input to tekton task

### DIFF
--- a/.tekton/pipelines/operator-e2e/README.md
+++ b/.tekton/pipelines/operator-e2e/README.md
@@ -21,6 +21,9 @@ The current conformance suite is written for that model: it exercises deployed s
 - `git-url` (default: `https://github.com/konflux-ci/konflux-ci.git`): repository URL used for clone + git-resolved local tasks.
 - `revision` (required): git ref from `git-url` to test.
 - `overrides-yaml` (default: empty): optional inline overrides consumed by deploy task.
+- `konflux-cr-configmap` (default: `konflux-deploy-cr`): optional ConfigMap in the PipelineRun namespace; when present, overrides the file from the clone.
+- `konflux-cr-configmap-key` (default: `konflux-cr.yaml`): data key holding the Konflux CR YAML.
+- `konflux-cr-relative-path` (default: `operator/config/samples/konflux-e2e.yaml`): CR path relative to the konflux-ci repo root when the ConfigMap is absent or the key is unset.
 - `konflux-ready-timeout` (default: `30m`): readiness timeout for Konflux CR.
 - `oci-container-repo` (required): OCI registry/repo prefix for kind-aws provision/deprovision artifacts (logs/state); no tag suffix—the pipeline appends `:$(context.pipelineRun.name)` for provision/deprovision. The deploy task also pushes **post-prep** `operator/pkg/manifests` to the **same repo** with tag `$(context.pipelineRun.name).pkg-manifests` so it does not replace the provision artifact.
 - `oci-container-repo-credentials-secret` (required): name of a Secret with registry credentials for `oci-container-repo` (kind-aws `oci-credentials`). This repo’s PAC PipelineRun uses `konflux-test-infra`.
@@ -31,6 +34,25 @@ The current conformance suite is written for that model: it exercises deployed s
 - `conformance-go-test-extra-args` (default: empty): optional space-separated extra flags appended to conformance `go test` after the fixed Ginkgo options (e.g. `-ginkgo.focus=Subsuite`), same idea as `./test/e2e/run-e2e.sh` forwarding `"$@"`.
 - `catalog-url` (default: `https://github.com/konflux-ci/tekton-integration-catalog.git`): integration catalog repository.
 - `catalog-revision` (default: pinned commit SHA): `tekton-integration-catalog` ref for catalog tasks; override to move to a different commit.
+
+### Examples: Konflux CR (ConfigMap vs sample file)
+
+**Precedence:** ConfigMap in the pipelineRun namespace → file at `konflux-cr-relative-path` in the konflux-ci clone. See `.tekton/tasks/deploy-konflux/README.md` for creating the ConfigMap.
+
+**Custom CR via ConfigMap** (typical for another repo’s PipelineRun—no CR YAML on the PipelineRun):
+
+```bash
+kubectl create configmap konflux-deploy-cr \
+  --from-file=konflux-cr.yaml=./my-konflux.yaml \
+  -n konflux-vanguard-tenant
+```
+
+**Sample CR from the konflux-ci clone** (no ConfigMap, or delete `konflux-deploy-cr` in the namespace):
+
+```yaml
+    - name: konflux-cr-relative-path
+      value: operator/config/samples/konflux_v1alpha1_konflux.yaml
+```
 
 ### Examples: `integration-go-test-extra-args` / `conformance-go-test-extra-args`
 
@@ -105,9 +127,15 @@ stringData:
   bucket: my-mapt-bucket
 ```
 
+## Verifying task or pipeline changes
+
+> **CI resolves `deploy-konflux` and `konflux-e2e-tests` Task YAML from `main`** in `pipeline.yaml` — tasks **`deploy-konflux-its`** and **`konflux-e2e-tests-its`** (`taskRef.params.revision: main`). Tekton cannot use PR/snapshot results in that resolver field.
+
+If you change this pipeline or `.tekton/tasks/deploy-konflux/` / `.tekton/tasks/konflux-e2e-tests/`, temporarily set **both** `revision` values to a **git ref that contains your change** (branch or commit SHA), run operator E2E to check for regressions, then **restore `main` before merge**.
+
 ## Resolution model
 
 - The pipeline itself is intended to be git-resolved by PipelineRun (`pipelineRef.resolver: git`) from `.tekton/pipelines/operator-e2e/pipeline.yaml`.
 - Catalog tasks are resolved via git resolver from `catalog-url`/`catalog-revision`.
-- Local tasks (`deploy-konflux`, `konflux-e2e-tests`) are resolved via git resolver from `git-url`/`revision`.
+- Local tasks (`deploy-konflux`, `konflux-e2e-tests`) are resolved via git resolver from `git-url`/`revision` on the PAC path; the ITS path uses `main` for task YAML (see above).
 - This allows external repos to reference this pipeline and pin which `konflux-ci` revision provides task logic.

--- a/.tekton/pipelines/operator-e2e/pipeline.yaml
+++ b/.tekton/pipelines/operator-e2e/pipeline.yaml
@@ -8,11 +8,13 @@
 # No Pipeline workspaces: deploy-konflux and konflux-e2e-tests clone konflux-ci into a Task emptyDir.
 #
 # Input modes:
-# - PAC / direct PipelineRun: leave SNAPSHOT empty; git-url, revision, overrides-yaml
-#   drive clone inside tasks, deploy resolver, and e2e.
+# - PAC / direct PipelineRun: leave SNAPSHOT empty; git-url, revision, overrides-yaml,
+#   konflux-cr-configmap / konflux-cr-relative-path drive deploy CR apply.
 # - IntegrationTestScenario: set SNAPSHOT (JSON); test-metadata supplies git-url and
 #   git-revision for clone inside tasks. Git taskRef for deploy/e2e Task YAML uses fixed
-#   konflux-ci + branch (Tekton does not substitute task results in remote Task resolver params).
+#   konflux-ci + main (Tekton does not substitute task results in remote Task resolver params).
+#   PR authors may temporarily set ITS taskRef revision to a branch/SHA for validation; revert
+#   to main before merge. See .tekton/pipelines/operator-e2e/README.md § Verifying task or pipeline changes.
 # - overrides-yaml examples:
 #   * PAC (from Pipelines as Code template values):
 #     ref: {{revision}}
@@ -72,6 +74,22 @@ spec:
       #     images:
       #       - orig: quay.io/konflux-ci/release-service
       #         replacement: $(tasks.test-metadata.results.container-image)
+    - name: konflux-cr-configmap
+      type: string
+      description: >-
+        Optional ConfigMap name in the PipelineRun namespace; when present, its key overrides
+        konflux-cr-relative-path. Missing ConfigMap is allowed (optional ref in deploy task).
+      default: konflux-deploy-cr
+    - name: konflux-cr-configmap-key
+      type: string
+      description: Data key in konflux-cr-configmap that holds the Konflux CR YAML.
+      default: konflux-cr.yaml
+    - name: konflux-cr-relative-path
+      type: string
+      description: >-
+        Path to Konflux CR YAML relative to the konflux-ci repository root when the ConfigMap is
+        absent or the key is unset.
+      default: operator/config/samples/konflux-e2e.yaml
     - name: konflux-ready-timeout
       type: string
       default: "30m"
@@ -203,6 +221,12 @@ spec:
           value: kfg-$(context.pipelineRun.name)
         - name: overrides-yaml
           value: $(params.overrides-yaml)
+        - name: konflux-cr-configmap
+          value: $(params.konflux-cr-configmap)
+        - name: konflux-cr-configmap-key
+          value: $(params.konflux-cr-configmap-key)
+        - name: konflux-cr-relative-path
+          value: $(params.konflux-cr-relative-path)
         - name: konflux-ready-timeout
           value: $(params.konflux-ready-timeout)
         - name: oci-container-repo
@@ -237,6 +261,12 @@ spec:
           value: kfg-$(context.pipelineRun.name)
         - name: overrides-yaml
           value: $(params.overrides-yaml)
+        - name: konflux-cr-configmap
+          value: $(params.konflux-cr-configmap)
+        - name: konflux-cr-configmap-key
+          value: $(params.konflux-cr-configmap-key)
+        - name: konflux-cr-relative-path
+          value: $(params.konflux-cr-relative-path)
         - name: konflux-ready-timeout
           value: $(params.konflux-ready-timeout)
         - name: oci-container-repo

--- a/.tekton/tasks/deploy-konflux/README.md
+++ b/.tekton/tasks/deploy-konflux/README.md
@@ -1,5 +1,7 @@
 # `deploy-konflux` Task
 
+> **Changing this Task?** CI resolves its YAML from **`main`** (`deploy-konflux-its` in [`pipeline.yaml`](../pipelines/operator-e2e/pipeline.yaml)). Temporarily point that `revision` at your branch/SHA to verify regressions, then restore **`main`** before merge. See [operator-e2e README](../pipelines/operator-e2e/README.md#verifying-task-or-pipeline-changes).
+
 Deploys Konflux on a provisioned cluster and waits for `konflux/konflux` to become `Ready`.
 
 ## Inputs (params)
@@ -8,7 +10,9 @@ Deploys Konflux on a provisioned cluster and waits for `konflux/konflux` to beco
 - `kubeconfig-secret-key` (default: `kubeconfig`): key inside the Secret that contains kubeconfig bytes.
 - `overrides-yaml` (default: empty): optional inline YAML consumed by `operator/cmd/overrides`.
 - `konflux-ready-timeout` (default: `30m`): timeout for waiting on Konflux Ready condition.
-- `konflux-cr-relative-path` (default: `operator/config/samples/konflux-e2e.yaml`): path to the Konflux CR YAML **relative to the repository root** of the clone (checkout is at `/mnt/konflux-ci/repo`).
+- `konflux-cr-configmap` (default: `konflux-deploy-cr`): optional ConfigMap in the Task namespace; when it exists and the key is set, its data takes precedence over `konflux-cr-relative-path` (see [Konflux CR inputs](#konflux-cr-inputs)).
+- `konflux-cr-configmap-key` (default: `konflux-cr.yaml`): data key in that ConfigMap.
+- `konflux-cr-relative-path` (default: `operator/config/samples/konflux-e2e.yaml`): path to Konflux CR YAML **relative to the repository root** of the clone when the ConfigMap is absent or the key is unset (checkout is at `/mnt/konflux-ci/repo`).
 - `kind-cluster-name` (default: `konflux-operator-e2e`): logical Kind cluster name passed to `deploy-local.sh`.
 
 ## Repository checkout (Task volumes)
@@ -37,6 +41,67 @@ No on-the-fly tool downloads; shared CLIs are copied from task-runner.
 ## Notes
 
 - This Task is Tekton `none`-mode oriented: it deploys dependencies, runs operator from source (`bin/manager`), applies Konflux CR, and waits for Ready.
+
+## Konflux CR inputs
+
+The Task loads the CR via Tekton [`env` + `configMapKeyRef`](https://tekton.dev/docs/pipelines/tasks/#using-env) on `stepTemplate` (`optional: true`). The CR YAML is **not** stored on the PipelineRun—only the ConfigMap name and key params (defaults below).
+
+### Precedence
+
+1. **ConfigMap** (`konflux-cr-configmap` / `konflux-cr-configmap-key`) in the **Task namespace**, when the object exists and the key is non-empty → written to `/mnt/e2e-shared/konflux-cr.yaml` and applied.
+2. **File in the clone** (`konflux-cr-relative-path` under the checked-out `git-url` / `revision`).
+
+If a ConfigMap with the configured name exists in the namespace, it **always wins** over the sample file path—even when testing a konflux-ci PR that only changes `konflux-cr-relative-path`. Remove or rename the ConfigMap to use the file from the clone.
+
+The document must be a complete `Konflux` resource (`kind: Konflux`, `metadata.name: konflux`). ConfigMaps are readable by anyone with `get configmap` in the namespace; do not put secrets in the CR (use normal cluster secrets for credentials).
+
+### Create the ConfigMap (before the PipelineRun)
+
+Defaults match the task params: name `konflux-deploy-cr`, data key `konflux-cr.yaml`.
+
+**From a file** (recommended — copy a sample and edit):
+
+```bash
+cp operator/config/samples/konflux-e2e.yaml /tmp/konflux-cr.yaml
+# edit /tmp/konflux-cr.yaml (e.g. webhookURLs — see webhook URL configuration guide)
+kubectl create configmap konflux-deploy-cr \
+  --from-file=konflux-cr.yaml=/tmp/konflux-cr.yaml \
+  -n <task-namespace>
+```
+
+**Manifest example** (structure only; complete the `spec` from [`konflux-e2e.yaml`](https://github.com/konflux-ci/konflux-ci/blob/main/operator/config/samples/konflux-e2e.yaml) or another sample):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: konflux-deploy-cr
+  namespace: <task-namespace>
+data:
+  konflux-cr.yaml: |
+    apiVersion: konflux.konflux-ci.dev/v1alpha1
+    kind: Konflux
+    metadata:
+      name: konflux
+    spec:
+      ui:
+        spec:
+          ingress:
+            nodePortService:
+              httpsPort: 30011
+      # ... remainder of spec (buildService, imageController, etc.)
+```
+
+Apply with `kubectl apply -f konflux-deploy-cr-configmap.yaml`.
+
+Override the name or key on the PipelineRun if needed:
+
+```yaml
+- name: konflux-cr-configmap
+  value: my-team-konflux-cr
+- name: konflux-cr-configmap-key
+  value: konflux-cr.yaml
+```
 
 ## `overrides-yaml` examples
 

--- a/.tekton/tasks/deploy-konflux/task.yaml
+++ b/.tekton/tasks/deploy-konflux/task.yaml
@@ -59,7 +59,21 @@ spec:
     - name: konflux-ready-timeout
       type: string
       default: "30m"
+    - name: konflux-cr-configmap
+      description: >-
+        Name of an optional ConfigMap in the Task namespace whose data key holds a Konflux CR
+        document. When the ConfigMap exists and the key is set, it takes precedence over
+        konflux-cr-relative-path. The reference is optional (missing ConfigMap uses the file path).
+      type: string
+      default: konflux-deploy-cr
+    - name: konflux-cr-configmap-key
+      description: Data key inside konflux-cr-configmap that contains the Konflux CR YAML.
+      type: string
+      default: konflux-cr.yaml
     - name: konflux-cr-relative-path
+      description: >-
+        Path to Konflux CR YAML relative to the repository root when the ConfigMap is absent or
+        the key is unset.
       type: string
       default: operator/config/samples/konflux-e2e.yaml
     - name: kind-cluster-name
@@ -87,6 +101,13 @@ spec:
         mountPath: /mnt/konflux-ci/repo
       - name: e2e-shared
         mountPath: /mnt/e2e-shared
+    env:
+      - name: E2E_KONFLUX_CR_YAML
+        valueFrom:
+          configMapKeyRef:
+            name: $(params.konflux-cr-configmap)
+            key: $(params.konflux-cr-configmap-key)
+            optional: true
   steps:
     - name: clone-repository
       image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
@@ -162,13 +183,14 @@ spec:
             secretKeyRef:
               name: konflux-operator-e2e-credentials
               key: SMEE_CHANNEL
+        - name: E2E_KONFLUX_CR_PATH
+          value: $(params.konflux-cr-relative-path)
       script: |
         #!/bin/bash
         set -euo pipefail
         cd /mnt/konflux-ci/repo
         exec env \
           E2E_OVERRIDES_YAML="$(params.overrides-yaml)" \
-          E2E_KONFLUX_CR="$(params.konflux-cr-relative-path)" \
           E2E_KIND_CLUSTER="$(params.kind-cluster-name)" \
           E2E_KONFLUX_READY_TIMEOUT="$(params.konflux-ready-timeout)" \
           bash scripts/operator-e2e/tekton-deploy-prep.sh /mnt/konflux-ci/repo
@@ -206,11 +228,13 @@ spec:
           memory: "8Gi"
       workingDir: /mnt/konflux-ci/repo
       image: registry.access.redhat.com/ubi10/go-toolset@sha256:0a1242b10a483946adcf3e35e18f5a19996869468f73deff2c5ce451ce0fa6bc
+      env:
+        - name: E2E_KONFLUX_CR_PATH
+          value: $(params.konflux-cr-relative-path)
       script: |
         #!/bin/bash
         set -euo pipefail
         cd /mnt/konflux-ci/repo
         exec env \
-          E2E_KONFLUX_CR="$(params.konflux-cr-relative-path)" \
           E2E_KONFLUX_READY_TIMEOUT="$(params.konflux-ready-timeout)" \
           bash scripts/operator-e2e/tekton-deploy-operator-and-wait.sh /mnt/konflux-ci/repo

--- a/.tekton/tasks/konflux-e2e-tests/README.md
+++ b/.tekton/tasks/konflux-e2e-tests/README.md
@@ -1,5 +1,7 @@
 # `konflux-e2e-tests` Task
 
+> **Changing this Task?** CI resolves its YAML from **`main`** (`konflux-e2e-tests-its` in [`pipeline.yaml`](../pipelines/operator-e2e/pipeline.yaml)). Temporarily point that `revision` at your branch/SHA to verify regressions, then restore **`main`** before merge. See [operator-e2e README](../pipelines/operator-e2e/README.md#verifying-task-or-pipeline-changes).
+
 Runs Konflux E2E test phases against an already deployed Konflux instance.
 
 ## Inputs (params)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ PRs trigger the following workflows:
 
 ## PR Guidelines
 
+- **`.tekton` task/pipeline edits:** `pipeline.yaml` tasks `deploy-konflux-its` and `konflux-e2e-tests-its` hardcode `taskRef.revision: main`. To verify changes, temporarily point both at the PR’s git ref, run operator E2E, then restore `main` before merge (see `.tekton/pipelines/operator-e2e/README.md`).
 - **Same-repo branches preferred**: E2E tests run automatically
 - **Fork PRs**: Require maintainer `/allow` comment to trigger tests
 - Run kube-linter before submitting

--- a/scripts/operator-e2e/README.md
+++ b/scripts/operator-e2e/README.md
@@ -41,6 +41,7 @@ Use **one token per flag** where possible (e.g. `-ginkgo.skip=Flaky`). Values wi
 | `run-conformance-tests.sh` | Runs conformance tests. Requires `GH_ORG`, `GH_TOKEN` (conformance clears `QUAY_TOKEN` for the test run). |
 | `tekton-fetch-kubeconfig.sh` | **Tekton:** decodes kubeconfig from Secret into `/mnt/e2e-shared/kubeconfig`. Args: `SECRET_NAME` `[KEY]`. Env: `POD_NAMESPACE`. |
 | `tekton-copy-shared-tools.sh` | **Tekton:** copies `kubectl`, `yq`, `jq` into `/mnt/e2e-shared/bin` and **`jq`’s shared libraries** (`libjq`, `libonig`) into `/mnt/e2e-shared/lib` for `ubi10/go-toolset` steps. |
+| `tekton-resolve-konflux-cr.sh` | **Tekton:** resolves optional ConfigMap env (`E2E_KONFLUX_CR_YAML`) or `E2E_KONFLUX_CR_PATH` to an absolute CR file path (stdout). |
 | `tekton-deploy-prep.sh` | **Tekton (go-toolset):** optional overrides via `operator/cmd/overrides`, then `deploy-local.sh` with `OPERATOR_INSTALL_METHOD=none`. |
 | `tekton-push-operator-pkg-manifests-oci.sh` | **Tekton (task-runner):** after prep, push `operator/pkg/manifests` to OCI as `${oci-container-repo}:${pipelineRun}.pkg-manifests` (skips if `E2E_OCI_CONTAINER_REPO` blank). |
 | `tekton-deploy-operator-and-wait.sh` | **Tekton (go-toolset):** `make install`/build, `bin/manager`, apply CR, wait Ready. |

--- a/scripts/operator-e2e/tekton-deploy-operator-and-wait.sh
+++ b/scripts/operator-e2e/tekton-deploy-operator-and-wait.sh
@@ -11,8 +11,10 @@ export LD_LIBRARY_PATH="/mnt/e2e-shared/lib:${LD_LIBRARY_PATH:-}"
 export KUBECONFIG="${KUBECONFIG:-/mnt/e2e-shared/kubeconfig}"
 kubectl config current-context
 
-: "${E2E_KONFLUX_CR:?}"
 : "${E2E_KONFLUX_READY_TIMEOUT:?}"
+
+E2E_KONFLUX_CR="$(bash "${REPO_ROOT}/scripts/operator-e2e/tekton-resolve-konflux-cr.sh" "${REPO_ROOT}")"
+export E2E_KONFLUX_CR
 
 OP_PID=""
 cleanup() {
@@ -39,7 +41,7 @@ echo "Starting bin/manager (logs: ${OPERATOR_LOG})..."
 OP_PID=$!
 sleep 5
 echo "Applying Konflux CR: ${E2E_KONFLUX_CR}"
-kubectl apply -f "${REPO_ROOT}/${E2E_KONFLUX_CR}"
+kubectl apply -f "${E2E_KONFLUX_CR}"
 echo "Waiting for Konflux to be Ready (timeout ${E2E_KONFLUX_READY_TIMEOUT})..."
 if ! kubectl wait --for=condition=Ready konflux konflux --timeout="${E2E_KONFLUX_READY_TIMEOUT}"; then
   echo "Konflux CR did not become Ready; operator log tail:" >&2

--- a/scripts/operator-e2e/tekton-deploy-prep.sh
+++ b/scripts/operator-e2e/tekton-deploy-prep.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 REPO_ROOT="$(cd "${1:?usage: $0 REPO_ROOT}" && pwd)"
 cd "${REPO_ROOT}"
 
-: "${E2E_KONFLUX_CR:?}"
 : "${E2E_KIND_CLUSTER:?}"
 : "${E2E_KONFLUX_READY_TIMEOUT:?}"
 
@@ -17,7 +16,8 @@ kubectl config current-context
 
 export DEPLOY_LOCAL_SKIP_KIND=1
 export KIND_CLUSTER="${E2E_KIND_CLUSTER}"
-export KONFLUX_CR="${E2E_KONFLUX_CR}"
+KONFLUX_CR="$(bash "${REPO_ROOT}/scripts/operator-e2e/tekton-resolve-konflux-cr.sh" "${REPO_ROOT}")"
+export KONFLUX_CR
 export KONFLUX_READY_TIMEOUT="${E2E_KONFLUX_READY_TIMEOUT}"
 export CONTAINER_TOOL=podman
 export OPERATOR_INSTALL_METHOD=none

--- a/scripts/operator-e2e/tekton-resolve-konflux-cr.sh
+++ b/scripts/operator-e2e/tekton-resolve-konflux-cr.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Resolve Konflux CR path for Tekton deploy-konflux (ConfigMap env or file in clone).
+#
+# Precedence:
+#   1. E2E_KONFLUX_CR_YAML (non-empty after stripping whitespace) from optional ConfigMap
+#      (task stepTemplate configMapKeyRef) -> write to E2E_SHARED_DIR/konflux-cr.yaml
+#   2. E2E_KONFLUX_CR_PATH relative to REPO_ROOT (or absolute path if already absolute)
+#
+# Usage:
+#   E2E_KONFLUX_CR=$(bash scripts/operator-e2e/tekton-resolve-konflux-cr.sh REPO_ROOT)
+#
+# Environment:
+#   E2E_KONFLUX_CR_YAML   - optional Konflux CR from ConfigMap (set by Tekton when CM exists)
+#   E2E_KONFLUX_CR_PATH   - path relative to REPO_ROOT when YAML env is unset/empty
+#   E2E_SHARED_DIR        - writable shared volume (default: /mnt/e2e-shared)
+set -euo pipefail
+
+REPO_ROOT="$(cd "${1:?usage: $0 REPO_ROOT}" && pwd)"
+E2E_KONFLUX_CR_YAML="${E2E_KONFLUX_CR_YAML:-}"
+E2E_KONFLUX_CR_PATH="${E2E_KONFLUX_CR_PATH:-operator/config/samples/konflux-e2e.yaml}"
+E2E_SHARED_DIR="${E2E_SHARED_DIR:-/mnt/e2e-shared}"
+
+if [[ -n "${E2E_KONFLUX_CR_YAML//[[:space:]]/}" ]]; then
+  mkdir -p "${E2E_SHARED_DIR}"
+  OUT="${E2E_SHARED_DIR}/konflux-cr.yaml"
+  printf '%s' "${E2E_KONFLUX_CR_YAML}" >"${OUT}"
+  echo "Using Konflux CR from ConfigMap (${OUT})" >&2
+  echo "${OUT}"
+  exit 0
+fi
+
+CR="${E2E_KONFLUX_CR_PATH}"
+if [[ "${CR}" != /* ]]; then
+  CR="${REPO_ROOT}/${CR}"
+fi
+
+if [[ ! -f "${CR}" ]]; then
+  echo "ERROR: Konflux CR file not found: ${CR}" >&2
+  exit 1
+fi
+
+echo "Using Konflux CR from clone (${CR})" >&2
+echo "${CR}"


### PR DESCRIPTION
Up until now, we were only allowing users to use one of the existing CR samples when using the Tekton task for deploying Konflux.

This change allows users to provide their own CR as an input to the task.

Assisted-by: Cursor