### PR TITLE
fix(ui): make cluster-ca volume required and update stale docs

### DIFF
--- a/operator/pkg/manifests/ui/manifests.yaml
+++ b/operator/pkg/manifests/ui/manifests.yaml
@@ -590,7 +590,6 @@ spec:
           items:
           - key: ca.crt
             path: ca-bundle.crt
-          optional: true
           secretName: ui-ca
       - configMap:
           name: openshift-service-ca.crt

--- a/operator/upstream-kustomizations/ui/README.md
+++ b/operator/upstream-kustomizations/ui/README.md
@@ -259,7 +259,7 @@ Each upstream uses a different trust anchor:
 |----------|-----------|--------|
 | Kubernetes API | Mounted SA CA | `tls_trust_pool file /var/run/secrets/kubernetes.io/serviceaccount/ca.crt` |
 | Dex | cert-manager Secret | `tls_trust_pool file /mnt/serving-cert/ca.crt` |
-| Namespace-lister | trust-manager ConfigMap | `tls_trust_pool file /mnt/trusted-ca/ca-bundle.crt` |
+| Namespace-lister | cert-manager Secret (cluster root CA) | `tls_trust_pool file /mnt/cluster-ca/ca-bundle.crt` |
 | Backend services | Platform-dependent | `import /mnt/caddy-snippets/backend-tls.conf` |
 
 Backend TLS is determined at init time by `generate-proxy-config.sh`:

--- a/operator/upstream-kustomizations/ui/core/proxy/proxy.yaml
+++ b/operator/upstream-kustomizations/ui/core/proxy/proxy.yaml
@@ -233,7 +233,6 @@ spec:
         - name: cluster-ca
           secret:
             secretName: ui-ca
-            optional: true
             items:
               - key: ca.crt
                 path: ca-bundle.crt


### PR DESCRIPTION
## Summary

Follow-up to #7197 — addresses review comments from @avi-biton and the fullsend-ai-review bot:

- Remove `optional: true` from the `ui-ca` Secret volume in both `operator/pkg/manifests/ui/manifests.yaml` and `operator/upstream-kustomizations/ui/core/proxy/proxy.yaml`. Caddy always expects `/mnt/cluster-ca/ca-bundle.crt` for namespace-lister TLS verification, so the pod should wait for the Secret rather than start with an empty mount.
- Update the TLS table in `operator/upstream-kustomizations/ui/README.md` to reflect the new CA source (cert-manager Secret) and mount path.

## Test plan

- [ ] Operator unit tests pass (`make test` from `operator/`)
- [ ] Verify the UI proxy pod starts correctly when `ui-ca` Secret exists
- [ ] Verify the pod stays in `Pending` when `ui-ca` Secret is missing (expected: blocks until Secret is created)

Assisted-by: Cursor

Made with [Cursor](https://cursor.com)