### PR TITLE
fix(KFLUXVNGD-1005): truncate segment-bridge image tag to commit hash

### DIFF
--- a/operator/pkg/manifests/segment-bridge/manifests.yaml
+++ b/operator/pkg/manifests/segment-bridge/manifests.yaml
@@ -94,7 +94,7 @@ spec:
             - secretRef:
                 name: segment-bridge-config
                 optional: true
-            image: quay.io/konflux-ci/segment-bridge:981c509119cf051a08c018cc1cebbb11c4dde1178666ea95618d573dd96fb093
+            image: quay.io/konflux-ci/segment-bridge:981c509119cf051a08c018cc1cebbb11c4dde117
             imagePullPolicy: IfNotPresent
             name: segment-bridge
             resources:

--- a/operator/upstream-kustomizations/segment-bridge/kustomization.yaml
+++ b/operator/upstream-kustomizations/segment-bridge/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: quay.io/konflux-ci/segment-bridge
   newName: quay.io/konflux-ci/segment-bridge
-  newTag: 981c509119cf051a08c018cc1cebbb11c4dde1178666ea95618d573dd96fb093
+  newTag: 981c509119cf051a08c018cc1cebbb11c4dde117


### PR DESCRIPTION
The segment-bridge newTag contained a 64-char value (commit hash + stale manifest-list digest suffix) instead of the expected 40-char git commit hash. This caused ImagePullBackOff on every Konflux install since the 64-char tag does not exist in the registry.

Introduced in b042688b which set newTag to a full manifest-list digest; every subsequent Renovate and automation update propagated the extra 24-char suffix via substring replacement.

Truncate newTag to the 40-char commit hash matching ?ref= so the CronJob image reference resolves correctly.

Ref: https://redhat.atlassian.net/browse/KFLUXVNGD-1005