### PR TITLE
test: remove label triggers from e2e workflow

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -2,7 +2,7 @@ name: Operator E2E Tests
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
   merge_group:
     types: [checks_requested]
   repository_dispatch:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,11 @@ Source PRs labeled `superseded-by-companion` fail the Operator E2E workflow gate
 (merge the manifest companion PR instead). Add `force-run-e2e` to run full E2E on
 the source PR anyway.
 
+**Operator E2E Tests** does not run when labels alone change (only on new
+commits, reopen, merge queue, or maintainer `/allow` on fork PRs). After you add
+`force-run-e2e`, start CI manually—for example re-run **Operator E2E Tests** from
+the PR Checks or Actions UI, or push a new commit to the PR branch.
+
 ## Automated E2E Tests
 
 The repository includes automated tests that run in GitHub Actions on both x86_64


### PR DESCRIPTION
fullsend is adding and removing labels quite often on PR branches. This is causing the e2e tests to be triggered far more often, which in turn eats up our GitHub rate limit quota, failing the tests on all PRs.

I don't think we actually need those triggers, so removing for now.