### PR TITLE
feat(KFLUXVNGD-1090): Add watch/own to internal registry resources

### DIFF
--- a/operator/internal/controller/internalregistry/konfluxinternalregistry_controller.go
+++ b/operator/internal/controller/internalregistry/konfluxinternalregistry_controller.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"golang.org/x/crypto/bcrypt"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -86,6 +87,7 @@ type KonfluxInternalRegistryReconciler struct {
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;patch;delete
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=trust.cert-manager.io,resources=bundles,verbs=get;list;watch;create;patch;delete
@@ -191,11 +193,16 @@ func (r *KonfluxInternalRegistryReconciler) SetupWithManager(mgr ctrl.Manager) e
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&konfluxv1alpha1.KonfluxInternalRegistry{}).
 		Named("konfluxinternalregistry").
-		// Watch for changes to registry resources
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
 		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&certmanagerv1.Certificate{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		// NOTE: trust-manager Bundle (trust.cert-manager.io/v1alpha1) is not owned here
+		// because trust-manager's Go module pulls controller-runtime/k8s.io versions
+		// incompatible with this operator. The Bundle is still applied via manifests
+		// but changes to it won't trigger reconciliation.
 		Complete(r)
 }
 

--- a/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
+++ b/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package internalregistry
 
 import (
+	"context"
 	"fmt"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -90,6 +92,385 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				}
 			}
 			Expect(found).To(BeTrue(), "Owner reference should be set")
+		})
+	})
+
+	Context("Self-healing", func() {
+		It("recreates Deployment when deleted", func(ctx context.Context) {
+			registry := &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+
+			deploymentNN := types.NamespacedName{
+				Name:      "registry",
+				Namespace: internalRegistryNamespace,
+			}
+
+			By("waiting for initial Deployment creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, deploymentNN, &appsv1.Deployment{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the Deployment")
+			Expect(k8sClient.Delete(ctx, &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: deploymentNN.Name, Namespace: deploymentNN.Namespace},
+			})).To(Succeed())
+
+			By("verifying the Deployment is recreated with correct spec")
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, deploymentNN, dep)).To(Succeed())
+				g.Expect(dep.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+				container := testutil.FindContainer(dep.Spec.Template.Spec.Containers, "registry")
+				g.Expect(container).NotTo(BeNil(), "registry container should exist")
+				g.Expect(container.Image).NotTo(BeEmpty(), "container image should be set")
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("recreates ConfigMap when deleted", func(ctx context.Context) {
+			registry := &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+
+			cmNN := types.NamespacedName{
+				Name:      "zot-config",
+				Namespace: internalRegistryNamespace,
+			}
+
+			By("waiting for initial ConfigMap creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, cmNN, &corev1.ConfigMap{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the ConfigMap")
+			Expect(k8sClient.Delete(ctx, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: cmNN.Name, Namespace: cmNN.Namespace},
+			})).To(Succeed())
+
+			By("verifying the ConfigMap is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+				g.Expect(cm.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("recreates Service when deleted", func(ctx context.Context) {
+			registry := &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+
+			svcNN := types.NamespacedName{
+				Name:      "registry-service",
+				Namespace: internalRegistryNamespace,
+			}
+
+			By("waiting for initial Service creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, svcNN, &corev1.Service{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the Service")
+			Expect(k8sClient.Delete(ctx, &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: svcNN.Name, Namespace: svcNN.Namespace},
+			})).To(Succeed())
+
+			By("verifying the Service is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("recreates Secret when deleted", func(ctx context.Context) {
+			registry := &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+
+			secretNN := types.NamespacedName{
+				Name:      HtpasswdSecretName,
+				Namespace: internalRegistryNamespace,
+			}
+
+			By("waiting for initial Secret creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, secretNN, &corev1.Secret{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the Secret")
+			Expect(k8sClient.Delete(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: secretNN.Name, Namespace: secretNN.Namespace},
+			})).To(Succeed())
+
+			By("verifying the Secret is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, secretNN, secret)).To(Succeed())
+				g.Expect(secret.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("recreates Certificate when deleted", func(ctx context.Context) {
+			registry := &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+
+			certNN := types.NamespacedName{
+				Name:      "registry-cert",
+				Namespace: internalRegistryNamespace,
+			}
+
+			By("waiting for initial Certificate creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, certNN, &certmanagerv1.Certificate{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the Certificate")
+			Expect(k8sClient.Delete(ctx, &certmanagerv1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Name: certNN.Name, Namespace: certNN.Namespace},
+			})).To(Succeed())
+
+			By("verifying the Certificate is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				cert := &certmanagerv1.Certificate{}
+				g.Expect(k8sClient.Get(ctx, certNN, cert)).To(Succeed())
+				g.Expect(cert.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+	})
+
+	Context("Drift correction", func() {
+		It("restores Deployment image when modified", func(ctx context.Context) {
+			registry := &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+
+			deploymentNN := types.NamespacedName{
+				Name:      "registry",
+				Namespace: internalRegistryNamespace,
+			}
+
+			By("waiting for initial Deployment creation")
+			var originalImage string
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, deploymentNN, dep)).To(Succeed())
+				container := testutil.FindContainer(dep.Spec.Template.Spec.Containers, "registry")
+				g.Expect(container).NotTo(BeNil())
+				originalImage = container.Image
+				g.Expect(originalImage).NotTo(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the Deployment image")
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, deploymentNN, dep)).To(Succeed())
+			container := testutil.FindContainer(dep.Spec.Template.Spec.Containers, "registry")
+			Expect(container).NotTo(BeNil())
+			container.Image = "tampered-image:latest"
+			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+
+			By("verifying the Deployment image is restored")
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, deploymentNN, dep)).To(Succeed())
+				container := testutil.FindContainer(dep.Spec.Template.Spec.Containers, "registry")
+				g.Expect(container).NotTo(BeNil())
+				g.Expect(container.Image).To(Equal(originalImage))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores ConfigMap data when modified", func(ctx context.Context) {
+			registry := &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+
+			cmNN := types.NamespacedName{
+				Name:      "zot-config",
+				Namespace: internalRegistryNamespace,
+			}
+
+			By("waiting for initial ConfigMap creation")
+			var originalData map[string]string
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+				g.Expect(cm.Data).NotTo(BeEmpty())
+				originalData = cm.Data
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the ConfigMap data")
+			cm := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+			cm.Data = map[string]string{"config.json": "tampered"}
+			Expect(k8sClient.Update(ctx, cm)).To(Succeed())
+
+			By("verifying the ConfigMap data is restored")
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+				g.Expect(cm.Data).To(Equal(originalData))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores Service spec when modified", func(ctx context.Context) {
+			registry := &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+
+			svcNN := types.NamespacedName{
+				Name:      "registry-service",
+				Namespace: internalRegistryNamespace,
+			}
+
+			By("waiting for initial Service creation")
+			var originalTargetPort int32
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Spec.Ports).NotTo(BeEmpty())
+				originalTargetPort = svc.Spec.Ports[0].TargetPort.IntVal
+				g.Expect(originalTargetPort).NotTo(BeZero())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the Service target port")
+			svc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+			svc.Spec.Ports[0].TargetPort.IntVal = 9999
+			Expect(k8sClient.Update(ctx, svc)).To(Succeed())
+
+			By("verifying the Service target port is restored")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Spec.Ports).NotTo(BeEmpty())
+				g.Expect(svc.Spec.Ports[0].TargetPort.IntVal).To(Equal(originalTargetPort))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores Certificate spec when modified", func(ctx context.Context) {
+			registry := &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+
+			certNN := types.NamespacedName{
+				Name:      "registry-cert",
+				Namespace: internalRegistryNamespace,
+			}
+
+			By("waiting for initial Certificate creation")
+			var originalDNSNames []string
+			Eventually(func(g Gomega) {
+				cert := &certmanagerv1.Certificate{}
+				g.Expect(k8sClient.Get(ctx, certNN, cert)).To(Succeed())
+				g.Expect(cert.Spec.DNSNames).NotTo(BeEmpty())
+				originalDNSNames = cert.Spec.DNSNames
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the Certificate DNS names")
+			cert := &certmanagerv1.Certificate{}
+			Expect(k8sClient.Get(ctx, certNN, cert)).To(Succeed())
+			cert.Spec.DNSNames = []string{"tampered.example.com"}
+			Expect(k8sClient.Update(ctx, cert)).To(Succeed())
+
+			By("verifying the Certificate DNS names are restored")
+			Eventually(func(g Gomega) {
+				cert := &certmanagerv1.Certificate{}
+				g.Expect(k8sClient.Get(ctx, certNN, cert)).To(Succeed())
+				g.Expect(cert.Spec.DNSNames).To(Equal(originalDNSNames))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("rotates credentials when htpasswd is cleared", func(ctx context.Context) {
+			registry := &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+
+			secretNN := types.NamespacedName{
+				Name:      HtpasswdSecretName,
+				Namespace: internalRegistryNamespace,
+			}
+
+			By("waiting for initial Secret creation")
+			var originalData []byte
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, secretNN, secret)).To(Succeed())
+				g.Expect(secret.Data).To(HaveKey("htpasswd"))
+				originalData = secret.Data["htpasswd"]
+				g.Expect(originalData).NotTo(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("clearing the Secret data to trigger credential rotation")
+			secret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, secretNN, secret)).To(Succeed())
+			secret.Data["htpasswd"] = []byte{}
+			Expect(k8sClient.Update(ctx, secret)).To(Succeed())
+
+			By("verifying the Secret data is repopulated")
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, secretNN, secret)).To(Succeed())
+				g.Expect(secret.Data).To(HaveKey("htpasswd"))
+				g.Expect(secret.Data["htpasswd"]).NotTo(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores Namespace labels when stripped", func(ctx context.Context) {
+			registry := &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+
+			nsNN := types.NamespacedName{
+				Name: internalRegistryNamespace,
+			}
+
+			By("waiting for initial Namespace creation with ownership labels")
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsNN, ns)).To(Succeed())
+				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("stripping ownership labels from the Namespace")
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsNN, ns)).To(Succeed())
+				delete(ns.Labels, constant.KonfluxOwnerLabel)
+				delete(ns.Labels, constant.KonfluxComponentLabel)
+				g.Expect(k8sClient.Update(ctx, ns)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Namespace labels are restored")
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsNN, ns)).To(Succeed())
+				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxComponentLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
This PR adds watch/own to the internal registry resources.

- Add watch/own for ConfigMap
- Add watch/own for certificate
- Add health tests for internal registry
- Add drift tests for internal registry

Assisted-by: Cursor + Opus 4.6