### PR TITLE
feat(KFLUXVNGD-1025): generalize logEncoder and add it to image-controller

### DIFF
--- a/operator/api/v1alpha1/common_types.go
+++ b/operator/api/v1alpha1/common_types.go
@@ -43,6 +43,21 @@ const (
 	LogLevelError LogLevel = "error"
 )
 
+// LogEncoder sets the log encoding format for controller-runtime based services.
+// "json" produces structured JSON logs (upstream default), "console" produces
+// human-readable output useful for development and debugging.
+// +kubebuilder:validation:Enum=json;console
+type LogEncoder string
+
+const (
+	LogEncoderJSON    LogEncoder = "json"
+	LogEncoderConsole LogEncoder = "console"
+
+	// ZapEncoderArg is the CLI flag that sets the log encoding format on
+	// controller-runtime based services.
+	ZapEncoderArg = "--zap-encoder"
+)
+
 // ControllerManagerDeploymentSpec defines customizations for the controller-manager deployment.
 type ControllerManagerDeploymentSpec struct {
 	// Replicas is the number of replicas for the controller-manager deployment.

--- a/operator/api/v1alpha1/konfluxbuildservice_types.go
+++ b/operator/api/v1alpha1/konfluxbuildservice_types.go
@@ -41,12 +41,9 @@ type KonfluxBuildServiceSpec struct {
 	PACWebhookInsecureSSL *bool `json:"pacWebhookInsecureSSL,omitempty"`
 
 	// LogEncoder sets the log encoding format for the build-service controller.
-	// "json" produces structured JSON logs (upstream default), "console" produces
-	// human-readable output useful for development and debugging.
 	// When not set, the upstream default (json) is used.
 	// +optional
-	// +kubebuilder:validation:Enum=json;console
-	LogEncoder string `json:"logEncoder,omitempty"`
+	LogEncoder LogEncoder `json:"logEncoder,omitempty"`
 
 	// WebhookURLs maps repository URL prefixes to externally-reachable webhook URLs.
 	// When configured, the build-service uses these URLs instead of the default PaC webhook

--- a/operator/api/v1alpha1/konfluximagecontroller_types.go
+++ b/operator/api/v1alpha1/konfluximagecontroller_types.go
@@ -42,6 +42,11 @@ type KonfluxImageControllerSpec struct {
 	// +optional
 	ImageControllerManager *ControllerManagerDeploymentSpec `json:"imageControllerManager,omitempty"`
 
+	// LogEncoder sets the log encoding format for the image-controller.
+	// When not set, the upstream default (json) is used.
+	// +optional
+	LogEncoder LogEncoder `json:"logEncoder,omitempty"`
+
 	// QuayCABundle configures a custom CA bundle for Quay registry communication.
 	// When set, the CA certificate from the referenced ConfigMap is mounted into the
 	// image-controller pod and used for TLS verification when connecting to Quay.

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxbuildservices.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxbuildservices.yaml
@@ -278,8 +278,6 @@ spec:
               logEncoder:
                 description: |-
                   LogEncoder sets the log encoding format for the build-service controller.
-                  "json" produces structured JSON logs (upstream default), "console" produces
-                  human-readable output useful for development and debugging.
                   When not set, the upstream default (json) is used.
                 enum:
                 - json

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
@@ -303,8 +303,6 @@ spec:
                       logEncoder:
                         description: |-
                           LogEncoder sets the log encoding format for the build-service controller.
-                          "json" produces structured JSON logs (upstream default), "console" produces
-                          human-readable output useful for development and debugging.
                           When not set, the upstream default (json) is used.
                         enum:
                         - json
@@ -720,6 +718,14 @@ spec:
                             minimum: 1
                             type: integer
                         type: object
+                      logEncoder:
+                        description: |-
+                          LogEncoder sets the log encoding format for the image-controller.
+                          When not set, the upstream default (json) is used.
+                        enum:
+                        - json
+                        - console
+                        type: string
                       quayCABundle:
                         description: |-
                           QuayCABundle configures a custom CA bundle for Quay registry communication.

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluximagecontrollers.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluximagecontrollers.yaml
@@ -275,6 +275,14 @@ spec:
                     minimum: 1
                     type: integer
                 type: object
+              logEncoder:
+                description: |-
+                  LogEncoder sets the log encoding format for the image-controller.
+                  When not set, the upstream default (json) is used.
+                enum:
+                - json
+                - console
+                type: string
               quayCABundle:
                 description: |-
                   QuayCABundle configures a custom CA bundle for Quay registry communication.

--- a/operator/config/samples/konflux-e2e.yaml
+++ b/operator/config/samples/konflux-e2e.yaml
@@ -90,6 +90,7 @@ spec:
       # Skip TLS verification for PaC webhook URLs — the e2e environment
       # exposes Pipelines-as-Code via a route with a self-signed certificate.
       pacWebhookInsecureSSL: true
+      # logEncoder: console  # Use human-readable logs (default: json)
       buildControllerManager:
         replicas: 1
         manager:
@@ -146,3 +147,5 @@ spec:
   # E2E-specific: Enable image-controller for E2E tests
   imageController:
     enabled: true
+    # spec:
+    #   logEncoder: console  # Use human-readable logs (default: json)

--- a/operator/config/samples/konflux_v1alpha1_konflux.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konflux.yaml
@@ -92,6 +92,7 @@ spec:
               memory: 128Mi
   buildService:
     spec:
+      # logEncoder: console  # Use human-readable logs (default: json)
       buildControllerManager:
         replicas: 1
         manager:

--- a/operator/config/samples/konflux_v1alpha1_konfluximagecontroller.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konfluximagecontroller.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: konflux-image-controller
 spec:
+  # logEncoder: console  # Use human-readable logs (default: json)
   imageControllerManager:
     replicas: 1
     manager:

--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
@@ -67,9 +67,6 @@ const (
 	pacWebhookURLEnvName      = "PAC_WEBHOOK_URL"
 	pacWebhookURLNonOpenShift = "http://pipelines-as-code-controller.pipelines-as-code.svc.cluster.local:8180"
 
-	// zapEncoderArg is the CLI flag that controls log encoding format.
-	zapEncoderArg = "--zap-encoder"
-
 	// Webhook config constants for the optional per-provider webhook URL mapping.
 	// The volume, mount, and arg are baked into the manifest with optional: true.
 	// The operator only needs to create the ConfigMap and update the volume reference.
@@ -283,7 +280,8 @@ func buildBuildControllerManagerOverlay(spec konfluxv1alpha1.KonfluxBuildService
 	}
 
 	if spec.LogEncoder != "" {
-		containerOpts = append(containerOpts, customization.WithArgs(zapEncoderArg+"="+spec.LogEncoder))
+		podOpts = append(podOpts, customization.WithArgReplace(
+			buildManagerContainerName, konfluxv1alpha1.ZapEncoderArg+"="+string(spec.LogEncoder)))
 	}
 
 	var deployCtx customization.DeploymentContext

--- a/operator/internal/controller/buildservice/konfluxbuildservice_customization_test.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_customization_test.go
@@ -146,10 +146,10 @@ func TestBuildBuildControllerManagerOverlay(t *testing.T) {
 		g.Expect(managerContainer.Image).To(gomega.Equal(originalImage))
 	})
 
-	t.Run("logEncoder=console appends zap-encoder arg", func(t *testing.T) {
+	t.Run("logEncoder=console sets zap-encoder arg", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
-			LogEncoder: "console",
+			LogEncoder: konfluxv1alpha1.LogEncoderConsole,
 		}
 
 		deployment := getBuildServiceDeployment(t)
@@ -164,13 +164,13 @@ func TestBuildBuildControllerManagerOverlay(t *testing.T) {
 		managerContainer = testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
 		g.Expect(managerContainer).NotTo(gomega.BeNil())
 		g.Expect(managerContainer.Args).To(gomega.HaveLen(baseArgCount + 1))
-		g.Expect(managerContainer.Args).To(gomega.ContainElement("--zap-encoder=console"))
+		g.Expect(managerContainer.Args).To(gomega.ContainElement(konfluxv1alpha1.ZapEncoderArg + "=" + string(konfluxv1alpha1.LogEncoderConsole)))
 	})
 
-	t.Run("logEncoder=json appends zap-encoder arg", func(t *testing.T) {
+	t.Run("logEncoder=json sets zap-encoder arg", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
-			LogEncoder: "json",
+			LogEncoder: konfluxv1alpha1.LogEncoderJSON,
 		}
 
 		deployment := getBuildServiceDeployment(t)
@@ -180,7 +180,7 @@ func TestBuildBuildControllerManagerOverlay(t *testing.T) {
 
 		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
 		g.Expect(managerContainer).NotTo(gomega.BeNil())
-		g.Expect(managerContainer.Args).To(gomega.ContainElement("--zap-encoder=json"))
+		g.Expect(managerContainer.Args).To(gomega.ContainElement(konfluxv1alpha1.ZapEncoderArg + "=" + string(konfluxv1alpha1.LogEncoderJSON)))
 	})
 
 	t.Run("empty logEncoder does not add zap-encoder arg", func(t *testing.T) {
@@ -205,7 +205,7 @@ func TestBuildBuildControllerManagerOverlay(t *testing.T) {
 	t.Run("logEncoder with buildControllerManager preserves base args and adds zap-encoder", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
-			LogEncoder: "console",
+			LogEncoder: konfluxv1alpha1.LogEncoderConsole,
 			BuildControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
 				Manager: &konfluxv1alpha1.ContainerSpec{
 					Resources: &corev1.ResourceRequirements{
@@ -232,8 +232,29 @@ func TestBuildBuildControllerManagerOverlay(t *testing.T) {
 		for _, arg := range baseArgs {
 			g.Expect(managerContainer.Args).To(gomega.ContainElement(arg))
 		}
-		g.Expect(managerContainer.Args).To(gomega.ContainElement("--zap-encoder=console"))
+		g.Expect(managerContainer.Args).To(gomega.ContainElement(konfluxv1alpha1.ZapEncoderArg + "=" + string(konfluxv1alpha1.LogEncoderConsole)))
 		g.Expect(managerContainer.Resources.Limits.Cpu().String()).To(gomega.Equal("500m"))
+	})
+
+	t.Run("logEncoder replaces existing base zap-encoder arg", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
+			LogEncoder: konfluxv1alpha1.LogEncoderConsole,
+		}
+
+		deployment := getBuildServiceDeployment(t)
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		managerContainer.Args = append(managerContainer.Args, konfluxv1alpha1.ZapEncoderArg+"="+string(konfluxv1alpha1.LogEncoderJSON))
+
+		overlay := buildBuildControllerManagerOverlay(spec, nil, "")
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer = testutil.FindContainer(deployment.Spec.Template.Spec.Containers, buildManagerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(managerContainer.Args).To(gomega.ContainElement(konfluxv1alpha1.ZapEncoderArg + "=" + string(konfluxv1alpha1.LogEncoderConsole)))
+		g.Expect(managerContainer.Args).NotTo(gomega.ContainElement(konfluxv1alpha1.ZapEncoderArg + "=" + string(konfluxv1alpha1.LogEncoderJSON)))
 	})
 
 	t.Run("pacWebhookInsecureSSL=true injects PAC_WEBHOOK_INSECURE_SSL env", func(t *testing.T) {
@@ -290,7 +311,7 @@ func TestBuildBuildControllerManagerOverlay(t *testing.T) {
 		g := gomega.NewWithT(t)
 		spec := konfluxv1alpha1.KonfluxBuildServiceSpec{
 			PACWebhookInsecureSSL: boolPtr(true),
-			LogEncoder:            "console",
+			LogEncoder:            konfluxv1alpha1.LogEncoderConsole,
 			BuildControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
 				Manager: &konfluxv1alpha1.ContainerSpec{
 					Resources: &corev1.ResourceRequirements{
@@ -312,7 +333,7 @@ func TestBuildBuildControllerManagerOverlay(t *testing.T) {
 		val, found := findEnvValue(managerContainer.Env, "PAC_WEBHOOK_INSECURE_SSL")
 		g.Expect(found).To(gomega.BeTrue())
 		g.Expect(val).To(gomega.Equal("1"))
-		g.Expect(managerContainer.Args).To(gomega.ContainElement("--zap-encoder=console"))
+		g.Expect(managerContainer.Args).To(gomega.ContainElement(konfluxv1alpha1.ZapEncoderArg + "=" + string(konfluxv1alpha1.LogEncoderConsole)))
 		g.Expect(managerContainer.Resources.Limits.Cpu().String()).To(gomega.Equal("500m"))
 	})
 

--- a/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
+++ b/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
@@ -227,6 +227,11 @@ func buildImageControllerManagerOverlay(spec konfluxv1alpha1.KonfluxImageControl
 		customization.FromContainerSpec(managerSpec),
 	)
 
+	if spec.LogEncoder != "" {
+		podOpts = append(podOpts, customization.WithArgReplace(
+			managerContainerName, konfluxv1alpha1.ZapEncoderArg+"="+string(spec.LogEncoder)))
+	}
+
 	podOpts = append(podOpts,
 		customization.WithContainerOpts(managerContainerName, deployCtx, containerOpts...),
 		customization.WithLeaderElection(managerContainerName, deployCtx.Replicas),

--- a/operator/internal/controller/imagecontroller/konfluximagecontroller_customization_test.go
+++ b/operator/internal/controller/imagecontroller/konfluximagecontroller_customization_test.go
@@ -222,6 +222,111 @@ func TestBuildImageControllerManagerOverlay(t *testing.T) {
 		g.Expect(managerContainer.Args).To(gomega.ContainElement("--leader-elect=true"))
 	})
 
+	t.Run("logEncoder console adds zap-encoder arg", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxImageControllerSpec{
+			LogEncoder: konfluxv1alpha1.LogEncoderConsole,
+		}
+
+		deployment := getImageControllerDeployment(t)
+		overlay, err := buildImageControllerManagerOverlay(spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		err = overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(managerContainer.Args).To(gomega.ContainElement(konfluxv1alpha1.ZapEncoderArg + "=" + string(konfluxv1alpha1.LogEncoderConsole)))
+	})
+
+	t.Run("logEncoder json adds zap-encoder arg", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxImageControllerSpec{
+			LogEncoder: konfluxv1alpha1.LogEncoderJSON,
+		}
+
+		deployment := getImageControllerDeployment(t)
+		overlay, err := buildImageControllerManagerOverlay(spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		err = overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(managerContainer.Args).To(gomega.ContainElement(konfluxv1alpha1.ZapEncoderArg + "=" + string(konfluxv1alpha1.LogEncoderJSON)))
+	})
+
+	t.Run("empty logEncoder does not add zap-encoder arg", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxImageControllerSpec{}
+
+		deployment := getImageControllerDeployment(t)
+		originalContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(originalContainer).NotTo(gomega.BeNil())
+		originalArgs := make([]string, len(originalContainer.Args))
+		copy(originalArgs, originalContainer.Args)
+
+		overlay, err := buildImageControllerManagerOverlay(spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		err = overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(managerContainer.Args).To(gomega.Equal(originalArgs))
+	})
+
+	t.Run("logEncoder with ImageControllerManager preserves base args", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxImageControllerSpec{
+			LogEncoder: konfluxv1alpha1.LogEncoderConsole,
+			ImageControllerManager: &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+				Replicas: 3,
+				Manager: &konfluxv1alpha1.ContainerSpec{
+					Resources: &corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("500m"),
+						},
+					},
+				},
+			},
+		}
+
+		deployment := getImageControllerDeployment(t)
+		overlay, err := buildImageControllerManagerOverlay(spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		err = overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(managerContainer.Args).To(gomega.ContainElement(konfluxv1alpha1.ZapEncoderArg + "=" + string(konfluxv1alpha1.LogEncoderConsole)))
+		g.Expect(managerContainer.Args).To(gomega.ContainElement("--leader-elect=true"))
+		g.Expect(managerContainer.Resources.Limits.Cpu().String()).To(gomega.Equal("500m"))
+	})
+
+	t.Run("logEncoder replaces existing base zap-encoder arg", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := konfluxv1alpha1.KonfluxImageControllerSpec{
+			LogEncoder: konfluxv1alpha1.LogEncoderConsole,
+		}
+
+		deployment := getImageControllerDeployment(t)
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		managerContainer.Args = append(managerContainer.Args, konfluxv1alpha1.ZapEncoderArg+"="+string(konfluxv1alpha1.LogEncoderJSON))
+
+		overlay, err := buildImageControllerManagerOverlay(spec)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		err = overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer = testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+		g.Expect(managerContainer.Args).To(gomega.ContainElement(konfluxv1alpha1.ZapEncoderArg + "=" + string(konfluxv1alpha1.LogEncoderConsole)))
+		g.Expect(managerContainer.Args).NotTo(gomega.ContainElement(konfluxv1alpha1.ZapEncoderArg + "=" + string(konfluxv1alpha1.LogEncoderJSON)))
+	})
+
 	t.Run("QuayCABundle and ImageControllerManager combined", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 		spec := konfluxv1alpha1.KonfluxImageControllerSpec{


### PR DESCRIPTION
- This change generalizes the `logEncoder` field to all controllers and adds it to the image-controller.
- Update build-service to use the generalized `logEncoder`
- `logEncoder` now uses `withArgReplace` to set the `zap-encoder` arg.
- Added tests for the `logEncoder` field.
- Added `logEncoder` field to the e2e sample.
- If other services will need this flag it can be easily added.

Assisted-by: Cursor + Opus 4.6