### PR TITLE
chore: upgrade go to 1.26

### DIFF
--- a/operator/docs/content/docs/installation/install-from-source.md
+++ b/operator/docs/content/docs/installation/install-from-source.md
@@ -17,7 +17,7 @@ to run a custom build. There are two modes:
 
 | Tool | Minimum version |
 |------|----------------|
-| [Go](https://go.dev/) | v1.25.0 |
+| [Go](https://go.dev/) | v1.26.0 |
 | [podman](https://podman.io/docs/installation) or [docker](https://docs.docker.com/engine/install/) | podman v5.3.1 / docker v27.0.1 *(required only when building an Operator image)* |
 | [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.31.4 |
 | [make](https://www.gnu.org/software/make/) | — |

--- a/operator/docs/content/docs/installation/install-openshift.md
+++ b/operator/docs/content/docs/installation/install-openshift.md
@@ -26,7 +26,7 @@ This is not the only way to install Konflux on OpenShift. You can also use:
 | `oc` or [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.31.4 |
 | [git](https://git-scm.com/) | v2.46 |
 | [make](https://www.gnu.org/software/make/) | — |
-| [Go](https://go.dev/) | v1.25.0 |
+| [Go](https://go.dev/) | v1.26.0 |
 | [openssl](https://www.openssl.org/) | v3.0.13 |
 
 - `cluster-admin` permissions

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/konflux-ci/konflux-ci/operator
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/cert-manager/cert-manager v1.20.2

--- a/test/go-tests/go.mod
+++ b/test/go-tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/konflux-ci/konflux-ci/test/go-tests
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/coder/websocket v1.8.14


### PR DESCRIPTION
The go-toolset image now has go 1.26, and dependencies start to require it.

Assisted-by: Cursor