### PR TITLE
feat(KFLUXVNGD-984): Add auth headers to KonfluxNamespaceLister CRD

### DIFF
--- a/operator/api/v1alpha1/konfluxnamespacelister_types.go
+++ b/operator/api/v1alpha1/konfluxnamespacelister_types.go
@@ -36,6 +36,22 @@ type KonfluxNamespaceListerSpec struct {
 	// NamespaceLister defines customizations for the namespace-lister deployment.
 	// +optional
 	NamespaceLister *NamespaceListerDeploymentSpec `json:"namespaceLister,omitempty"`
+
+	// AuthUsernameHeader is the HTTP header name from which the namespace-lister
+	// extracts the authenticated user's identity.
+	// When set, the namespace-lister trusts the named header for username.
+	// When omitted, header-based auth is disabled.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	AuthUsernameHeader string `json:"authUsernameHeader,omitempty"`
+
+	// AuthGroupsHeader is the HTTP header name from which the namespace-lister
+	// extracts the authenticated user's group memberships.
+	// When set, the namespace-lister trusts the named header for groups.
+	// When omitted, group extraction from headers is disabled.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	AuthGroupsHeader string `json:"authGroupsHeader,omitempty"`
 }
 
 // KonfluxNamespaceListerStatus defines the observed state of KonfluxNamespaceLister.

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
@@ -1310,6 +1310,22 @@ spec:
                   spec:
                     description: Spec configures the namespace-lister component.
                     properties:
+                      authGroupsHeader:
+                        description: |-
+                          AuthGroupsHeader is the HTTP header name from which the namespace-lister
+                          extracts the authenticated user's group memberships.
+                          When set, the namespace-lister trusts the named header for groups.
+                          When omitted, group extraction from headers is disabled.
+                        minLength: 1
+                        type: string
+                      authUsernameHeader:
+                        description: |-
+                          AuthUsernameHeader is the HTTP header name from which the namespace-lister
+                          extracts the authenticated user's identity.
+                          When set, the namespace-lister trusts the named header for username.
+                          When omitted, header-based auth is disabled.
+                        minLength: 1
+                        type: string
                       namespaceLister:
                         description: NamespaceLister defines customizations for the
                           namespace-lister deployment.

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxnamespacelisters.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxnamespacelisters.yaml
@@ -41,6 +41,22 @@ spec:
             default: {}
             description: KonfluxNamespaceListerSpec defines the desired state of KonfluxNamespaceLister.
             properties:
+              authGroupsHeader:
+                description: |-
+                  AuthGroupsHeader is the HTTP header name from which the namespace-lister
+                  extracts the authenticated user's group memberships.
+                  When set, the namespace-lister trusts the named header for groups.
+                  When omitted, group extraction from headers is disabled.
+                minLength: 1
+                type: string
+              authUsernameHeader:
+                description: |-
+                  AuthUsernameHeader is the HTTP header name from which the namespace-lister
+                  extracts the authenticated user's identity.
+                  When set, the namespace-lister trusts the named header for username.
+                  When omitted, header-based auth is disabled.
+                minLength: 1
+                type: string
               namespaceLister:
                 description: NamespaceLister defines customizations for the namespace-lister
                   deployment.

--- a/operator/config/samples/konflux-e2e.yaml
+++ b/operator/config/samples/konflux-e2e.yaml
@@ -102,6 +102,8 @@ spec:
               memory: 128Mi
   namespaceLister:
     spec:
+      authUsernameHeader: "X-User"
+      authGroupsHeader: "X-Group"
       namespaceLister:
         replicas: 1
         namespaceLister:

--- a/operator/config/samples/konflux_v1alpha1_konflux.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konflux.yaml
@@ -113,6 +113,8 @@ spec:
       #   # defaultPipelineName: my-custom-pipeline  # Use custom pipeline as default
   namespaceLister:
     spec:
+      authUsernameHeader: "X-User"
+      authGroupsHeader: "X-Group"
       namespaceLister:
         replicas: 1
         namespaceLister:

--- a/operator/config/samples/konflux_v1alpha1_konfluxnamespacelister.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konfluxnamespacelister.yaml
@@ -8,6 +8,8 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: konflux-namespace-lister
 spec:
+  authUsernameHeader: "X-User"
+  authGroupsHeader: "X-Group"
   namespaceLister:
     replicas: 3
     namespaceLister:

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
@@ -49,6 +49,9 @@ const (
 
 	// namespaceListerContainerName is the name of the namespace-lister container
 	namespaceListerContainerName = "namespace-lister"
+
+	envAuthUsernameHeader = "AUTH_USERNAME_HEADER"
+	envAuthGroupsHeader   = "AUTH_GROUPS_HEADER"
 )
 
 // NamespaceListerCleanupGVKs defines which resource types should be cleaned up when they are
@@ -168,23 +171,27 @@ func (r *KonfluxNamespaceListerReconciler) applyManifests(ctx context.Context, t
 
 // applyNamespaceListerCustomizations applies user-defined customizations to the namespace-lister deployment.
 func applyNamespaceListerCustomizations(deployment *appsv1.Deployment, spec konfluxv1alpha1.KonfluxNamespaceListerSpec) error {
-	if spec.NamespaceLister == nil {
-		return nil
+	var containerSpec *konfluxv1alpha1.ContainerSpec
+	if spec.NamespaceLister != nil {
+		// Apply replicas if set (non-zero value)
+		if spec.NamespaceLister.Replicas > 0 {
+			deployment.Spec.Replicas = &spec.NamespaceLister.Replicas
+		}
+		containerSpec = spec.NamespaceLister.NamespaceLister
 	}
 
-	deploymentSpec := spec.NamespaceLister
-
-	// Apply replicas if set (non-zero value)
-	if deploymentSpec.Replicas > 0 {
-		deployment.Spec.Replicas = &deploymentSpec.Replicas
+	containerOpts := []customization.ContainerOption{
+		customization.FromContainerSpec(containerSpec),
+		// Typed CRD fields applied after FromContainerSpec — always take precedence
+		customization.WithOptionalEnvOverride(envAuthUsernameHeader, spec.AuthUsernameHeader),
+		customization.WithOptionalEnvOverride(envAuthGroupsHeader, spec.AuthGroupsHeader),
 	}
 
-	// Build and apply container customizations using pkg/customization
 	overlay := customization.BuildPodOverlay(
 		customization.DeploymentContext{},
 		customization.WithContainerBuilder(
 			namespaceListerContainerName,
-			customization.FromContainerSpec(deploymentSpec.NamespaceLister),
+			containerOpts...,
 		),
 	)
 	return overlay.ApplyToDeployment(deployment)

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
@@ -33,6 +33,22 @@ import (
 
 const namespaceListerNamespace = "namespace-lister"
 
+// findEnvValue returns the last value of the named env var.
+// Checks the last match to match Kubernetes behavior where later entries override earlier ones.
+//
+//nolint:unparam
+func findEnvValue(envs []corev1.EnvVar, name string) (string, bool) {
+	var value string
+	var found bool
+	for _, env := range envs {
+		if env.Name == name {
+			value = env.Value
+			found = true
+		}
+	}
+	return value, found
+}
+
 var _ = Describe("KonfluxNamespaceLister Controller", func() {
 	Context("When reconciling a resource", func() {
 		It("should successfully reconcile the resource", func(ctx context.Context) {
@@ -69,7 +85,7 @@ var _ = Describe("applyNamespaceListerCustomizations", func() {
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
-								Name: namespaceListerNamespace,
+								Name: namespaceListerContainerName,
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:    resource.MustParse("50m"),
@@ -155,5 +171,219 @@ var _ = Describe("applyNamespaceListerCustomizations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(*deployment.Spec.Replicas).To(Equal(int32(2)))
 		Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("256Mi"))
+	})
+
+	Context("authGroupsHeader typed field", func() {
+		It("should inject AUTH_GROUPS_HEADER when set", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				AuthGroupsHeader: "X-Group",
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			val, found := findEnvValue(container.Env, envAuthGroupsHeader)
+			Expect(found).To(BeTrue())
+			Expect(val).To(Equal("X-Group"))
+		})
+
+		It("should not inject AUTH_GROUPS_HEADER when omitted", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			_, found := findEnvValue(container.Env, envAuthGroupsHeader)
+			Expect(found).To(BeFalse())
+		})
+
+		It("should take precedence over same var in ContainerSpec.Env", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				AuthGroupsHeader: "X-Forwarded-Groups",
+				NamespaceLister: &konfluxv1alpha1.NamespaceListerDeploymentSpec{
+					NamespaceLister: &konfluxv1alpha1.ContainerSpec{
+						Env: []corev1.EnvVar{
+							{Name: envAuthGroupsHeader, Value: "X-Remote-Groups"},
+						},
+					},
+				},
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			val, found := findEnvValue(container.Env, envAuthGroupsHeader)
+			Expect(found).To(BeTrue())
+			Expect(val).To(Equal("X-Forwarded-Groups"), "typed CRD field should take precedence over ContainerSpec.Env")
+		})
+
+		It("should let ContainerSpec.Env pass through when typed field is omitted", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				NamespaceLister: &konfluxv1alpha1.NamespaceListerDeploymentSpec{
+					NamespaceLister: &konfluxv1alpha1.ContainerSpec{
+						Env: []corev1.EnvVar{
+							{Name: envAuthGroupsHeader, Value: "X-Remote-Groups"},
+						},
+					},
+				},
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			val, found := findEnvValue(container.Env, envAuthGroupsHeader)
+			Expect(found).To(BeTrue())
+			Expect(val).To(Equal("X-Remote-Groups"), "ContainerSpec.Env should pass through when typed field is omitted")
+		})
+	})
+
+	Context("both auth headers combined", func() {
+		It("should inject both when both are set", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				AuthUsernameHeader: "X-User",
+				AuthGroupsHeader:   "X-Group",
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			uVal, uFound := findEnvValue(container.Env, envAuthUsernameHeader)
+			Expect(uFound).To(BeTrue())
+			Expect(uVal).To(Equal("X-User"))
+			gVal, gFound := findEnvValue(container.Env, envAuthGroupsHeader)
+			Expect(gFound).To(BeTrue())
+			Expect(gVal).To(Equal("X-Group"))
+		})
+
+		It("should inject neither when both are omitted", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			_, uFound := findEnvValue(container.Env, envAuthUsernameHeader)
+			Expect(uFound).To(BeFalse())
+			_, gFound := findEnvValue(container.Env, envAuthGroupsHeader)
+			Expect(gFound).To(BeFalse())
+		})
+
+		It("should inject only username header when groups header is omitted", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				AuthUsernameHeader: "X-User",
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			uVal, uFound := findEnvValue(container.Env, envAuthUsernameHeader)
+			Expect(uFound).To(BeTrue())
+			Expect(uVal).To(Equal("X-User"))
+			_, gFound := findEnvValue(container.Env, envAuthGroupsHeader)
+			Expect(gFound).To(BeFalse())
+		})
+
+		It("should inject only groups header when username header is omitted", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				AuthGroupsHeader: "X-Group",
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			_, uFound := findEnvValue(container.Env, envAuthUsernameHeader)
+			Expect(uFound).To(BeFalse())
+			gVal, gFound := findEnvValue(container.Env, envAuthGroupsHeader)
+			Expect(gFound).To(BeTrue())
+			Expect(gVal).To(Equal("X-Group"))
+		})
+	})
+
+	Context("authUsernameHeader typed field", func() {
+		It("should inject AUTH_USERNAME_HEADER when set", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				AuthUsernameHeader: "X-User",
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			val, found := findEnvValue(container.Env, envAuthUsernameHeader)
+			Expect(found).To(BeTrue())
+			Expect(val).To(Equal("X-User"))
+		})
+
+		It("should not inject AUTH_USERNAME_HEADER when omitted", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			_, found := findEnvValue(container.Env, envAuthUsernameHeader)
+			Expect(found).To(BeFalse())
+		})
+
+		It("should treat explicit empty string the same as omitted", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				AuthUsernameHeader: "",
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			_, found := findEnvValue(container.Env, envAuthUsernameHeader)
+			Expect(found).To(BeFalse())
+		})
+
+		It("should take precedence over same var in ContainerSpec.Env", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				AuthUsernameHeader: "X-Forwarded-User",
+				NamespaceLister: &konfluxv1alpha1.NamespaceListerDeploymentSpec{
+					NamespaceLister: &konfluxv1alpha1.ContainerSpec{
+						Env: []corev1.EnvVar{
+							{Name: envAuthUsernameHeader, Value: "X-Remote-User"},
+						},
+					},
+				},
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			val, found := findEnvValue(container.Env, envAuthUsernameHeader)
+			Expect(found).To(BeTrue())
+			Expect(val).To(Equal("X-Forwarded-User"), "typed CRD field should take precedence over ContainerSpec.Env")
+		})
+
+		It("should let ContainerSpec.Env pass through when typed field is omitted", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				NamespaceLister: &konfluxv1alpha1.NamespaceListerDeploymentSpec{
+					NamespaceLister: &konfluxv1alpha1.ContainerSpec{
+						Env: []corev1.EnvVar{
+							{Name: envAuthUsernameHeader, Value: "X-Remote-User"},
+						},
+					},
+				},
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			val, found := findEnvValue(container.Env, envAuthUsernameHeader)
+			Expect(found).To(BeTrue())
+			Expect(val).To(Equal("X-Remote-User"), "ContainerSpec.Env should pass through when typed field is omitted")
+		})
 	})
 })

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_customization_test.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_customization_test.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespacelister
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
+)
+
+// getNamespaceListerDeployment returns a deep copy of the namespace-lister deployment from the embedded manifests.
+func getNamespaceListerDeployment(t *testing.T) *appsv1.Deployment {
+	t.Helper()
+	store := testutil.GetTestObjectStore(t)
+	objects, err := store.GetForComponent(manifests.NamespaceLister)
+	if err != nil {
+		t.Fatalf("failed to get NamespaceLister manifests: %v", err)
+	}
+
+	for _, obj := range objects {
+		if deployment, ok := obj.(*appsv1.Deployment); ok {
+			if deployment.Name == "namespace-lister" {
+				return deployment
+			}
+		}
+	}
+	t.Fatalf("deployment %q not found in NamespaceLister manifests", "namespace-lister")
+	return nil
+}
+
+func TestAuthGroupsHeaderWithRealManifest(t *testing.T) {
+	t.Run("embedded manifest does not contain AUTH_GROUPS_HEADER", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		_, found := findEnvValue(container.Env, envAuthGroupsHeader)
+		g.Expect(found).To(gomega.BeFalse(), "AUTH_GROUPS_HEADER should not be in the embedded base manifest")
+	})
+
+	t.Run("field set injects env var into real manifest", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+			AuthGroupsHeader: "X-Group",
+		}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		val, found := findEnvValue(container.Env, envAuthGroupsHeader)
+		g.Expect(found).To(gomega.BeTrue())
+		g.Expect(val).To(gomega.Equal("X-Group"))
+	})
+
+	t.Run("field omitted leaves env var absent in real manifest", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		_, found := findEnvValue(container.Env, envAuthGroupsHeader)
+		g.Expect(found).To(gomega.BeFalse(), "upstream default should apply — env var should be absent")
+	})
+
+	t.Run("field overrides same var set via ContainerSpec.Env on real manifest", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+			AuthGroupsHeader: "X-Forwarded-Groups",
+			NamespaceLister: &konfluxv1alpha1.NamespaceListerDeploymentSpec{
+				NamespaceLister: &konfluxv1alpha1.ContainerSpec{
+					Env: []corev1.EnvVar{
+						{Name: envAuthGroupsHeader, Value: "X-Remote-Groups"},
+					},
+				},
+			},
+		}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		val, found := findEnvValue(container.Env, envAuthGroupsHeader)
+		g.Expect(found).To(gomega.BeTrue())
+		g.Expect(val).To(gomega.Equal("X-Forwarded-Groups"), "typed field should win over ContainerSpec.Env")
+	})
+
+	t.Run("ContainerSpec.Env passes through when field omitted on real manifest", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+			NamespaceLister: &konfluxv1alpha1.NamespaceListerDeploymentSpec{
+				NamespaceLister: &konfluxv1alpha1.ContainerSpec{
+					Env: []corev1.EnvVar{
+						{Name: envAuthGroupsHeader, Value: "X-Remote-Groups"},
+					},
+				},
+			},
+		}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		val, found := findEnvValue(container.Env, envAuthGroupsHeader)
+		g.Expect(found).To(gomega.BeTrue())
+		g.Expect(val).To(gomega.Equal("X-Remote-Groups"), "ContainerSpec.Env should pass through")
+	})
+}
+
+func TestBothAuthHeadersWithRealManifest(t *testing.T) {
+	t.Run("both set injects both env vars", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+			AuthUsernameHeader: "X-User",
+			AuthGroupsHeader:   "X-Group",
+		}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		uVal, uFound := findEnvValue(container.Env, envAuthUsernameHeader)
+		g.Expect(uFound).To(gomega.BeTrue())
+		g.Expect(uVal).To(gomega.Equal("X-User"))
+		gVal, gFound := findEnvValue(container.Env, envAuthGroupsHeader)
+		g.Expect(gFound).To(gomega.BeTrue())
+		g.Expect(gVal).To(gomega.Equal("X-Group"))
+	})
+
+	t.Run("both omitted leaves both env vars absent", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		_, uFound := findEnvValue(container.Env, envAuthUsernameHeader)
+		g.Expect(uFound).To(gomega.BeFalse())
+		_, gFound := findEnvValue(container.Env, envAuthGroupsHeader)
+		g.Expect(gFound).To(gomega.BeFalse())
+	})
+
+	t.Run("only username set injects only username env var", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+			AuthUsernameHeader: "X-User",
+		}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		uVal, uFound := findEnvValue(container.Env, envAuthUsernameHeader)
+		g.Expect(uFound).To(gomega.BeTrue())
+		g.Expect(uVal).To(gomega.Equal("X-User"))
+		_, gFound := findEnvValue(container.Env, envAuthGroupsHeader)
+		g.Expect(gFound).To(gomega.BeFalse())
+	})
+
+	t.Run("only groups set injects only groups env var", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+			AuthGroupsHeader: "X-Group",
+		}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		_, uFound := findEnvValue(container.Env, envAuthUsernameHeader)
+		g.Expect(uFound).To(gomega.BeFalse())
+		gVal, gFound := findEnvValue(container.Env, envAuthGroupsHeader)
+		g.Expect(gFound).To(gomega.BeTrue())
+		g.Expect(gVal).To(gomega.Equal("X-Group"))
+	})
+}
+
+func TestAuthUsernameHeaderWithRealManifest(t *testing.T) {
+	t.Run("embedded manifest does not contain AUTH_USERNAME_HEADER", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		_, found := findEnvValue(container.Env, envAuthUsernameHeader)
+		g.Expect(found).To(gomega.BeFalse(), "AUTH_USERNAME_HEADER should not be in the embedded base manifest")
+	})
+
+	t.Run("field set injects env var into real manifest", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+			AuthUsernameHeader: "X-User",
+		}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		val, found := findEnvValue(container.Env, envAuthUsernameHeader)
+		g.Expect(found).To(gomega.BeTrue())
+		g.Expect(val).To(gomega.Equal("X-User"))
+	})
+
+	t.Run("field omitted leaves env var absent in real manifest", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		_, found := findEnvValue(container.Env, envAuthUsernameHeader)
+		g.Expect(found).To(gomega.BeFalse(), "upstream default should apply — env var should be absent")
+	})
+
+	t.Run("field overrides same var set via ContainerSpec.Env on real manifest", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+			AuthUsernameHeader: "X-Forwarded-User",
+			NamespaceLister: &konfluxv1alpha1.NamespaceListerDeploymentSpec{
+				NamespaceLister: &konfluxv1alpha1.ContainerSpec{
+					Env: []corev1.EnvVar{
+						{Name: envAuthUsernameHeader, Value: "X-Remote-User"},
+					},
+				},
+			},
+		}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		val, found := findEnvValue(container.Env, envAuthUsernameHeader)
+		g.Expect(found).To(gomega.BeTrue())
+		g.Expect(val).To(gomega.Equal("X-Forwarded-User"), "typed field should win over ContainerSpec.Env")
+	})
+
+	t.Run("ContainerSpec.Env passes through when field omitted on real manifest", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+			NamespaceLister: &konfluxv1alpha1.NamespaceListerDeploymentSpec{
+				NamespaceLister: &konfluxv1alpha1.ContainerSpec{
+					Env: []corev1.EnvVar{
+						{Name: envAuthUsernameHeader, Value: "X-Remote-User"},
+					},
+				},
+			},
+		}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		val, found := findEnvValue(container.Env, envAuthUsernameHeader)
+		g.Expect(found).To(gomega.BeTrue())
+		g.Expect(val).To(gomega.Equal("X-Remote-User"), "ContainerSpec.Env should pass through")
+	})
+}

--- a/operator/pkg/manifests/namespace-lister/manifests.yaml
+++ b/operator/pkg/manifests/namespace-lister/manifests.yaml
@@ -94,10 +94,6 @@ spec:
           value: 10m
         - name: CACHE_NAMESPACE_LABELSELECTOR
           value: konflux-ci.dev/type=tenant
-        - name: AUTH_USERNAME_HEADER
-          value: X-User
-        - name: AUTH_GROUPS_HEADER
-          value: X-Group
         image: quay.io/konflux-ci/namespace-lister@sha256:990e0ad159168851beed23ecc32bc3b66983729167768b8b7d3e77fc12df0a42
         livenessProbe:
           httpGet:

--- a/operator/upstream-kustomizations/namespace-lister/kustomization.yaml
+++ b/operator/upstream-kustomizations/namespace-lister/kustomization.yaml
@@ -23,15 +23,3 @@ patches:
     - op: add
       path: /spec/progressDeadlineSeconds
       value: 2147483647
-- path: ./patches/with_header_auth_user.yaml
-  target:
-    group: apps
-    kind: Deployment
-    name: namespace-lister
-    namespace: namespace-lister
-- path: ./patches/with_header_auth_groups.yaml
-  target:
-    group: apps
-    kind: Deployment
-    name: namespace-lister
-    namespace: namespace-lister

--- a/operator/upstream-kustomizations/namespace-lister/patches/with_header_auth_groups.yaml
+++ b/operator/upstream-kustomizations/namespace-lister/patches/with_header_auth_groups.yaml
@@ -1,5 +1,0 @@
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
-    name: AUTH_GROUPS_HEADER
-    value: X-Group

--- a/operator/upstream-kustomizations/namespace-lister/patches/with_header_auth_user.yaml
+++ b/operator/upstream-kustomizations/namespace-lister/patches/with_header_auth_user.yaml
@@ -1,5 +1,0 @@
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
-    name: AUTH_USERNAME_HEADER
-    value: X-User


### PR DESCRIPTION
This change adds two new fields to the KonfluxNamespaceLister CRD:
- `authUsernameHeader`: specifies the HTTP header name from which the namespace-lister
  extracts the authenticated user's identity.
- `authGroupsHeader`: specifies the HTTP header name from which the namespace-lister
  extracts the authenticated user's group memberships.

Both fields are optional. When omitted, the corresponding header-based auth is disabled
and upstream default behavior is used.

- Remove with_header_auth_user.yaml and with_header_auth_groups.yaml patches
- Add authUsernameHeader and authGroupsHeader to KonfluxNamespaceLister CRD
- Add tests for both auth header fields and all four combinations
- Add tests for namespace-lister customization against real embedded manifest
- Add both auth headers to sample yamls

Assisted-by: Cursor + Opus 4.6