### PR TITLE
test: add concurrency group of e2e tests

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -8,6 +8,39 @@ on:
   repository_dispatch:
     types: [e2e]
 
+# Serialize Operator E2E for dependency bots that open many PRs at once (MintMaker /
+# Renovate via konflux-ci-update-bot, Konflux image bumps via red-hat-konflux). All
+# runs from those authors share one concurrency group, so only one bot workflow runs
+# at a time and they do not compete for the shared GitHub App / smee channel.
+#
+# How the group expression works (GitHub evaluates the whole ${{ }} once):
+#   1. pull_request + bot author → fixed group "operator-e2e-serial-dependency-bots"
+#   2. pull_request + anyone else → per-PR group "operator-e2e-pr-<number>"
+#   3. repository_dispatch (/allow e2e) → per PR from client_payload
+#   4. all other events (including merge_group) → unique group per run
+#
+# cancel-in-progress:
+#   - false for dependency bots so their shared group is queued (never cancels peers)
+#   - true otherwise so a new push on the same PR/dispatched PR cancels stale runs
+concurrency:
+  group: >-
+    ${{
+      github.event_name == 'pull_request' && (
+        contains(fromJSON('["konflux-ci-update-bot[bot]","app/konflux-ci-update-bot","red-hat-konflux[bot]","app/red-hat-konflux"]'), github.event.pull_request.user.login)
+        && 'operator-e2e-serial-dependency-bots'
+        || format('operator-e2e-pr-{0}', github.event.pull_request.number)
+      )
+      || (github.event_name == 'repository_dispatch' && format('operator-e2e-dispatch-{0}', github.event.client_payload.pr_number))
+      || format('operator-e2e-fallback-{0}', github.run_id)
+    }}
+  cancel-in-progress: >-
+    ${{
+      !(
+        github.event_name == 'pull_request' &&
+        contains(fromJSON('["konflux-ci-update-bot[bot]","app/konflux-ci-update-bot","red-hat-konflux[bot]","app/red-hat-konflux"]'), github.event.pull_request.user.login)
+      )
+    }}
+
 jobs:
   # Gate: fork PRs (inline, before checkout) and superseded-by-companion (script; opt out: force-run-e2e).
   check-prerequisites:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,28 @@ the source PR anyway.
 
 ## Automated E2E Tests
 
+**Operator E2E concurrency:** PRs opened by the dependency bots (`konflux-ci-update-bot`
+or `red-hat-konflux`, including `app/…` and `…[bot]` login forms) share a single
+GitHub Actions concurrency group so only one Operator E2E workflow runs at a time
+during dependency bursts. Human and other bot PRs still run E2E in parallel (one
+group per PR number).
+
+If you need to merge a bot PR urgently, you can cancel all in-progress/queued
+**Operator E2E Tests** runs for currently open PRs from those two bot users:
+
+```bash
+REPO="konflux-ci/konflux-ci"
+
+SHAS_JSON="$(
+  gh pr list --repo "$REPO" --state open --json author,headRefOid \
+  | jq '[.[] | select(.author.login as $l | ["konflux-ci-update-bot[bot]","app/konflux-ci-update-bot","red-hat-konflux[bot]","app/red-hat-konflux"] | index($l)) | .headRefOid]'
+)"
+
+gh run list --repo "$REPO" --workflow "Operator E2E Tests" --limit 200 --json databaseId,headSha,status \
+| jq -r --argjson shas "$SHAS_JSON" '.[] | select(.status != "completed" and (.headSha as $h | $shas | index($h))) | .databaseId' \
+| xargs -r -n1 -I{} gh run cancel {} --repo "$REPO"
+```
+
 The repository includes automated tests that run in GitHub Actions on both x86_64
 and ARM64 architectures. There are **two test suites** in `test/go-tests`:
 


### PR DESCRIPTION
This is mainly for making bots queue their e2e tests rather than running them in parallel.

Assisted-by: Cursor