### PR TITLE
test(KFLUXVNGD-1081): use default-tenant for proxy tests

### DIFF
--- a/generate-err-logs.sh
+++ b/generate-err-logs.sh
@@ -243,7 +243,7 @@ generate_logs() {
     kubectl get repositories.pipelinesascode.tekton.dev --all-namespaces -o json > "$artifacts_dir/repositories.json" || true
 
     # Pod logs from key namespaces (system services + test namespaces)
-    for ns in build-service integration-service release-service application-service pipelines-as-code openshift-pipelines user-ns2 user-ns2-managed; do
+    for ns in build-service integration-service release-service application-service pipelines-as-code openshift-pipelines konflux-ui default-tenant default-managed-tenant; do
         for pod in $(kubectl get pods -n "$ns" -o name 2>/dev/null); do
             podname="${pod//pod\//}"
             kubectl logs -n "$ns" "$pod" --all-containers --ignore-errors > "$artifacts_dir/pods/${ns}_${podname}.log" 2>&1 || true

--- a/scripts/operator-e2e/README.md
+++ b/scripts/operator-e2e/README.md
@@ -46,6 +46,24 @@ Use **one token per flag** where possible (e.g. `-ginkgo.skip=Flaky`). Values wi
 | `tekton-push-operator-pkg-manifests-oci.sh` | **Tekton (task-runner):** after prep, push `operator/pkg/manifests` to OCI as `${oci-container-repo}:${pipelineRun}.pkg-manifests` (skips if `E2E_OCI_CONTAINER_REPO` blank). |
 | `tekton-deploy-operator-and-wait.sh` | **Tekton (go-toolset):** `make install`/build, `bin/manager`, apply CR, wait Ready. |
 | `tekton-run-e2e-tests.sh` | **Tekton:** `deploy-test-resources.sh` (`SKIP_SAMPLE_COMPONENTS=true`), optional `kubectl port-forward` + `KONFLUX_PROXY_URL` for remote Kind, integration + conformance `go test`. Proxy tests wait for Konflux Ready and read `status.uiURL` in Go (`BeforeSuite` in `test/go-tests/proxy_setup.go`). Optional env: `KONFLUX_PROXY_URL`, `E2E_INTEGRATION_GO_TEST_EXTRA_ARGS`, `E2E_CONFORMANCE_GO_TEST_EXTRA_ARGS`. |
+| `run-proxy-integration-tests.sh` | Select proxy auth mode and run `go test` in `test/go-tests`. OpenShift OAuth runs in test `BeforeSuite`. Called from `test/e2e/run-e2e.sh`. |
+
+## Proxy integration tests
+
+`test/e2e/run-e2e.sh` runs `run-proxy-integration-tests.sh` before conformance. OpenShift OAuth (kubeadmin → Dex `id_token`) is implemented in Go (`test/go-tests/proxy_oauth_openshift.go`) and runs in proxy test `BeforeSuite` when `KONFLUX_PROXY_AUTH=openshift`. Useful env vars:
+
+| Variable | Purpose |
+|----------|---------|
+| `KONFLUX_PROXY_AUTH` | `openshift` or `dex` (default: infer — openshift when `OPENSHIFT_PASSWORD`, `KUBEADMIN_PASSWORD_FILE`, or `SHARED_DIR/kubeadmin-password` is set and `TEST_ENVIRONMENT!=upstream`, else dex) |
+| `KONFLUX_PROXY_AUTH_METHOD` | Set by the runner: `openshift-oauth` or `dex-password-grant` |
+| `OPENSHIFT_PASSWORD` / `KUBEADMIN_PASSWORD_FILE` / `SHARED_DIR/kubeadmin-password` | Kubeadmin password for OpenShift OAuth (same sources as infra-deployments `ci-common.sh`) |
+| `KONFLUX_PROXY_ID_TOKEN` | Optional override: skip OAuth and use a pre-obtained Dex `id_token` |
+| `KONFLUX_PROXY_ID_TOKEN_USER1` / `KONFLUX_PROXY_ID_TOKEN_USER2` | Optional per-user tokens for Dex-only specs |
+| `KONFLUX_PROXY_URL` | Proxy base URL (default: `konflux/konflux` `status.uiURL`) |
+| `KONFLUX_PROXY_WAIT_UI_ONLY` | When `true`, `BeforeSuite` waits for `ui.Ready` instead of full Konflux Ready |
+| `KONFLUX_PROXY_TEST_NAMESPACE` | Tenant namespace for proxied API paths (default: `default-tenant`) |
+
+On OpenShift CI, Dex-only specs are skipped via `-ginkgo.label-filter='!proxy-dex'`.
 
 ## Override YAML schema
 

--- a/scripts/operator-e2e/run-proxy-integration-tests.sh
+++ b/scripts/operator-e2e/run-proxy-integration-tests.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Obtain proxy auth tokens (Dex or OpenShift OAuth) and run proxy integration tests.
+#
+# Usage: run-proxy-integration-tests.sh [REPO_ROOT]
+#
+# Auth selection:
+#   KONFLUX_PROXY_AUTH=openshift|dex (default: infer from CI env)
+#   openshift → OAuth authorization-code flow in test BeforeSuite (kubeadmin password required)
+#   dex       → proxy tests use Dex password grant at runtime
+set -euo pipefail
+
+REPO_ROOT="$(cd "${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}" && pwd)"
+
+if [[ -z "${KONFLUX_PROXY_AUTH:-}" ]]; then
+	if [[ "${TEST_ENVIRONMENT:-}" != "upstream" ]] && {
+		[[ -n "${OPENSHIFT_PASSWORD:-}" ]] ||
+			[[ -n "${KUBEADMIN_PASSWORD_FILE:-}" && -s "${KUBEADMIN_PASSWORD_FILE}" ]] ||
+			[[ -n "${SHARED_DIR:-}" && -s "${SHARED_DIR}/kubeadmin-password" ]]
+	}; then
+		KONFLUX_PROXY_AUTH=openshift
+		echo "Proxy auth: inferred openshift (OpenShift CI kubeadmin credentials, TEST_ENVIRONMENT!=upstream)"
+	else
+		KONFLUX_PROXY_AUTH=dex
+	fi
+fi
+export KONFLUX_PROXY_AUTH
+
+case "${KONFLUX_PROXY_AUTH}" in
+openshift)
+	echo "Proxy auth: OpenShift OAuth (obtained in test BeforeSuite)"
+	export KONFLUX_PROXY_AUTH_METHOD=openshift-oauth
+	;;
+dex)
+	echo "Proxy auth: Dex password grant"
+	export KONFLUX_PROXY_AUTH_METHOD=dex-password-grant
+	;;
+*)
+	echo "Error: unsupported KONFLUX_PROXY_AUTH=${KONFLUX_PROXY_AUTH} (expected openshift or dex)" >&2
+	exit 1
+	;;
+esac
+
+cd "${REPO_ROOT}/test/go-tests"
+echo "Running proxy integration tests..."
+GINKGO_ARGS=()
+if [[ "${KONFLUX_PROXY_AUTH}" == "openshift" ]]; then
+	GINKGO_ARGS+=(-ginkgo.label-filter='!proxy-dex')
+fi
+go test -mod=mod . -v -timeout 10m "${GINKGO_ARGS[@]}"

--- a/test/e2e/e2e.env.template
+++ b/test/e2e/e2e.env.template
@@ -48,3 +48,30 @@ if [ -z "${CUSTOM_DOCKER_BUILD_OCI_TA_MIN_PIPELINE_BUNDLE:-}" ]; then
   fi
   unset _e2e_manifest
 fi
+
+# ==============================================================================
+# Proxy integration tests (optional — run via test/e2e/run-e2e.sh)
+# ==============================================================================
+
+# Auth mode: openshift (OAuth in test BeforeSuite via kubeadmin) or dex (password grant at test runtime).
+# Default: dex on upstream/kind; openshift inferred on OpenShift CI when kubeadmin creds exist.
+# export KONFLUX_PROXY_AUTH=dex
+
+# Set by run-proxy-integration-tests.sh: openshift-oauth or dex-password-grant.
+# export KONFLUX_PROXY_AUTH_METHOD=
+
+# Pre-obtained id_token (optional: skip OpenShift OAuth in BeforeSuite).
+# export KONFLUX_PROXY_ID_TOKEN=
+
+# Optional per-user tokens for Dex-only specs (user1@konflux.dev / user2@konflux.dev).
+# export KONFLUX_PROXY_ID_TOKEN_USER1=
+# export KONFLUX_PROXY_ID_TOKEN_USER2=
+
+# Override proxy URL (e.g. https://localhost:9443 with kubectl port-forward).
+# export KONFLUX_PROXY_URL=
+
+# Wait for ui.Ready only instead of full Konflux Ready (overlay / OpenShift e2e).
+# export KONFLUX_PROXY_WAIT_UI_ONLY=true
+
+# Tenant namespace for proxied API paths (default: default-tenant).
+# export KONFLUX_PROXY_TEST_NAMESPACE=default-tenant

--- a/test/e2e/run-e2e.sh
+++ b/test/e2e/run-e2e.sh
@@ -26,12 +26,9 @@ fi
 # Deploy test resources (idempotent — safe to run if already deployed)
 SKIP_SAMPLE_COMPONENTS="true" "${REPO_ROOT}/deploy-test-resources.sh"
 
-cd "${REPO_ROOT}/test/go-tests"
-# -mod=mod overrides GOFLAGS=-mod=vendor that may be present on some systems; this repo doesn't vendor.
-
-echo "Running proxy integration tests..."
-go test -mod=mod . -v -timeout 10m
+bash "${REPO_ROOT}/scripts/operator-e2e/run-proxy-integration-tests.sh" "${REPO_ROOT}"
 
 echo "Running E2E conformance tests..."
+cd "${REPO_ROOT}/test/go-tests"
+# -mod=mod overrides GOFLAGS=-mod=vendor that may be present on some systems; this repo doesn't vendor.
 go test -mod=mod ./tests/conformance -v -timeout 45m -ginkgo.vv "$@"
-

--- a/test/go-tests/proxy_auth.go
+++ b/test/go-tests/proxy_auth.go
@@ -1,0 +1,91 @@
+package go_tests
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+const (
+	envProxyAuth       = "KONFLUX_PROXY_AUTH"
+	envProxyAuthMethod = "KONFLUX_PROXY_AUTH_METHOD"
+	envProxyIDToken    = "KONFLUX_PROXY_ID_TOKEN"
+
+	envProxyIDTokenUser1 = "KONFLUX_PROXY_ID_TOKEN_USER1"
+	envProxyIDTokenUser2 = "KONFLUX_PROXY_ID_TOKEN_USER2"
+
+	proxyAuthOpenShift = "openshift"
+	proxyAuthDex       = "dex"
+
+	proxyAuthMethodOpenShiftOAuth   = "openshift-oauth"
+	proxyAuthMethodDexPasswordGrant = "dex-password-grant"
+)
+
+var logProxyAuthOnce sync.Once
+
+var proxyOpenShiftIDToken string
+
+func setProxyOpenShiftIDToken(token string) {
+	proxyOpenShiftIDToken = token
+}
+
+func proxyAuthMode() string {
+	mode := strings.ToLower(strings.TrimSpace(os.Getenv(envProxyAuth)))
+	if mode == "" {
+		return proxyAuthDex
+	}
+	return mode
+}
+
+func proxyAuthMethodFromEnv() string {
+	if method := strings.TrimSpace(os.Getenv(envProxyAuthMethod)); method != "" {
+		return method
+	}
+	if isProxyOpenShiftAuth() {
+		return proxyAuthMethodOpenShiftOAuth
+	}
+	return proxyAuthMethodDexPasswordGrant
+}
+
+func logProxyAuthMethod(method string) {
+	logProxyAuthOnce.Do(func() {
+		line := fmt.Sprintf("proxy auth method: %s\n", method)
+		_, _ = fmt.Fprint(os.Stderr, line)
+		_, _ = fmt.Fprint(GinkgoWriter, line)
+	})
+}
+
+func proxyIDTokenFromEnv(user string) (string, bool) {
+	switch strings.TrimSpace(user) {
+	case "user1@konflux.dev":
+		if token := strings.TrimSpace(os.Getenv(envProxyIDTokenUser1)); token != "" {
+			return token, true
+		}
+	case "user2@konflux.dev":
+		if token := strings.TrimSpace(os.Getenv(envProxyIDTokenUser2)); token != "" {
+			return token, true
+		}
+	}
+
+	if token := strings.TrimSpace(os.Getenv(envProxyIDToken)); token != "" {
+		return token, true
+	}
+	return "", false
+}
+
+func proxyIDTokenForUser(user string) (string, bool) {
+	if token, ok := proxyIDTokenFromEnv(user); ok {
+		return token, true
+	}
+	if isProxyOpenShiftAuth() && proxyOpenShiftIDToken != "" {
+		return proxyOpenShiftIDToken, true
+	}
+	return "", false
+}
+
+func isProxyOpenShiftAuth() bool {
+	return proxyAuthMode() == proxyAuthOpenShift
+}

--- a/test/go-tests/proxy_oauth_openshift.go
+++ b/test/go-tests/proxy_oauth_openshift.go
@@ -1,0 +1,449 @@
+package go_tests
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	htmlpkg "html"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	openShiftOAuthScope        = "openid profile email groups"
+	openShiftOAuthClientID     = "oauth2-proxy"
+	openShiftOAuthMaxRedirects = 30
+)
+
+// openshiftHTTPDoer performs OAuth HTTP steps (injectable for tests).
+type openshiftHTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// envOpenShiftPasswordSource reads password from CI env vars/files.
+type envOpenShiftPasswordSource struct{}
+
+func (envOpenShiftPasswordSource) OpenShiftPassword() (string, error) {
+	if password := strings.TrimSpace(os.Getenv("OPENSHIFT_PASSWORD")); password != "" {
+		return password, nil
+	}
+	if path := strings.TrimSpace(os.Getenv("KUBEADMIN_PASSWORD_FILE")); path != "" {
+		if data, err := os.ReadFile(path); err == nil && len(strings.TrimSpace(string(data))) > 0 {
+			return strings.TrimSpace(strings.ReplaceAll(string(data), "\n", "")), nil
+		}
+	}
+	if shared := strings.TrimSpace(os.Getenv("SHARED_DIR")); shared != "" {
+		path := shared + "/kubeadmin-password"
+		if data, err := os.ReadFile(path); err == nil && len(strings.TrimSpace(string(data))) > 0 {
+			return strings.TrimSpace(strings.ReplaceAll(string(data), "\n", "")), nil
+		}
+	}
+	return "", fmt.Errorf("openshift password required: set OPENSHIFT_PASSWORD, KUBEADMIN_PASSWORD_FILE, or SHARED_DIR/kubeadmin-password")
+}
+
+// kubeOAuth2ProxySecretSource loads oauth2-proxy-client-secret from dex or konflux-ui.
+type kubeOAuth2ProxySecretSource struct {
+	client    crclient.Client
+	namespace string
+}
+
+func (k kubeOAuth2ProxySecretSource) OAuth2ProxyClientSecret(ctx context.Context) (string, error) {
+	namespaces := []string{"dex", k.namespace}
+	if k.namespace == "dex" {
+		namespaces = []string{"dex"}
+	}
+	for _, ns := range namespaces {
+		secret := &v1.Secret{}
+		err := k.client.Get(ctx, crclient.ObjectKey{Namespace: ns, Name: "oauth2-proxy-client-secret"}, secret)
+		if err != nil {
+			continue
+		}
+		raw, ok := secret.Data["client-secret"]
+		if !ok {
+			return "", fmt.Errorf("client-secret not found in secret %s/oauth2-proxy-client-secret", ns)
+		}
+		return string(raw), nil
+	}
+	return "", fmt.Errorf("oauth2-proxy-client-secret not found in dex or %s", k.namespace)
+}
+
+// OpenShiftOAuthConfig holds inputs for the authorization-code flow.
+type OpenShiftOAuthConfig struct {
+	UIURL        string
+	Username     string
+	Password     string
+	ClientSecret string
+	Scope        string
+	MaxRedirects int
+}
+
+// OpenShiftOAuthClient runs the browser-less OpenShift → Dex OAuth flow.
+type OpenShiftOAuthClient struct {
+	http openshiftHTTPDoer
+}
+
+func newOpenShiftOAuthClient(base *http.Client) (*OpenShiftOAuthClient, error) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, err
+	}
+	transport := base.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	client := &http.Client{
+		Timeout:       base.Timeout,
+		Transport:     transport,
+		Jar:           jar,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	return &OpenShiftOAuthClient{http: client}, nil
+}
+
+func obtainOpenShiftProxyIDToken(ctx context.Context, baseHTTP *http.Client, kube crclient.Client, uiURL string) (string, error) {
+	oauthHTTP, err := newOpenShiftOAuthClient(baseHTTP)
+	if err != nil {
+		return "", err
+	}
+	password, err := (envOpenShiftPasswordSource{}).OpenShiftPassword()
+	if err != nil {
+		return "", err
+	}
+	ns := strings.TrimSpace(os.Getenv("KONFLUX_UI_NAMESPACE"))
+	if ns == "" {
+		ns = "konflux-ui"
+	}
+	secret, err := (kubeOAuth2ProxySecretSource{client: kube, namespace: ns}).OAuth2ProxyClientSecret(ctx)
+	if err != nil {
+		return "", err
+	}
+	username := strings.TrimSpace(os.Getenv("OPENSHIFT_USERNAME"))
+	if username == "" {
+		username = "kubeadmin"
+	}
+	cfg := OpenShiftOAuthConfig{
+		UIURL:        strings.TrimRight(strings.TrimSpace(uiURL), "/"),
+		Username:     username,
+		Password:     password,
+		ClientSecret: secret,
+		Scope:        openShiftOAuthScope,
+		MaxRedirects: openShiftOAuthMaxRedirects,
+	}
+	return oauthHTTP.ObtainIDToken(ctx, cfg)
+}
+
+// ObtainIDToken completes the OAuth authorization-code flow and returns a Dex id_token.
+func (c *OpenShiftOAuthClient) ObtainIDToken(ctx context.Context, cfg OpenShiftOAuthConfig) (string, error) {
+	if cfg.Scope == "" {
+		cfg.Scope = openShiftOAuthScope
+	}
+	if cfg.MaxRedirects <= 0 {
+		cfg.MaxRedirects = openShiftOAuthMaxRedirects
+	}
+	redirectURI := cfg.UIURL + "/oauth2/callback"
+	authCode, err := c.obtainAuthorizationCode(ctx, cfg, redirectURI)
+	if err != nil {
+		return "", err
+	}
+	return c.exchangeAuthorizationCode(ctx, cfg, redirectURI, authCode)
+}
+
+func (c *OpenShiftOAuthClient) obtainAuthorizationCode(ctx context.Context, cfg OpenShiftOAuthConfig, redirectURI string) (string, error) {
+	start, err := url.Parse(cfg.UIURL + "/idp/auth/openshift")
+	if err != nil {
+		return "", err
+	}
+	q := start.Query()
+	q.Set("client_id", openShiftOAuthClientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("response_type", "code")
+	q.Set("scope", cfg.Scope)
+	start.RawQuery = q.Encode()
+
+	current := start.String()
+	var pendingAuthorize string
+
+	for i := 0; i < cfg.MaxRedirects; i++ {
+		if code := queryParam(current, "code"); code != "" && strings.Contains(current, "/oauth2/callback") {
+			return code, nil
+		}
+
+		status, location, body, err := c.doGET(ctx, current)
+		if err != nil {
+			return "", err
+		}
+
+		if status >= 300 && status < 400 && location != "" {
+			if strings.Contains(location, "/oauth/authorize") {
+				pendingAuthorize, err = resolveURL(current, location)
+				if err != nil {
+					return "", err
+				}
+			}
+			current, err = resolveURL(current, location)
+			if err != nil {
+				return "", err
+			}
+			if code := queryParam(current, "code"); code != "" && strings.Contains(current, "/oauth2/callback") {
+				return code, nil
+			}
+			if strings.Contains(current, "/login") {
+				_, _, loginBody, err := c.doGET(ctx, current)
+				if err != nil {
+					return "", err
+				}
+				current, err = c.submitLoginAndFollow(ctx, current, loginBody, cfg, pendingAuthorize)
+				if err != nil {
+					return "", err
+				}
+			}
+			continue
+		}
+
+		if status == http.StatusOK && strings.Contains(current, "/login") {
+			current, err = c.submitLoginAndFollow(ctx, current, body, cfg, pendingAuthorize)
+			if err != nil {
+				return "", err
+			}
+			continue
+		}
+
+		if status == http.StatusOK && strings.Contains(current, "/authorize/approve") {
+			current, err = c.submitGrant(ctx, current, body)
+			if err != nil {
+				return "", err
+			}
+			continue
+		}
+
+		return "", fmt.Errorf("unexpected OAuth response (http=%d, url=%s)", status, redactOAuthURL(current))
+	}
+	return "", fmt.Errorf("too many redirects during OpenShift OAuth flow")
+}
+
+func (c *OpenShiftOAuthClient) submitLoginAndFollow(ctx context.Context, pageURL string, body []byte, cfg OpenShiftOAuthConfig, pendingAuthorize string) (string, error) {
+	action, csrf, err := parseLoginForm(pageURL, body)
+	if err != nil {
+		return "", err
+	}
+	form := url.Values{}
+	form.Set("csrf", csrf)
+	form.Set("username", cfg.Username)
+	form.Set("password", cfg.Password)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, action, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	status, location, _, err := c.doRequest(req)
+	if err != nil {
+		return "", err
+	}
+	if status >= 300 && status < 400 && location != "" {
+		return resolveURL(action, location)
+	}
+	if pendingAuthorize != "" {
+		return pendingAuthorize, nil
+	}
+	return "", fmt.Errorf("OpenShift login succeeded but no redirect target was found")
+}
+
+func (c *OpenShiftOAuthClient) submitGrant(ctx context.Context, pageURL string, body []byte) (string, error) {
+	action, form, err := parseGrantForm(pageURL, body)
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, action, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	status, location, _, err := c.doRequest(req)
+	if err != nil {
+		return "", err
+	}
+	if status >= 300 && status < 400 && location != "" {
+		return resolveURL(pageURL, location)
+	}
+	return "", fmt.Errorf("OpenShift grant approval succeeded but no redirect target was found")
+}
+
+func (c *OpenShiftOAuthClient) exchangeAuthorizationCode(ctx context.Context, cfg OpenShiftOAuthConfig, redirectURI, authCode string) (string, error) {
+	tokenURL := cfg.UIURL + "/idp/token"
+	auth := base64.StdEncoding.EncodeToString([]byte("oauth2-proxy:" + cfg.ClientSecret))
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", authCode)
+	form.Set("redirect_uri", redirectURI)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Basic "+auth)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var tokenResp struct {
+		IDToken string `json:"id_token"`
+		Error   string `json:"error"`
+		Desc    string `json:"error_description"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("token exchange failed: decode response: %w", err)
+	}
+	if tokenResp.IDToken != "" {
+		return tokenResp.IDToken, nil
+	}
+	if tokenResp.Error != "" || tokenResp.Desc != "" {
+		return "", fmt.Errorf("token exchange failed: error=%q description=%q", tokenResp.Error, tokenResp.Desc)
+	}
+	return "", fmt.Errorf("token exchange failed: no id_token in response (%d bytes)", len(body))
+}
+
+func (c *OpenShiftOAuthClient) doGET(ctx context.Context, rawURL string) (int, string, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return 0, "", nil, err
+	}
+	return c.doRequest(req)
+}
+
+func (c *OpenShiftOAuthClient) doRequest(req *http.Request) (int, string, []byte, error) {
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, "", nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, "", nil, err
+	}
+	return resp.StatusCode, resp.Header.Get("Location"), body, nil
+}
+
+var (
+	reFormAction   = regexp.MustCompile(`(?i)<form[^>]*action="([^"]*)"`)
+	reInputCSRF    = regexp.MustCompile(`(?i)name="csrf"[^>]*value="([^"]*)"`)
+	reHiddenInput  = regexp.MustCompile(`(?i)<input type="hidden" name="([^"]*)" value="([^"]*)"`)
+	reCheckedScope = regexp.MustCompile(`(?i)<input type="checkbox"[^>]*checked[^>]*name="scope" value="([^"]*)"`)
+	reApproveValue = regexp.MustCompile(`(?i)name="approve"[^>]*value="([^"]*)"`)
+)
+
+func parseLoginForm(pageURL string, body []byte) (actionURL, csrf string, err error) {
+	pageHTML := string(body)
+	actionMatch := reFormAction.FindStringSubmatch(pageHTML)
+	csrfMatch := reInputCSRF.FindStringSubmatch(pageHTML)
+	if len(actionMatch) < 2 || len(csrfMatch) < 2 {
+		return "", "", fmt.Errorf("OpenShift login form not found at %s", redactOAuthURL(pageURL))
+	}
+	action := htmlpkg.UnescapeString(actionMatch[1])
+	actionURL, err = resolveURL(pageURL, action)
+	if err != nil {
+		return "", "", err
+	}
+	if action == "/login" || action == "login" {
+		base := pageURL
+		if i := strings.Index(base, "?"); i >= 0 {
+			base = base[:i]
+		}
+		actionURL = base
+		if strings.Contains(pageURL, "?") {
+			actionURL = pageURL
+		}
+	}
+	return actionURL, htmlpkg.UnescapeString(csrfMatch[1]), nil
+}
+
+func parseGrantForm(pageURL string, body []byte) (actionURL string, form url.Values, err error) {
+	pageHTML := string(body)
+	if !strings.Contains(pageHTML, `name="csrf"`) {
+		return "", nil, fmt.Errorf("OpenShift grant approval form not found at %s", redactOAuthURL(pageURL))
+	}
+	action := "approve"
+	if m := reFormAction.FindStringSubmatch(pageHTML); len(m) >= 2 {
+		action = m[1]
+	}
+	actionURL, err = resolveURL(pageURL, action)
+	if err != nil {
+		return "", nil, err
+	}
+	form = url.Values{}
+	for _, m := range reHiddenInput.FindAllStringSubmatch(pageHTML, -1) {
+		if len(m) >= 3 {
+			form.Set(htmlpkg.UnescapeString(m[1]), htmlpkg.UnescapeString(m[2]))
+		}
+	}
+	for _, m := range reCheckedScope.FindAllStringSubmatch(pageHTML, -1) {
+		if len(m) >= 2 {
+			form.Add("scope", htmlpkg.UnescapeString(m[1]))
+		}
+	}
+	approve := "Allow selected permissions"
+	if m := reApproveValue.FindStringSubmatch(pageHTML); len(m) >= 2 {
+		approve = htmlpkg.UnescapeString(m[1])
+	}
+	form.Set("approve", approve)
+	return actionURL, form, nil
+}
+
+func queryParam(rawURL, name string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.Query().Get(name)
+}
+
+func redactOAuthURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	q := u.Query()
+	if q.Has("code") {
+		q.Set("code", "REDACTED")
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func resolveURL(base, ref string) (string, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", fmt.Errorf("empty URL reference")
+	}
+	if strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://") {
+		return ref, nil
+	}
+	baseURL, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	if strings.HasPrefix(ref, "//") {
+		return baseURL.Scheme + ":" + ref, nil
+	}
+	refURL, err := url.Parse(ref)
+	if err != nil {
+		return "", err
+	}
+	return baseURL.ResolveReference(refURL).String(), nil
+}

--- a/test/go-tests/proxy_oauth_openshift_test.go
+++ b/test/go-tests/proxy_oauth_openshift_test.go
@@ -1,0 +1,253 @@
+package go_tests
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveURL(t *testing.T) {
+	t.Parallel()
+	base := "https://ui.example.com/oauth/authorize?foo=1"
+
+	tests := []struct {
+		ref  string
+		want string
+	}{
+		{"https://other.example/path", "https://other.example/path"},
+		{"//other.example/path", "https://other.example/path"},
+		{"/login", "https://ui.example.com/login"},
+		{"../authorize", "https://ui.example.com/authorize"},
+		{"approve", "https://ui.example.com/oauth/approve"},
+	}
+	for _, tc := range tests {
+		got, err := resolveURL(base, tc.ref)
+		if err != nil {
+			t.Fatalf("resolveURL(%q): %v", tc.ref, err)
+		}
+		if got != tc.want {
+			t.Errorf("resolveURL(%q) = %q, want %q", tc.ref, got, tc.want)
+		}
+	}
+}
+
+func TestQueryParam(t *testing.T) {
+	t.Parallel()
+	raw := "https://ui.example.com/oauth2/callback?code=abc123&state=xyz"
+	if got := queryParam(raw, "code"); got != "abc123" {
+		t.Fatalf("queryParam code = %q", got)
+	}
+}
+
+func TestRedactOAuthURL(t *testing.T) {
+	t.Parallel()
+	raw := "https://ui.example.com/oauth2/callback?code=secret&state=ok"
+	got := redactOAuthURL(raw)
+	if strings.Contains(got, "secret") {
+		t.Fatalf("code not redacted: %s", got)
+	}
+	if !strings.Contains(got, "REDACTED") {
+		t.Fatalf("expected REDACTED in %s", got)
+	}
+}
+
+func TestParseLoginForm(t *testing.T) {
+	t.Parallel()
+	body := []byte(`<html><form action="/login" method="post">
+	<input name="csrf" type="hidden" value="tok123">
+	</form></html>`)
+	action, csrf, err := parseLoginForm("https://oauth.example.com/login?then=%2Fauthorize", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if csrf != "tok123" {
+		t.Fatalf("csrf = %q", csrf)
+	}
+	if action != "https://oauth.example.com/login?then=%2Fauthorize" {
+		t.Fatalf("action = %q", action)
+	}
+}
+
+func TestParseGrantForm(t *testing.T) {
+	t.Parallel()
+	body := []byte(`<form action="approve">
+	<input type="hidden" name="csrf" value="c&amp;1">
+	<input type="hidden" name="client_id" value="oauth2-proxy">
+	<input type="checkbox" checked name="scope" value="openid">
+	<input type="checkbox" checked name="scope" value="groups">
+	<input type="submit" name="approve" value="Allow selected permissions">
+	</form>`)
+	action, form, err := parseGrantForm("https://oauth.example.com/authorize/approve", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(action, "/approve") {
+		t.Fatalf("action = %q", action)
+	}
+	if form.Get("csrf") != "c&1" {
+		t.Fatalf("csrf = %q", form.Get("csrf"))
+	}
+	if form["scope"] == nil || len(form["scope"]) != 2 {
+		t.Fatalf("scope = %v", form["scope"])
+	}
+	if form.Get("approve") != "Allow selected permissions" {
+		t.Fatalf("approve = %q", form.Get("approve"))
+	}
+}
+
+func TestEnvOpenShiftPasswordSource(t *testing.T) {
+	t.Setenv("OPENSHIFT_PASSWORD", "")
+	t.Setenv("KUBEADMIN_PASSWORD_FILE", "")
+	t.Setenv("SHARED_DIR", "")
+
+	if _, err := (envOpenShiftPasswordSource{}).OpenShiftPassword(); err == nil {
+		t.Fatal("expected error when no password configured")
+	}
+
+	t.Setenv("OPENSHIFT_PASSWORD", "from-env")
+	got, err := (envOpenShiftPasswordSource{}).OpenShiftPassword()
+	if err != nil || got != "from-env" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kubeadmin-password")
+	if err := os.WriteFile(path, []byte("from-file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OPENSHIFT_PASSWORD", "")
+	t.Setenv("KUBEADMIN_PASSWORD_FILE", path)
+	got, err = (envOpenShiftPasswordSource{}).OpenShiftPassword()
+	if err != nil || got != "from-file" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+}
+
+func TestOpenShiftOAuthClient_ObtainIDToken(t *testing.T) {
+	const clientSecret = "test-client-secret"
+	var uiURL string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/idp/auth/openshift", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, uiURL+"/login", http.StatusFound)
+	})
+	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			fmt.Fprint(w, `<form action="/login"><input name="csrf" value="csrf-login"></form>`)
+			return
+		}
+		http.Redirect(w, r, uiURL+"/authorize/approve", http.StatusFound)
+	})
+	mux.HandleFunc("/authorize/approve", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			fmt.Fprint(w, `<form action="approve">
+				<input type="hidden" name="csrf" value="csrf-grant">
+				<input type="checkbox" checked name="scope" value="openid">
+				<input type="submit" name="approve" value="Allow selected permissions">
+			</form>`)
+			return
+		}
+		http.Redirect(w, r, uiURL+"/oauth2/callback?code=auth-code-123", http.StatusFound)
+	})
+	mux.HandleFunc("/oauth2/callback", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/idp/token", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if r.Form.Get("code") != "auth-code-123" {
+			http.Error(w, "bad code", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id_token":"eyJ.test.token"}`)
+	})
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+	uiURL = strings.TrimRight(server.URL, "/")
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{
+		Transport:     server.Client().Transport,
+		Jar:           jar,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+
+	oauth := &OpenShiftOAuthClient{http: client}
+	token, err := oauth.ObtainIDToken(context.Background(), OpenShiftOAuthConfig{
+		UIURL:        uiURL,
+		Username:     "kubeadmin",
+		Password:     "pass",
+		ClientSecret: clientSecret,
+	})
+	if err != nil {
+		t.Fatalf("ObtainIDToken: %v", err)
+	}
+	if token != "eyJ.test.token" {
+		t.Fatalf("token = %q", token)
+	}
+}
+
+func TestOpenShiftOAuthClient_ExchangeAuthorizationCodeError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, `{"error":"invalid_grant","error_description":"expired"}`)
+	}))
+	defer server.Close()
+
+	uiURL := strings.TrimRight(server.URL, "/")
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{
+		Transport:     server.Client().Transport,
+		Jar:           jar,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	oauth := &OpenShiftOAuthClient{http: client}
+	_, err := oauth.exchangeAuthorizationCode(context.Background(), OpenShiftOAuthConfig{
+		UIURL:        uiURL,
+		ClientSecret: "secret",
+	}, uiURL+"/oauth2/callback", "code")
+	if err == nil || !strings.Contains(err.Error(), "invalid_grant") {
+		t.Fatalf("expected invalid_grant error, got %v", err)
+	}
+}
+
+func TestOpenShiftOAuthClient_ExchangeAuthorizationCodeInvalidJSON(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, `<html>not json</html>`)
+	}))
+	defer server.Close()
+
+	uiURL := strings.TrimRight(server.URL, "/")
+	oauth := &OpenShiftOAuthClient{http: server.Client()}
+	_, err := oauth.exchangeAuthorizationCode(context.Background(), OpenShiftOAuthConfig{
+		UIURL:        uiURL,
+		ClientSecret: "secret",
+	}, uiURL+"/oauth2/callback", "code")
+	if err == nil || !strings.Contains(err.Error(), "decode response") {
+		t.Fatalf("expected decode response error, got %v", err)
+	}
+}
+
+func TestProxyIDTokenForUser_OpenShiftMemory(t *testing.T) {
+	t.Setenv(envProxyAuth, proxyAuthOpenShift)
+	proxyOpenShiftIDToken = "memory-token"
+	defer func() { proxyOpenShiftIDToken = "" }()
+
+	token, ok := proxyIDTokenForUser("user2@konflux.dev")
+	if !ok || token != "memory-token" {
+		t.Fatalf("got %q ok=%v", token, ok)
+	}
+}

--- a/test/go-tests/proxy_setup.go
+++ b/test/go-tests/proxy_setup.go
@@ -4,32 +4,39 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/coder/websocket"
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	konfluxCRName              = "konflux"
-	konfluxReadyWaitTimeout    = 5 * time.Minute
-	konfluxHealthWaitTimeout   = 5 * time.Minute
-	konfluxReadyPollInterval   = 2 * time.Second
-	proxyHTTPRequestTimeout    = 30 * time.Second
+	konfluxCRName               = "konflux"
+	defaultProxyTenantNamespace = "default-tenant"
+	konfluxReadyWaitTimeout     = 5 * time.Minute
+	konfluxHealthWaitTimeout    = 5 * time.Minute
+	konfluxReadyPollInterval    = 2 * time.Second
+	proxyHTTPRequestTimeout     = 30 * time.Second
+	proxyAPITransientRetryTimeout = 2 * time.Minute
 )
 
 var (
 	proxyBase       *url.URL
 	proxyHome       string
 	tokenURL        string
-	proxyHTTPClient *http.Client
-	proxyClient     crclient.Client
+	proxyHTTPClient          *http.Client
+	proxyWebSocketHTTPClient *http.Client
+	proxyClient              crclient.Client
 )
 
 var _ = BeforeSuite(func() {
@@ -38,12 +45,14 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(proxyClient).NotTo(BeNil())
 
-	proxyHTTPClient = &http.Client{
-		Timeout: proxyHTTPRequestTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
+	wsTransport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
+	proxyHTTPClient = &http.Client{
+		Timeout:   proxyHTTPRequestTimeout,
+		Transport: wsTransport,
+	}
+	proxyWebSocketHTTPClient = &http.Client{Transport: wsTransport}
 
 	ctx := context.Background()
 
@@ -51,12 +60,17 @@ var _ = BeforeSuite(func() {
 		konflux := &konfluxv1alpha1.Konflux{}
 		getErr := proxyClient.Get(ctx, crclient.ObjectKey{Name: konfluxCRName}, konflux)
 		g.Expect(getErr).NotTo(HaveOccurred())
-		g.Expect(konflux.IsReady()).To(BeTrue(), konflux.ReadyConditionMessage())
+
+		if proxyWaitUIOnly() {
+			g.Expect(konfluxUIReady(konflux)).To(BeTrue(), konfluxUIReadyMessage(konflux))
+		} else {
+			g.Expect(konflux.IsReady()).To(BeTrue(), konflux.ReadyConditionMessage())
+		}
 
 		baseURL := strings.TrimSpace(os.Getenv("KONFLUX_PROXY_URL"))
 		if baseURL == "" {
 			baseURL = konflux.Status.UIURL
-			g.Expect(baseURL).NotTo(BeEmpty(), "expected konflux/konflux status.uiURL to be set once Ready")
+			g.Expect(baseURL).NotTo(BeEmpty(), "expected konflux/konflux status.uiURL to be set")
 		}
 		g.Expect(setProxyBase(baseURL)).NotTo(HaveOccurred())
 	}).WithTimeout(konfluxReadyWaitTimeout).WithPolling(konfluxReadyPollInterval).Should(Succeed())
@@ -67,7 +81,34 @@ var _ = BeforeSuite(func() {
 		defer resp.Body.Close()
 		g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
 	}).WithTimeout(konfluxHealthWaitTimeout).WithPolling(konfluxReadyPollInterval).Should(Succeed())
+
+	if isProxyOpenShiftAuth() {
+		if _, ok := proxyIDTokenFromEnv(""); !ok {
+			token, oauthErr := obtainOpenShiftProxyIDToken(ctx, proxyHTTPClient, proxyClient, proxyHome)
+			Expect(oauthErr).NotTo(HaveOccurred())
+			setProxyOpenShiftIDToken(token)
+			logProxyAuthMethod(proxyAuthMethodOpenShiftOAuth)
+		}
+	}
 })
+
+func proxyWaitUIOnly() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("KONFLUX_PROXY_WAIT_UI_ONLY")))
+	return v == "1" || v == "true" || v == "yes"
+}
+
+func konfluxUIReady(konflux *konfluxv1alpha1.Konflux) bool {
+	cond := apimeta.FindStatusCondition(konflux.Status.Conditions, "ui.Ready")
+	return cond != nil && cond.Status == metav1.ConditionTrue
+}
+
+func konfluxUIReadyMessage(konflux *konfluxv1alpha1.Konflux) string {
+	cond := apimeta.FindStatusCondition(konflux.Status.Conditions, "ui.Ready")
+	if cond == nil {
+		return "konflux ui.Ready condition not found in status"
+	}
+	return fmt.Sprintf("konflux ui.Ready=%s reason=%s message=%s", cond.Status, cond.Reason, cond.Message)
+}
 
 func setProxyBase(raw string) error {
 	u, err := url.Parse(strings.TrimSpace(raw))
@@ -88,6 +129,155 @@ func setProxyBase(raw string) error {
 	proxyHome = proxyBase.String()
 	tokenURL = proxyURL("/idp/token")
 	return nil
+}
+
+func proxyTenantNamespace() string {
+	if ns := strings.TrimSpace(os.Getenv("KONFLUX_PROXY_TEST_NAMESPACE")); ns != "" {
+		return ns
+	}
+	return defaultProxyTenantNamespace
+}
+
+// proxyCoreV1Path returns a namespaced core/v1 API path under the test tenant.
+func proxyCoreV1Path(resource string) string {
+	ns := proxyTenantNamespace()
+	return fmt.Sprintf("/api/k8s/api/v1/namespaces/%s/%s", ns, resource)
+}
+
+// proxyUnauthenticatedNSPath returns the legacy unauthenticated proxy path shape.
+func proxyUnauthenticatedNSPath(resource string) string {
+	ns := proxyTenantNamespace()
+	return fmt.Sprintf("/api/k8s/ns/%s/api/v1/namespaces/%s/%s", ns, ns, resource)
+}
+
+// proxyAppStudioPath returns a namespaced appstudio API path under the test tenant.
+func proxyAppStudioPath(resource string) string {
+	ns := proxyTenantNamespace()
+	return fmt.Sprintf("/api/k8s/apis/appstudio.redhat.com/v1alpha1/namespaces/%s/%s", ns, resource)
+}
+
+// proxyUnauthenticatedAppStudioPath returns the legacy unauthenticated appstudio proxy path.
+func proxyUnauthenticatedAppStudioPath(resource string) string {
+	ns := proxyTenantNamespace()
+	return fmt.Sprintf("/api/k8s/ns/%s/apis/appstudio.redhat.com/v1alpha1/namespaces/%s/%s", ns, ns, resource)
+}
+
+// proxyTektonPath returns a namespaced tekton.dev API path under the test tenant.
+func proxyTektonPath(resource string) string {
+	ns := proxyTenantNamespace()
+	return fmt.Sprintf("/api/k8s/apis/tekton.dev/v1/namespaces/%s/%s", ns, resource)
+}
+
+// proxyTektonWSPath returns the WebSocket route for tekton.dev resources (/wss/k8s/* in Caddy).
+func proxyTektonWSPath(resource string) string {
+	ns := proxyTenantNamespace()
+	return fmt.Sprintf("/wss/k8s/apis/tekton.dev/v1/namespaces/%s/%s", ns, resource)
+}
+
+// proxySecretsListExpectedStatus is the expected HTTP status for listing secrets in the
+// test tenant. OpenShift CI uses kubeadmin (cluster-admin) → 200. Dex on default-tenant
+// grants maintainer only → 403. Legacy user-ns* demo fixtures bind admin → 200.
+func proxySecretsListExpectedStatus() int {
+	if proxyAuthMethodFromEnv() == proxyAuthMethodOpenShiftOAuth {
+		return http.StatusOK
+	}
+	if proxyTenantNamespace() == defaultProxyTenantNamespace {
+		return http.StatusForbidden
+	}
+	return http.StatusOK
+}
+
+// expectProxyHTTPStatus asserts the response status without dumping bodies that may
+// contain cluster secrets (Prow log censorship).
+func expectProxyHTTPStatus(resp *http.Response, body []byte, expected int, path string) {
+	GinkgoHelper()
+	if resp.StatusCode == expected {
+		return
+	}
+	Expect(resp.StatusCode).To(Equal(expected), proxyHTTPStatusMismatch(resp, body, expected, path))
+}
+
+func proxyHTTPStatusMismatch(resp *http.Response, body []byte, expected int, path string) string {
+	if strings.Contains(path, "/secrets") {
+		return fmt.Sprintf("%s: expected %d, got %d (%d bytes, body omitted)", path, expected, resp.StatusCode, len(body))
+	}
+	snippet := strings.TrimSpace(string(body))
+	if len(snippet) > 240 {
+		snippet = snippet[:240] + "..."
+	}
+	return fmt.Sprintf("%s: expected %d, got %d: %s", path, expected, resp.StatusCode, snippet)
+}
+
+func proxyTransientHTTPStatus(code int) bool {
+	return code == http.StatusTooManyRequests || code == http.StatusServiceUnavailable
+}
+
+func proxyDrainResponseBody(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}
+
+// expectProxyGETWithBearer GETs a proxied Kubernetes API path with retries on transient
+// API server responses (e.g. 429 storage is (re)initializing right after CRD install).
+func expectProxyGETWithBearer(path, token string, expected int) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		req, err := http.NewRequest(http.MethodGet, proxyURL(path), nil)
+		g.Expect(err).NotTo(HaveOccurred())
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := proxyHTTPClient.Do(req)
+		g.Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		if proxyTransientHTTPStatus(resp.StatusCode) {
+			g.Expect(resp.StatusCode).To(Equal(expected),
+				fmt.Sprintf("%s: transient HTTP %d, retrying", path, resp.StatusCode))
+			return
+		}
+		g.Expect(resp.StatusCode).To(Equal(expected), proxyHTTPStatusMismatch(resp, body, expected, path))
+	}).WithTimeout(proxyAPITransientRetryTimeout).WithPolling(konfluxReadyPollInterval).Should(Succeed())
+}
+
+// expectProxyWebSocketDialWithBearer dials a proxied /wss/k8s/ endpoint with retries on
+// transient API server responses during the WebSocket upgrade (e.g. HTTP 429).
+func expectProxyWebSocketDialWithBearer(wsPath, token string) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		ctx, cancel := context.WithTimeout(context.Background(), proxyHTTPRequestTimeout)
+		defer cancel()
+
+		conn, resp, err := websocket.Dial(ctx, proxyWebSocketURL(wsPath), &websocket.DialOptions{
+			HTTPClient:   proxyWebSocketHTTPClient,
+			Subprotocols: []string{"base64.binary.k8s.io"},
+			HTTPHeader: http.Header{
+				"Authorization": []string{"Bearer " + token},
+				"Origin":        []string{proxyHome},
+			},
+		})
+
+		if resp != nil && proxyTransientHTTPStatus(resp.StatusCode) {
+			proxyDrainResponseBody(resp)
+			g.Expect(resp.StatusCode).To(Equal(http.StatusSwitchingProtocols),
+				fmt.Sprintf("%s: transient HTTP %d on WebSocket upgrade, retrying", wsPath, resp.StatusCode))
+			return
+		}
+		if err != nil || conn == nil || resp == nil || resp.StatusCode != http.StatusSwitchingProtocols {
+			proxyDrainResponseBody(resp)
+		}
+		g.Expect(err).NotTo(HaveOccurred(), "WebSocket connection should be established")
+		if resp != nil {
+			g.Expect(resp.StatusCode).To(Equal(http.StatusSwitchingProtocols))
+		}
+		g.Expect(conn).NotTo(BeNil())
+		_ = conn.Close(websocket.StatusNormalClosure, "test complete")
+	}).WithTimeout(proxyAPITransientRetryTimeout).WithPolling(konfluxReadyPollInterval).Should(Succeed())
 }
 
 func proxyURL(path string) string {

--- a/test/go-tests/proxy_test.go
+++ b/test/go-tests/proxy_test.go
@@ -37,14 +37,10 @@ var _ = Describe("Test Proxy endpoints", func() {
 		},
 		Entry("Home", "", 200),
 		Entry("Health", "/health", 200),
-		Entry("Secrets",
-			"/api/k8s/ns/user-ns2/api/v1/namespaces/user-ns2/secrets", 401),
-		Entry("Release",
-			"/api/k8s/ns/user-ns2/apis/appstudio.redhat.com/v1alpha1/namespaces/user-ns2/releaseplans", 401),
-		Entry("Applications",
-			"/api/k8s/ns/user-ns2/apis/appstudio.redhat.com/v1alpha1/namespaces/user-ns2/applications", 401),
-		Entry("Namespaces",
-			"/api/k8s/api/v1/namespaces", 401),
+		Entry("Secrets", proxyUnauthenticatedNSPath("secrets"), 401),
+		Entry("Release", proxyUnauthenticatedAppStudioPath("releaseplans"), 401),
+		Entry("Applications", proxyUnauthenticatedAppStudioPath("applications"), 401),
+		Entry("Namespaces", "/api/k8s/api/v1/namespaces", 401),
 	)
 
 	DescribeTable("Test endpoints with token",
@@ -53,65 +49,32 @@ var _ = Describe("Test Proxy endpoints", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(token).ToNot(BeEmpty())
 
-			request, err := http.NewRequest("GET", proxyURL(path), nil)
-			Expect(err).NotTo(HaveOccurred())
-			request.Header.Set("Authorization", "Bearer "+token)
-
-			response, err := proxyHTTPClient.Do(request)
-			Expect(err).NotTo(HaveOccurred())
-
-			defer response.Body.Close()
-			rbody, err := io.ReadAll(response.Body)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(response.StatusCode).To(Equal(expectedStatus), string(rbody))
+			expectProxyGETWithBearer(path, token, expectedStatus)
 		},
 		Entry("Home", "", 200),
 		Entry("Health", "/health", 200),
-		Entry("Secrets",
-			"/api/k8s/api/v1/namespaces/user-ns2/secrets", 200),
-		Entry("Release",
-			"/api/k8s/apis/appstudio.redhat.com/v1alpha1/namespaces/user-ns2/releaseplans", 200),
-		Entry("Applications",
-			"/api/k8s/apis/appstudio.redhat.com/v1alpha1/namespaces/user-ns2/applications", 200),
-		Entry("Namespaces",
-			"/api/k8s/api/v1/namespaces", 200),
-		Entry("PipelineRuns",
-			"/api/k8s/apis/tekton.dev/v1/namespaces/user-ns2/pipelineruns", 200),
+		Entry("Secrets", proxyCoreV1Path("secrets"), proxySecretsListExpectedStatus()),
+		Entry("Release", proxyAppStudioPath("releaseplans"), 200),
+		Entry("Applications", proxyAppStudioPath("applications"), 200),
+		Entry("Namespaces", "/api/k8s/api/v1/namespaces", 200),
+		Entry("PipelineRuns", proxyTektonPath("pipelineruns"), 200),
 	)
 
 	Describe("Test WebSocket endpoint", func() {
-		const wsPath = "/wss/k8s/apis/tekton.dev/v1/namespaces/user-ns2/pipelineruns?watch=true"
-
 		It("should establish a WebSocket connection through /wss/k8s/", func() {
 			token, err := ExtractToken(proxyClient)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(token).ToNot(BeEmpty())
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-
-			httpClient := &http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-				},
-			}
-
-			conn, resp, err := websocket.Dial(ctx, proxyWebSocketURL(wsPath), &websocket.DialOptions{
-				HTTPClient:   httpClient,
-				Subprotocols: []string{"base64.binary.k8s.io"},
-				HTTPHeader: http.Header{
-					"Authorization": []string{"Bearer " + token},
-					"Origin":        []string{proxyHome},
-				},
-			})
-			Expect(err).NotTo(HaveOccurred(), "WebSocket connection should be established")
-			Expect(resp.StatusCode).To(Equal(http.StatusSwitchingProtocols))
-			defer conn.Close(websocket.StatusNormalClosure, "test complete")
+			wsPath := proxyTektonWSPath("pipelineruns") + "?watch=true"
+			expectProxyWebSocketDialWithBearer(wsPath, token)
 		})
 
 		It("should reject WebSocket connection without token", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
+
+			wsPath := proxyTektonWSPath("pipelineruns") + "?watch=true"
 
 			httpClient := &http.Client{
 				Transport: &http.Transport{
@@ -166,7 +129,7 @@ var _ = Describe("Test Proxy endpoints", func() {
 		})
 	})
 
-	Describe("Test group-based RBAC", func() {
+	Describe("Test group-based RBAC", Label("proxy-dex"), func() {
 		It("should grant access to namespaces the user's groups are bound to", func() {
 			token, err := ExtractTokenForUser(proxyClient, "user1@konflux.dev", "password")
 			Expect(err).NotTo(HaveOccurred())
@@ -181,7 +144,7 @@ var _ = Describe("Test Proxy endpoints", func() {
 
 			body, err := io.ReadAll(response.Body)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(response.StatusCode).To(Equal(200), string(body))
+			expectProxyHTTPStatus(response, body, http.StatusOK, "/api/k8s/api/v1/namespaces")
 		})
 
 		It("should pass groups from ID token as Impersonate-Group headers", func() {
@@ -202,17 +165,17 @@ var _ = Describe("Test Proxy endpoints", func() {
 
 			body, err := io.ReadAll(response.Body)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(response.StatusCode).To(Equal(201), string(body))
+			expectProxyHTTPStatus(response, body, http.StatusCreated,
+				"/api/k8s/apis/authorization.k8s.io/v1/selfsubjectaccessreviews")
 		})
 	})
 
-	Describe("Test user with no IdP groups", func() {
+	Describe("Test user with no IdP groups", Label("proxy-dex"), func() {
 		It("should succeed when the user has no IdP groups", func() {
 			token, err := ExtractTokenForUser(proxyClient, "user2@konflux.dev", "password")
 			Expect(err).NotTo(HaveOccurred())
 
-			request, err := http.NewRequest("GET",
-				proxyURL("/api/k8s/api/v1/namespaces/user-ns2/secrets"), nil)
+			request, err := http.NewRequest("GET", proxyURL(proxyAppStudioPath("applications")), nil)
 			Expect(err).NotTo(HaveOccurred())
 			request.Header.Set("Authorization", "Bearer "+token)
 
@@ -222,8 +185,7 @@ var _ = Describe("Test Proxy endpoints", func() {
 
 			body, err := io.ReadAll(response.Body)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(response.StatusCode).To(Equal(200), string(body),
-				"Request should succeed when user has no IdP groups (plugin adds system:authenticated only)")
+			expectProxyHTTPStatus(response, body, http.StatusOK, proxyAppStudioPath("applications"))
 		})
 	})
 
@@ -242,7 +204,7 @@ var _ = Describe("Test Proxy endpoints", func() {
 
 			body, err := io.ReadAll(response.Body)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(response.StatusCode).To(Equal(200), string(body))
+			expectProxyHTTPStatus(response, body, http.StatusOK, "/api/k8s/api/v1/namespaces")
 
 			var nsList map[string]interface{}
 			err = json.Unmarshal(body, &nsList)
@@ -345,6 +307,20 @@ func ExtractToken(client crclient.Client) (string, error) {
 }
 
 func ExtractTokenForUser(client crclient.Client, user, pass string) (string, error) {
+	if token, ok := proxyIDTokenForUser(user); ok {
+		logProxyAuthMethod(proxyAuthMethodFromEnv())
+		return token, nil
+	}
+
+	if isProxyOpenShiftAuth() {
+		return "", fmt.Errorf(
+			"%s=%s but no id_token available for %q (dex password grant disabled in openshift mode)",
+			envProxyAuth, proxyAuthOpenShift, user,
+		)
+	}
+
+	logProxyAuthMethod(proxyAuthMethodDexPasswordGrant)
+
 	namespace := "dex"
 	ns := &v1.Namespace{}
 	err := client.Get(context.TODO(), crclient.ObjectKey{Name: "dex"}, ns)


### PR DESCRIPTION
The tests were relying on hard coded users and passwords. This was fine in tests for konflux-ci/konflux-ci, but when used in infra-deployments, it's hard to predict where the development overlay might be used.

For the chances that someone may use it in an environment in which the hard coded passwords might be exploited, we switched to using the default-tenant for the proxy tests, and having the tests on OpenShift login with OpenShift.

Assisted-by: Cursor