### PR TITLE
feat(KFLUXVNGD-983): update ec-defaults ConfigMap to conforma

### DIFF
--- a/operator/pkg/manifests/enterprise-contract/manifests.yaml
+++ b/operator/pkg/manifests/enterprise-contract/manifests.yaml
@@ -388,10 +388,10 @@ subjects:
 ---
 apiVersion: v1
 data:
-  verify_ec_task_bundle: quay.io/enterprise-contract/ec-task-bundle@sha256:bb9b38c0528c535ba4f79c87c6292648bc672ad98e579c3e2004f76b25957662
+  verify_ec_task_bundle: quay.io/conforma/tekton-task:latest@sha256:7df8d121c09999d0376e189c1eb8a8263078aab697aa5ee966512f581427a6ce
   verify_ec_task_git_pathInRepo: tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
-  verify_ec_task_git_revision: 1026da746d2717e25c0adac582f2d37694b0bd84
-  verify_ec_task_git_url: https://github.com/enterprise-contract/ec-cli.git
+  verify_ec_task_git_revision: b345847182602d9a5ce9e957fa76fe02575c8018
+  verify_ec_task_git_url: https://github.com/conforma/cli.git
 kind: ConfigMap
 metadata:
   name: ec-defaults

--- a/operator/upstream-kustomizations/enterprise-contract/core/kustomization.yaml
+++ b/operator/upstream-kustomizations/enterprise-contract/core/kustomization.yaml
@@ -14,9 +14,9 @@ configMapGenerator:
   - name: ec-defaults
     namespace: enterprise-contract-service
     literals:
-      - verify_ec_task_bundle=quay.io/enterprise-contract/ec-task-bundle@sha256:bb9b38c0528c535ba4f79c87c6292648bc672ad98e579c3e2004f76b25957662
-      - verify_ec_task_git_url=https://github.com/enterprise-contract/ec-cli.git
-      - verify_ec_task_git_revision=1026da746d2717e25c0adac582f2d37694b0bd84
+      - verify_ec_task_bundle=quay.io/conforma/tekton-task:latest@sha256:7df8d121c09999d0376e189c1eb8a8263078aab697aa5ee966512f581427a6ce
+      - verify_ec_task_git_url=https://github.com/conforma/cli.git
+      - verify_ec_task_git_revision=b345847182602d9a5ce9e957fa76fe02575c8018
       - verify_ec_task_git_pathInRepo=tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
 
 patches:

--- a/renovate.json
+++ b/renovate.json
@@ -88,11 +88,10 @@
         "operator/upstream-kustomizations/enterprise-contract/core/kustomization.yaml"
       ],
       "matchStrings": [
-        "- verify_ec_task_bundle=(?<depName>quay\\.io/enterprise-contract/ec-task-bundle)@(?<currentDigest>sha256:[a-f0-9]{64})"
+        "- verify_ec_task_bundle=(?<depName>quay\\.io/conforma/tekton-task):latest@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
-      "autoReplaceStringTemplate": "- verify_ec_task_bundle={{depName}}@{{newDigest}}",
       "datasourceTemplate": "docker",
-      "currentValueTemplate": "snapshot"
+      "currentValueTemplate": "latest"
     },
     {
       "customType": "regex",
@@ -101,7 +100,7 @@
         "operator/upstream-kustomizations/enterprise-contract/core/kustomization.yaml"
       ],
       "matchStrings": [
-        "- verify_ec_task_git_url=(?<packageName>https:\/\/github\\.com\/enterprise-contract\/ec-cli)\\.git",
+        "- verify_ec_task_git_url=(?<packageName>https:\/\/github\\.com\/conforma\/cli)\\.git",
         "- verify_ec_task_git_revision=(?<currentDigest>[a-f0-9]{40})"
       ],
       "datasourceTemplate": "git-refs",


### PR DESCRIPTION
- Migrate the ec-defaults ConfigMap values from the retired enterprise-contract org to the conforma org.
- Update the Renovate regex rules to match the new image and git URLs.

Assisted-by: Cursor + Opus 4.6