### PR TITLE
chore(KFLUXVNGD-1007): ai skill for reviewing go upgrades

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ PRs trigger the following workflows:
 
 ## PR Guidelines
 
+- **Go / `go.mod` PRs:** Apply **go-toolchain-upgrade** (`skills/go-toolchain-upgrade/SKILL.md`) and follow its triage table—do not summarize the workflow from memory.
 - **`.tekton` task/pipeline edits:** `pipeline.yaml` tasks `deploy-konflux-its` and `konflux-e2e-tests-its` hardcode `taskRef.revision: main`. To verify changes, temporarily point both at the PR’s git ref, run operator E2E, then restore `main` before merge (see `.tekton/pipelines/operator-e2e/README.md`).
 - **Same-repo branches preferred**: E2E tests run automatically
 - **Fork PRs**: Require maintainer `/allow` comment to trigger tests
@@ -110,3 +111,11 @@ PRs trigger the following workflows:
 ## Skills
 
 Detailed guides live in `skills/` — each subdirectory contains a `SKILL.md` with instructions.
+
+| Skill | Use when |
+|-------|----------|
+| [go-toolchain-upgrade](skills/go-toolchain-upgrade/SKILL.md) | `go.mod`/`go.sum`, Go pins, or `go.mod requires go` CI failures |
+| [create-pr](skills/create-pr/SKILL.md) | Opening PRs, fork `/allow` behavior |
+| [debug-e2e-tests](skills/debug-e2e-tests/SKILL.md) | Investigating failed e2e / OpenShift CI runs |
+| [update-upstream-deps](skills/update-upstream-deps/SKILL.md) | Bumping pinned upstream component SHAs |
+| [local-dev-setup](skills/local-dev-setup/SKILL.md) | Local Kind / dev environment |

--- a/skills/debug-e2e-tests/SKILL.md
+++ b/skills/debug-e2e-tests/SKILL.md
@@ -284,3 +284,10 @@ Present findings as:
 - File(s) to change: ...
 - If upstream: repo + what to fix
 ```
+
+## Go toolchain failures
+
+If logs contain `go.mod requires go >=` or `running go 1.X` with a lower toolchain,
+switch to [go-toolchain-upgrade](../go-toolchain-upgrade/SKILL.md) — the fix is usually
+bumping Prow `build_root` / runner images in openshift/release or rebuilding
+`e2e-test-runner`, not only changing this repo.

--- a/skills/go-toolchain-upgrade/SKILL.md
+++ b/skills/go-toolchain-upgrade/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: go-toolchain-upgrade
+description: >-
+  Use when konflux-ci/konflux-ci PRs touch go.mod, go.sum, the go directive,
+  golangci-lint or controller-gen pins, or deploy/e2e scripts that run go or make;
+  or when CI logs show go.mod requires go >=, GOTOOLCHAIN/local mismatch, or
+  OpenShift Prow failures on deploy-konflux-on-ocp.sh (cd operator; make install) or controller-gen.
+---
+
+# Go Toolchain Upgrade
+
+**Triage first.** Most `go.mod`/`go.sum` PRs are dependency-only—do not block them for
+cross-repo checklists. Escalate only when minimum Go or CI **images** must change.
+
+## Triage
+
+| Signal | Result | Action |
+|--------|--------|--------|
+| Only `require`/`replace`/indirect changes; **`go` unchanged** | Routine | Short note; **stop** |
+| `go.sum` only | Routine | Same |
+| **`go` minor increases** (e.g. 1.25→1.26) in any module | Significant | → **Significant** |
+| golangci-lint, controller-gen, or Makefile tool pins | Significant | → **Significant** |
+| `deploy-konflux-on-ocp.sh`, `test/e2e/run-e2e.sh`, workflow Go pins | Significant | → **Significant** |
+| PR states new language/stdlib minimum | Significant | → **Significant** |
+| Unclear large dep bump | Check | If `go` unchanged and CI green → **Routine** |
+
+Compare `^go ` in `operator/go.mod`, `test/go-tests/go.mod`, `operator/docs/go.mod`.
+Patch within same minor (1.26.0→1.26.1) = **Routine** unless other signals apply.
+
+## Routine (inform only)
+
+```markdown
+**Go toolchain (routine):** Dependency-only update; minimum Go unchanged. No
+openshift/release or infra-deployments image changes expected. In-repo CI suffices.
+```
+
+Do not request **Go toolchain impact**, parallel PRs, or local `make test`/`make lint`.
+
+## Significant (author plans cross-repo)
+
+**In-repo:** Trust green `operator-test`, `operator-lint`, `operator-verify-generated-files`.
+Do not ask the author to run them locally. Prow-only paths (`deploy-konflux-on-ocp.sh`:
+`cd operator` then `make install`) are not covered by GitHub Actions—see [reference.md](reference.md).
+
+**Author must identify** (link PRs; external repos may have no agent skills):
+
+- openshift/release — `build_root` / golang tags for konflux-ci jobs; rehearse OpenShift e2e
+- infra-deployments / legacy — `e2e-test-runner` if `test/go-tests` minimum Go rose
+- `.github/workflows` / `.tekton/` only if this PR changes Go or builder pins there
+
+Paths, PR body template, grep: [reference.md](reference.md). On significant PRs,
+request changes if **Go toolchain impact** is missing.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Block every `go.mod` PR for openshift/release | Triage; deps-only = routine |
+| `GOTOOLCHAIN=auto` on RHEL Prow builders | Bump `build_root` image; `local` wins |
+| Match golang tag to cluster variant (`ocp420` → 4.21 golang) | Builder stream ≠ cluster version; see reference |
+| Fix only konflux-ci when `test/go-tests` `go` rose | Rebuild `redhat-appstudio/ci:e2e-test-runner` |
+| Ask author to run `make test` locally | CI already runs on PR |
+
+## Rationalizations (do not accept)
+
+| Excuse | Reality |
+|--------|---------|
+| "go.mod changed → need full checklist" | Only if `go` directive or significant signals |
+| "GA is green → merge" (significant) | Prow may still fail on older golang image |
+| "We'll fix openshift/release after merge" | Plan parallel PR + merge order before merge |
+| "Mintmaker/Renovate = platform upgrade" | Default routine unless `go` line moved |
+
+## Related
+
+- `go.mod requires go >=` in logs: [debug-e2e-tests](../debug-e2e-tests/SKILL.md), then re-triage here as significant
+- Cross-repo map: [reference.md](reference.md)

--- a/skills/go-toolchain-upgrade/reference.md
+++ b/skills/go-toolchain-upgrade/reference.md
@@ -1,0 +1,97 @@
+# Go toolchain upgrade — reference
+
+Paths are in **external** repos unless noted. Grep current image tags before editing.
+
+## Dependency overview
+
+```
+konflux-ci/konflux-ci (no root go.mod)
+  ├─► operator/go.mod, test/go-tests/go.mod, operator/docs/go.mod
+  ├─► GitHub Actions — operator-test, operator-lint, operator-test-e2e (test/go-tests)
+  ├─► deploy-konflux-on-ocp.sh → cd operator && make install (Prow; not all GA jobs)
+  ├─► test/e2e/run-e2e.sh → test/go-tests
+  ├─► openshift/release — konflux-ci build_root, install-operator/e2e (from: src)
+  └─► legacy — redhat-appstudio/ci:e2e-test-runner ← konflux-ci/e2e-tests
+        conformance-tests ← clones test/go-tests
+```
+
+**Cluster version ≠ builder version:** `__ocp420` configs test OCP 4.20 but may use
+`rhel-9-release-golang-1.26-openshift-5.0` for `build_root`.
+
+## openshift/release — konflux-ci/konflux-ci
+
+| Area | Update |
+|------|--------|
+| `ci-operator/config/konflux-ci/konflux-ci/konflux-ci-konflux-ci-main*.yaml` | `build_root`, `base_images.e2e-test-runner` |
+| `ci-operator/step-registry/konflux-ci/install-operator/`, `e2e-tests/` | `from: src` (uses `build_root`) |
+| `ci-operator/config/konflux-ci/community-catalog/` | separate catalog jobs |
+
+Jobs: `konflux-e2e-v420`, `konflux-e2e-v420-optional`, `konflux-e2e-v420-arm64-optional`.
+
+No `golang-1.26-openshift-4.21` tag may exist—use a newer stream (e.g. `1.26-openshift-5.0`)
+while keeping `releases.*.version: "4.20"`.
+
+```bash
+cd openshift/release
+make ci-operator-prowgen WHAT='--config-dir ci-operator/config/konflux-ci/konflux-ci'
+```
+
+## openshift/release — infra-deployments & legacy
+
+| Area | Notes |
+|------|--------|
+| `ci-operator/config/redhat-appstudio/infra-deployments/redhat-appstudio-infra-deployments-main.yaml` | `appstudio-e2e-tests`; `e2e-test-runner` → `redhat-appstudio/ci` |
+| `ci-operator/step-registry/redhat-appstudio/conformance-tests/` | `from: e2e-test-runner` |
+| `ci-operator/step-registry/konflux-ci/install-konflux/` | `from: e2e-test-runner` |
+| `ci-operator/config/konflux-ci/e2e-tests/konflux-ci-e2e-tests-main.yaml` | builds/promotes `e2e-test-runner` |
+
+## konflux-ci/e2e-tests
+
+Rebuild when `test/go-tests` minimum Go rises—image is `redhat-appstudio/ci:e2e-test-runner`.
+
+## infra-deployments docs
+
+- `components/konflux-operator/ci/openshift-overlay-e2e/README.md` — overlay step images
+- `docs/temp/operator-overlay-openshift-ci-e2e-notes.md` — `e2e-test-runner` vs `from: src`
+
+Legacy `appstudio-e2e-tests`: `konflux-ci-install-konflux` + `redhat-appstudio-conformance-tests`.
+
+## PR template (significant only)
+
+```markdown
+## Go toolchain impact
+**New minimum Go:**
+### konflux-ci/konflux-ci
+- Modules touched:
+### openshift/release
+- [ ] build_root / golang tags:
+- [ ] Rehearse e2e:
+### infra-deployments / legacy
+- [ ] e2e-test-runner / overlay images:
+### Merge order
+```
+
+## Grep helpers
+
+Use **`rg`** ([ripgrep](https://github.com/BurntSushi/ripgrep)) or `grep -r` from the repo root.
+
+```bash
+# openshift/release
+rg 'golang-1\.' ci-operator/config/konflux-ci/
+rg 'golang-1\.' ci-operator/config/redhat-appstudio/infra-deployments/
+rg 'e2e-test-runner|build_root' ci-operator/config/konflux-ci/konflux-ci/
+rg 'from: e2e-test-runner|from: src' ci-operator/step-registry/konflux-ci/
+rg 'from: e2e-test-runner' ci-operator/step-registry/redhat-appstudio/
+
+# konflux-ci/konflux-ci
+rg '^go 1\.' operator/go.mod test/go-tests/go.mod operator/docs/go.mod
+rg 'GOTOOLCHAIN|golang|go version' deploy-konflux-on-ocp.sh test/e2e/run-e2e.sh .github .tekton
+```
+
+## CI log signatures
+
+| Log | Likely cause |
+|-----|----------------|
+| `go.mod requires go >= 1.26` / `running go 1.25` | Stale Prow `build_root` or runner |
+| `GOTOOLCHAIN=auto` but env is `local` | RHEL builder; bump image |
+| infra-deployments conformance only fails | Stale `e2e-test-runner` |


### PR DESCRIPTION
Recently, upgrading the go toolchain in this repo has caused CI to fail in unexpected places. This change introduces a skill that will facilitate AI agents in identifying potential future cases like that and ask the PR author to make sure the required steps are taken in this repo and others to minimize CI downtime.

Assisted-by: Cursor