### PR TITLE
test: debug logs for e2e release failures

### DIFF
--- a/test/go-tests/tests/conformance/conformance.go
+++ b/test/go-tests/tests/conformance/conformance.go
@@ -385,14 +385,17 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 								klog.Errorf("release PipelineRun %s/%s condition: type=%s reason=%s message=%s",
 									pr.GetNamespace(), pr.GetName(), c.Type, c.Reason, c.Message)
 							}
-							if failedLogs, logErr := tekton.GetFailedPipelineRunLogs(
+							var failedLogs string
+							if logs, logErr := tekton.GetFailedPipelineRunLogs(
 								fw.AsKubeAdmin.ReleaseController.KubeRest(),
 								fw.AsKubeAdmin.ReleaseController.KubeInterface(),
 								pr); logErr == nil {
+								failedLogs = logs
 								klog.Errorf("release PipelineRun %s/%s failed task logs:\n%s", pr.GetNamespace(), pr.GetName(), failedLogs)
 							} else {
 								klog.Errorf("release PipelineRun %s/%s could not get failed logs: %v", pr.GetNamespace(), pr.GetName(), logErr)
 							}
+							logReleaseFailureDiagnostics(fw.AsKubeAdmin, pr, release, managedNamespace, failedLogs)
 							// Fetch verify-conforma logs separately: they contain EC policy
 							// violation details that are not captured by the generic failed-task
 							// logs above, and are useful even when another task caused the failure.

--- a/test/go-tests/tests/conformance/diagnostics.go
+++ b/test/go-tests/tests/conformance/diagnostics.go
@@ -1,0 +1,332 @@
+package conformance
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/constants"
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/framework"
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+const (
+	githubAPIBodyLogLimit        = 200
+	githubAPIProbeTimeout        = 5 * time.Second
+	collectDataGitHubFlakeMarker = "diagnostic: known-flake collect-data-github-api"
+	// collect-data logs the curl line and jq parse error back-to-back; ignore distant pairings.
+	collectDataGitHubAPIFlakeParseErrorWindow = 512
+)
+
+// probedGitHubAPI tracks PipelineRuns for which the outbound GitHub probe already ran.
+// The release failure path is polled by Eventually; probing once avoids repeated
+// outbound calls and extra load on shared CI egress rate limits.
+var probedGitHubAPI sync.Map
+
+// collectDataGitHubAPIFlakeRe matches the unauthenticated GitHub commit lookup in
+// release-service-catalog collect-data when jq fails on a non-JSON response.
+var collectDataGitHubAPIFlakeRe = regexp.MustCompile(`api\.github\.com/repos/[^\s"']+/commits/[0-9a-f]+`)
+
+// logReleaseFailureDiagnostics records cluster state to help triage release PipelineRun
+// failures. Uses klog because GinkgoWriter is suppressed during Eventually retries.
+func logReleaseFailureDiagnostics(
+	hub *framework.ControllerHub,
+	pr *pipeline.PipelineRun,
+	release *releaseApi.Release,
+	managedNamespace string,
+	failedLogs string,
+) {
+	if pr == nil {
+		return
+	}
+
+	klog.Errorf("diagnostic: release PipelineRun %s/%s failure details", pr.Namespace, pr.Name)
+	for _, c := range pr.Status.Conditions {
+		klog.Errorf("diagnostic:   PipelineRun condition type=%s status=%s reason=%s message=%s",
+			c.Type, c.Status, c.Reason, c.Message)
+	}
+
+	logReleasePipelineRunTaskRuns(hub, pr)
+
+	if release != nil {
+		logReleaseCRDiagnostics(hub, release)
+		logReleasePlanAdmissionDiagnostics(hub, release, failedLogs, pipelineRunKey(pr))
+	} else {
+		klog.Errorf("diagnostic: Release CR unavailable (nil)")
+	}
+
+	dumpManagedPipelineRuns(hub, managedNamespace)
+}
+
+func logReleasePipelineRunTaskRuns(hub *framework.ControllerHub, pr *pipeline.PipelineRun) {
+	client := hub.ReleaseController.KubeRest()
+	for _, chr := range pr.Status.ChildReferences {
+		taskRun := &pipeline.TaskRun{}
+		key := types.NamespacedName{Namespace: pr.Namespace, Name: chr.Name}
+		if err := client.Get(context.Background(), key, taskRun); err != nil {
+			klog.Errorf("diagnostic:   TaskRun %s/%s: get error: %v", key.Namespace, key.Name, err)
+			continue
+		}
+
+		klog.Infof("diagnostic:   TaskRun %s/%s pipelineTask=%q pod=%s",
+			taskRun.Namespace, taskRun.Name, chr.PipelineTaskName, taskRun.Status.PodName)
+		for _, tc := range taskRun.Status.Conditions {
+			klog.Infof("diagnostic:     condition type=%s status=%s reason=%s message=%s",
+				tc.Type, tc.Status, tc.Reason, tc.Message)
+		}
+		for _, step := range taskRun.Status.Steps {
+			if step.Terminated != nil {
+				klog.Infof("diagnostic:     step %q container=%s reason=%s exitCode=%d message=%q",
+					step.Name, step.Container, step.Terminated.Reason, step.Terminated.ExitCode, step.Terminated.Message)
+			} else if step.Running != nil {
+				klog.Infof("diagnostic:     step %q container=%s running", step.Name, step.Container)
+			} else if step.Waiting != nil {
+				klog.Infof("diagnostic:     step %q container=%s waiting reason=%s message=%q",
+					step.Name, step.Container, step.Waiting.Reason, step.Waiting.Message)
+			}
+		}
+	}
+}
+
+func logReleaseCRDiagnostics(hub *framework.ControllerHub, release *releaseApi.Release) {
+	fresh, err := hub.ReleaseController.GetRelease(release.Name, "", release.Namespace)
+	if err != nil {
+		klog.Errorf("diagnostic: Release %s/%s: re-fetch error: %v", release.Namespace, release.Name, err)
+		return
+	}
+
+	klog.Infof("diagnostic: Release %s/%s spec.releasePlan=%q spec.snapshot=%q",
+		fresh.Namespace, fresh.Name, fresh.Spec.ReleasePlan, fresh.Spec.Snapshot)
+	for _, c := range fresh.Status.Conditions {
+		klog.Infof("diagnostic:   Release condition type=%s status=%s reason=%s message=%s",
+			c.Type, c.Status, c.Reason, c.Message)
+	}
+	klog.Infof("diagnostic:   Release collectorsProcessing managed=%+v tenant=%+v",
+		fresh.Status.CollectorsProcessing.ManagedCollectorsProcessing,
+		fresh.Status.CollectorsProcessing.TenantCollectorsProcessing)
+}
+
+func logReleasePlanAdmissionDiagnostics(
+	hub *framework.ControllerHub,
+	release *releaseApi.Release,
+	failedLogs string,
+	pipelineRunKey string,
+) {
+	releasePlanName := release.Spec.ReleasePlan
+	if releasePlanName == "" {
+		klog.Errorf("diagnostic: ReleasePlan name unknown (empty release.spec.releasePlan)")
+		return
+	}
+
+	releasePlan, err := hub.ReleaseController.GetReleasePlan(releasePlanName, release.Namespace)
+	if err != nil {
+		klog.Errorf("diagnostic: ReleasePlan %s/%s: get error: %v", release.Namespace, releasePlanName, err)
+		return
+	}
+
+	matched := strings.TrimSpace(releasePlan.Status.ReleasePlanAdmission.Name)
+	if matched == "" {
+		klog.Errorf("diagnostic: ReleasePlan %s/%s has no matched ReleasePlanAdmission in status",
+			release.Namespace, releasePlanName)
+		return
+	}
+
+	rpaNamespace, rpaName, ok := parseNamespacedName(matched)
+	if !ok {
+		klog.Errorf("diagnostic: ReleasePlan %s/%s status.releasePlanAdmission.name %q is not a valid namespaced name",
+			release.Namespace, releasePlanName, matched)
+		return
+	}
+
+	rpa, err := hub.ReleaseController.GetReleasePlanAdmission(rpaName, rpaNamespace)
+	if err != nil {
+		klog.Errorf("diagnostic: ReleasePlanAdmission %s/%s: get error: %v", rpaNamespace, rpaName, err)
+		return
+	}
+
+	if rpa.Spec.Pipeline == nil {
+		klog.Infof("diagnostic: ReleasePlanAdmission %s/%s has no pipeline spec", rpaNamespace, rpaName)
+		return
+	}
+
+	ref := rpa.Spec.Pipeline.PipelineRef
+	klog.Infof("diagnostic: ReleasePlanAdmission %s/%s pipelineRef resolver=%q ociStorage=%q useEmptyDir=%v",
+		rpaNamespace, rpaName, ref.Resolver, ref.OciStorage, ref.UseEmptyDir)
+	for _, p := range ref.Params {
+		klog.Infof("diagnostic:   pipelineRef param %s=%q", p.Name, p.Value)
+	}
+
+	probeGitHubCommitAPIIfNeeded(failedLogs, ref, pipelineRunKey)
+}
+
+func pipelineRunKey(pr *pipeline.PipelineRun) string {
+	return pr.Namespace + "/" + pr.Name
+}
+
+func dumpManagedPipelineRuns(hub *framework.ControllerHub, managedNamespace string) {
+	prs, err := hub.TektonController.ListAllPipelineRuns(managedNamespace)
+	if err != nil {
+		klog.Errorf("diagnostic: could not list PipelineRuns in %s: %v", managedNamespace, err)
+		return
+	}
+
+	klog.Infof("diagnostic: PipelineRuns in %s: %d", managedNamespace, len(prs.Items))
+	for _, pr := range prs.Items {
+		status := "Pending"
+		for _, c := range pr.Status.Conditions {
+			status = fmt.Sprintf("%s (reason: %s, message: %s)", c.Status, c.Reason, c.Message)
+		}
+		klog.Infof("diagnostic:   - %s release=%s status=%s",
+			pr.Name,
+			pr.Labels["release.appstudio.openshift.io/release"],
+			status)
+	}
+}
+
+func probeGitHubCommitAPIIfNeeded(failedLogs string, ref tektonutils.PipelineRef, pipelineRunKey string) {
+	if !isCollectDataGitHubAPIFlake(failedLogs) {
+		return
+	}
+	if githubAPIAlreadyProbed(pipelineRunKey) {
+		return
+	}
+
+	gitURL := pipelineRefParam(ref, "url")
+	revision := pipelineRefParam(ref, "revision")
+	pathInRepo := pipelineRefParam(ref, "pathInRepo")
+	org, repo, ok := parseGitHubOrgRepo(gitURL)
+	if !ok {
+		klog.Errorf("%s: could not parse org/repo from pipelineRef url %q", collectDataGitHubFlakeMarker, gitURL)
+		return
+	}
+
+	klog.Errorf("%s org=%s repo=%s revision=%s pathInRepo=%q",
+		collectDataGitHubFlakeMarker, org, repo, revision, pathInRepo)
+
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/commits/%s", org, repo, revision)
+	probeGitHubCommitAPI(apiURL, "unauthenticated", "")
+	if token := strings.TrimSpace(os.Getenv(constants.GITHUB_TOKEN_ENV)); token != "" {
+		probeGitHubCommitAPI(apiURL, "authenticated", token)
+	} else {
+		klog.Infof("diagnostic: GitHub API probe skipped authenticated request (%s not set)", constants.GITHUB_TOKEN_ENV)
+	}
+}
+
+func isCollectDataGitHubAPIFlake(logs string) bool {
+	match := collectDataGitHubAPIFlakeRe.FindStringIndex(logs)
+	if match == nil {
+		return false
+	}
+	after := logs[match[1]:]
+	if len(after) > collectDataGitHubAPIFlakeParseErrorWindow {
+		after = after[:collectDataGitHubAPIFlakeParseErrorWindow]
+	}
+	return strings.Contains(after, "parse error")
+}
+
+func githubAPIAlreadyProbed(pipelineRunKey string) bool {
+	_, loaded := probedGitHubAPI.LoadOrStore(pipelineRunKey, true)
+	return loaded
+}
+
+func parseNamespacedName(name string) (namespace, objName string, ok bool) {
+	name = strings.TrimSpace(name)
+	parts := strings.SplitN(name, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func pipelineRefParam(ref tektonutils.PipelineRef, name string) string {
+	for _, p := range ref.Params {
+		if p.Name == name {
+			return p.Value
+		}
+	}
+	return ""
+}
+
+func parseGitHubOrgRepo(gitURL string) (org, repo string, ok bool) {
+	gitURL = strings.TrimSpace(gitURL)
+	gitURL = strings.TrimSuffix(gitURL, ".git")
+	const marker = "github.com/"
+	idx := strings.Index(gitURL, marker)
+	if idx < 0 {
+		return "", "", false
+	}
+	path := strings.Trim(gitURL[idx+len(marker):], "/")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func probeGitHubCommitAPI(apiURL, label, token string) {
+	ctx, cancel := context.WithTimeout(context.Background(), githubAPIProbeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		klog.Errorf("diagnostic: GitHub API probe (%s): build request: %v", label, err)
+		return
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "konflux-conformance-e2e")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		klog.Errorf("diagnostic: GitHub API probe (%s) GET %s: %v", label, apiURL, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Unauthenticated probe: log a short body prefix to spot non-JSON/HTML responses
+	// (the collect-data jq failure mode). Authenticated responses can include full
+	// commit metadata and are omitted from CI logs; status and rate-limit headers suffice.
+	if token != "" {
+		klog.Errorf("diagnostic: GitHub API probe (%s) GET %s: status=%d retry-after=%q x-ratelimit-limit=%q x-ratelimit-remaining=%q x-ratelimit-reset=%q x-ratelimit-resource=%q",
+			label,
+			apiURL,
+			resp.StatusCode,
+			resp.Header.Get("Retry-After"),
+			resp.Header.Get("X-Ratelimit-Limit"),
+			resp.Header.Get("X-Ratelimit-Remaining"),
+			resp.Header.Get("X-Ratelimit-Reset"),
+			resp.Header.Get("X-Ratelimit-Resource"),
+		)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, githubAPIBodyLogLimit))
+	if err != nil {
+		klog.Errorf("diagnostic: GitHub API probe (%s) GET %s: read body: %v", label, apiURL, err)
+		return
+	}
+
+	klog.Errorf("diagnostic: GitHub API probe (%s) GET %s: status=%d retry-after=%q x-ratelimit-limit=%q x-ratelimit-remaining=%q x-ratelimit-reset=%q x-ratelimit-resource=%q body-prefix=%q",
+		label,
+		apiURL,
+		resp.StatusCode,
+		resp.Header.Get("Retry-After"),
+		resp.Header.Get("X-Ratelimit-Limit"),
+		resp.Header.Get("X-Ratelimit-Remaining"),
+		resp.Header.Get("X-Ratelimit-Reset"),
+		resp.Header.Get("X-Ratelimit-Resource"),
+		strings.TrimSpace(string(body)),
+	)
+}

--- a/test/go-tests/tests/conformance/diagnostics_test.go
+++ b/test/go-tests/tests/conformance/diagnostics_test.go
@@ -1,0 +1,138 @@
+package conformance
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/onsi/gomega"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+)
+
+func TestIsCollectDataGitHubAPIFlake(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	positive := "++ curl -s https://api.github.com/repos/konflux-ci/release-service-catalog/commits/c194bc7304852c66394290d2d1d36a7e848e3652\nparse error: Invalid numeric literal at line 1, column 10"
+	g.Expect(isCollectDataGitHubAPIFlake(positive)).To(gomega.BeTrue(), "expected positive match for collect-data GitHub API flake logs")
+
+	negative := []string{
+		"",
+		"api.github.com/repos/foo/bar/commits/deadbeef",
+		"parse error: something else",
+		"failed to push image to quay.io",
+		"curl -s https://api.github.com/repos/foo/bar/commits/deadbeef\n" +
+			strings.Repeat("x", collectDataGitHubAPIFlakeParseErrorWindow+1) + "\nparse error: unrelated jq failure",
+	}
+	for _, logs := range negative {
+		g.Expect(isCollectDataGitHubAPIFlake(logs)).To(gomega.BeFalse(), "expected no match for logs: %q", logs)
+	}
+}
+
+func TestParseNamespacedName(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	tests := []struct {
+		input         string
+		wantNamespace string
+		wantName      string
+		wantOK        bool
+	}{
+		{input: "default-managed-tenant/local-release", wantNamespace: "default-managed-tenant", wantName: "local-release", wantOK: true},
+		{input: "  ns/obj  ", wantNamespace: "ns", wantName: "obj", wantOK: true},
+		{input: "", wantOK: false},
+		{input: "no-slash", wantOK: false},
+		{input: "/missing-ns", wantOK: false},
+		{input: "missing-name/", wantOK: false},
+	}
+
+	for _, tc := range tests {
+		ns, name, ok := parseNamespacedName(tc.input)
+		g.Expect(ok).To(gomega.Equal(tc.wantOK), "parseNamespacedName(%q) ok", tc.input)
+		if !ok {
+			continue
+		}
+		g.Expect(ns).To(gomega.Equal(tc.wantNamespace), "parseNamespacedName(%q) namespace", tc.input)
+		g.Expect(name).To(gomega.Equal(tc.wantName), "parseNamespacedName(%q) name", tc.input)
+	}
+}
+
+func TestParseGitHubOrgRepo(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	tests := []struct {
+		url    string
+		org    string
+		repo   string
+		wantOK bool
+	}{
+		{
+			url:    "https://github.com/konflux-ci/release-service-catalog.git",
+			org:    "konflux-ci",
+			repo:   "release-service-catalog",
+			wantOK: true,
+		},
+		{
+			url:    "https://github.com/org/repo",
+			org:    "org",
+			repo:   "repo",
+			wantOK: true,
+		},
+		{
+			url:    "https://gitlab.com/org/repo.git",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		org, repo, ok := parseGitHubOrgRepo(tc.url)
+		g.Expect(ok).To(gomega.Equal(tc.wantOK), "parseGitHubOrgRepo(%q) ok", tc.url)
+		if !ok {
+			continue
+		}
+		g.Expect(org).To(gomega.Equal(tc.org), "parseGitHubOrgRepo(%q) org", tc.url)
+		g.Expect(repo).To(gomega.Equal(tc.repo), "parseGitHubOrgRepo(%q) repo", tc.url)
+	}
+}
+
+func TestPipelineRefParam(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	ref := tektonutils.PipelineRef{
+		Params: []tektonutils.Param{
+			{Name: "url", Value: "https://github.com/konflux-ci/release-service-catalog.git"},
+			{Name: "revision", Value: "abc123"},
+		},
+	}
+
+	g.Expect(pipelineRefParam(ref, "revision")).To(gomega.Equal("abc123"))
+	g.Expect(pipelineRefParam(ref, "missing")).To(gomega.BeEmpty())
+}
+
+func TestGitHubAPIProbedOnce(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	key := "default-managed-tenant/managed-test"
+	t.Cleanup(func() { probedGitHubAPI.Delete(key) })
+
+	g.Expect(githubAPIAlreadyProbed(key)).To(gomega.BeFalse(), "expected first probe attempt to run")
+	g.Expect(githubAPIAlreadyProbed(key)).To(gomega.BeTrue(), "expected second probe attempt to be skipped")
+}
+
+func TestProbeGitHubCommitAPI(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Ratelimit-Limit", "60")
+		w.Header().Set("X-Ratelimit-Remaining", "0")
+		w.Header().Set("X-Ratelimit-Resource", "core")
+		got := r.Header.Get("Authorization")
+		g.Expect(got).To(gomega.Or(gomega.BeEmpty(), gomega.Equal("Bearer test-token")), "unexpected Authorization header %q", got)
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"API rate limit exceeded"}`))
+	}))
+	defer server.Close()
+
+	probeGitHubCommitAPI(server.URL, "test", "")
+	probeGitHubCommitAPI(server.URL, "test-authenticated", "test-token")
+}


### PR DESCRIPTION
Recent flakiness during the release phase in the e2e tests was hard to troubleshoot. This commit dump some more logs that might be useful to understand the root cause of the failures.

Assisted-by: Cursor