### PR TITLE
fix(ui): use shared cluster CA for namespace-lister TLS verification

### DIFF
--- a/operator/pkg/manifests/ui/manifests.yaml
+++ b/operator/pkg/manifests/ui/manifests.yaml
@@ -127,7 +127,7 @@ data:
   Caddyfile: "{\n\tauto_https off\n\tadmin off\n\torder inject_cached_vars before
     reverse_proxy\n\tfile_watcher {\n\t\tcache kube_token /var/run/secrets/konflux-ci.dev/serviceaccount/token\n\t\tcache
     backend_token /var/run/secrets/konflux-ci.dev/backend/token\n\t\twatch /var/run/secrets/kubernetes.io/serviceaccount\n\t\twatch
-    /mnt/trusted-ca\n\t\twatch /mnt/service-ca\n\t\twatch /mnt/serving-cert\n\t}\n}\n\n#
+    /mnt/cluster-ca\n\t\twatch /mnt/service-ca\n\t\twatch /mnt/serving-cert\n\t}\n}\n\n#
     TODO: protect metrics with kube-rbac-proxy sidecar (https://github.com/openshift/kube-rbac-proxy)\n:2112
     {\n\tmetrics /metrics\n}\n\n:9443 {\n\ttls {\n\t\tget_certificate file {\n\t\t\tcert
     /mnt/serving-cert/tls.crt\n\t\t\tkey /mnt/serving-cert/tls.key\n\t\t}\n\t}\n\n\t#
@@ -149,7 +149,7 @@ data:
     X-Auth-Request-Groups\n\t\t\t}\n\t\t\timpersonate {\n\t\t\t\ttarget_user X-User\n\t\t\t\ttarget_group
     X-Group\n\t\t\t}\n\t\t\trewrite * /api/v1/namespaces\n\t\t\treverse_proxy https://namespace-lister.namespace-lister.svc.cluster.local:8080
     {\n\t\t\t\theader_down -X-Correlation-ID\n\t\t\t\ttransport http {\n\t\t\t\t\tread_timeout
-    30m\n\t\t\t\t\twrite_timeout 30m\n\t\t\t\t\ttls_trust_pool file /mnt/trusted-ca/ca-bundle.crt\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n\n\t#
+    30m\n\t\t\t\t\twrite_timeout 30m\n\t\t\t\t\ttls_trust_pool file /mnt/cluster-ca/ca-bundle.crt\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n\n\t#
     Backend snippets (tekton-results, kubearchive, etc.) loaded from init-generated
     configs.\n\t# NOTE: Imported snippets MUST use paths more specific than /api/k8s/
     to avoid\n\t# shadowing the Kube API catch-all handler below. Caddy evaluates
@@ -174,7 +174,7 @@ data:
     {path} /index.html\n\t\tfile_server\n\t}\n}\n"
 kind: ConfigMap
 metadata:
-  name: proxy-caddyfile-4k244mbkbd
+  name: proxy-caddyfile-8477t8hg9h
   namespace: konflux-ui
 ---
 apiVersion: v1
@@ -445,8 +445,8 @@ spec:
         - mountPath: /mnt/caddy-snippets
           name: caddy-snippets
           readOnly: true
-        - mountPath: /mnt/trusted-ca
-          name: trusted-ca
+        - mountPath: /mnt/cluster-ca
+          name: cluster-ca
           readOnly: true
         - mountPath: /mnt/service-ca
           name: service-ca
@@ -570,7 +570,7 @@ spec:
           items:
           - key: Caddyfile
             path: Caddyfile
-          name: proxy-caddyfile-4k244mbkbd
+          name: proxy-caddyfile-8477t8hg9h
         name: proxy-caddyfile
       - configMap:
           defaultMode: 420
@@ -585,10 +585,13 @@ spec:
       - name: serving-cert
         secret:
           secretName: serving-cert
-      - configMap:
-          name: trusted-ca
+      - name: cluster-ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca-bundle.crt
           optional: true
-        name: trusted-ca
+          secretName: ui-ca
       - configMap:
           name: openshift-service-ca.crt
           optional: true
@@ -663,7 +666,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: self-signed-cluster-issuer
+    name: ca-issuer
   privateKey:
     algorithm: ECDSA
     size: 256

--- a/operator/upstream-kustomizations/cert-manager/README.md
+++ b/operator/upstream-kustomizations/cert-manager/README.md
@@ -1,0 +1,118 @@
+# Konflux PKI (Public Key Infrastructure)
+
+Konflux uses [cert-manager](https://cert-manager.io/) to manage TLS certificates
+for internal service-to-service communication. All services share a single trust
+root so any service can verify any other service's certificate using just the
+root CA.
+
+## Architecture
+
+```
+self-signed-cluster-issuer (SelfSigned ClusterIssuer)
+│
+│   Only purpose: bootstrap the root CA declaratively.
+│   Not used by any service directly.
+│
+└── selfsigned-ca (Certificate, isCA: true)
+        │
+        ▼
+    Secret "root-secret" (cert-manager namespace)
+    Contains the root CA key + cert.
+        │
+        ▼
+    ca-issuer (ClusterIssuer)
+    The single issuer all Konflux services use.
+        │
+        ├── namespace-lister cert (leaf, in namespace-lister ns)
+        ├── registry cert (leaf, in kind-registry ns)
+        │
+        └── ui-ca (sub-CA, isCA: true, in konflux-ui ns)
+                │
+                ▼
+            ui-ca-issuer (namespace Issuer, in konflux-ui ns)
+                │
+                ├── serving-cert (leaf, proxy TLS on port 9443)
+                ├── dex-cert (leaf, Dex TLS)
+                └── oauth2-proxy-cert (CA bundle for oauth2-proxy → Dex)
+```
+
+## Bootstrap sequence
+
+1. **`self-signed-cluster-issuer`** — A SelfSigned ClusterIssuer. Its only job is
+   to issue the root CA certificate. If you could manually create a CA key pair
+   and store it in a Secret, you wouldn't need this at all. It's purely a
+   cert-manager pattern for declarative root CA generation.
+
+2. **`selfsigned-ca` Certificate** — An `isCA: true` Certificate issued by the
+   self-signed issuer. cert-manager generates a key pair and stores it in
+   `root-secret` in the `cert-manager` namespace.
+
+3. **`ca-issuer` ClusterIssuer** — A CA issuer backed by `root-secret`. This is
+   the "real" issuer that all Konflux services reference.
+
+## How services get their certificates
+
+Services reference `ca-issuer` (or a namespace-scoped sub-CA issued by it) in
+their Certificate resources:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-service
+  namespace: my-namespace
+spec:
+  dnsNames:
+    - my-service.my-namespace.svc.cluster.local
+  issuerRef:
+    kind: ClusterIssuer
+    name: ca-issuer
+  secretName: my-service-tls
+```
+
+cert-manager creates a Secret containing:
+
+| Field     | Content                                    |
+|-----------|--------------------------------------------|
+| `tls.crt` | The leaf certificate (+ chain if intermediate) |
+| `tls.key` | The private key                            |
+| `ca.crt`  | The CA certificate that signed this cert   |
+
+## Why the UI uses a sub-CA
+
+The UI (`konflux-ui` namespace) has a special constraint: OpenShift's
+Ingress-to-Route controller reads `tls.crt` (not `ca.crt`) from the Secret
+referenced by the `route.openshift.io/destination-ca-certificate-secret`
+annotation. It expects a **CA certificate** (CA:TRUE) in that field.
+
+If the UI's serving-cert were issued directly by `ca-issuer`, the Secret's
+`tls.crt` would be a leaf cert (CA:FALSE) — which the OpenShift router rejects,
+causing 503 errors.
+
+The fix: create `ui-ca` as a sub-CA (isCA: true) issued by `ca-issuer`. Its
+Secret has `tls.crt` = a CA cert, satisfying the Route. A namespace-scoped
+`ui-ca-issuer` then issues the actual leaf certs (serving-cert, dex-cert).
+
+## Cross-service TLS verification
+
+Since all certificates chain to the same root (`root-secret`), any service can
+verify any other service's TLS certificate using the root CA cert.
+
+For example, the UI proxy verifies the namespace-lister's certificate by mounting
+`ui-ca` Secret's `ca.crt` field — which contains the root CA cert (because
+cert-manager stores the issuing CA in `ca.crt`, and `ui-ca` is issued by
+`ca-issuer` which uses `root-secret`).
+
+If a service has its own intermediate CA (like the UI), the chain is:
+`leaf → intermediate → root`. The verifying party only needs the root CA to
+validate the entire chain, because the intermediate cert is included in the
+`tls.crt` bundle sent during the TLS handshake.
+
+## Operator management
+
+The `KonfluxCertManager` controller (reconciling the `KonfluxCertManager` CR)
+manages the bootstrap resources in this directory. When
+`spec.createClusterIssuer` is true (the default), it applies the
+self-signed-cluster-issuer, selfsigned-ca Certificate, and ca-issuer
+ClusterIssuer. Individual component controllers then manage their own
+Certificate/Issuer resources in their respective namespaces.

--- a/operator/upstream-kustomizations/ui/certmanager/certificate.yaml
+++ b/operator/upstream-kustomizations/ui/certmanager/certificate.yaml
@@ -1,9 +1,10 @@
 ---
-# CA Certificate: creates a self-signed CA in the konflux-ui namespace.
-# The resulting Secret (ui-ca) contains the CA cert in tls.crt.
-# This Secret is referenced by the Ingress annotation
-# route.openshift.io/destination-ca-certificate-secret so that the
-# OpenShift Ingress-to-Route controller can read the CA for TLS re-encryption.
+# CA Certificate: creates a sub-CA under the shared cluster root (ca-issuer)
+# in the konflux-ui namespace.
+# The resulting Secret (ui-ca) contains:
+#   tls.crt = the sub-CA cert (CA:TRUE) — referenced by the Ingress annotation
+#             route.openshift.io/destination-ca-certificate-secret for TLS re-encryption
+#   ca.crt  = the cluster root CA — used by the proxy to verify namespace-lister TLS
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -16,7 +17,7 @@ spec:
     algorithm: ECDSA
     size: 256
   issuerRef:
-    name: self-signed-cluster-issuer
+    name: ca-issuer
     kind: ClusterIssuer
     group: cert-manager.io
 ---

--- a/operator/upstream-kustomizations/ui/core/proxy/Caddyfile
+++ b/operator/upstream-kustomizations/ui/core/proxy/Caddyfile
@@ -6,7 +6,7 @@
 		cache kube_token /var/run/secrets/konflux-ci.dev/serviceaccount/token
 		cache backend_token /var/run/secrets/konflux-ci.dev/backend/token
 		watch /var/run/secrets/kubernetes.io/serviceaccount
-		watch /mnt/trusted-ca
+		watch /mnt/cluster-ca
 		watch /mnt/service-ca
 		watch /mnt/serving-cert
 	}
@@ -77,7 +77,7 @@
 				transport http {
 					read_timeout 30m
 					write_timeout 30m
-					tls_trust_pool file /mnt/trusted-ca/ca-bundle.crt
+					tls_trust_pool file /mnt/cluster-ca/ca-bundle.crt
 				}
 			}
 		}

--- a/operator/upstream-kustomizations/ui/core/proxy/proxy.yaml
+++ b/operator/upstream-kustomizations/ui/core/proxy/proxy.yaml
@@ -139,8 +139,8 @@ spec:
           - name: caddy-snippets
             mountPath: /mnt/caddy-snippets
             readOnly: true
-          - name: trusted-ca
-            mountPath: /mnt/trusted-ca
+          - name: cluster-ca
+            mountPath: /mnt/cluster-ca
             readOnly: true
           - name: service-ca
             mountPath: /mnt/service-ca
@@ -230,10 +230,13 @@ spec:
         - name: serving-cert
           secret:
             secretName: serving-cert
-        - name: trusted-ca
-          configMap:
-            name: trusted-ca
+        - name: cluster-ca
+          secret:
+            secretName: ui-ca
             optional: true
+            items:
+              - key: ca.crt
+                path: ca-bundle.crt
         - name: service-ca
           configMap:
             name: openshift-service-ca.crt


### PR DESCRIPTION
Previously, the UI proxy verified namespace-lister's TLS certificate using a trust-manager Bundle (trusted-ca ConfigMap). This had two problems:

1. The Bundle was part of the internal-registry component, which defaults to disabled — leaving the ConfigMap missing on most deployments.
2. It introduced a dependency on trust-manager, a separate controller that watches Bundle CRs and distributes CA certs as ConfigMaps.

The root cause was that the UI had an independent CA hierarchy (self-signed via self-signed-cluster-issuer) with no trust relationship to the cluster-wide ca-issuer that signs namespace-lister's cert.

Fix this by issuing ui-ca from ca-issuer instead of self-signed-cluster-issuer, making it a sub-CA under the shared cluster root. Since cert-manager stores the issuing CA in the Secret's ca.crt field, the ui-ca Secret now contains the root CA cert — the same CA that signed namespace-lister's certificate. The proxy mounts this and uses it for TLS verification, eliminating the trust-manager dependency entirely.

Trust chain (after):

  root-secret (root CA, in cert-manager ns)
    └── ca-issuer (ClusterIssuer, signs all Konflux service certs)
          ├── namespace-lister cert (leaf)
          └── ui-ca (sub-CA, in konflux-ui ns)
                └── ui-ca-issuer (namespace Issuer)
                      ├── serving-cert (proxy TLS)
                      └── dex-cert (Dex TLS)

The OpenShift Route annotation (destination-ca-certificate-secret) continues to work: ui-ca Secret's tls.crt is still a CA cert (CA:TRUE), which the Ingress-to-Route controller requires.

Assisted-by: Cursor