### PR TITLE
feat(KONFLUX-14248): add arg replacement logic in pod customization

### DIFF
--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
@@ -295,7 +295,6 @@ func buildBuildControllerManagerOverlay(spec konfluxv1alpha1.KonfluxBuildService
 
 	containerOpts = append(containerOpts,
 		customization.FromContainerSpec(managerSpec),
-		customization.WithLeaderElection(),
 	)
 
 	if spec.PACWebhookInsecureSSL != nil {
@@ -308,6 +307,7 @@ func buildBuildControllerManagerOverlay(spec konfluxv1alpha1.KonfluxBuildService
 
 	podOpts = append(podOpts,
 		customization.WithContainerOpts(buildManagerContainerName, deployCtx, containerOpts...),
+		customization.WithLeaderElection(buildManagerContainerName, deployCtx.Replicas),
 	)
 	return customization.NewPodOverlay(podOpts...)
 }

--- a/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
+++ b/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
@@ -225,11 +225,11 @@ func buildImageControllerManagerOverlay(spec konfluxv1alpha1.KonfluxImageControl
 
 	containerOpts = append(containerOpts,
 		customization.FromContainerSpec(managerSpec),
-		customization.WithLeaderElection(),
 	)
 
 	podOpts = append(podOpts,
 		customization.WithContainerOpts(managerContainerName, deployCtx, containerOpts...),
+		customization.WithLeaderElection(managerContainerName, deployCtx.Replicas),
 	)
 	return customization.NewPodOverlay(podOpts...), nil
 }

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
@@ -242,17 +242,16 @@ func buildControllerManagerOverlay(spec *konfluxv1alpha1.ControllerManagerDeploy
 		managerSpec = spec.Manager
 	}
 
-	return customization.BuildPodOverlay(
-		customization.DeploymentContext{Replicas: replicas},
-		customization.WithContainerBuilder(
-			managerContainerName,
+	deployCtx := customization.DeploymentContext{Replicas: replicas}
+	return customization.NewPodOverlay(
+		customization.WithContainerOpts(managerContainerName, deployCtx,
 			customization.FromContainerSpec(managerSpec),
-			customization.WithLeaderElection(),
 			customization.WithEnvOverride("CONSOLE_URL", consoleURLTemplate),
 			customization.WithOptionalEnvOverride(envPipelineTimeout, integrationSpec.PipelineTimeout),
 			customization.WithOptionalEnvOverride(envTasksTimeout, integrationSpec.TasksTimeout),
 			customization.WithOptionalEnvOverride(envFinallyTimeout, integrationSpec.FinallyTimeout),
 		),
+		customization.WithLeaderElection(managerContainerName, replicas),
 	)
 }
 

--- a/operator/internal/controller/releaseservice/konfluxreleaseservice_controller.go
+++ b/operator/internal/controller/releaseservice/konfluxreleaseservice_controller.go
@@ -204,13 +204,12 @@ func buildReleaseControllerManagerOverlay(spec *konfluxv1alpha1.ControllerManage
 		return customization.NewPodOverlay()
 	}
 
-	return customization.BuildPodOverlay(
-		customization.DeploymentContext{Replicas: spec.Replicas},
-		customization.WithContainerBuilder(
-			releaseManagerContainerName,
+	deployCtx := customization.DeploymentContext{Replicas: spec.Replicas}
+	return customization.NewPodOverlay(
+		customization.WithContainerOpts(releaseManagerContainerName, deployCtx,
 			customization.FromContainerSpec(spec.Manager),
-			customization.WithLeaderElection(),
 		),
+		customization.WithLeaderElection(releaseManagerContainerName, spec.Replicas),
 	)
 }
 

--- a/operator/pkg/customization/container.go
+++ b/operator/pkg/customization/container.go
@@ -154,12 +154,3 @@ func WithOptionalEnvOverride(name, value string) ContainerOption {
 }
 
 // --- Context-aware options ---
-
-// WithLeaderElection adds --leader-elect=true if replicas > 1.
-func WithLeaderElection() ContainerOption {
-	return func(c *corev1.Container, ctx DeploymentContext) {
-		if ctx.Replicas > 1 {
-			c.Args = append(c.Args, "--leader-elect=true")
-		}
-	}
-}

--- a/operator/pkg/customization/container_test.go
+++ b/operator/pkg/customization/container_test.go
@@ -442,52 +442,6 @@ func TestWithImage(t *testing.T) {
 	})
 }
 
-func TestWithLeaderElection(t *testing.T) {
-	tests := []struct {
-		name          string
-		replicas      int32
-		expectedArgs  int
-		shouldContain string
-	}{
-		{
-			name:         "single replica - no leader election",
-			replicas:     1,
-			expectedArgs: 0,
-		},
-		{
-			name:          "multiple replicas - adds leader election",
-			replicas:      2,
-			expectedArgs:  1,
-			shouldContain: "--leader-elect=true",
-		},
-		{
-			name:          "many replicas - adds leader election",
-			replicas:      5,
-			expectedArgs:  1,
-			shouldContain: "--leader-elect=true",
-		},
-		{
-			name:         "zero replicas - no leader election",
-			replicas:     0,
-			expectedArgs: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
-			ctx := DeploymentContext{Replicas: tt.replicas}
-			c := NewContainerOverlay(ctx, WithLeaderElection())
-
-			g.Expect(c.Args).To(gomega.HaveLen(tt.expectedArgs))
-
-			if tt.expectedArgs > 0 {
-				g.Expect(c.Args).To(gomega.ContainElement(tt.shouldContain))
-			}
-		})
-	}
-}
-
 func TestCombinedOptions(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := DeploymentContext{Replicas: 3}
@@ -508,16 +462,12 @@ func TestCombinedOptions(t *testing.T) {
 		WithImage("my-image:v1"),
 		WithArgs("--config=/etc/config"),
 		WithEnv(corev1.EnvVar{Name: "LOG_LEVEL", Value: "debug"}),
-		WithLeaderElection(),
 	)
 
-	// Verify all options were applied
 	g.Expect(c.Image).To(gomega.Equal("my-image:v1"))
 	g.Expect(c.Resources.Limits.Cpu().String()).To(gomega.Equal("500m"))
-	// Should have 2 args: --config and --leader-elect
-	g.Expect(c.Args).To(gomega.HaveLen(2))
-	g.Expect(c.Args).To(gomega.ContainElements("--config=/etc/config", "--leader-elect=true"))
-	// Should have 2 env vars: FROM_SPEC from spec and LOG_LEVEL from WithEnv
+	g.Expect(c.Args).To(gomega.HaveLen(1))
+	g.Expect(c.Args).To(gomega.ContainElement("--config=/etc/config"))
 	g.Expect(c.Env).To(gomega.HaveLen(2))
 	g.Expect(c.Env[0].Name).To(gomega.Equal("FROM_SPEC"))
 	g.Expect(c.Env[1].Name).To(gomega.Equal("LOG_LEVEL"))

--- a/operator/pkg/customization/pod.go
+++ b/operator/pkg/customization/pod.go
@@ -17,6 +17,8 @@ limitations under the License.
 package customization
 
 import (
+	"strings"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -33,6 +35,9 @@ type PodOverlay struct {
 	configMapVolumeUpdates map[string]string
 	// secretVolumeUpdates holds updates to existing Secret volume references
 	secretVolumeUpdates map[string]string
+	// argReplacements holds args that replace (not append) base args with the same
+	// flag key. Key is the container name, value is the list of replacement args.
+	argReplacements map[string][]string
 }
 
 // PodOverlayOption is a functional option for configuring a PodOverlay.
@@ -141,6 +146,33 @@ func WithSecretVolumeUpdate(volumeName, secretName string) PodOverlayOption {
 	}
 }
 
+// WithArgReplace replaces a base arg that has the same flag key, or appends if no match.
+// The flag key is everything up to and including "=" (e.g. "--zap-encoder=" in
+// "--zap-encoder=console"). For standalone flags (no "="), the full arg is the key.
+//
+// This is a PodOverlayOption (not a ContainerOption) because replacements run after
+// the regular overlay merge — they can replace both original base args and args
+// appended by WithArgs in the same overlay.
+// Use this instead of WithArgs when an upstream manifest might already contain the flag.
+func WithArgReplace(containerName string, args ...string) PodOverlayOption {
+	return func(p *PodOverlay) {
+		if p.argReplacements == nil {
+			p.argReplacements = make(map[string][]string)
+		}
+		p.argReplacements[containerName] = append(p.argReplacements[containerName], args...)
+	}
+}
+
+// WithLeaderElection adds --leader-elect=true if replicas > 1.
+// It uses WithArgReplace so that any existing --leader-elect flag in the base
+// manifest is replaced rather than duplicated.
+func WithLeaderElection(containerName string, replicas int32) PodOverlayOption {
+	if replicas <= 1 {
+		return func(_ *PodOverlay) {}
+	}
+	return WithArgReplace(containerName, "--leader-elect=true")
+}
+
 // WithServiceAccountName sets the service account name for the pod.
 func WithServiceAccountName(name string) PodOverlayOption {
 	return func(p *PodOverlay) {
@@ -189,11 +221,11 @@ func (p *PodOverlay) ApplyToPodTemplateSpec(template *corev1.PodTemplateSpec) er
 	}
 
 	// Apply per-container customizations
-	if p.containerOverlays != nil {
-		if err := mergeContainerList(template.Spec.Containers, p.containerOverlays); err != nil {
+	if p.containerOverlays != nil || len(p.argReplacements) > 0 {
+		if err := mergeContainerList(template.Spec.Containers, p.containerOverlays, p.argReplacements); err != nil {
 			return err
 		}
-		if err := mergeContainerList(template.Spec.InitContainers, p.containerOverlays); err != nil {
+		if err := mergeContainerList(template.Spec.InitContainers, p.containerOverlays, p.argReplacements); err != nil {
 			return err
 		}
 	}
@@ -235,7 +267,14 @@ func (p *PodOverlay) ApplyToDaemonSet(daemonSet *appsv1.DaemonSet) error {
 // Container.Args is tagged +listType=atomic in the Kubernetes API, so strategic merge
 // replaces the entire args list. We handle args separately: save them before merge,
 // then append after merge so overlay args are added to (not replace) the base args.
-func mergeContainerList(containers []corev1.Container, overlays map[string]*corev1.Container) error {
+//
+// argReplacements are applied after the regular overlay merge. Each replacement arg
+// replaces a base arg with the same flag key, or is appended if no match exists.
+func mergeContainerList(
+	containers []corev1.Container,
+	overlays map[string]*corev1.Container,
+	argReplacements map[string][]string,
+) error {
 	for i := range containers {
 		base := &containers[i]
 		if overlay := overlays[base.Name]; overlay != nil {
@@ -252,8 +291,35 @@ func mergeContainerList(containers []corev1.Container, overlays map[string]*core
 			overlay.Args = extraArgs
 			base.Args = append(base.Args, extraArgs...)
 		}
+
+		for _, replacement := range argReplacements[base.Name] {
+			key := argKey(replacement)
+			replaced := false
+			for j, baseArg := range base.Args {
+				if argKey(baseArg) == key {
+					base.Args[j] = replacement
+					replaced = true
+					break
+				}
+			}
+			if !replaced {
+				base.Args = append(base.Args, replacement)
+			}
+		}
 	}
 	return nil
+}
+
+// argKey returns the flag key for deduplication.
+// For "--key=value" it returns "--key"; for standalone flags it returns the full arg.
+// This ensures "--leader-elect" and "--leader-elect=true" are treated as the same key.
+// Space-separated args (e.g. "--flag" "value" as two elements) are not handled;
+// controller-runtime uses --flag=value syntax exclusively.
+func argKey(arg string) string {
+	if idx := strings.Index(arg, "="); idx >= 0 {
+		return arg[:idx]
+	}
+	return arg
 }
 
 // applyConfigMapVolumeUpdates updates ConfigMap volume references in-place.

--- a/operator/pkg/customization/pod_test.go
+++ b/operator/pkg/customization/pod_test.go
@@ -477,8 +477,8 @@ func TestComplexScenario(t *testing.T) {
 					},
 				}),
 				WithEnv(corev1.EnvVar{Name: "LOG_LEVEL", Value: "info"}),
-				WithLeaderElection(),
 			),
+			WithLeaderElection("app", ctx.Replicas),
 			WithContainerOpts("sidecar", ctx,
 				WithResources(corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -535,10 +535,9 @@ func TestMergeContainerList_ArgsAppend(t *testing.T) {
 	t.Run("overlay args are appended to base args", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		ctx := DeploymentContext{Replicas: 3}
 		p := NewPodOverlay(
-			WithContainerOpts("manager", ctx,
-				WithLeaderElection(),
+			WithContainerOpts("manager", DeploymentContext{},
+				WithArgs("--custom-flag=value"),
 			),
 		)
 
@@ -568,7 +567,7 @@ func TestMergeContainerList_ArgsAppend(t *testing.T) {
 			"base args must be preserved")
 		g.Expect(container.Args).To(gomega.ContainElement("--health-probe-bind-address=:8081"),
 			"base args must be preserved")
-		g.Expect(container.Args).To(gomega.ContainElement("--leader-elect=true"),
+		g.Expect(container.Args).To(gomega.ContainElement("--custom-flag=value"),
 			"overlay args must be appended")
 		g.Expect(container.Args).To(gomega.HaveLen(3))
 	})
@@ -640,11 +639,10 @@ func TestMergeContainerList_ArgsAppend(t *testing.T) {
 	t.Run("multiple overlay args appended in order", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		ctx := DeploymentContext{Replicas: 2}
 		p := NewPodOverlay(
-			WithContainerOpts("manager", ctx,
+			WithContainerOpts("manager", DeploymentContext{},
 				WithArgs("--custom-flag=value"),
-				WithLeaderElection(),
+				WithArgs("--another-flag"),
 			),
 		)
 
@@ -670,7 +668,7 @@ func TestMergeContainerList_ArgsAppend(t *testing.T) {
 		g.Expect(container.Args).To(gomega.Equal([]string{
 			"--base-flag",
 			"--custom-flag=value",
-			"--leader-elect=true",
+			"--another-flag",
 		}))
 	})
 
@@ -710,6 +708,652 @@ func TestMergeContainerList_ArgsAppend(t *testing.T) {
 			gomega.Equal([]string{"--base", "--injected"}),
 			"second apply must produce the same result")
 	})
+}
+
+func TestWithArgReplace(t *testing.T) {
+	t.Run("replaces base arg with same flag key", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithArgReplace("manager", "--zap-encoder=console"),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "manager",
+								Args: []string{
+									"--metrics-bind-address=:8443",
+									"--zap-encoder=json",
+									"--health-probe-bind-address=:8081",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{
+			"--metrics-bind-address=:8443",
+			"--zap-encoder=console",
+			"--health-probe-bind-address=:8081",
+		}))
+	})
+
+	t.Run("appends when no matching base arg exists", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithArgReplace("manager", "--zap-encoder=console"),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "manager",
+								Args: []string{"--metrics-bind-address=:8443"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{
+			"--metrics-bind-address=:8443",
+			"--zap-encoder=console",
+		}))
+	})
+
+	t.Run("value-form replacement replaces standalone base flag", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithArgReplace("manager", "--leader-elect=true"),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "manager",
+								Args: []string{"--leader-elect", "--other-flag"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{
+			"--leader-elect=true",
+			"--other-flag",
+		}))
+	})
+
+	t.Run("standalone replacement replaces value-form base flag", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithArgReplace("manager", "--leader-elect"),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "manager",
+								Args: []string{"--leader-elect=false", "--other-flag"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{
+			"--leader-elect",
+			"--other-flag",
+		}))
+	})
+
+	t.Run("standalone flag replaces exact duplicate", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithArgReplace("manager", "--leader-elect"),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "manager",
+								Args: []string{"--leader-elect", "--other-flag"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{
+			"--leader-elect",
+			"--other-flag",
+		}))
+	})
+
+	t.Run("WithArgs still appends without dedup", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithContainerOpts("manager", DeploymentContext{},
+				WithArgs("--zap-encoder=console"),
+			),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "manager",
+								Args: []string{"--zap-encoder=json"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{
+			"--zap-encoder=json",
+			"--zap-encoder=console",
+		}), "WithArgs must preserve existing append-only behavior")
+	})
+
+	t.Run("mixed WithArgs and WithArgReplace", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithContainerOpts("manager", DeploymentContext{},
+				WithArgs("--custom-flag=value"),
+			),
+			WithArgReplace("manager", "--leader-elect=true"),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "manager",
+								Args: []string{
+									"--leader-elect=false",
+									"--metrics-bind-address=:8443",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{
+			"--leader-elect=true",
+			"--metrics-bind-address=:8443",
+			"--custom-flag=value",
+		}))
+	})
+
+	t.Run("applies without container overlay", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithArgReplace("manager", "--zap-encoder=console"),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "manager",
+								Image: "manager:v1",
+								Args:  []string{"--zap-encoder=json"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{"--zap-encoder=console"}))
+		g.Expect(container.Image).To(gomega.Equal("manager:v1"), "image should be unchanged")
+	})
+
+	t.Run("does not affect non-matching containers", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithArgReplace("manager", "--zap-encoder=console"),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "manager",
+								Args: []string{"--zap-encoder=json"},
+							},
+							{
+								Name: "sidecar",
+								Args: []string{"--zap-encoder=json"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		g.Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(
+			gomega.Equal([]string{"--zap-encoder=console"}))
+		g.Expect(deployment.Spec.Template.Spec.Containers[1].Args).To(
+			gomega.Equal([]string{"--zap-encoder=json"}),
+			"sidecar should be unchanged")
+	})
+
+	t.Run("appends when base has no args", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithArgReplace("manager", "--zap-encoder=console"),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "manager", Image: "manager:v1"},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{"--zap-encoder=console"}))
+	})
+
+	t.Run("is reusable across multiple apply calls", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithArgReplace("manager", "--zap-encoder=console"),
+		)
+
+		makeDeployment := func() *appsv1.Deployment {
+			return &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "manager", Args: []string{"--zap-encoder=json"}},
+							},
+						},
+					},
+				},
+			}
+		}
+
+		d1 := makeDeployment()
+		err := p.ApplyToDeployment(d1)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(d1.Spec.Template.Spec.Containers[0].Args).To(
+			gomega.Equal([]string{"--zap-encoder=console"}))
+
+		d2 := makeDeployment()
+		err = p.ApplyToDeployment(d2)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(d2.Spec.Template.Spec.Containers[0].Args).To(
+			gomega.Equal([]string{"--zap-encoder=console"}),
+			"second apply must produce the same result")
+	})
+
+	t.Run("applies to init containers", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithArgReplace("init-db", "--log-level=debug"),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						InitContainers: []corev1.Container{
+							{
+								Name: "init-db",
+								Args: []string{"--log-level=info", "--timeout=30s"},
+							},
+						},
+						Containers: []corev1.Container{
+							{Name: "app", Image: "app:v1"},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		initContainer := deployment.Spec.Template.Spec.InitContainers[0]
+		g.Expect(initContainer.Args).To(gomega.Equal([]string{
+			"--log-level=debug",
+			"--timeout=30s",
+		}))
+	})
+
+	t.Run("ignored when container name is absent from pod spec", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithArgReplace("nonexistent", "--zap-encoder=console"),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "manager",
+								Args: []string{"--metrics-bind-address=:8443"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{"--metrics-bind-address=:8443"}),
+			"existing container args should be untouched")
+	})
+
+	t.Run("multiple replacements on same container", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithArgReplace("manager", "--zap-encoder=console", "--leader-elect=true"),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "manager",
+								Args: []string{
+									"--leader-elect=false",
+									"--metrics-bind-address=:8443",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{
+			"--leader-elect=true",
+			"--metrics-bind-address=:8443",
+			"--zap-encoder=console",
+		}))
+	})
+}
+
+func TestWithLeaderElection(t *testing.T) {
+	t.Run("single replica - no leader election arg", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithLeaderElection("manager", 1),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "manager",
+								Args: []string{"--metrics-bind-address=:8443"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{"--metrics-bind-address=:8443"}))
+	})
+
+	t.Run("multiple replicas - adds leader election", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithLeaderElection("manager", 2),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "manager",
+								Args: []string{"--metrics-bind-address=:8443"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{
+			"--metrics-bind-address=:8443",
+			"--leader-elect=true",
+		}))
+	})
+
+	t.Run("zero replicas - no leader election arg", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithLeaderElection("manager", 0),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "manager", Args: []string{"--flag"}},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{"--flag"}))
+	})
+
+	t.Run("replaces existing leader-elect=false in base", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithLeaderElection("manager", 3),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "manager",
+								Args: []string{
+									"--metrics-bind-address=:8443",
+									"--leader-elect=false",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{
+			"--metrics-bind-address=:8443",
+			"--leader-elect=true",
+		}))
+	})
+
+	t.Run("replaces standalone leader-elect in base", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		p := NewPodOverlay(
+			WithLeaderElection("manager", 5),
+		)
+
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "manager",
+								Args: []string{"--leader-elect", "--other-flag"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := p.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		g.Expect(container.Args).To(gomega.Equal([]string{
+			"--leader-elect=true",
+			"--other-flag",
+		}))
+	})
+}
+
+func TestArgKey(t *testing.T) {
+	tests := []struct {
+		arg  string
+		want string
+	}{
+		{"--zap-encoder=console", "--zap-encoder"},
+		{"--leader-elect=true", "--leader-elect"},
+		{"--leader-elect", "--leader-elect"},
+		{"--metrics-bind-address=:8443", "--metrics-bind-address"},
+		{"-v=5", "-v"},
+		{"positional", "positional"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arg, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			g.Expect(argKey(tt.arg)).To(gomega.Equal(tt.want))
+		})
+	}
 }
 
 func TestWithConfigMapVolumeUpdate(t *testing.T) {


### PR DESCRIPTION
- Add arg replacement logic to the pod customization.
- Add tests for the arg replacement logic.
- Modify leader election logic to use arg replacement.

fix #7102 

Assited-by: Cursor + Opus 4.6