### PR TITLE
fix: temp set toolchain to auto for tests on openshift

### DIFF
--- a/deploy-konflux-on-ocp.sh
+++ b/deploy-konflux-on-ocp.sh
@@ -24,6 +24,11 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+# Temporary: OpenShift CI/Prow builder images ship Go 1.25 with GOTOOLCHAIN=local baked in.
+# Unconditionally override so Go can download the toolchain required by go.mod (currently 1.26).
+# Remove once openshift/release uses rhel-9-release-golang-1.26-openshift-* in konflux-ci job configs.
+export GOTOOLCHAIN=auto
+
 # Determine the absolute path of the repository root
 REPO_ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
@@ -113,6 +118,7 @@ echo ""
 echo "=== Step 2/6: Installing Operator CRDs ==="
 cd operator
 # Clear GOFLAGS to allow downloading tools (CI may have -mod=vendor set)
+echo "DEBUG GOTOOLCHAIN=$GOTOOLCHAIN ($(go env GOTOOLCHAIN))"
 GOFLAGS="" make install
 
 # Step 3: Deploy the operator using the Konflux-built image

--- a/test/e2e/run-e2e.sh
+++ b/test/e2e/run-e2e.sh
@@ -8,6 +8,11 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+# Temporary: OpenShift CI/Prow builder images ship Go 1.25 with GOTOOLCHAIN=local baked in.
+# Unconditionally override so Go can download the toolchain required by go.mod (currently 1.26).
+# Remove once openshift/release uses rhel-9-release-golang-1.26-openshift-* in konflux-ci job configs.
+export GOTOOLCHAIN=auto
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
@@ -29,6 +34,7 @@ SKIP_SAMPLE_COMPONENTS="true" "${REPO_ROOT}/deploy-test-resources.sh"
 # Run E2E conformance tests
 echo "Running E2E conformance tests..."
 cd "${REPO_ROOT}/test/go-tests"
+echo "DEBUG GOTOOLCHAIN=$GOTOOLCHAIN ($(go env GOTOOLCHAIN))"
 # -mod=mod overrides GOFLAGS=-mod=vendor that may be present on some systems; this repo doesn't vendor.
 go test -mod=mod ./tests/conformance -v -timeout 45m -ginkgo.vv "$@"
 


### PR DESCRIPTION
We moved to use go 1.26, but there's no
rhel-9-release-golang-1.26-openshift-4.21 base image yet, so for now we set the toolchain to auto for the tests on openshift, to allow us access to the go 1.26 toolchain.

Assisted-by: Cursor