### PR TITLE
test: skip e2e tests on label

### DIFF
--- a/.github/scripts/check-operator-e2e-prerequisites.sh
+++ b/.github/scripts/check-operator-e2e-prerequisites.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Reject Operator E2E on PRs superseded by a manifest companion (opt out: force-run-e2e).
+#
+# Usage (CI only, after checkout in operator-test-e2e.yaml):
+#   check-operator-e2e-prerequisites.sh
+#
+# Fork PR rejection runs inline in the workflow (before checkout) so fork heads cannot
+# replace this script. Labels are passed from the workflow event payload (trusted).
+#
+# Required environment:
+#   GITHUB_EVENT_NAME
+#   GITHUB_STEP_SUMMARY
+#
+# Optional environment:
+#   PR_LABELS_JSON          - JSON array of PR labels (pull_request events)
+#   SUPERSEDED_BY_COMPANION_LABEL - default: superseded-by-companion
+#   FORCE_RUN_E2E_LABEL     - default: force-run-e2e
+#
+# Exits 1 on superseded-by-companion PRs unless force-run-e2e. Exits 0 otherwise.
+#
+set -euo pipefail
+
+SUPERSEDED_BY_COMPANION_LABEL="${SUPERSEDED_BY_COMPANION_LABEL:-superseded-by-companion}"
+FORCE_RUN_E2E_LABEL="${FORCE_RUN_E2E_LABEL:-force-run-e2e}"
+SUMMARY_FILE="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+  labels_json="${PR_LABELS_JSON:-[]}"
+  if echo "${labels_json}" | jq -e --arg label "${SUPERSEDED_BY_COMPANION_LABEL}" \
+    'map(.name) | index($label)' >/dev/null; then
+    if ! echo "${labels_json}" | jq -e --arg label "${FORCE_RUN_E2E_LABEL}" \
+      'map(.name) | index($label)' >/dev/null; then
+      echo "❌ PR has label ${SUPERSEDED_BY_COMPANION_LABEL}; Operator E2E does not run on this PR." >&2
+      {
+        echo "### Operator E2E not run (superseded by companion)"
+        echo ""
+        echo "Merge the manifest companion PR instead of this PR."
+        echo "Add label \`${FORCE_RUN_E2E_LABEL}\` to run Operator E2E on this PR anyway."
+      } >>"${SUMMARY_FILE}"
+      exit 1
+    fi
+  fi
+fi

--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -9,21 +9,33 @@ on:
     types: [e2e]
 
 jobs:
-  # Gate: only same-repo PRs run heavy jobs on push. Fork PRs need /allow. Trusted contexts (dispatch, merge_group) always run.
+  # Gate: fork PRs (inline, before checkout) and superseded-by-companion (script; opt out: force-run-e2e).
   check-prerequisites:
     runs-on: ubuntu-latest
     steps:
-    - name: Check prerequisites
-      run: |
-        # Fork PRs: fail so heavy jobs do not run on push (no secrets). Only /allow can trigger them.
-        if [[ "${{ github.event_name }}" == 'pull_request' && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]]; then
-          echo "❌ Fork PR: heavy jobs do not run on push (no secrets). Comment /allow to trigger tests."
-          echo "### Fork PR" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Tests are not run automatically from forks." >> $GITHUB_STEP_SUMMARY
-          echo "**Action Required:** A maintainer must comment \`/allow\` on this PR to trigger tests." >> $GITHUB_STEP_SUMMARY
+      # Inline so fork PRs cannot replace checked-out script content (see renovate-manifest-companion.yaml).
+      - name: Reject fork PRs
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          set -euo pipefail
+          echo "❌ Fork PR: heavy jobs do not run on push (no secrets). Comment /allow to trigger tests." >&2
+          {
+            echo "### Fork PR"
+            echo ""
+            echo "Tests are not run automatically from forks."
+            echo "**Action Required:** A maintainer must comment \`/allow\` on this PR to trigger tests."
+          } >>"${GITHUB_STEP_SUMMARY}"
           exit 1
-        fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check superseded-by-companion label
+        env:
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
+        run: bash .github/scripts/check-operator-e2e-prerequisites.sh
 
   check-changes:
     name: Check for relevant changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,10 @@ after verify starts are still caught). E2E was cancelled because manifests are
 out of sync; fix verify or use the manifest companion PR. To keep E2E running
 despite a verify failure, add the label `force-run-e2e` to the PR.
 
+Source PRs labeled `superseded-by-companion` fail the Operator E2E workflow gate
+(merge the manifest companion PR instead). Add `force-run-e2e` to run full E2E on
+the source PR anyway.
+
 ## Automated E2E Tests
 
 The repository includes automated tests that run in GitHub Actions on both x86_64


### PR DESCRIPTION
Skips e2e tests early if the PR is labeled with superseded-by-companion

Assisted-by: Cursor

Should be merged after (or instead): https://github.com/konflux-ci/konflux-ci/pull/6979