### PR TITLE
feat(KFLUXVNGD-984): Add logLevel to KonfluxNamespaceLister CRD

### DIFF
--- a/operator/api/v1alpha1/common_types.go
+++ b/operator/api/v1alpha1/common_types.go
@@ -32,6 +32,17 @@ type ContainerSpec struct {
 	Env []corev1.EnvVar `json:"env,omitempty"`
 }
 
+// LogLevel sets the minimum severity for log output.
+// +kubebuilder:validation:Enum=debug;info;warn;error
+type LogLevel string
+
+const (
+	LogLevelDebug LogLevel = "debug"
+	LogLevelInfo  LogLevel = "info"
+	LogLevelWarn  LogLevel = "warn"
+	LogLevelError LogLevel = "error"
+)
+
 // ControllerManagerDeploymentSpec defines customizations for the controller-manager deployment.
 type ControllerManagerDeploymentSpec struct {
 	// Replicas is the number of replicas for the controller-manager deployment.

--- a/operator/api/v1alpha1/konfluxnamespacelister_types.go
+++ b/operator/api/v1alpha1/konfluxnamespacelister_types.go
@@ -45,6 +45,12 @@ type KonfluxNamespaceListerSpec struct {
 	// +optional
 	// +kubebuilder:validation:Pattern=`^([0-9]+(s|m|h))+$`
 	CacheResyncPeriod string `json:"cacheResyncPeriod,omitempty"`
+
+	// LogLevel sets the minimum log severity for the namespace-lister.
+	// Accepted values: debug, info, warn, error.
+	// When omitted, the namespace-lister defaults to error level.
+	// +optional
+	LogLevel LogLevel `json:"logLevel,omitempty"`
 }
 
 // KonfluxNamespaceListerStatus defines the observed state of KonfluxNamespaceLister.

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
@@ -1319,6 +1319,17 @@ spec:
                           with no periodic resync.
                         pattern: ^([0-9]+(s|m|h))+$
                         type: string
+                      logLevel:
+                        description: |-
+                          LogLevel sets the minimum log severity for the namespace-lister.
+                          Accepted values: debug, info, warn, error.
+                          When omitted, the namespace-lister defaults to error level.
+                        enum:
+                        - debug
+                        - info
+                        - warn
+                        - error
+                        type: string
                       namespaceLister:
                         description: NamespaceLister defines customizations for the
                           namespace-lister deployment.

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxnamespacelisters.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxnamespacelisters.yaml
@@ -50,6 +50,17 @@ spec:
                   with no periodic resync.
                 pattern: ^([0-9]+(s|m|h))+$
                 type: string
+              logLevel:
+                description: |-
+                  LogLevel sets the minimum log severity for the namespace-lister.
+                  Accepted values: debug, info, warn, error.
+                  When omitted, the namespace-lister defaults to error level.
+                enum:
+                - debug
+                - info
+                - warn
+                - error
+                type: string
               namespaceLister:
                 description: NamespaceLister defines customizations for the namespace-lister
                   deployment.

--- a/operator/config/samples/konflux-e2e.yaml
+++ b/operator/config/samples/konflux-e2e.yaml
@@ -103,6 +103,7 @@ spec:
   namespaceLister:
     spec:
       cacheResyncPeriod: "10m"
+      logLevel: info
       namespaceLister:
         replicas: 1
         namespaceLister:

--- a/operator/config/samples/konflux_v1alpha1_konflux.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konflux.yaml
@@ -114,6 +114,7 @@ spec:
   namespaceLister:
     spec:
       cacheResyncPeriod: "10m"
+      logLevel: info
       namespaceLister:
         replicas: 1
         namespaceLister:

--- a/operator/config/samples/konflux_v1alpha1_konfluxnamespacelister.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konfluxnamespacelister.yaml
@@ -9,6 +9,7 @@ metadata:
   name: konflux-namespace-lister
 spec:
   cacheResyncPeriod: "10m"
+  logLevel: info
   namespaceLister:
     replicas: 3
     namespaceLister:
@@ -20,8 +21,6 @@ spec:
           cpu: 512m
           memory: 1Gi
       env:
-        - name: LOG_LEVEL
-          value: "0"
         - name: EXAMPLE_CUSTOM_CONFIG
           valueFrom:
             configMapKeyRef:

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
@@ -51,7 +51,30 @@ const (
 	namespaceListerContainerName = "namespace-lister"
 
 	envCacheResyncPeriod = "CACHE_RESYNC_PERIOD"
+	envLogLevel          = "LOG_LEVEL"
 )
+
+// logLevelToEnvValue maps the CRD enum to the integer value the upstream namespace-lister expects.
+var logLevelToEnvValue = map[konfluxv1alpha1.LogLevel]string{
+	konfluxv1alpha1.LogLevelDebug: "-4",
+	konfluxv1alpha1.LogLevelInfo:  "0",
+	konfluxv1alpha1.LogLevelWarn:  "4",
+	konfluxv1alpha1.LogLevelError: "8",
+}
+
+// resolveLogLevelEnvValue converts a LogLevel to the env var value.
+// Returns ("", nil) when level is empty (field omitted), the mapped value when
+// known, or an error for unrecognised non-empty values.
+func resolveLogLevelEnvValue(level konfluxv1alpha1.LogLevel) (string, error) {
+	if level == "" {
+		return "", nil
+	}
+	v, ok := logLevelToEnvValue[level]
+	if !ok {
+		return "", fmt.Errorf("unsupported logLevel %q", level)
+	}
+	return v, nil
+}
 
 // NamespaceListerCleanupGVKs defines which resource types should be cleaned up when they are
 // no longer part of the desired state. All resources managed by this controller are always
@@ -178,9 +201,15 @@ func applyNamespaceListerCustomizations(deployment *appsv1.Deployment, spec konf
 		containerSpec = spec.NamespaceLister.NamespaceLister
 	}
 
+	logLevelValue, err := resolveLogLevelEnvValue(spec.LogLevel)
+	if err != nil {
+		return fmt.Errorf("invalid namespace-lister spec: %w", err)
+	}
+
 	containerOpts := []customization.ContainerOption{
 		customization.FromContainerSpec(containerSpec),
 		customization.WithOptionalEnvOverride(envCacheResyncPeriod, spec.CacheResyncPeriod),
+		customization.WithOptionalEnvOverride(envLogLevel, logLevelValue),
 	}
 
 	overlay := customization.BuildPodOverlay(

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
@@ -173,6 +173,105 @@ var _ = Describe("applyNamespaceListerCustomizations", func() {
 		Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("256Mi"))
 	})
 
+	Context("logLevel typed field", func() {
+		It("should inject LOG_LEVEL as slog integer when set to info", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				LogLevel: konfluxv1alpha1.LogLevelInfo,
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			val, found := findEnvValue(container.Env, envLogLevel)
+			Expect(found).To(BeTrue())
+			Expect(val).To(Equal("0"))
+		})
+
+		It("should map all enum values to correct slog integers", func() {
+			cases := map[konfluxv1alpha1.LogLevel]string{
+				konfluxv1alpha1.LogLevelDebug: "-4",
+				konfluxv1alpha1.LogLevelInfo:  "0",
+				konfluxv1alpha1.LogLevelWarn:  "4",
+				konfluxv1alpha1.LogLevelError: "8",
+			}
+			for level, expected := range cases {
+				spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+					LogLevel: level,
+				}
+				err := applyNamespaceListerCustomizations(deployment, spec)
+				Expect(err).NotTo(HaveOccurred())
+
+				container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+				Expect(container).NotTo(BeNil())
+				val, found := findEnvValue(container.Env, envLogLevel)
+				Expect(found).To(BeTrue())
+				Expect(val).To(Equal(expected), "logLevel %q should map to %q", level, expected)
+			}
+		})
+
+		It("should not inject LOG_LEVEL when omitted", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			_, found := findEnvValue(container.Env, envLogLevel)
+			Expect(found).To(BeFalse())
+		})
+
+		It("should return an error for unsupported logLevel values", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				LogLevel: konfluxv1alpha1.LogLevel("trace"),
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unsupported logLevel"))
+		})
+
+		It("should take precedence over same var in ContainerSpec.Env", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				LogLevel: konfluxv1alpha1.LogLevelDebug,
+				NamespaceLister: &konfluxv1alpha1.NamespaceListerDeploymentSpec{
+					NamespaceLister: &konfluxv1alpha1.ContainerSpec{
+						Env: []corev1.EnvVar{
+							{Name: envLogLevel, Value: "8"},
+						},
+					},
+				},
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			val, found := findEnvValue(container.Env, envLogLevel)
+			Expect(found).To(BeTrue())
+			Expect(val).To(Equal("-4"), "typed CRD field should take precedence over ContainerSpec.Env")
+		})
+
+		It("should let ContainerSpec.Env pass through when typed field is omitted", func() {
+			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+				NamespaceLister: &konfluxv1alpha1.NamespaceListerDeploymentSpec{
+					NamespaceLister: &konfluxv1alpha1.ContainerSpec{
+						Env: []corev1.EnvVar{
+							{Name: envLogLevel, Value: "4"},
+						},
+					},
+				},
+			}
+			err := applyNamespaceListerCustomizations(deployment, spec)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+			Expect(container).NotTo(BeNil())
+			val, found := findEnvValue(container.Env, envLogLevel)
+			Expect(found).To(BeTrue())
+			Expect(val).To(Equal("4"), "ContainerSpec.Env should pass through when typed field is omitted")
+		})
+	})
+
 	Context("cacheResyncPeriod typed field", func() {
 		It("should inject CACHE_RESYNC_PERIOD when set", func() {
 			spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_customization_test.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_customization_test.go
@@ -48,6 +48,95 @@ func getNamespaceListerDeployment(t *testing.T) *appsv1.Deployment {
 	return nil
 }
 
+func TestLogLevelWithRealManifest(t *testing.T) {
+	t.Run("embedded manifest does not contain LOG_LEVEL", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		_, found := findEnvValue(container.Env, envLogLevel)
+		g.Expect(found).To(gomega.BeFalse(), "LOG_LEVEL should not be in the embedded base manifest")
+	})
+
+	t.Run("field set to info injects LOG_LEVEL=0 into real manifest", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+			LogLevel: konfluxv1alpha1.LogLevelInfo,
+		}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		val, found := findEnvValue(container.Env, envLogLevel)
+		g.Expect(found).To(gomega.BeTrue())
+		g.Expect(val).To(gomega.Equal("0"))
+	})
+
+	t.Run("all enum values map to correct slog integers on real manifest", func(t *testing.T) {
+		cases := map[konfluxv1alpha1.LogLevel]string{
+			konfluxv1alpha1.LogLevelDebug: "-4",
+			konfluxv1alpha1.LogLevelInfo:  "0",
+			konfluxv1alpha1.LogLevelWarn:  "4",
+			konfluxv1alpha1.LogLevelError: "8",
+		}
+		for level, expected := range cases {
+			t.Run(string(level), func(t *testing.T) {
+				g := gomega.NewWithT(t)
+				deployment := getNamespaceListerDeployment(t)
+				spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+					LogLevel: level,
+				}
+				err := applyNamespaceListerCustomizations(deployment, spec)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+				g.Expect(container).NotTo(gomega.BeNil())
+				val, found := findEnvValue(container.Env, envLogLevel)
+				g.Expect(found).To(gomega.BeTrue())
+				g.Expect(val).To(gomega.Equal(expected))
+			})
+		}
+	})
+
+	t.Run("field omitted leaves env var absent in real manifest", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		_, found := findEnvValue(container.Env, envLogLevel)
+		g.Expect(found).To(gomega.BeFalse(), "upstream default should apply — env var should be absent")
+	})
+
+	t.Run("field overrides same var set via ContainerSpec.Env on real manifest", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		deployment := getNamespaceListerDeployment(t)
+		spec := konfluxv1alpha1.KonfluxNamespaceListerSpec{
+			LogLevel: konfluxv1alpha1.LogLevelDebug,
+			NamespaceLister: &konfluxv1alpha1.NamespaceListerDeploymentSpec{
+				NamespaceLister: &konfluxv1alpha1.ContainerSpec{
+					Env: []corev1.EnvVar{
+						{Name: envLogLevel, Value: "8"},
+					},
+				},
+			},
+		}
+		err := applyNamespaceListerCustomizations(deployment, spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, namespaceListerContainerName)
+		g.Expect(container).NotTo(gomega.BeNil())
+		val, found := findEnvValue(container.Env, envLogLevel)
+		g.Expect(found).To(gomega.BeTrue())
+		g.Expect(val).To(gomega.Equal("-4"), "typed field should win over ContainerSpec.Env")
+	})
+}
+
 func TestCacheResyncPeriodWithRealManifest(t *testing.T) {
 	t.Run("embedded manifest does not contain CACHE_RESYNC_PERIOD", func(t *testing.T) {
 		g := gomega.NewWithT(t)

--- a/operator/pkg/manifests/namespace-lister/manifests.yaml
+++ b/operator/pkg/manifests/namespace-lister/manifests.yaml
@@ -88,8 +88,6 @@ spec:
         - -cert-path=/var/tls/tls.crt
         - -key-path=/var/tls/tls.key
         env:
-        - name: LOG_LEVEL
-          value: "0"
         - name: CACHE_NAMESPACE_LABELSELECTOR
           value: konflux-ci.dev/type=tenant
         - name: AUTH_USERNAME_HEADER

--- a/operator/upstream-kustomizations/namespace-lister/deployment.yaml
+++ b/operator/upstream-kustomizations/namespace-lister/deployment.yaml
@@ -33,8 +33,6 @@ spec:
         name: namespace-lister
         image: quay.io/konflux-ci/namespace-lister:foo
         env:
-        - name: LOG_LEVEL
-          value: "0"
         - name: CACHE_NAMESPACE_LABELSELECTOR
           value: konflux-ci.dev/type=tenant
         livenessProbe:


### PR DESCRIPTION
This change adds a new field to the KonfluxNamespaceLister CRD called logLevel. This field is used to specify the minimum severity for namespace-lister log output.

The field is optional and when omitted, the namespace-lister defaults to error level. logLevel is an enum with the following values: debug, info, warn, error.

- Add logLevel to KonfluxNamespaceLister CRD
- Add tests for logLevel
- Add tests for namespace-lister customization
- Add logLevel to sample yamls

The logLevel field is mapped to the slog integer the upstream namespace-lister expects. See See https://github.com/konflux-ci/namespace-lister/blob/main/internal/log/log.go
 for more details.
 
 ## Upgrade notes

Existing `KonfluxNamespaceLister` CRs (or `Konflux` CRs with a `namespaceLister` section)
should add the following field to preserve current behavior:

    spec:
      logLevel: info

When omitted, `logLevel` defaults to error-only logging.
 
 Assited-by: Cursor + Opus 4.6