### PR TITLE
fix(KFLUXVNGD-983): add missing enterprisecontract-configmap-viewer-role ClusterRole

### DIFF
--- a/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
+++ b/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
@@ -57,6 +57,9 @@ var _ = Describe("KonfluxEnterpriseContract Controller", func() {
 
 			By("verifying a representative ClusterRole was created")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "enterprisecontractpolicy-viewer-role"}, &rbacv1.ClusterRole{})).To(Succeed())
+
+			By("verifying the configmap-viewer ClusterRole was created")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "enterprisecontract-configmap-viewer-role"}, &rbacv1.ClusterRole{})).To(Succeed())
 		})
 	})
 })

--- a/operator/pkg/manifests/enterprise-contract/manifests.yaml
+++ b/operator/pkg/manifests/enterprise-contract/manifests.yaml
@@ -296,6 +296,24 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: enterprisecontract-configmap-viewer-role
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - ec-defaults
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: enterprisecontractpolicy-editor-role
 rules:

--- a/operator/upstream-kustomizations/enterprise-contract/core/configmap-viewer-role.yaml
+++ b/operator/upstream-kustomizations/enterprise-contract/core/configmap-viewer-role.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: enterprisecontract-configmap-viewer-role
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - ec-defaults
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/operator/upstream-kustomizations/enterprise-contract/core/kustomization.yaml
+++ b/operator/upstream-kustomizations/enterprise-contract/core/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - https://github.com/conforma/crds/config/crd?ref=6f685d079f1991c801d39d011b74ffa9c1fb09e3
   - ns.yaml
+  - configmap-viewer-role.yaml
   - public-ecp-rbac.yaml
 
 namespace: enterprise-contract-service


### PR DESCRIPTION
The operator's enterprise-contract manifests included a RoleBinding (public-ec-cm) referencing the enterprisecontract-configmap-viewer-role ClusterRole, but the ClusterRole itself was never created. This left a dangling reference, preventing authenticated users from reading the ec-defaults ConfigMap in the enterprise-contract-service namespace.

Add the ClusterRole to the upstream kustomizations and embedded manifests.

Assisted-by: Cursor + Opus 4.6