### PR TITLE
refactor: rename PKI resources with konflux- prefix

### DIFF
--- a/dependencies/cluster-issuer/konflux-pki.yaml
+++ b/dependencies/cluster-issuer/konflux-pki.yaml
@@ -2,32 +2,32 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: self-signed-cluster-issuer
+  name: konflux-bootstrap-issuer
 spec:
   selfSigned: {}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: selfsigned-ca
+  name: konflux-ca
   namespace: cert-manager
 spec:
   isCA: true
-  commonName: selfsigned-ca
-  secretName: root-secret
+  commonName: konflux-ca
+  secretName: konflux-ca-secret
   privateKey:
     algorithm: ECDSA
     size: 256
   issuerRef:
-    name: self-signed-cluster-issuer
+    name: konflux-bootstrap-issuer
     kind: ClusterIssuer
     group: cert-manager.io
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: ca-issuer
+  name: konflux-issuer
   namespace: cert-manager
 spec:
   ca:
-    secretName: root-secret
+    secretName: konflux-ca-secret

--- a/dependencies/cluster-issuer/kustomization.yml
+++ b/dependencies/cluster-issuer/kustomization.yml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - self-signed-cluster-issuer.yaml
+  - konflux-pki.yaml

--- a/dependencies/dex/dex.yaml
+++ b/dependencies/dex/dex.yaml
@@ -19,7 +19,7 @@ spec:
   - dex.dex
   issuerRef:
     kind: ClusterIssuer
-    name: self-signed-cluster-issuer
+    name: konflux-bootstrap-issuer
   secretName: dex-cert
 ---
 apiVersion: apps/v1

--- a/dependencies/quay/certificate.yaml
+++ b/dependencies/quay/certificate.yaml
@@ -15,5 +15,5 @@ spec:
     - quay-service.quay.svc.cluster.local
   issuerRef:
     kind: ClusterIssuer
-    name: ca-issuer
+    name: konflux-issuer
   secretName: quay-tls

--- a/dependencies/registry/certificate.yaml
+++ b/dependencies/registry/certificate.yaml
@@ -14,6 +14,6 @@ spec:
   - registry-service.kind-registry
   issuerRef:
     kind: ClusterIssuer
-    name: ca-issuer
+    name: konflux-issuer
   secretName: local-registry-tls
   

--- a/dependencies/registry/trust-bundle.yaml
+++ b/dependencies/registry/trust-bundle.yaml
@@ -7,7 +7,7 @@ spec:
   sources:
   - useDefaultCAs: true
   - secret:
-      name: "root-secret"
+      name: "konflux-ca-secret"
       key: "ca.crt"
   target:
     configMap:

--- a/operator/internal/controller/certmanager/konfluxcertmanager_controller.go
+++ b/operator/internal/controller/certmanager/konfluxcertmanager_controller.go
@@ -61,6 +61,11 @@ var CertManagerCleanupGVKs = []schema.GroupVersionKind{
 var CertManagerClusterScopedAllowList = tracking.ClusterScopedAllowList{
 	// ClusterIssuers are only created when spec.createClusterIssuer is true
 	{Group: "cert-manager.io", Version: "v1", Kind: "ClusterIssuer"}: sets.New(
+		"konflux-bootstrap-issuer",
+		"konflux-issuer",
+		// Legacy names (pre-rename) kept so orphan cleanup deletes them on
+		// upgrade from releases that used the old names.
+		// TODO(pki-renames): remove after v1.5 ships.
 		"self-signed-cluster-issuer",
 		"ca-issuer",
 	),

--- a/operator/internal/controller/certmanager/konfluxcertmanager_controller_test.go
+++ b/operator/internal/controller/certmanager/konfluxcertmanager_controller_test.go
@@ -104,8 +104,8 @@ var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 		// OwnerReferences do not trigger cascading deletion.
 		AfterEach(func(ctx context.Context) {
 			testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxCertManager{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
-			testutil.DeleteAndWait(ctx, k8sClient, newClusterIssuer("self-signed-cluster-issuer"))
-			testutil.DeleteAndWait(ctx, k8sClient, newClusterIssuer("ca-issuer"))
+			testutil.DeleteAndWait(ctx, k8sClient, newClusterIssuer("konflux-bootstrap-issuer"))
+			testutil.DeleteAndWait(ctx, k8sClient, newClusterIssuer("konflux-issuer"))
 		})
 
 		Context("with createClusterIssuer unset (defaults to enabled)", func() {
@@ -116,8 +116,8 @@ var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 				Eventually(waitForReady).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 				By("verifying ClusterIssuers were created")
-				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "self-signed-cluster-issuer"}, newClusterIssuer("self-signed-cluster-issuer"))).To(Succeed())
-				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "ca-issuer"}, newClusterIssuer("ca-issuer"))).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-bootstrap-issuer"}, newClusterIssuer("konflux-bootstrap-issuer"))).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-issuer"}, newClusterIssuer("konflux-issuer"))).To(Succeed())
 			})
 		})
 
@@ -131,8 +131,8 @@ var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 				Eventually(waitForReady).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 				By("verifying ClusterIssuers were created")
-				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "self-signed-cluster-issuer"}, newClusterIssuer("self-signed-cluster-issuer"))).To(Succeed())
-				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "ca-issuer"}, newClusterIssuer("ca-issuer"))).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-bootstrap-issuer"}, newClusterIssuer("konflux-bootstrap-issuer"))).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-issuer"}, newClusterIssuer("konflux-issuer"))).To(Succeed())
 			})
 		})
 
@@ -146,12 +146,13 @@ var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 				Eventually(waitForReady).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 				By("verifying no ClusterIssuers were created")
-				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "self-signed-cluster-issuer"}, newClusterIssuer("self-signed-cluster-issuer"))).
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-bootstrap-issuer"}, newClusterIssuer("konflux-bootstrap-issuer"))).
 					To(MatchError(ContainSubstring("not found")))
-				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "ca-issuer"}, newClusterIssuer("ca-issuer"))).
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-issuer"}, newClusterIssuer("konflux-issuer"))).
 					To(MatchError(ContainSubstring("not found")))
 			})
 		})
+
 	})
 
 	Context("tracking.IsNoKindMatchError helper function", func() {

--- a/operator/pkg/manifests/cert-manager/manifests.yaml
+++ b/operator/pkg/manifests/cert-manager/manifests.yaml
@@ -1,32 +1,32 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: selfsigned-ca
+  name: konflux-ca
   namespace: cert-manager
 spec:
-  commonName: selfsigned-ca
+  commonName: konflux-ca
   isCA: true
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: self-signed-cluster-issuer
+    name: konflux-bootstrap-issuer
   privateKey:
     algorithm: ECDSA
     size: 256
-  secretName: root-secret
+  secretName: konflux-ca-secret
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: ca-issuer
+  name: konflux-issuer
   namespace: cert-manager
 spec:
   ca:
-    secretName: root-secret
+    secretName: konflux-ca-secret
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: self-signed-cluster-issuer
+  name: konflux-bootstrap-issuer
 spec:
   selfSigned: {}

--- a/operator/pkg/manifests/namespace-lister/manifests.yaml
+++ b/operator/pkg/manifests/namespace-lister/manifests.yaml
@@ -154,7 +154,7 @@ spec:
   - namespace-lister.namespace-lister.svc.cluster.local
   issuerRef:
     kind: ClusterIssuer
-    name: ca-issuer
+    name: konflux-issuer
   secretName: namespace-lister-tls
 ---
 apiVersion: networking.k8s.io/v1

--- a/operator/pkg/manifests/registry/manifests.yaml
+++ b/operator/pkg/manifests/registry/manifests.yaml
@@ -131,7 +131,7 @@ spec:
   isCA: true
   issuerRef:
     kind: ClusterIssuer
-    name: ca-issuer
+    name: konflux-issuer
   secretName: local-registry-tls
   subject:
     organizations:
@@ -146,7 +146,7 @@ spec:
   - useDefaultCAs: true
   - secret:
       key: ca.crt
-      name: root-secret
+      name: konflux-ca-secret
   target:
     configMap:
       key: ca-bundle.crt

--- a/operator/pkg/manifests/ui/manifests.yaml
+++ b/operator/pkg/manifests/ui/manifests.yaml
@@ -619,7 +619,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: ca-issuer
+    name: konflux-issuer
   secretName: cluster-root-ref
 ---
 apiVersion: cert-manager.io/v1
@@ -680,7 +680,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: self-signed-cluster-issuer
+    name: konflux-bootstrap-issuer
   privateKey:
     algorithm: ECDSA
     size: 256

--- a/operator/upstream-kustomizations/cert-manager/README.md
+++ b/operator/upstream-kustomizations/cert-manager/README.md
@@ -2,24 +2,24 @@
 
 Konflux uses [cert-manager](https://cert-manager.io/) to manage TLS certificates
 for internal service-to-service communication. Most services share a cluster-wide
-trust root (`ca-issuer`). The UI namespace uses its own self-signed root for the
+trust root (`konflux-issuer`). The UI namespace uses its own self-signed root for the
 OpenShift route trust chain (see "Why the UI uses a self-signed root CA" below).
 
 ## Architecture
 
 ```
-self-signed-cluster-issuer (SelfSigned ClusterIssuer)
+konflux-bootstrap-issuer (SelfSigned ClusterIssuer)
 │
 │   Bootstraps both the cluster root CA and the UI namespace root.
 │
-├── selfsigned-ca (Certificate, isCA: true, cert-manager ns)
+├── konflux-ca (Certificate, isCA: true, cert-manager ns)
 │       │
 │       ▼
-│   Secret "root-secret" (cert-manager namespace)
+│   Secret "konflux-ca-secret" (cert-manager namespace)
 │   Contains the cluster root CA key + cert.
 │       │
 │       ▼
-│   ca-issuer (ClusterIssuer)
+│   konflux-issuer (ClusterIssuer)
 │   The issuer for cluster-wide services.
 │       │
 │       ├── namespace-lister cert (leaf, in namespace-lister ns)
@@ -38,22 +38,23 @@ self-signed-cluster-issuer (SelfSigned ClusterIssuer)
 
 ## Bootstrap sequence
 
-1. **`self-signed-cluster-issuer`** — A SelfSigned ClusterIssuer. Its only job is
+1. **`konflux-bootstrap-issuer`** — A SelfSigned ClusterIssuer. Its only job is
    to issue the root CA certificate. If you could manually create a CA key pair
    and store it in a Secret, you wouldn't need this at all. It's purely a
    cert-manager pattern for declarative root CA generation.
 
-2. **`selfsigned-ca` Certificate** — An `isCA: true` Certificate issued by the
-   self-signed issuer. cert-manager generates a key pair and stores it in
-   `root-secret` in the `cert-manager` namespace.
+2. **`konflux-ca` Certificate** — An `isCA: true` Certificate issued by the
+   bootstrap issuer. cert-manager generates a key pair and stores it in
+   `konflux-ca-secret` in the `cert-manager` namespace.
 
-3. **`ca-issuer` ClusterIssuer** — A CA issuer backed by `root-secret`. This is
-   the "real" issuer that all Konflux services reference.
+3. **`konflux-issuer` ClusterIssuer** — A CA issuer backed by
+   `konflux-ca-secret`. This is the "real" issuer that all Konflux services
+   reference.
 
 ## How services get their certificates
 
-Services reference `ca-issuer` (or a namespace-scoped sub-CA issued by it) in
-their Certificate resources:
+Services reference `konflux-issuer` (or a namespace-scoped sub-CA issued by it)
+in their Certificate resources:
 
 ```yaml
 apiVersion: cert-manager.io/v1
@@ -66,7 +67,7 @@ spec:
     - my-service.my-namespace.svc.cluster.local
   issuerRef:
     kind: ClusterIssuer
-    name: ca-issuer
+    name: konflux-issuer
   secretName: my-service-tls
 ```
 
@@ -88,11 +89,11 @@ For TLS re-encryption to succeed, the trust anchor must be a **self-signed**
 CA:TRUE certificate — HAProxy requires a complete chain ending at a self-signed
 root. cert-manager intentionally omits self-signed roots from `tls.crt` of
 certificates it issues (per TLS spec), so an intermediate CA issued by
-`ca-issuer` would produce a `tls.crt` containing only the intermediate, causing
+`konflux-issuer` would produce a `tls.crt` containing only the intermediate, causing
 chain verification failures (503 errors).
 
 The fix: `ui-ca` is a **self-signed** root CA (issued by
-`self-signed-cluster-issuer`). Its `tls.crt` is inherently self-signed, so the
+`konflux-bootstrap-issuer`). Its `tls.crt` is inherently self-signed, so the
 router can verify: `serving-cert → ui-ca (self-signed root)`.
 
 ## Cross-service TLS verification
@@ -102,16 +103,16 @@ The UI namespace has two trust domains:
 1. **Internal (ui-ca)** — Dex, serving-cert, and oauth2-proxy-cert all chain to
    `ui-ca`. The proxy verifies Dex using `serving-cert`'s `ca.crt` (= `ui-ca`).
 
-2. **Cluster (ca-issuer)** — namespace-lister and other cluster services chain
-   to the cluster root (`root-secret`). The proxy verifies namespace-lister
+2. **Cluster (konflux-issuer)** — namespace-lister and other cluster services chain
+   to the cluster root (`konflux-ca-secret`). The proxy verifies namespace-lister
    using `cluster-root-ref`'s `ca.crt` field, which cert-manager populates with
-   the cluster root CA (the signing CA of `ca-issuer`).
+   the cluster root CA (the signing CA of `konflux-issuer`).
 
 ## Operator management
 
 The `KonfluxCertManager` controller (reconciling the `KonfluxCertManager` CR)
 manages the bootstrap resources in this directory. When
-`spec.createClusterIssuer` is true (the default), it applies the
-self-signed-cluster-issuer, selfsigned-ca Certificate, and ca-issuer
+`spec.createClusterIssuer` is true (the default), it applies
+`konflux-bootstrap-issuer`, `konflux-ca` Certificate, and `konflux-issuer`
 ClusterIssuer. Individual component controllers then manage their own
 Certificate/Issuer resources in their respective namespaces.

--- a/operator/upstream-kustomizations/cert-manager/konflux-pki.yaml
+++ b/operator/upstream-kustomizations/cert-manager/konflux-pki.yaml
@@ -2,32 +2,32 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: self-signed-cluster-issuer
+  name: konflux-bootstrap-issuer
 spec:
   selfSigned: {}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: selfsigned-ca
+  name: konflux-ca
   namespace: cert-manager
 spec:
   isCA: true
-  commonName: selfsigned-ca
-  secretName: root-secret
+  commonName: konflux-ca
+  secretName: konflux-ca-secret
   privateKey:
     algorithm: ECDSA
     size: 256
   issuerRef:
-    name: self-signed-cluster-issuer
+    name: konflux-bootstrap-issuer
     kind: ClusterIssuer
     group: cert-manager.io
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: ca-issuer
+  name: konflux-issuer
   namespace: cert-manager
 spec:
   ca:
-    secretName: root-secret
+    secretName: konflux-ca-secret

--- a/operator/upstream-kustomizations/cert-manager/kustomization.yml
+++ b/operator/upstream-kustomizations/cert-manager/kustomization.yml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - self-signed-cluster-issuer.yaml
+  - konflux-pki.yaml

--- a/operator/upstream-kustomizations/namespace-lister/certificate.yaml
+++ b/operator/upstream-kustomizations/namespace-lister/certificate.yaml
@@ -10,5 +10,5 @@ spec:
   - namespace-lister.namespace-lister.svc.cluster.local
   issuerRef:
     kind: ClusterIssuer
-    name: ca-issuer
+    name: konflux-issuer
   secretName: namespace-lister-tls

--- a/operator/upstream-kustomizations/registry/certificate.yaml
+++ b/operator/upstream-kustomizations/registry/certificate.yaml
@@ -14,6 +14,6 @@ spec:
   - registry-service.kind-registry
   issuerRef:
     kind: ClusterIssuer
-    name: ca-issuer
+    name: konflux-issuer
   secretName: local-registry-tls
   

--- a/operator/upstream-kustomizations/registry/trust-bundle.yaml
+++ b/operator/upstream-kustomizations/registry/trust-bundle.yaml
@@ -7,7 +7,7 @@ spec:
   sources:
   - useDefaultCAs: true
   - secret:
-      name: "root-secret"
+      name: "konflux-ca-secret"
       key: "ca.crt"
   target:
     configMap:

--- a/operator/upstream-kustomizations/ui/certmanager/certificate.yaml
+++ b/operator/upstream-kustomizations/ui/certmanager/certificate.yaml
@@ -17,7 +17,7 @@ spec:
     algorithm: ECDSA
     size: 256
   issuerRef:
-    name: self-signed-cluster-issuer
+    name: konflux-bootstrap-issuer
     kind: ClusterIssuer
     group: cert-manager.io
 ---
@@ -49,8 +49,9 @@ spec:
   secretName: serving-cert
 ---
 # Reference certificate whose sole purpose is to surface the cluster root CA
-# (from ca-issuer / root-secret) in this namespace. The proxy mounts its
-# ca.crt field to verify namespace-lister TLS, which is issued by ca-issuer.
+# (from konflux-issuer / konflux-ca-secret) in this namespace. The proxy mounts
+# its ca.crt field to verify namespace-lister TLS, which is issued by
+# konflux-issuer.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -61,6 +62,6 @@ spec:
     - cluster-root-ref.konflux-ui.svc
   secretName: cluster-root-ref
   issuerRef:
-    name: ca-issuer
+    name: konflux-issuer
     kind: ClusterIssuer
     group: cert-manager.io


### PR DESCRIPTION
Rename the cert-manager bootstrap resources to avoid name collisions in the shared cert-manager namespace and to clearly associate them with Konflux:

- self-signed-cluster-issuer → konflux-bootstrap-issuer
- selfsigned-ca              → konflux-ca
- root-secret                → konflux-ca-secret
- ca-issuer                  → konflux-issuer

Assisted-by: Cursor