### PR TITLE
test: track task-runner:v1 in tekton e2e tests

### DIFF
--- a/.tekton/tasks/deploy-konflux/README.md
+++ b/.tekton/tasks/deploy-konflux/README.md
@@ -32,7 +32,7 @@ Reads keys from Secret `konflux-operator-e2e-credentials` in the Task namespace 
 
 ## Steps / images
 
-1. **fetch-kubeconfig** / **copy-shared-tools** — `quay.io/konflux-ci/task-runner:0.2.0` (pinned by digest in `task.yaml`).
+1. **fetch-kubeconfig** / **copy-shared-tools** — `quay.io/konflux-ci/task-runner:v1` (pinned by digest in `task.yaml`).
 2. **deploy-prep** — `registry.access.redhat.com/ubi10/go-toolset` (pinned by digest): optional overrides via `go run ./cmd/overrides`, then `deploy-local.sh` with `OPERATOR_INSTALL_METHOD=none` (needs credentials below).
 3. **deploy-operator-and-wait** — `registry.access.redhat.com/ubi10/go-toolset` (pinned by digest): uses `kubectl`/`yq`/`jq` from `/mnt/e2e-shared/bin` and **`LD_LIBRARY_PATH=/mnt/e2e-shared/lib`** for `jq`, then `make` + out-of-cluster `bin/manager`, CR apply, Ready wait.
 

--- a/.tekton/tasks/deploy-konflux/task.yaml
+++ b/.tekton/tasks/deploy-konflux/task.yaml
@@ -110,7 +110,7 @@ spec:
             optional: true
   steps:
     - name: clone-repository
-      image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
+      image: quay.io/konflux-ci/task-runner:v1@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
       env:
         - name: GIT_URL
           value: $(params.git-url)
@@ -125,12 +125,14 @@ spec:
         mkdir -p "${REPO_ROOT}"
         # REPO_ROOT is an emptyDir mount point; rm -rf on it fails (device busy). Clear contents only.
         find "${REPO_ROOT}" -mindepth 1 -delete
+        # task-runner runs as non-root; emptyDir is root-owned (git safe.directory check).
+        git config --global --add safe.directory "${REPO_ROOT}"
         git init "${REPO_ROOT}"
         git -C "${REPO_ROOT}" remote add origin "${GIT_URL}"
         git -C "${REPO_ROOT}" fetch --depth "${GIT_DEPTH}" origin "${GIT_REVISION}"
         git -C "${REPO_ROOT}" checkout -q FETCH_HEAD
     - name: fetch-kubeconfig
-      image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
+      image: quay.io/konflux-ci/task-runner:v1@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
       workingDir: /mnt/konflux-ci/repo
       env:
         - name: POD_NAMESPACE
@@ -143,7 +145,7 @@ spec:
         cd /mnt/konflux-ci/repo
         exec bash scripts/operator-e2e/tekton-fetch-kubeconfig.sh "$(params.cluster-access-secret)" "$(params.kubeconfig-secret-key)"
     - name: copy-shared-tools
-      image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
+      image: quay.io/konflux-ci/task-runner:v1@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
       workingDir: /mnt/konflux-ci/repo
       script: |
         #!/bin/bash
@@ -195,7 +197,7 @@ spec:
           E2E_KONFLUX_READY_TIMEOUT="$(params.konflux-ready-timeout)" \
           bash scripts/operator-e2e/tekton-deploy-prep.sh /mnt/konflux-ci/repo
     - name: push-operator-pkg-manifests-oci
-      image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
+      image: quay.io/konflux-ci/task-runner:v1@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
       workingDir: /mnt/konflux-ci/repo
       volumeMounts:
         - name: repo

--- a/.tekton/tasks/konflux-e2e-tests/README.md
+++ b/.tekton/tasks/konflux-e2e-tests/README.md
@@ -40,7 +40,7 @@ Reads keys from Secret `konflux-operator-e2e-credentials` in the Task namespace:
 
 ## Steps / images
 
-1. **fetch-kubeconfig** / **copy-shared-tools** — `quay.io/konflux-ci/task-runner:0.2.0` (copies `kubectl`/`yq`/`jq` to `/mnt/e2e-shared/bin` and `jq`’s `.so` deps to `/mnt/e2e-shared/lib`).
+1. **fetch-kubeconfig** / **copy-shared-tools** — `quay.io/konflux-ci/task-runner:v1` (copies `kubectl`/`yq`/`jq` to `/mnt/e2e-shared/bin` and `jq`’s `.so` deps to `/mnt/e2e-shared/lib`).
 2. **run-tests** — `registry.access.redhat.com/ubi10/go-toolset`: integration + conformance (`go test`), plus `kubectl`/`curl` from shared bin and image.
 
 ## Notes

--- a/.tekton/tasks/konflux-e2e-tests/task.yaml
+++ b/.tekton/tasks/konflux-e2e-tests/task.yaml
@@ -67,7 +67,7 @@ spec:
         mountPath: /mnt/e2e-shared
   steps:
     - name: clone-repository
-      image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
+      image: quay.io/konflux-ci/task-runner:v1@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
       env:
         - name: GIT_URL
           value: $(params.git-url)
@@ -82,12 +82,14 @@ spec:
         mkdir -p "${REPO_ROOT}"
         # emptyDir mount: clear contents only (cannot rm the mount point).
         find "${REPO_ROOT}" -mindepth 1 -delete
+        # task-runner runs as non-root; emptyDir is root-owned (git safe.directory check).
+        git config --global --add safe.directory "${REPO_ROOT}"
         git init "${REPO_ROOT}"
         git -C "${REPO_ROOT}" remote add origin "${GIT_URL}"
         git -C "${REPO_ROOT}" fetch --depth "${GIT_DEPTH}" origin "${GIT_REVISION}"
         git -C "${REPO_ROOT}" checkout -q FETCH_HEAD
     - name: fetch-kubeconfig
-      image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
+      image: quay.io/konflux-ci/task-runner:v1@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
       workingDir: /mnt/konflux-ci/repo
       env:
         - name: POD_NAMESPACE
@@ -100,7 +102,7 @@ spec:
         cd /mnt/konflux-ci/repo
         exec bash scripts/operator-e2e/tekton-fetch-kubeconfig.sh "$(params.cluster-access-secret)" "$(params.kubeconfig-secret-key)"
     - name: copy-shared-tools
-      image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
+      image: quay.io/konflux-ci/task-runner:v1@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
       workingDir: /mnt/konflux-ci/repo
       script: |
         #!/bin/bash

--- a/scripts/operator-e2e/tekton-copy-shared-tools.sh
+++ b/scripts/operator-e2e/tekton-copy-shared-tools.sh
@@ -4,8 +4,8 @@
 # jq is dynamically linked to libjq and libonig; copy those .so files into /mnt/e2e-shared/lib
 # and set LD_LIBRARY_PATH in go-toolset scripts (see tekton-run-e2e-tests.sh, deploy-prep, etc.).
 #
-# Clone / fetch-kubeconfig run as root; go-toolset runs non-root. Without fixing modes,
-# apply-overrides and other writers get "permission denied" on root-owned files under the repo.
+# task-runner steps run as non-root (taskuser); go-toolset runs as a different non-root UID.
+# Widen repo file modes so later go-toolset steps can write (apply-overrides, deploy-prep, etc.).
 set -euo pipefail
 
 DEST="${TEKTON_SHARED_BIN:-/mnt/e2e-shared/bin}"
@@ -24,5 +24,7 @@ chmod -R a+rX "${DEST_LIB}"
 
 REPO_ROOT="${TEKTON_REPO_ROOT:-/mnt/konflux-ci/repo}"
 if [[ -d "${REPO_ROOT}" ]]; then
-  chmod -R a+rwX "${REPO_ROOT}"
+  # chmod -R on REPO_ROOT itself fails: the emptyDir mount point stays root-owned and
+  # taskuser cannot change its mode ("Operation not permitted"). Only fix contents.
+  find "${REPO_ROOT}" -mindepth 1 -exec chmod a+rwX {} +
 fi

--- a/scripts/operator-e2e/tekton-deploy-operator-and-wait.sh
+++ b/scripts/operator-e2e/tekton-deploy-operator-and-wait.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "${1:?usage: $0 REPO_ROOT}" && pwd)"
 cd "${REPO_ROOT}"
+# Cloned on a root-owned emptyDir mount by task-runner; go-toolset runs as a different UID.
+git config --global --add safe.directory "${REPO_ROOT}"
 
 export PATH="/mnt/e2e-shared/bin:${PATH}"
 export LD_LIBRARY_PATH="/mnt/e2e-shared/lib:${LD_LIBRARY_PATH:-}"

--- a/scripts/operator-e2e/tekton-deploy-prep.sh
+++ b/scripts/operator-e2e/tekton-deploy-prep.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "${1:?usage: $0 REPO_ROOT}" && pwd)"
 cd "${REPO_ROOT}"
+# Cloned on a root-owned emptyDir mount by task-runner; go-toolset runs as a different UID.
+git config --global --add safe.directory "${REPO_ROOT}"
 
 : "${E2E_KIND_CLUSTER:?}"
 : "${E2E_KONFLUX_READY_TIMEOUT:?}"

--- a/scripts/operator-e2e/tekton-run-e2e-tests.sh
+++ b/scripts/operator-e2e/tekton-run-e2e-tests.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "${1:?usage: $0 REPO_ROOT}" && pwd)"
 cd "${REPO_ROOT}"
+# Cloned on a root-owned emptyDir mount by task-runner; go-toolset runs as a different UID.
+git config --global --add safe.directory "${REPO_ROOT}"
 
 : "${E2E_KONFLUX_READY_TIMEOUT:?}"
 


### PR DESCRIPTION
The Tekton tasks used for e2e tests were tracking task-runner 0.2.0. There's no tag latest to track, so instead we track v1 for now, which should point to the latest release until v2 is out.

Assisted-by: Cursor