### PR TITLE
feat(KFLUXVNGD-1026): add builder and releaser bot actions ClusterRoles

### DIFF
--- a/operator/internal/controller/rbac/konfluxrbac_controller_test.go
+++ b/operator/internal/controller/rbac/konfluxrbac_controller_test.go
@@ -48,8 +48,10 @@ var _ = Describe("KonfluxRBAC Controller", func() {
 				g.Expect(condition.IsConditionTrue(cr, condition.TypeReady)).To(BeTrue())
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
-			By("verifying a representative ClusterRole was created")
+			By("verifying representative ClusterRoles were created")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-admin-user-actions-batch"}, &rbacv1.ClusterRole{})).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-builder-bot-actions"}, &rbacv1.ClusterRole{})).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-releaser-bot-actions"}, &rbacv1.ClusterRole{})).To(Succeed())
 		})
 	})
 })

--- a/operator/pkg/manifests/rbac/manifests.yaml
+++ b/operator/pkg/manifests/rbac/manifests.yaml
@@ -202,6 +202,24 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: konflux-builder-bot-actions
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   labels:
     rbac.konflux-ci.dev/aggregate-to-contributor: "true"
   name: konflux-contributor-user-actions-core
@@ -444,6 +462,30 @@ rules:
   - get
   - list
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-releaser-bot-actions
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - releases
+  verbs:
+  - list
+  - get
+  - watch
+  - create
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - snapshots
+  verbs:
+  - list
+  - get
+  - watch
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/operator/upstream-kustomizations/rbac/core/konflux-builder-bot-actions.yaml
+++ b/operator/upstream-kustomizations/rbac/core/konflux-builder-bot-actions.yaml
@@ -1,0 +1,18 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-builder-bot-actions
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns

--- a/operator/upstream-kustomizations/rbac/core/konflux-releaser-bot-actions.yaml
+++ b/operator/upstream-kustomizations/rbac/core/konflux-releaser-bot-actions.yaml
@@ -1,0 +1,24 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-releaser-bot-actions
+rules:
+  - verbs:
+      - list
+      - get
+      - watch
+      - create
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releases
+  - verbs:
+      - list
+      - get
+      - watch
+      - create
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - snapshots

--- a/operator/upstream-kustomizations/rbac/core/kustomization.yaml
+++ b/operator/upstream-kustomizations/rbac/core/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
 - konflux-admin-user-actions-batch.yaml
 - konflux-contributor-user-actions-core.yaml
 - konflux-maintainer-user-actions-core.yaml
+- konflux-builder-bot-actions.yaml
+- konflux-releaser-bot-actions.yaml
 - konflux-self-access-reviewer.yaml
 - konflux-viewer-user-actions-core.yaml
 # Deprecated


### PR DESCRIPTION
Add ClusterRoles for builder and releaser bot actions to the RBAC manifests. 
These roles are used to grant permissions to the builder and releaser bot services to perform their respective actions.

Assisted-by: Cursor + Opus 4.6