### PR TITLE
feat(KFLUXVNGD-1089): add owns to the namespacelister resources

### DIFF
--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"fmt"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -233,10 +235,13 @@ func (r *KonfluxNamespaceListerReconciler) SetupWithManager(mgr ctrl.Manager) er
 		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).
+		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
 		Owns(&rbacv1.ClusterRole{}).
 		Owns(&rbacv1.ClusterRoleBinding{}).
+		Owns(&networkingv1.NetworkPolicy{}).
+		Owns(&certmanagerv1.Certificate{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		Complete(r)
 }

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
@@ -19,19 +19,27 @@ package namespacelister
 import (
 	"context"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 )
 
-const namespaceListerNamespace = "namespace-lister"
+const (
+	namespaceListerNamespace            = "namespace-lister"
+	networkPolicyAllowFromKonfluxUIName = "namespace-lister-allow-from-konfluxui"
+	networkPolicyAllowToAPIServerName   = "namespace-lister-allow-to-apiserver"
+)
 
 // findEnvValue returns the last value of the named env var.
 // Checks the last match to match Kubernetes behavior where later entries override earlier ones.
@@ -71,6 +79,251 @@ var _ = Describe("KonfluxNamespaceLister Controller", func() {
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
+
+	Context("Self-healing", func() {
+		It("recreates Deployment when deleted", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			deploymentNN := types.NamespacedName{
+				Name:      namespaceListerNamespace,
+				Namespace: namespaceListerNamespace,
+			}
+
+			By("waiting for initial Deployment creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, deploymentNN, &appsv1.Deployment{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the Deployment")
+			Expect(k8sClient.Delete(ctx, &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: deploymentNN.Name, Namespace: deploymentNN.Namespace},
+			})).To(Succeed())
+
+			By("verifying the Deployment is recreated with correct spec")
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, deploymentNN, dep)).To(Succeed())
+				g.Expect(dep.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+				container := testutil.FindContainer(dep.Spec.Template.Spec.Containers, namespaceListerContainerName)
+				g.Expect(container).NotTo(BeNil(), "namespace-lister container should exist")
+				g.Expect(container.Image).NotTo(BeEmpty(), "container image should be set")
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("recreates ServiceAccount when deleted", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			saNN := types.NamespacedName{
+				Name:      namespaceListerNamespace,
+				Namespace: namespaceListerNamespace,
+			}
+
+			By("waiting for initial ServiceAccount creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, saNN, &corev1.ServiceAccount{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the ServiceAccount")
+			Expect(k8sClient.Delete(ctx, &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: saNN.Name, Namespace: saNN.Namespace},
+			})).To(Succeed())
+
+			By("verifying the ServiceAccount is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, saNN, sa)).To(Succeed())
+				g.Expect(sa.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("recreates ingress NetworkPolicy when deleted", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			npNN := types.NamespacedName{
+				Name:      networkPolicyAllowFromKonfluxUIName,
+				Namespace: namespaceListerNamespace,
+			}
+
+			By("waiting for initial NetworkPolicy creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, npNN, &networkingv1.NetworkPolicy{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the NetworkPolicy")
+			Expect(k8sClient.Delete(ctx, &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: npNN.Name, Namespace: npNN.Namespace},
+			})).To(Succeed())
+
+			By("verifying the NetworkPolicy is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				np := &networkingv1.NetworkPolicy{}
+				g.Expect(k8sClient.Get(ctx, npNN, np)).To(Succeed())
+				g.Expect(np.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("recreates egress NetworkPolicy when deleted", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			npNN := types.NamespacedName{
+				Name:      networkPolicyAllowToAPIServerName,
+				Namespace: namespaceListerNamespace,
+			}
+
+			By("waiting for initial NetworkPolicy creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, npNN, &networkingv1.NetworkPolicy{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the NetworkPolicy")
+			Expect(k8sClient.Delete(ctx, &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: npNN.Name, Namespace: npNN.Namespace},
+			})).To(Succeed())
+
+			By("verifying the NetworkPolicy is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				np := &networkingv1.NetworkPolicy{}
+				g.Expect(k8sClient.Get(ctx, npNN, np)).To(Succeed())
+				g.Expect(np.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("recreates Certificate when deleted", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			certNN := types.NamespacedName{
+				Name:      namespaceListerNamespace,
+				Namespace: namespaceListerNamespace,
+			}
+
+			By("waiting for initial Certificate creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, certNN, &certmanagerv1.Certificate{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the Certificate")
+			Expect(k8sClient.Delete(ctx, &certmanagerv1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Name: certNN.Name, Namespace: certNN.Namespace},
+			})).To(Succeed())
+
+			By("verifying the Certificate is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				cert := &certmanagerv1.Certificate{}
+				g.Expect(k8sClient.Get(ctx, certNN, cert)).To(Succeed())
+				g.Expect(cert.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("recreates Service when deleted", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			svcNN := types.NamespacedName{
+				Name:      namespaceListerNamespace,
+				Namespace: namespaceListerNamespace,
+			}
+
+			By("waiting for initial Service creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, svcNN, &corev1.Service{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the Service")
+			Expect(k8sClient.Delete(ctx, &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: svcNN.Name, Namespace: svcNN.Namespace},
+			})).To(Succeed())
+
+			By("verifying the Service is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("recreates ClusterRole when deleted", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			crNN := types.NamespacedName{Name: "namespace-lister-authorizer"}
+
+			By("waiting for initial ClusterRole creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, crNN, &rbacv1.ClusterRole{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
+			})
+
+			By("deleting the ClusterRole")
+			Expect(k8sClient.Delete(ctx, &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
+			})).To(Succeed())
+
+			By("verifying the ClusterRole is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				cr := &rbacv1.ClusterRole{}
+				g.Expect(k8sClient.Get(ctx, crNN, cr)).To(Succeed())
+				g.Expect(cr.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("recreates ClusterRoleBinding when deleted", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			crbNN := types.NamespacedName{Name: "namespace-lister-authorizer"}
+
+			By("waiting for initial ClusterRoleBinding creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, crbNN, &rbacv1.ClusterRoleBinding{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: crbNN.Name},
+			})
+
+			By("deleting the ClusterRoleBinding")
+			Expect(k8sClient.Delete(ctx, &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: crbNN.Name},
+			})).To(Succeed())
+
+			By("verifying the ClusterRoleBinding is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				crb := &rbacv1.ClusterRoleBinding{}
+				g.Expect(k8sClient.Get(ctx, crbNN, crb)).To(Succeed())
+				g.Expect(crb.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+	})
 })
 
 var _ = Describe("applyNamespaceListerCustomizations", func() {
@@ -85,7 +338,7 @@ var _ = Describe("applyNamespaceListerCustomizations", func() {
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
-								Name: namespaceListerNamespace,
+								Name: namespaceListerContainerName,
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:    resource.MustParse("50m"),


### PR DESCRIPTION
This patch adds ownership to the namespacelister resources.

- add owns to namespacelister network policy
- add owns to namespacelister certificate
- add owns to namespacelister service account
- add health check tests for the namespacelister resources

Assisted-by: Cursor + Opus 4.6