### PR TITLE
feat(KFLUXVNGD-984): Add cacheResyncPeriod to KonfluxNamespaceLister CRD

### DIFF
--- a/operator/api/v1alpha1/konfluxnamespacelister_types.go
+++ b/operator/api/v1alpha1/konfluxnamespacelister_types.go
@@ -36,6 +36,15 @@ type KonfluxNamespaceListerSpec struct {
 	// NamespaceLister defines customizations for the namespace-lister deployment.
 	// +optional
 	NamespaceLister *NamespaceListerDeploymentSpec `json:"namespaceLister,omitempty"`
+
+	// CacheResyncPeriod controls how often the namespace-lister's access cache
+	// fully re-evaluates RBAC permissions as a safety net.
+	// Accepts a Go duration string (e.g. "5s", "10m", "1h").
+	// When omitted, the namespace-lister relies solely on watch events
+	// with no periodic resync.
+	// +optional
+	// +kubebuilder:validation:Pattern=`^([0-9]+(s|m|h))+$`
+	CacheResyncPeriod string `json:"cacheResyncPeriod,omitempty"`
 }
 
 // KonfluxNamespaceListerStatus defines the observed state of KonfluxNamespaceLister.

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
@@ -1310,6 +1310,15 @@ spec:
                   spec:
                     description: Spec configures the namespace-lister component.
                     properties:
+                      cacheResyncPeriod:
+                        description: |-
+                          CacheResyncPeriod controls how often the namespace-lister's access cache
+                          fully re-evaluates RBAC permissions as a safety net.
+                          Accepts a Go duration string (e.g. "5s", "10m", "1h").
+                          When omitted, the namespace-lister relies solely on watch events
+                          with no periodic resync.
+                        pattern: ^([0-9]+(s|m|h))+$
+                        type: string
                       namespaceLister:
                         description: NamespaceLister defines customizations for the
                           namespace-lister deployment.

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxnamespacelisters.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxnamespacelisters.yaml
@@ -41,6 +41,15 @@ spec:
             default: {}
             description: KonfluxNamespaceListerSpec defines the desired state of KonfluxNamespaceLister.
             properties:
+              cacheResyncPeriod:
+                description: |-
+                  CacheResyncPeriod controls how often the namespace-lister's access cache
+                  fully re-evaluates RBAC permissions as a safety net.
+                  Accepts a Go duration string (e.g. "5s", "10m", "1h").
+                  When omitted, the namespace-lister relies solely on watch events
+                  with no periodic resync.
+                pattern: ^([0-9]+(s|m|h))+$
+                type: string
               namespaceLister:
                 description: NamespaceLister defines customizations for the namespace-lister
                   deployment.

--- a/operator/config/samples/konflux-e2e.yaml
+++ b/operator/config/samples/konflux-e2e.yaml
@@ -102,6 +102,7 @@ spec:
               memory: 128Mi
   namespaceLister:
     spec:
+      cacheResyncPeriod: "10m"
       namespaceLister:
         replicas: 1
         namespaceLister:

--- a/operator/config/samples/konflux_v1alpha1_konflux.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konflux.yaml
@@ -113,6 +113,7 @@ spec:
       #   # defaultPipelineName: my-custom-pipeline  # Use custom pipeline as default
   namespaceLister:
     spec:
+      cacheResyncPeriod: "10m"
       namespaceLister:
         replicas: 1
         namespaceLister:

--- a/operator/config/samples/konflux_v1alpha1_konfluxnamespacelister.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konfluxnamespacelister.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: konflux-namespace-lister
 spec:
+  cacheResyncPeriod: "10m"
   namespaceLister:
     replicas: 3
     namespaceLister:
@@ -21,8 +22,6 @@ spec:
       env:
         - name: LOG_LEVEL
           value: "0"
-        - name: CACHE_RESYNC_PERIOD
-          value: "10m"
         - name: EXAMPLE_CUSTOM_CONFIG
           valueFrom:
             configMapKeyRef:

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
@@ -49,6 +49,8 @@ const (
 
 	// namespaceListerContainerName is the name of the namespace-lister container
 	namespaceListerContainerName = "namespace-lister"
+
+	envCacheResyncPeriod = "CACHE_RESYNC_PERIOD"
 )
 
 // NamespaceListerCleanupGVKs defines which resource types should be cleaned up when they are
@@ -168,23 +170,24 @@ func (r *KonfluxNamespaceListerReconciler) applyManifests(ctx context.Context, t
 
 // applyNamespaceListerCustomizations applies user-defined customizations to the namespace-lister deployment.
 func applyNamespaceListerCustomizations(deployment *appsv1.Deployment, spec konfluxv1alpha1.KonfluxNamespaceListerSpec) error {
-	if spec.NamespaceLister == nil {
-		return nil
+	var containerSpec *konfluxv1alpha1.ContainerSpec
+	if spec.NamespaceLister != nil {
+		if spec.NamespaceLister.Replicas > 0 {
+			deployment.Spec.Replicas = &spec.NamespaceLister.Replicas
+		}
+		containerSpec = spec.NamespaceLister.NamespaceLister
 	}
 
-	deploymentSpec := spec.NamespaceLister
-
-	// Apply replicas if set (non-zero value)
-	if deploymentSpec.Replicas > 0 {
-		deployment.Spec.Replicas = &deploymentSpec.Replicas
+	containerOpts := []customization.ContainerOption{
+		customization.FromContainerSpec(containerSpec),
+		customization.WithOptionalEnvOverride(envCacheResyncPeriod, spec.CacheResyncPeriod),
 	}
 
-	// Build and apply container customizations using pkg/customization
 	overlay := customization.BuildPodOverlay(
 		customization.DeploymentContext{},
 		customization.WithContainerBuilder(
 			namespaceListerContainerName,
-			customization.FromContainerSpec(deploymentSpec.NamespaceLister),
+			containerOpts...,
 		),
 	)
 	return overlay.ApplyToDeployment(deployment)

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
@@ -33,6 +33,22 @@ import (
 
 const namespaceListerNamespace = "namespace-lister"
 
+// findEnvValue returns the last value of the named env var.
+// Checks the last match to match Kubernetes behavior where later entries override earlier ones.
+//
+//nolint:unparam
+func findEnvValue(envs []corev1.EnvVar, name string) (string, bool) {
+	var value string
+	var found bool
+	for _, env := range envs {
+		if env.Name == name {
+			value = env.Value
+			found = true
+		}
+	}
+	return value, found
+}
+
 var _ = Describe("KonfluxNamespaceLister Controller", func() {
 	Context("When reconciling a resource", func() {
 		It("should successfully reconcile the resource", func(ctx context.Context) {
@@ -155,5 +171,89 @@ var _ = Describe("applyNamespaceListerCustomizations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(*deployment.Spec.Replicas).To(Equal(int32(2)))
 		Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("256Mi"))
+	})
+
+	Context("cacheResyncPeriod typed field", func() {
+		It("should inject CACHE_RESYNC_PERIOD when set", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				CacheResyncPeriod: "10m",
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			val, found := findEnvValue(container.Env, envCacheResyncPeriod)
+			Expect(found).To(BeTrue())
+			Expect(val).To(Equal("10m"))
+		})
+
+		It("should not inject CACHE_RESYNC_PERIOD when omitted", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			_, found := findEnvValue(container.Env, envCacheResyncPeriod)
+			Expect(found).To(BeFalse())
+		})
+
+		It("should accept various duration formats", func() {
+			for _, dur := range []string{"5s", "1h", "30m", "1h30m"} {
+				spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+					CacheResyncPeriod: dur,
+				}
+				err := applyNamespaceListerCustomizations(deployment, spec)
+				Expect(err).NotTo(HaveOccurred())
+
+				container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+				Expect(container).NotTo(BeNil())
+				val, found := findEnvValue(container.Env, envCacheResyncPeriod)
+				Expect(found).To(BeTrue())
+				Expect(val).To(Equal(dur))
+			}
+		})
+
+		It("should take precedence over same var in ContainerSpec.Env", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				CacheResyncPeriod: "5m",
+				NamespaceLister: &konfluxv1alpha1.NamespaceListerDeploymentSpec{
+					NamespaceLister: &konfluxv1alpha1.ContainerSpec{
+						Env: []corev1.EnvVar{
+							{Name: envCacheResyncPeriod, Value: "30m"},
+						},
+					},
+				},
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			val, found := findEnvValue(container.Env, envCacheResyncPeriod)
+			Expect(found).To(BeTrue())
+			Expect(val).To(Equal("5m"), "typed CRD field should take precedence over ContainerSpec.Env")
+		})
+
+		It("should let ContainerSpec.Env pass through when typed field is omitted", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				NamespaceLister: &konfluxv1alpha1.NamespaceListerDeploymentSpec{
+					NamespaceLister: &konfluxv1alpha1.ContainerSpec{
+						Env: []corev1.EnvVar{
+							{Name: envCacheResyncPeriod, Value: "30m"},
+						},
+					},
+				},
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			val, found := findEnvValue(container.Env, envCacheResyncPeriod)
+			Expect(found).To(BeTrue())
+			Expect(val).To(Equal("30m"), "ContainerSpec.Env should pass through when typed field is omitted")
+		})
 	})
 })

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_customization_test.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_customization_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespacelister
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
+)
+
+// getNamespaceListerDeployment returns a deep copy of the namespace-lister deployment from the embedded manifests.
+func getNamespaceListerDeployment(t *testing.T) *appsv1.Deployment {
+	t.Helper()
+	store := testutil.GetTestObjectStore(t)
+	objects, err := store.GetForComponent(manifests.NamespaceLister)
+	if err != nil {
+		t.Fatalf("failed to get NamespaceLister manifests: %v", err)
+	}
+
+	for _, obj := range objects {
+		if deployment, ok := obj.(*appsv1.Deployment); ok {
+			if deployment.Name == "namespace-lister" {
+				return deployment
+			}
+		}
+	}
+	t.Fatalf("deployment %q not found in NamespaceLister manifests", "namespace-lister")
+	return nil
+}
+
+func TestCacheResyncPeriodWithRealManifest(t *testing.T) {
+	t.Run("embedded manifest does not contain CACHE_RESYNC_PERIOD", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		_, found := findEnvValue(container.Env, envCacheResyncPeriod)
+		g.Expect(found).To(gomega.BeFalse(), "CACHE_RESYNC_PERIOD should not be in the embedded base manifest")
+	})
+
+	t.Run("field set injects env var into real manifest", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+			CacheResyncPeriod: "10m",
+		}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		val, found := findEnvValue(container.Env, envCacheResyncPeriod)
+		g.Expect(found).To(gomega.BeTrue())
+		g.Expect(val).To(gomega.Equal("10m"))
+	})
+
+	t.Run("field omitted leaves env var absent in real manifest", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		_, found := findEnvValue(container.Env, envCacheResyncPeriod)
+		g.Expect(found).To(gomega.BeFalse(), "upstream default should apply — env var should be absent")
+	})
+
+	t.Run("field overrides same var set via ContainerSpec.Env on real manifest", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+			CacheResyncPeriod: "5m",
+			NamespaceLister: &konfluxv1alpha1.NamespaceListerDeploymentSpec{
+				NamespaceLister: &konfluxv1alpha1.ContainerSpec{
+					Env: []corev1.EnvVar{
+						{Name: envCacheResyncPeriod, Value: "30m"},
+					},
+				},
+			},
+		}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		val, found := findEnvValue(container.Env, envCacheResyncPeriod)
+		g.Expect(found).To(gomega.BeTrue())
+		g.Expect(val).To(gomega.Equal("5m"), "typed field should win over ContainerSpec.Env")
+	})
+
+	t.Run("ContainerSpec.Env passes through when field omitted on real manifest", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+			NamespaceLister: &konfluxv1alpha1.NamespaceListerDeploymentSpec{
+				NamespaceLister: &konfluxv1alpha1.ContainerSpec{
+					Env: []corev1.EnvVar{
+						{Name: envCacheResyncPeriod, Value: "30m"},
+					},
+				},
+			},
+		}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		val, found := findEnvValue(container.Env, envCacheResyncPeriod)
+		g.Expect(found).To(gomega.BeTrue())
+		g.Expect(val).To(gomega.Equal("30m"), "ContainerSpec.Env should pass through")
+	})
+}

--- a/operator/pkg/manifests/namespace-lister/manifests.yaml
+++ b/operator/pkg/manifests/namespace-lister/manifests.yaml
@@ -90,8 +90,6 @@ spec:
         env:
         - name: LOG_LEVEL
           value: "0"
-        - name: CACHE_RESYNC_PERIOD
-          value: 10m
         - name: CACHE_NAMESPACE_LABELSELECTOR
           value: konflux-ci.dev/type=tenant
         - name: AUTH_USERNAME_HEADER

--- a/operator/upstream-kustomizations/namespace-lister/deployment.yaml
+++ b/operator/upstream-kustomizations/namespace-lister/deployment.yaml
@@ -35,8 +35,6 @@ spec:
         env:
         - name: LOG_LEVEL
           value: "0"
-        - name: CACHE_RESYNC_PERIOD
-          value: 10m
         - name: CACHE_NAMESPACE_LABELSELECTOR
           value: konflux-ci.dev/type=tenant
         livenessProbe:


### PR DESCRIPTION
This change adds a new field to the KonfluxNamespaceLister CRD called cacheResyncPeriod. This field is used to specify the duration of the cache resync period for the namespace-lister.

The field is optional and when omitted, the upstream namespace-lister defaults to zero (no periodic resync).

- Add cacheResyncPeriod to KonfluxNamespaceLister CRD
- Add tests for cacheResyncPeriod
- Add tests for namespace-lister customization
- Add cacheResyncPeriod to sample yamls

Note for upgrades: 
Previously, `CACHE_RESYNC_PERIOD=10m` was hardcoded. After this change, the field must be explicitly set in the CR to retain periodic resync. 
Existing deployments upgrading without setting `cacheResyncPeriod` will switch to watch-only mode (no periodic resync).

Assisted-by: Cursor + Opus 4.6