### PR TITLE
fix(KFLUXVNGD-1005): truncate segment-bridge image tag to commit hash (release-0.1 backport)

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -82,6 +82,10 @@ spec:
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
+    - name: enable-package-registry-proxy
+      default: 'true'
+      description: Use the package registry proxy when prefetching dependencies
+      type: string
   results:
     - description: ""
       name: IMAGE_URL
@@ -174,6 +178,8 @@ spec:
           value: $(params.output-image).prefetch
         - name: ociArtifactExpiresAfter
           value: $(params.image-expires-after)
+        - name: enable-package-registry-proxy
+          value: $(params.enable-package-registry-proxy)
       runAfter:
         - clone-repository
       taskRef:

--- a/operator/pkg/manifests/segment-bridge/manifests.yaml
+++ b/operator/pkg/manifests/segment-bridge/manifests.yaml
@@ -94,7 +94,7 @@ spec:
             - secretRef:
                 name: segment-bridge-config
                 optional: true
-            image: quay.io/konflux-ci/segment-bridge:d8f2d2b2c868c17d4eb51874a1ea2cbdc912a07f8666ea95618d573dd96fb093
+            image: quay.io/konflux-ci/segment-bridge:d8f2d2b2c868c17d4eb51874a1ea2cbdc912a07f
             imagePullPolicy: IfNotPresent
             name: segment-bridge
             resources:

--- a/operator/upstream-kustomizations/segment-bridge/kustomization.yaml
+++ b/operator/upstream-kustomizations/segment-bridge/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: quay.io/konflux-ci/segment-bridge
   newName: quay.io/konflux-ci/segment-bridge
-  newTag: d8f2d2b2c868c17d4eb51874a1ea2cbdc912a07f8666ea95618d573dd96fb093
+  newTag: d8f2d2b2c868c17d4eb51874a1ea2cbdc912a07f


### PR DESCRIPTION
## Summary

Backport of the main branch fix (PR from `fix/KFLUXVNGD-1005/segment-bridge-image-tag`) to `release-0.1`.

- The `segment-bridge` CronJob image tag contained a **64-char value** (commit hash + stale manifest-list digest suffix) instead of the expected **40-char git commit hash**, causing `ImagePullBackOff` on every Konflux v0.1.x install.
- Truncate `newTag` to the 40-char commit hash matching `?ref=` so the CronJob image reference resolves correctly.

**Jira:** [KFLUXVNGD-1005](https://redhat.atlassian.net/browse/KFLUXVNGD-1005)
**Support ticket:** [KFLUXSPRT-7933](https://redhat.atlassian.net/browse/KFLUXSPRT-7933)

## Test plan

- [ ] Verify `quay.io/konflux-ci/segment-bridge:d8f2d2b2c868c17d4eb51874a1ea2cbdc912a07f` resolves in the registry
- [ ] Deploy on a test cluster and confirm the segment-bridge CronJob pod pulls successfully
- [ ] Confirm next Renovate bump produces a correct 40-char `newTag`

[KFLUXVNGD-1005]: https://redhat.atlassian.net/browse/KFLUXVNGD-1005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KFLUXSPRT-7933]: https://redhat.atlassian.net/browse/KFLUXSPRT-7933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ