### PR TITLE
fix(ui): make ui-ca a self-signed root to fix route TLS re-encryption

### DIFF
--- a/operator/pkg/manifests/ui/manifests.yaml
+++ b/operator/pkg/manifests/ui/manifests.yaml
@@ -590,7 +590,7 @@ spec:
           items:
           - key: ca.crt
             path: ca-bundle.crt
-          secretName: ui-ca
+          secretName: cluster-root-ref
       - configMap:
           name: openshift-service-ca.crt
           optional: true
@@ -606,6 +606,22 @@ spec:
             path: url
           optional: true
           secretName: segment-bridge-config
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cluster-root-ref
+  namespace: konflux-ui
+spec:
+  commonName: cluster-root-ref
+  dnsNames:
+  - cluster-root-ref.konflux-ui.svc
+  duration: 87600h
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: ca-issuer
+  secretName: cluster-root-ref
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -665,7 +681,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: ca-issuer
+    name: self-signed-cluster-issuer
   privateKey:
     algorithm: ECDSA
     size: 256

--- a/operator/pkg/manifests/ui/manifests.yaml
+++ b/operator/pkg/manifests/ui/manifests.yaml
@@ -616,7 +616,6 @@ spec:
   commonName: cluster-root-ref
   dnsNames:
   - cluster-root-ref.konflux-ui.svc
-  duration: 87600h
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer

--- a/operator/upstream-kustomizations/cert-manager/README.md
+++ b/operator/upstream-kustomizations/cert-manager/README.md
@@ -1,9 +1,9 @@
 # Konflux PKI (Public Key Infrastructure)
 
 Konflux uses [cert-manager](https://cert-manager.io/) to manage TLS certificates
-for internal service-to-service communication. All services share a single trust
-root so any service can verify any other service's certificate using just the
-root CA.
+for internal service-to-service communication. Most services share a cluster-wide
+trust root (`ca-issuer`). The UI namespace uses its own self-signed root for the
+OpenShift route trust chain (see "Why the UI uses a self-signed root CA" below).
 
 ## Architecture
 

--- a/operator/upstream-kustomizations/cert-manager/README.md
+++ b/operator/upstream-kustomizations/cert-manager/README.md
@@ -10,30 +10,30 @@ root CA.
 ```
 self-signed-cluster-issuer (SelfSigned ClusterIssuer)
 │
-│   Only purpose: bootstrap the root CA declaratively.
-│   Not used by any service directly.
+│   Bootstraps both the cluster root CA and the UI namespace root.
 │
-└── selfsigned-ca (Certificate, isCA: true)
+├── selfsigned-ca (Certificate, isCA: true, cert-manager ns)
+│       │
+│       ▼
+│   Secret "root-secret" (cert-manager namespace)
+│   Contains the cluster root CA key + cert.
+│       │
+│       ▼
+│   ca-issuer (ClusterIssuer)
+│   The issuer for cluster-wide services.
+│       │
+│       ├── namespace-lister cert (leaf, in namespace-lister ns)
+│       ├── registry cert (leaf, in kind-registry ns)
+│       └── cluster-root-ref (leaf, in konflux-ui ns — only for ca.crt)
+│
+└── ui-ca (Certificate, isCA: true, self-signed, in konflux-ui ns)
         │
         ▼
-    Secret "root-secret" (cert-manager namespace)
-    Contains the root CA key + cert.
+    ui-ca-issuer (namespace Issuer, in konflux-ui ns)
         │
-        ▼
-    ca-issuer (ClusterIssuer)
-    The single issuer all Konflux services use.
-        │
-        ├── namespace-lister cert (leaf, in namespace-lister ns)
-        ├── registry cert (leaf, in kind-registry ns)
-        │
-        └── ui-ca (sub-CA, isCA: true, in konflux-ui ns)
-                │
-                ▼
-            ui-ca-issuer (namespace Issuer, in konflux-ui ns)
-                │
-                ├── serving-cert (leaf, proxy TLS on port 9443)
-                ├── dex-cert (leaf, Dex TLS)
-                └── oauth2-proxy-cert (CA bundle for oauth2-proxy → Dex)
+        ├── serving-cert (leaf, proxy TLS on port 9443)
+        ├── dex-cert (leaf, Dex TLS)
+        └── oauth2-proxy-cert (CA bundle for oauth2-proxy → Dex)
 ```
 
 ## Bootstrap sequence
@@ -78,35 +78,34 @@ cert-manager creates a Secret containing:
 | `tls.key` | The private key                            |
 | `ca.crt`  | The CA certificate that signed this cert   |
 
-## Why the UI uses a sub-CA
+## Why the UI uses a self-signed root CA
 
-The UI (`konflux-ui` namespace) has a special constraint: OpenShift's
-Ingress-to-Route controller reads `tls.crt` (not `ca.crt`) from the Secret
-referenced by the `route.openshift.io/destination-ca-certificate-secret`
-annotation. It expects a **CA certificate** (CA:TRUE) in that field.
+OpenShift's Ingress-to-Route controller reads `tls.crt` (not `ca.crt`) from the
+Secret referenced by the `route.openshift.io/destination-ca-certificate-secret`
+annotation. The router uses this as a trust anchor to verify the backend's TLS.
 
-If the UI's serving-cert were issued directly by `ca-issuer`, the Secret's
-`tls.crt` would be a leaf cert (CA:FALSE) — which the OpenShift router rejects,
-causing 503 errors.
+For TLS re-encryption to succeed, the trust anchor must be a **self-signed**
+CA:TRUE certificate — HAProxy requires a complete chain ending at a self-signed
+root. cert-manager intentionally omits self-signed roots from `tls.crt` of
+certificates it issues (per TLS spec), so an intermediate CA issued by
+`ca-issuer` would produce a `tls.crt` containing only the intermediate, causing
+chain verification failures (503 errors).
 
-The fix: create `ui-ca` as a sub-CA (isCA: true) issued by `ca-issuer`. Its
-Secret has `tls.crt` = a CA cert, satisfying the Route. A namespace-scoped
-`ui-ca-issuer` then issues the actual leaf certs (serving-cert, dex-cert).
+The fix: `ui-ca` is a **self-signed** root CA (issued by
+`self-signed-cluster-issuer`). Its `tls.crt` is inherently self-signed, so the
+router can verify: `serving-cert → ui-ca (self-signed root)`.
 
 ## Cross-service TLS verification
 
-Since all certificates chain to the same root (`root-secret`), any service can
-verify any other service's TLS certificate using the root CA cert.
+The UI namespace has two trust domains:
 
-For example, the UI proxy verifies the namespace-lister's certificate by mounting
-`ui-ca` Secret's `ca.crt` field — which contains the root CA cert (because
-cert-manager stores the issuing CA in `ca.crt`, and `ui-ca` is issued by
-`ca-issuer` which uses `root-secret`).
+1. **Internal (ui-ca)** — Dex, serving-cert, and oauth2-proxy-cert all chain to
+   `ui-ca`. The proxy verifies Dex using `serving-cert`'s `ca.crt` (= `ui-ca`).
 
-If a service has its own intermediate CA (like the UI), the chain is:
-`leaf → intermediate → root`. The verifying party only needs the root CA to
-validate the entire chain, because the intermediate cert is included in the
-`tls.crt` bundle sent during the TLS handshake.
+2. **Cluster (ca-issuer)** — namespace-lister and other cluster services chain
+   to the cluster root (`root-secret`). The proxy verifies namespace-lister
+   using `cluster-root-ref`'s `ca.crt` field, which cert-manager populates with
+   the cluster root CA (the signing CA of `ca-issuer`).
 
 ## Operator management
 

--- a/operator/upstream-kustomizations/ui/certmanager/certificate.yaml
+++ b/operator/upstream-kustomizations/ui/certmanager/certificate.yaml
@@ -1,10 +1,10 @@
 ---
-# CA Certificate: creates a sub-CA under the shared cluster root (ca-issuer)
-# in the konflux-ui namespace.
-# The resulting Secret (ui-ca) contains:
-#   tls.crt = the sub-CA cert (CA:TRUE) — referenced by the Ingress annotation
-#             route.openshift.io/destination-ca-certificate-secret for TLS re-encryption
-#   ca.crt  = the cluster root CA — used by the proxy to verify namespace-lister TLS
+# Self-signed root CA for the konflux-ui namespace.
+# This is the trust anchor for the OpenShift Route's TLS re-encryption:
+# the Ingress annotation route.openshift.io/destination-ca-certificate-secret
+# points at this Secret. Because it is self-signed, tls.crt contains a
+# CA:TRUE cert that HAProxy can use as a root trust anchor without needing
+# any parent CA in the chain.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -17,7 +17,7 @@ spec:
     algorithm: ECDSA
     size: 256
   issuerRef:
-    name: ca-issuer
+    name: self-signed-cluster-issuer
     kind: ClusterIssuer
     group: cert-manager.io
 ---
@@ -31,7 +31,7 @@ spec:
   ca:
     secretName: ui-ca
 ---
-# Leaf certificate for the proxy's TLS serving endpoint (nginx on port 9443).
+# Leaf certificate for the proxy's TLS serving endpoint (Caddy on port 9443).
 # Issued by the namespace CA Issuer so the CA chain stays within konflux-ui.
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -47,3 +47,21 @@ spec:
     kind: Issuer
     name: ui-ca-issuer
   secretName: serving-cert
+---
+# Reference certificate whose sole purpose is to surface the cluster root CA
+# (from ca-issuer / root-secret) in this namespace. The proxy mounts its
+# ca.crt field to verify namespace-lister TLS, which is issued by ca-issuer.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cluster-root-ref
+spec:
+  commonName: cluster-root-ref
+  dnsNames:
+    - cluster-root-ref.konflux-ui.svc
+  secretName: cluster-root-ref
+  duration: 87600h
+  issuerRef:
+    name: ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/operator/upstream-kustomizations/ui/certmanager/certificate.yaml
+++ b/operator/upstream-kustomizations/ui/certmanager/certificate.yaml
@@ -60,7 +60,6 @@ spec:
   dnsNames:
     - cluster-root-ref.konflux-ui.svc
   secretName: cluster-root-ref
-  duration: 87600h
   issuerRef:
     name: ca-issuer
     kind: ClusterIssuer

--- a/operator/upstream-kustomizations/ui/core/proxy/proxy.yaml
+++ b/operator/upstream-kustomizations/ui/core/proxy/proxy.yaml
@@ -232,7 +232,7 @@ spec:
             secretName: serving-cert
         - name: cluster-ca
           secret:
-            secretName: ui-ca
+            secretName: cluster-root-ref
             items:
               - key: ca.crt
                 path: ca-bundle.crt


### PR DESCRIPTION
## Summary

- **Root cause**: cert-manager omits self-signed root CAs from `tls.crt` (per TLS spec). When `ui-ca` was an intermediate CA issued by `ca-issuer`, the OpenShift route's `destinationCACertificate` contained only the intermediate — HAProxy couldn't build a complete chain to a self-signed root, causing 503 errors on TLS re-encryption.
- **Fix**: Make `ui-ca` a self-signed root (issued by `self-signed-cluster-issuer`). Its `tls.crt` is now inherently self-signed, giving HAProxy a valid trust anchor: `serving-cert → ui-ca (self-signed root)`.
- **Namespace-lister trust**: A new `cluster-root-ref` Certificate (issued by `ca-issuer`) surfaces the cluster root CA in the namespace so the proxy can still verify namespace-lister TLS.

## Changes

| File | Change |
|------|--------|
| `operator/upstream-kustomizations/ui/certmanager/certificate.yaml` | Changed `ui-ca` issuerRef to `self-signed-cluster-issuer`; added `cluster-root-ref` Certificate |
| `operator/upstream-kustomizations/ui/core/proxy/proxy.yaml` | Changed `cluster-ca` volume secret from `ui-ca` to `cluster-root-ref` |
| `operator/upstream-kustomizations/cert-manager/README.md` | Updated architecture diagram and docs |
| `operator/pkg/manifests/ui/manifests.yaml` | Regenerated via `kustomize build` |

## Test plan

- [x] `make test` passes (all operator unit/integration tests)
- [x] Deploy to OpenShift and verify:
  - `kubectl get secret ui-ca -n konflux-ui -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout` shows self-signed (Subject == Issuer)
  - Route no longer returns 503
  - Namespace-lister accessible through the UI proxy
  - Dex login flow works end-to-end

Made with [Cursor](https://cursor.com)