### PR TITLE
fix: use repositories instead of repository in RPAs

### DIFF
--- a/operator/docs/content/docs/onboard/release.md
+++ b/operator/docs/content/docs/onboard/release.md
@@ -66,9 +66,9 @@ To do all that, follow these steps:
    - Under `applications`, verify that your application is the one listed.
 
    - Under the components mapping list, set the `name` field so it matches the name
-     of your component and replace the value of the `repository` field with the URL of
-     the repository on the registry to which your released images are to be pushed. This
-     is typically a different repository from the one builds are pushed to during tests.
+     of your component and set `repositories[].url` to the registry URL to which your
+     released images are to be pushed. This is typically a different repository from
+     the one builds are pushed to during tests.
 
      For example, if your component is called `test-component` and you wish to release
      your images to a Quay.io repository called `my-user/my-konflux-component-release`:
@@ -77,7 +77,8 @@ To do all that, follow these steps:
          mapping:
            components:
              - name: test-component
-               repository: quay.io/my-user/my-konflux-component-release
+               repositories:
+                 - url: quay.io/my-user/my-konflux-component-release
      ```
 
    - The example release pipeline requires a repository into which trusted artifacts

--- a/operator/pkg/manifests/cli/manifests.yaml
+++ b/operator/pkg/manifests/cli/manifests.yaml
@@ -230,13 +230,13 @@ data:
     SSO credentials creation\"\nfi\n\n# Step 12: Create ReleasePlanAdmission\necho
     \"\U0001F4CB Creating ReleasePlanAdmission...\"\n\n# Build the components mapping
     YAML\nCOMPONENTS_YAML=\"\"\nfor ((i = 0; i < ${#COMPONENTS[@]}; i++)); do\n    COMPONENT=\"${COMPONENTS[i]}\"\n
-    \   COMPONENTS_YAML=\"${COMPONENTS_YAML}\n        - name: ${COMPONENT}\n          repository:
-    ${REPO_IMAGE_URLS[i]}\"\ndone\n\nkubectl apply -f - <<EOF\napiVersion: appstudio.redhat.com/v1alpha1\nkind:
-    ReleasePlanAdmission\nmetadata:\n  name: ${RELEASE_NAME}\n  namespace: ${MANAGED_NS}\n
-    \ labels:\n    release.appstudio.openshift.io/auto-release: 'true'\nspec:\n  applications:\n
-    \   - ${APPLICATION}\n  origin: ${TENANT_NS}\n  policy: ${CONFORMA_POLICY}\n  data:\n
-    \   mapping:\n      defaults:\n        pushSourceContainer: false\n        tags:\n
-    \         - latest\n          - '{{ git_sha }}'\n      components:${COMPONENTS_YAML}\n
+    \   COMPONENTS_YAML=\"${COMPONENTS_YAML}\n        - name: ${COMPONENT}\n          repositories:\n
+    \           - url: ${REPO_IMAGE_URLS[i]}\"\ndone\n\nkubectl apply -f - <<EOF\napiVersion:
+    appstudio.redhat.com/v1alpha1\nkind: ReleasePlanAdmission\nmetadata:\n  name:
+    ${RELEASE_NAME}\n  namespace: ${MANAGED_NS}\n  labels:\n    release.appstudio.openshift.io/auto-release:
+    'true'\nspec:\n  applications:\n    - ${APPLICATION}\n  origin: ${TENANT_NS}\n
+    \ policy: ${CONFORMA_POLICY}\n  data:\n    mapping:\n      defaults:\n        pushSourceContainer:
+    false\n        tags:\n          - latest\n          - '{{ git_sha }}'\n      components:${COMPONENTS_YAML}\n
     \   releaseNotes:\n      product_name: '${PRODUCT_NAME}'\n      product_version:
     '${PRODUCT_VERSION}'\n  pipeline:\n    pipelineRef:\n      resolver: git\n      ociStorage:
     ${TA_IMAGE_URL}\n      useEmptyDir: true\n      params:\n        - name: url\n

--- a/operator/upstream-kustomizations/cli/setup-release.sh
+++ b/operator/upstream-kustomizations/cli/setup-release.sh
@@ -376,7 +376,8 @@ for ((i = 0; i < ${#COMPONENTS[@]}; i++)); do
     COMPONENT="${COMPONENTS[i]}"
     COMPONENTS_YAML="${COMPONENTS_YAML}
         - name: ${COMPONENT}
-          repository: ${REPO_IMAGE_URLS[i]}"
+          repositories:
+            - url: ${REPO_IMAGE_URLS[i]}"
 done
 
 kubectl apply -f - <<EOF

--- a/test/resources/demo-users/user/sample-components/managed-ns1/rpa.yaml
+++ b/test/resources/demo-users/user/sample-components/managed-ns1/rpa.yaml
@@ -16,7 +16,8 @@ spec:
     mapping:
       components:
         - name: sample-component
-          repository: <repository url>
+          repositories:
+            - url: <repository url>
   origin: user-ns1
   pipeline:
     pipelineRef:

--- a/test/resources/demo-users/user/sample-components/managed-ns2/rpa.yaml
+++ b/test/resources/demo-users/user/sample-components/managed-ns2/rpa.yaml
@@ -12,7 +12,8 @@ spec:
     mapping:
       components:
         - name: test-component
-          repository: registry-service.kind-registry/test-component-release
+          repositories:
+            - url: registry-service.kind-registry/test-component-release
           tags:
             - latest
   origin: user-ns2

--- a/test/resources/demo-users/user/sample-components/ns1/release-plan.yaml
+++ b/test/resources/demo-users/user/sample-components/ns1/release-plan.yaml
@@ -40,4 +40,5 @@ spec:
     mapping:
       components:
         - name: testrepo
-          repository: "quay.io/scoheb_devconfworkshop/releases/testrepo"
+          repositories:
+            - url: "quay.io/scoheb_devconfworkshop/releases/testrepo"


### PR DESCRIPTION
repository field is deprecated in favor of repositories. We need to have this updated as repository was recently removed from the RPA spec, which fails CI now if trying to update the upstream ref for release-service-catalog.

Assisted-by: Cursor

Addresses the failure in: https://github.com/konflux-ci/konflux-ci/pull/7030