### PR TITLE
test(KFLUXVNGD-1081): resolve ui url from cr

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -273,18 +273,11 @@ jobs:
         run: |
           kubectl get namespace
 
-      - name: Deploy Test Resources
-        working-directory: ${{ github.workspace }}
-        env:
-          SKIP_SAMPLE_COMPONENTS: "true"
-        run: |
-          ./deploy-test-resources.sh
-
-      - name: Run Konflux Integration Tests
+      - name: Run go-tests pkg unit tests
         working-directory: ${{ github.workspace }}
         run: |
           cd test/go-tests
-          go test . ./pkg/...
+          go test ./pkg/...
 
       - name: Set build pipeline bundle (min)
         if: matrix.test_scope == 'integration+e2e'

--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           files: |
             operator/**
+            test/go-tests/**
             .github/workflows/operator-test.yaml
             .codecov.yml
 

--- a/.tekton/tasks/konflux-e2e-tests/task.yaml
+++ b/.tekton/tasks/konflux-e2e-tests/task.yaml
@@ -4,7 +4,8 @@
 # Requires a ServiceAccount that can read the cluster-access Secret in this namespace.
 #
 # task-runner: clone + kubeconfig fetch + copy kubectl/yq/jq to /mnt/e2e-shared/bin (+ jq .so to /mnt/e2e-shared/lib).
-# go-toolset: port-forward, go test (integration + conformance).
+# go-toolset: port-forward (remote Kind), go test (integration + conformance).
+# Proxy tests resolve the UI URL in Go from Konflux status.uiURL (see test/go-tests/proxy_setup.go).
 #
 apiVersion: tekton.dev/v1
 kind: Task
@@ -12,8 +13,9 @@ metadata:
   name: konflux-e2e-tests
 spec:
   description: >-
-    Clone konflux-ci (git-url/revision), fetch kubeconfig, copy shared CLIs, wait for Konflux CR Ready,
-    then run deploy-test-resources, integration tests, and conformance tests.
+    Clone konflux-ci (git-url/revision), fetch kubeconfig, copy shared CLIs, run deploy-test-resources,
+    then integration tests and conformance tests. Proxy integration tests wait for Konflux Ready and
+    read status.uiURL in Go (BeforeSuite).
   volumes:
     - name: repo
       emptyDir: {}

--- a/operator/api/v1alpha1/konflux_types.go
+++ b/operator/api/v1alpha1/konflux_types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -261,6 +264,21 @@ func (k *Konflux) GetConditions() []metav1.Condition {
 // SetConditions sets the conditions on the Konflux status.
 func (k *Konflux) SetConditions(conditions []metav1.Condition) {
 	k.Status.Conditions = conditions
+}
+
+// IsReady reports whether the Konflux Ready condition is True.
+func (k *Konflux) IsReady() bool {
+	cond := apimeta.FindStatusCondition(k.Status.Conditions, "Ready")
+	return cond != nil && cond.Status == metav1.ConditionTrue
+}
+
+// ReadyConditionMessage returns a diagnostic string for the Ready condition.
+func (k *Konflux) ReadyConditionMessage() string {
+	cond := apimeta.FindStatusCondition(k.Status.Conditions, "Ready")
+	if cond == nil {
+		return "konflux Ready condition not found in status"
+	}
+	return fmt.Sprintf("konflux Ready=%s reason=%s message=%s", cond.Status, cond.Reason, cond.Message)
 }
 
 // IsImageControllerEnabled returns true if image-controller is enabled.

--- a/operator/api/v1alpha1/konflux_types_test.go
+++ b/operator/api/v1alpha1/konflux_types_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestKonflux_IsReady(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	g.Expect((&Konflux{}).IsReady()).To(gomega.BeFalse())
+
+	k := &Konflux{
+		Status: KonfluxStatus{
+			Conditions: []metav1.Condition{
+				{Type: "Ready", Status: metav1.ConditionFalse},
+			},
+		},
+	}
+	g.Expect(k.IsReady()).To(gomega.BeFalse())
+
+	k.Status.Conditions[0].Status = metav1.ConditionTrue
+	g.Expect(k.IsReady()).To(gomega.BeTrue())
+}
+
+func TestKonflux_ReadyConditionMessage(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	g.Expect((&Konflux{}).ReadyConditionMessage()).
+		To(gomega.Equal("konflux Ready condition not found in status"))
+
+	k := &Konflux{
+		Status: KonfluxStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:    "Ready",
+					Status:  metav1.ConditionFalse,
+					Reason:  "ComponentsNotReady",
+					Message: "waiting for ui",
+				},
+			},
+		},
+	}
+	g.Expect(k.ReadyConditionMessage()).
+		To(gomega.Equal("konflux Ready=False reason=ComponentsNotReady message=waiting for ui"))
+}

--- a/scripts/operator-e2e/README.md
+++ b/scripts/operator-e2e/README.md
@@ -45,7 +45,7 @@ Use **one token per flag** where possible (e.g. `-ginkgo.skip=Flaky`). Values wi
 | `tekton-deploy-prep.sh` | **Tekton (go-toolset):** optional overrides via `operator/cmd/overrides`, then `deploy-local.sh` with `OPERATOR_INSTALL_METHOD=none`. |
 | `tekton-push-operator-pkg-manifests-oci.sh` | **Tekton (task-runner):** after prep, push `operator/pkg/manifests` to OCI as `${oci-container-repo}:${pipelineRun}.pkg-manifests` (skips if `E2E_OCI_CONTAINER_REPO` blank). |
 | `tekton-deploy-operator-and-wait.sh` | **Tekton (go-toolset):** `make install`/build, `bin/manager`, apply CR, wait Ready. |
-| `tekton-run-e2e-tests.sh` | **Tekton:** waits for Konflux Ready, `deploy-test-resources.sh` (`SKIP_SAMPLE_COMPONENTS=true`), integration + conformance `go test`. Optional env: `E2E_INTEGRATION_GO_TEST_EXTRA_ARGS`, `E2E_CONFORMANCE_GO_TEST_EXTRA_ARGS` (space-separated; pipeline params `integration-go-test-extra-args` / `conformance-go-test-extra-args` set these). |
+| `tekton-run-e2e-tests.sh` | **Tekton:** `deploy-test-resources.sh` (`SKIP_SAMPLE_COMPONENTS=true`), optional `kubectl port-forward` + `KONFLUX_PROXY_URL` for remote Kind, integration + conformance `go test`. Proxy tests wait for Konflux Ready and read `status.uiURL` in Go (`BeforeSuite` in `test/go-tests/proxy_setup.go`). Optional env: `KONFLUX_PROXY_URL`, `E2E_INTEGRATION_GO_TEST_EXTRA_ARGS`, `E2E_CONFORMANCE_GO_TEST_EXTRA_ARGS`. |
 
 ## Override YAML schema
 

--- a/test/e2e/run-e2e.sh
+++ b/test/e2e/run-e2e.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# Deploy test resources and run E2E conformance tests.
-# Extra arguments are forwarded to "go test", e.g.:
+# Deploy test resources, run proxy integration tests, then E2E conformance tests.
+# Extra arguments are forwarded to the conformance "go test" only, e.g.:
 #   ./test/e2e/run-e2e.sh -ginkgo.focus="build" -ginkgo.junit-report=report.xml
 
 set -o nounset
@@ -26,9 +26,12 @@ fi
 # Deploy test resources (idempotent — safe to run if already deployed)
 SKIP_SAMPLE_COMPONENTS="true" "${REPO_ROOT}/deploy-test-resources.sh"
 
-# Run E2E conformance tests
-echo "Running E2E conformance tests..."
 cd "${REPO_ROOT}/test/go-tests"
 # -mod=mod overrides GOFLAGS=-mod=vendor that may be present on some systems; this repo doesn't vendor.
+
+echo "Running proxy integration tests..."
+go test -mod=mod . -v -timeout 10m
+
+echo "Running E2E conformance tests..."
 go test -mod=mod ./tests/conformance -v -timeout 45m -ginkgo.vv "$@"
 

--- a/test/go-tests/go.mod
+++ b/test/go-tests/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/konflux-ci/build-service v0.0.0-20240611083846-2dee6cfe6fe4
 	github.com/konflux-ci/image-controller v0.0.0-20260529185104-b31f86d8dce9
 	github.com/konflux-ci/integration-service v0.0.0-20260529092316-83730ca82bdd
+	github.com/konflux-ci/konflux-ci/operator v0.0.0
 	github.com/konflux-ci/operator-toolkit v0.0.0-20260312101100-d4e398191a68
 	github.com/konflux-ci/release-service v0.0.0-20260602124756-b97c146ba02e
 	github.com/mitchellh/go-homedir v1.1.0
@@ -50,6 +51,7 @@ replace (
 	github.com/docker/distribution => github.com/docker/distribution v2.8.3+incompatible
 	github.com/docker/distribution/reference => github.com/distribution/reference v0.5.0
 	github.com/docker/docker => github.com/docker/docker v23.0.18+incompatible
+	github.com/konflux-ci/konflux-ci/operator => ../../operator
 	k8s.io/api => k8s.io/api v0.35.3
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.35.3
 	k8s.io/apimachinery => k8s.io/apimachinery v0.35.3

--- a/test/go-tests/k8s_client.go
+++ b/test/go-tests/k8s_client.go
@@ -1,0 +1,48 @@
+package go_tests
+
+import (
+	"context"
+	"fmt"
+
+	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+var (
+	proxyScheme     = runtime.NewScheme()
+	proxyKubeConfig *rest.Config
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(proxyScheme))
+	utilruntime.Must(konfluxv1alpha1.AddToScheme(proxyScheme))
+}
+
+// NewClient builds a controller-runtime client from KUBECONFIG or ~/.kube/config.
+func NewClient() (crclient.Client, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	proxyKubeConfig = cfg
+	return crclient.New(cfg, crclient.Options{Scheme: proxyScheme})
+}
+
+func serviceProxyGet(ctx context.Context, namespace, serviceName, portName, path string) ([]byte, error) {
+	if proxyKubeConfig == nil {
+		return nil, fmt.Errorf("kubernetes client not initialized")
+	}
+	clientset, err := kubernetes.NewForConfig(proxyKubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	return clientset.CoreV1().Services(namespace).
+		ProxyGet("http", serviceName, portName, path, nil).
+		DoRaw(ctx)
+}

--- a/test/go-tests/proxy_setup.go
+++ b/test/go-tests/proxy_setup.go
@@ -1,0 +1,112 @@
+package go_tests
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	konfluxCRName              = "konflux"
+	konfluxReadyWaitTimeout    = 5 * time.Minute
+	konfluxHealthWaitTimeout   = 5 * time.Minute
+	konfluxReadyPollInterval   = 2 * time.Second
+	proxyHTTPRequestTimeout    = 30 * time.Second
+)
+
+var (
+	proxyBase       *url.URL
+	proxyHome       string
+	tokenURL        string
+	proxyHTTPClient *http.Client
+	proxyClient     crclient.Client
+)
+
+var _ = BeforeSuite(func() {
+	var err error
+	proxyClient, err = NewClient()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(proxyClient).NotTo(BeNil())
+
+	proxyHTTPClient = &http.Client{
+		Timeout: proxyHTTPRequestTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	ctx := context.Background()
+
+	Eventually(func(g Gomega) {
+		konflux := &konfluxv1alpha1.Konflux{}
+		getErr := proxyClient.Get(ctx, crclient.ObjectKey{Name: konfluxCRName}, konflux)
+		g.Expect(getErr).NotTo(HaveOccurred())
+		g.Expect(konflux.IsReady()).To(BeTrue(), konflux.ReadyConditionMessage())
+
+		baseURL := strings.TrimSpace(os.Getenv("KONFLUX_PROXY_URL"))
+		if baseURL == "" {
+			baseURL = konflux.Status.UIURL
+			g.Expect(baseURL).NotTo(BeEmpty(), "expected konflux/konflux status.uiURL to be set once Ready")
+		}
+		g.Expect(setProxyBase(baseURL)).NotTo(HaveOccurred())
+	}).WithTimeout(konfluxReadyWaitTimeout).WithPolling(konfluxReadyPollInterval).Should(Succeed())
+
+	Eventually(func(g Gomega) {
+		resp, doErr := proxyHTTPClient.Get(proxyURL("/health"))
+		g.Expect(doErr).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	}).WithTimeout(konfluxHealthWaitTimeout).WithPolling(konfluxReadyPollInterval).Should(Succeed())
+})
+
+func setProxyBase(raw string) error {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return err
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("proxy base URL must include scheme and host: %q", raw)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("proxy base URL must use https scheme: %q", raw)
+	}
+	u.Path = ""
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	proxyBase = u
+	proxyHome = proxyBase.String()
+	tokenURL = proxyURL("/idp/token")
+	return nil
+}
+
+func proxyURL(path string) string {
+	if path == "" {
+		return proxyBase.String()
+	}
+	return proxyBase.ResolveReference(mustParseProxyPath(path)).String()
+}
+
+func proxyWebSocketURL(path string) string {
+	wsBase := *proxyBase
+	wsBase.Scheme = "wss"
+	return wsBase.ResolveReference(mustParseProxyPath(path)).String()
+}
+
+func mustParseProxyPath(path string) *url.URL {
+	ref, err := url.Parse(path)
+	if err != nil {
+		panic(fmt.Sprintf("invalid proxy path %q: %v", path, err))
+	}
+	return ref
+}

--- a/test/go-tests/proxy_test.go
+++ b/test/go-tests/proxy_test.go
@@ -17,61 +17,47 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
-	tokenUrl = "https://localhost:9443/idp/token"
 	userName = "user2@konflux.dev"
 	password = "password"
 )
 
 var _ = Describe("Test Proxy endpoints", func() {
-	// Create insecure http client (skip TLS verification)
-	customTransport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	client := &http.Client{
-		Transport: customTransport,
-	}
-	home := "https://localhost:9443"
-	DescribeTable("Test endpoints without token", func(url string, expectedStatus int) {
-		// Create a GET request
-		request, err := http.NewRequest("GET", url, nil)
-		Expect(err).NotTo(HaveOccurred())
-		// Send the request
-		response, err := client.Do(request)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(response.StatusCode).To(Equal(expectedStatus))
-	},
-		Entry("Home", home, 200),
-		Entry("Health", home+"/health", 200),
+	DescribeTable("Test endpoints without token",
+		func(path string, expectedStatus int) {
+			request, err := http.NewRequest("GET", proxyURL(path), nil)
+			Expect(err).NotTo(HaveOccurred())
+			response, err := proxyHTTPClient.Do(request)
+			Expect(err).NotTo(HaveOccurred())
+			defer response.Body.Close()
+			Expect(response.StatusCode).To(Equal(expectedStatus))
+		},
+		Entry("Home", "", 200),
+		Entry("Health", "/health", 200),
 		Entry("Secrets",
-			home+"/api/k8s/ns/user-ns2/api/v1/namespaces/user-ns2/secrets", 401),
+			"/api/k8s/ns/user-ns2/api/v1/namespaces/user-ns2/secrets", 401),
 		Entry("Release",
-			home+"/api/k8s/ns/user-ns2/apis/appstudio.redhat.com/v1alpha1/namespaces/user-ns2/releaseplans", 401),
+			"/api/k8s/ns/user-ns2/apis/appstudio.redhat.com/v1alpha1/namespaces/user-ns2/releaseplans", 401),
 		Entry("Applications",
-			home+"/api/k8s/ns/user-ns2/apis/appstudio.redhat.com/v1alpha1/namespaces/user-ns2/applications", 401),
+			"/api/k8s/ns/user-ns2/apis/appstudio.redhat.com/v1alpha1/namespaces/user-ns2/applications", 401),
 		Entry("Namespaces",
-			home+"/api/k8s/api/v1/namespaces", 401),
+			"/api/k8s/api/v1/namespaces", 401),
 	)
-	k8sClient, err := CreateK8sClient()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
 
 	DescribeTable("Test endpoints with token",
-		func(url string, expectedStatus int) {
-			token, err := ExtractToken(k8sClient)
+		func(path string, expectedStatus int) {
+			token, err := ExtractToken(proxyClient)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(token).ToNot(BeEmpty())
-			// Create a Get request
-			request, err := http.NewRequest("GET", url, nil)
+
+			request, err := http.NewRequest("GET", proxyURL(path), nil)
 			Expect(err).NotTo(HaveOccurred())
-			// Add authorization header to the request
 			request.Header.Set("Authorization", "Bearer "+token)
-			// Send the request
-			response, err := client.Do(request)
+
+			response, err := proxyHTTPClient.Do(request)
 			Expect(err).NotTo(HaveOccurred())
 
 			defer response.Body.Close()
@@ -79,31 +65,30 @@ var _ = Describe("Test Proxy endpoints", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(response.StatusCode).To(Equal(expectedStatus), string(rbody))
 		},
-
-		Entry("Home", home, 200),
-		Entry("Health", home+"/health", 200),
+		Entry("Home", "", 200),
+		Entry("Health", "/health", 200),
 		Entry("Secrets",
-			home+"/api/k8s/api/v1/namespaces/user-ns2/secrets", 200),
+			"/api/k8s/api/v1/namespaces/user-ns2/secrets", 200),
 		Entry("Release",
-			home+"/api/k8s/apis/appstudio.redhat.com/v1alpha1/namespaces/user-ns2/releaseplans", 200),
+			"/api/k8s/apis/appstudio.redhat.com/v1alpha1/namespaces/user-ns2/releaseplans", 200),
 		Entry("Applications",
-			home+"/api/k8s/apis/appstudio.redhat.com/v1alpha1/namespaces/user-ns2/applications", 200),
+			"/api/k8s/apis/appstudio.redhat.com/v1alpha1/namespaces/user-ns2/applications", 200),
 		Entry("Namespaces",
-			home+"/api/k8s/api/v1/namespaces", 200),
+			"/api/k8s/api/v1/namespaces", 200),
 		Entry("PipelineRuns",
-			home+"/api/k8s/apis/tekton.dev/v1/namespaces/user-ns2/pipelineruns", 200),
+			"/api/k8s/apis/tekton.dev/v1/namespaces/user-ns2/pipelineruns", 200),
 	)
 
 	Describe("Test WebSocket endpoint", func() {
+		const wsPath = "/wss/k8s/apis/tekton.dev/v1/namespaces/user-ns2/pipelineruns?watch=true"
+
 		It("should establish a WebSocket connection through /wss/k8s/", func() {
-			token, err := ExtractToken(k8sClient)
+			token, err := ExtractToken(proxyClient)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(token).ToNot(BeEmpty())
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-
-			wsURL := "wss://localhost:9443/wss/k8s/apis/tekton.dev/v1/namespaces/user-ns2/pipelineruns?watch=true"
 
 			httpClient := &http.Client{
 				Transport: &http.Transport{
@@ -111,13 +96,12 @@ var _ = Describe("Test Proxy endpoints", func() {
 				},
 			}
 
-			conn, resp, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+			conn, resp, err := websocket.Dial(ctx, proxyWebSocketURL(wsPath), &websocket.DialOptions{
 				HTTPClient:   httpClient,
 				Subprotocols: []string{"base64.binary.k8s.io"},
 				HTTPHeader: http.Header{
 					"Authorization": []string{"Bearer " + token},
-					// This is needed to allow the WebSocket connection to be established
-					"Origin":        []string{"https://localhost:9443"},
+					"Origin":        []string{proxyHome},
 				},
 			})
 			Expect(err).NotTo(HaveOccurred(), "WebSocket connection should be established")
@@ -129,19 +113,16 @@ var _ = Describe("Test Proxy endpoints", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
-			wsURL := "wss://localhost:9443/wss/k8s/apis/tekton.dev/v1/namespaces/user-ns2/pipelineruns?watch=true"
-
 			httpClient := &http.Client{
 				Transport: &http.Transport{
 					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 				},
 			}
 
-			_, resp, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+			_, resp, err := websocket.Dial(ctx, proxyWebSocketURL(wsPath), &websocket.DialOptions{
 				HTTPClient: httpClient,
 				HTTPHeader: http.Header{
-					// This is needed to allow the WebSocket connection to be established
-					"Origin": []string{"https://localhost:9443"},
+					"Origin": []string{proxyHome},
 				},
 			})
 			Expect(err).To(HaveOccurred(), "WebSocket connection should be rejected without token")
@@ -153,15 +134,15 @@ var _ = Describe("Test Proxy endpoints", func() {
 
 	Describe("Test Impersonate header stripping", func() {
 		It("should reject client-sent Impersonate-User headers", func() {
-			token, err := ExtractToken(k8sClient)
+			token, err := ExtractToken(proxyClient)
 			Expect(err).NotTo(HaveOccurred())
 
-			request, err := http.NewRequest("GET", home+"/api/k8s/api/v1/namespaces", nil)
+			request, err := http.NewRequest("GET", proxyURL("/api/k8s/api/v1/namespaces"), nil)
 			Expect(err).NotTo(HaveOccurred())
 			request.Header.Set("Authorization", "Bearer "+token)
 			request.Header.Set("Impersonate-User", "system:admin")
 
-			response, err := client.Do(request)
+			response, err := proxyHTTPClient.Do(request)
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
 			Expect(response.StatusCode).To(Equal(200),
@@ -169,15 +150,15 @@ var _ = Describe("Test Proxy endpoints", func() {
 		})
 
 		It("should reject client-sent Impersonate-Group headers", func() {
-			token, err := ExtractToken(k8sClient)
+			token, err := ExtractToken(proxyClient)
 			Expect(err).NotTo(HaveOccurred())
 
-			request, err := http.NewRequest("GET", home+"/api/k8s/api/v1/namespaces", nil)
+			request, err := http.NewRequest("GET", proxyURL("/api/k8s/api/v1/namespaces"), nil)
 			Expect(err).NotTo(HaveOccurred())
 			request.Header.Set("Authorization", "Bearer "+token)
 			request.Header.Set("Impersonate-Group", "system:masters")
 
-			response, err := client.Do(request)
+			response, err := proxyHTTPClient.Do(request)
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
 			Expect(response.StatusCode).To(Equal(200),
@@ -187,14 +168,14 @@ var _ = Describe("Test Proxy endpoints", func() {
 
 	Describe("Test group-based RBAC", func() {
 		It("should grant access to namespaces the user's groups are bound to", func() {
-			token, err := ExtractTokenForUser(k8sClient, "user1@konflux.dev", "password")
+			token, err := ExtractTokenForUser(proxyClient, "user1@konflux.dev", "password")
 			Expect(err).NotTo(HaveOccurred())
 
-			request, err := http.NewRequest("GET", home+"/api/k8s/api/v1/namespaces", nil)
+			request, err := http.NewRequest("GET", proxyURL("/api/k8s/api/v1/namespaces"), nil)
 			Expect(err).NotTo(HaveOccurred())
 			request.Header.Set("Authorization", "Bearer "+token)
 
-			response, err := client.Do(request)
+			response, err := proxyHTTPClient.Do(request)
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
 
@@ -204,23 +185,18 @@ var _ = Describe("Test Proxy endpoints", func() {
 		})
 
 		It("should pass groups from ID token as Impersonate-Group headers", func() {
-			token, err := ExtractTokenForUser(k8sClient, "user1@konflux.dev", "password")
+			token, err := ExtractTokenForUser(proxyClient, "user1@konflux.dev", "password")
 			Expect(err).NotTo(HaveOccurred())
-
-			request, err := http.NewRequest("GET",
-				home+"/api/k8s/apis/authorization.k8s.io/v1/selfsubjectaccessreviews", nil)
-			Expect(err).NotTo(HaveOccurred())
-			request.Header.Set("Authorization", "Bearer "+token)
 
 			sarBody := `{"apiVersion":"authorization.k8s.io/v1","kind":"SelfSubjectAccessReview","spec":{"resourceAttributes":{"verb":"list","resource":"namespaces"}}}`
-			request, err = http.NewRequest("POST",
-				home+"/api/k8s/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
+			request, err := http.NewRequest("POST",
+				proxyURL("/api/k8s/apis/authorization.k8s.io/v1/selfsubjectaccessreviews"),
 				strings.NewReader(sarBody))
 			Expect(err).NotTo(HaveOccurred())
 			request.Header.Set("Authorization", "Bearer "+token)
 			request.Header.Set("Content-Type", "application/json")
 
-			response, err := client.Do(request)
+			response, err := proxyHTTPClient.Do(request)
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
 
@@ -231,21 +207,16 @@ var _ = Describe("Test Proxy endpoints", func() {
 	})
 
 	Describe("Test user with no IdP groups", func() {
-		// When a user has no groups in the identity provider (e.g. Dex local
-		// password connector), the impersonate plugin only adds the static
-		// "system:authenticated" group. This test validates that users with
-		// no IdP groups can still authenticate and access resources normally.
 		It("should succeed when the user has no IdP groups", func() {
-			// user2 has no groups in the Dex static password config.
-			token, err := ExtractTokenForUser(k8sClient, "user2@konflux.dev", "password")
+			token, err := ExtractTokenForUser(proxyClient, "user2@konflux.dev", "password")
 			Expect(err).NotTo(HaveOccurred())
 
 			request, err := http.NewRequest("GET",
-				home+"/api/k8s/api/v1/namespaces/user-ns2/secrets", nil)
+				proxyURL("/api/k8s/api/v1/namespaces/user-ns2/secrets"), nil)
 			Expect(err).NotTo(HaveOccurred())
 			request.Header.Set("Authorization", "Bearer "+token)
 
-			response, err := client.Do(request)
+			response, err := proxyHTTPClient.Do(request)
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
 
@@ -258,14 +229,14 @@ var _ = Describe("Test Proxy endpoints", func() {
 
 	Describe("Test namespace-lister endpoint", func() {
 		It("should return namespaces for authenticated user", func() {
-			token, err := ExtractToken(k8sClient)
+			token, err := ExtractToken(proxyClient)
 			Expect(err).NotTo(HaveOccurred())
 
-			request, err := http.NewRequest("GET", home+"/api/k8s/api/v1/namespaces", nil)
+			request, err := http.NewRequest("GET", proxyURL("/api/k8s/api/v1/namespaces"), nil)
 			Expect(err).NotTo(HaveOccurred())
 			request.Header.Set("Authorization", "Bearer "+token)
 
-			response, err := client.Do(request)
+			response, err := proxyHTTPClient.Do(request)
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
 
@@ -280,30 +251,27 @@ var _ = Describe("Test Proxy endpoints", func() {
 		})
 
 		It("should route non-GET methods to Kube API, not namespace-lister", func() {
-			token, err := ExtractToken(k8sClient)
+			token, err := ExtractToken(proxyClient)
 			Expect(err).NotTo(HaveOccurred())
 
-			request, err := http.NewRequest("POST", home+"/api/k8s/api/v1/namespaces",
+			request, err := http.NewRequest("POST", proxyURL("/api/k8s/api/v1/namespaces"),
 				strings.NewReader(`{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"test-reject"}}`))
 			Expect(err).NotTo(HaveOccurred())
 			request.Header.Set("Authorization", "Bearer "+token)
 			request.Header.Set("Content-Type", "application/json")
 
-			response, err := client.Do(request)
+			response, err := proxyHTTPClient.Do(request)
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
-			// Namespace-lister only handles GET; a POST reaching it would return 405.
-			// Any other status (201 if the user can create, 403 if not) proves
-			// the request was routed to the Kube API instead.
 			Expect(response.StatusCode).NotTo(Equal(405),
 				"POST should be routed to the Kube API, not namespace-lister")
 		})
 
 		It("should require authentication for namespace-lister", func() {
-			request, err := http.NewRequest("GET", home+"/api/k8s/api/v1/namespaces", nil)
+			request, err := http.NewRequest("GET", proxyURL("/api/k8s/api/v1/namespaces"), nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			response, err := client.Do(request)
+			response, err := proxyHTTPClient.Do(request)
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
 			Expect(response.StatusCode).To(Equal(401))
@@ -311,36 +279,30 @@ var _ = Describe("Test Proxy endpoints", func() {
 	})
 
 	Describe("Test Tekton Results endpoint", func() {
+		const resultsPath = "/api/k8s/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/-/results"
+
 		It("should proxy authenticated requests to Tekton Results", func() {
-			token, err := ExtractToken(k8sClient)
+			token, err := ExtractToken(proxyClient)
 			Expect(err).NotTo(HaveOccurred())
 
-			request, err := http.NewRequest("GET",
-				home+"/api/k8s/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/-/results",
-				nil)
+			request, err := http.NewRequest("GET", proxyURL(resultsPath), nil)
 			Expect(err).NotTo(HaveOccurred())
 			request.Header.Set("Authorization", "Bearer "+token)
 
-			response, err := client.Do(request)
+			response, err := proxyHTTPClient.Do(request)
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
 
-			// 200 if Tekton Results is deployed and the token is accepted,
-			// 502 if the upstream is unreachable,
-			// 401 if Tekton Results rejects the proxy SA token (known upstream
-			// limitation — see tektoncd/results#1331).
 			Expect(response.StatusCode).To(SatisfyAny(
 				Equal(200), Equal(502), Equal(401)),
 				"Tekton Results endpoint should be proxied")
 		})
 
 		It("should reject unauthenticated requests to Tekton Results", func() {
-			request, err := http.NewRequest("GET",
-				home+"/api/k8s/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/-/results",
-				nil)
+			request, err := http.NewRequest("GET", proxyURL(resultsPath), nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			response, err := client.Do(request)
+			response, err := proxyHTTPClient.Do(request)
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
 			Expect(response.StatusCode).To(Equal(401))
@@ -349,14 +311,7 @@ var _ = Describe("Test Proxy endpoints", func() {
 
 	Describe("Test metrics endpoint", func() {
 		It("should expose Prometheus metrics on the metrics port", func() {
-			k8sClient, err := CreateK8sClient()
-			Expect(err).NotTo(HaveOccurred())
-
-			// Caddy serves Prometheus metrics on port 2112, exposed via the
-			// proxy Service. Use the Kubernetes API service proxy to reach it.
-			raw, err := k8sClient.CoreV1().Services("konflux-ui").
-				ProxyGet("http", "proxy", "metrics", "/metrics", nil).
-				DoRaw(context.TODO())
+			raw, err := serviceProxyGet(context.TODO(), "konflux-ui", "proxy", "metrics", "/metrics")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(raw)).To(ContainSubstring("caddy_"),
 				"metrics should contain Caddy-specific metrics")
@@ -364,7 +319,6 @@ var _ = Describe("Test Proxy endpoints", func() {
 	})
 })
 
-// A struct to hold the response of a token request
 type TokenResponse struct {
 	AccessToken string `json:"access_token"`
 	ExpiresIn   int    `json:"expires_in"`
@@ -372,9 +326,6 @@ type TokenResponse struct {
 	IdToken     string `json:"id_token"`
 }
 
-// Create a header from a given secret.
-// It takes a pointer to a Kubernetes Secret as input and returns a string representing the header.
-// If the client-secret is not found in the secret, it returns an error
 func CreateHeaderFromSecret(secret *v1.Secret) (string, error) {
 	encodedSecret, exists := secret.Data["client-secret"]
 	if !exists {
@@ -385,59 +336,24 @@ func CreateHeaderFromSecret(secret *v1.Secret) (string, error) {
 	return header, nil
 }
 
-// Retrieve the id_token from the tokenUrl using the provided username, password, and header.
 func GetIdToken(header string) (string, error) {
-	// Build the Post request to retrieve the id_token
-	formData := url.Values{}
-	formData.Add("grant_type", "password")
-	formData.Add("scope", "openid profile email groups")
-	formData.Add("username", userName)
-	formData.Add("password", password)
-
-	request, err := http.NewRequest("POST", tokenUrl, bytes.NewBufferString(formData.Encode()))
-	if err != nil {
-		return " ", err
-	}
-	request.Header.Set("Authorization", "Basic "+header)
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	customTransport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // Skip TLS verification (insecure!)
-	}
-	client := &http.Client{Transport: customTransport}
-	// send the request
-	resp, err := client.Do(request)
-	if err != nil {
-		return " ", err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return " ", err
-	}
-
-	// Unmarshal the response body and send the id_token
-	var tokenResp TokenResponse
-	err = json.Unmarshal(body, &tokenResp)
-	if err != nil {
-		return " ", err
-	}
-	return tokenResp.IdToken, nil
+	return GetIdTokenForUser(header, userName, password)
 }
 
-func ExtractToken(k8sClient *kubernetes.Clientset) (string, error) {
-	return ExtractTokenForUser(k8sClient, userName, password)
+func ExtractToken(client crclient.Client) (string, error) {
+	return ExtractTokenForUser(client, userName, password)
 }
 
-func ExtractTokenForUser(k8sClient *kubernetes.Clientset, user, pass string) (string, error) {
+func ExtractTokenForUser(client crclient.Client, user, pass string) (string, error) {
 	namespace := "dex"
-	_, err := k8sClient.CoreV1().Namespaces().Get(context.TODO(), "dex", metav1.GetOptions{})
+	ns := &v1.Namespace{}
+	err := client.Get(context.TODO(), crclient.ObjectKey{Name: "dex"}, ns)
 	if err != nil {
 		namespace = "konflux-ui"
 	}
 
-	secret, err := k8sClient.CoreV1().Secrets(namespace).Get(context.TODO(), "oauth2-proxy-client-secret", metav1.GetOptions{})
+	secret := &v1.Secret{}
+	err = client.Get(context.TODO(), crclient.ObjectKey{Namespace: namespace, Name: "oauth2-proxy-client-secret"}, secret)
 	if err != nil {
 		return "", err
 	}
@@ -445,11 +361,7 @@ func ExtractTokenForUser(k8sClient *kubernetes.Clientset, user, pass string) (st
 	if err != nil {
 		return "", err
 	}
-	token, err := GetIdTokenForUser(header, user, pass)
-	if err != nil {
-		return "", err
-	}
-	return token, nil
+	return GetIdTokenForUser(header, user, pass)
 }
 
 func GetIdTokenForUser(header, user, pass string) (string, error) {
@@ -459,18 +371,14 @@ func GetIdTokenForUser(header, user, pass string) (string, error) {
 	formData.Add("username", user)
 	formData.Add("password", pass)
 
-	request, err := http.NewRequest("POST", tokenUrl, bytes.NewBufferString(formData.Encode()))
+	request, err := http.NewRequest("POST", tokenURL, bytes.NewBufferString(formData.Encode()))
 	if err != nil {
 		return "", err
 	}
 	request.Header.Set("Authorization", "Basic "+header)
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	customTransport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	client := &http.Client{Transport: customTransport}
-	resp, err := client.Do(request)
+	resp, err := proxyHTTPClient.Do(request)
 	if err != nil {
 		return "", err
 	}

--- a/test/go-tests/suite_test.go
+++ b/test/go-tests/suite_test.go
@@ -1,39 +1,13 @@
 package go_tests
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 func TestGoTests(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "GoTests Suite")
-}
-
-// Create a new Kubernetes client using local config file
-func CreateK8sClient() (*kubernetes.Clientset, error) {
-	kubeconfig := os.Getenv("KUBECONFIG")
-	if kubeconfig == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-		kubeconfig = homeDir + "/.kube/config"
-	}
-
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		return nil, err
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	return clientset, nil
 }

--- a/test/go-tests/tests/conformance/README.md
+++ b/test/go-tests/tests/conformance/README.md
@@ -38,7 +38,7 @@ They run against an upstream Konflux instance deployed via scripts in the [konfl
    ```bash
    ./test/e2e/run-e2e.sh
    ```
-   This deploys test resources and runs the conformance suite.
+   This deploys test resources, runs proxy integration tests (`test/go-tests`), then runs this conformance suite.
 
    You can also run `go test . -v` directly from this directory, but that
    skips test resource deployment — you must ensure resources are already


### PR DESCRIPTION
Proxy tests were hard coded to use localhost. To be able to run them on OpenShift, we need to be able to run them remotely. Resolving the UI URL from the CR provides a unified approach for getting the URL.

Assisted-by: Cursor