### PR TITLE
feat(KFLUXVNGD-1085): add drift correction and self-healing tests to build-service

### DIFF
--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
@@ -40,8 +40,14 @@ import (
 )
 
 const (
-	buildServiceNamespace = "build-service"
-	sccName               = "appstudio-pipelines-scc"
+	buildServiceNamespace                 = "build-service"
+	sccName                               = "appstudio-pipelines-scc"
+	metricsServiceName                    = "build-service-controller-manager-metrics-service"
+	pipelineConfigMapName                 = "build-pipeline-config"
+	pipelineReadOnlyRoleName              = "build-service-build-pipeline-config-read-only"
+	pipelineReadOnlyRoleBindingName       = "build-pipeline-config-read-only-binding"
+	pipelinesRunnerClusterRoleName        = "appstudio-pipelines-runner"
+	pipelinesRunnerClusterRoleBindingName = "build-pipeline-runner-rolebinding"
 )
 
 var _ = Describe("KonfluxBuildService Controller", func() {
@@ -200,8 +206,8 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 
 		BeforeEach(func() {
 			configMapNN = types.NamespacedName{
-				Name:      "build-pipeline-config",
-				Namespace: "build-service",
+				Name:      pipelineConfigMapName,
+				Namespace: buildServiceNamespace,
 			}
 		})
 
@@ -564,7 +570,7 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
 
 			svcNN := types.NamespacedName{
-				Name:      "build-service-controller-manager-metrics-service",
+				Name:      metricsServiceName,
 				Namespace: buildServiceNamespace,
 			}
 
@@ -596,7 +602,7 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
 
 			cmNN := types.NamespacedName{
-				Name:      "build-pipeline-config",
+				Name:      pipelineConfigMapName,
 				Namespace: buildServiceNamespace,
 			}
 
@@ -628,7 +634,7 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
 
 			roleNN := types.NamespacedName{
-				Name:      "build-service-build-pipeline-config-read-only",
+				Name:      pipelineReadOnlyRoleName,
 				Namespace: buildServiceNamespace,
 			}
 
@@ -660,7 +666,7 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
 
 			rbNN := types.NamespacedName{
-				Name:      "build-pipeline-config-read-only-binding",
+				Name:      pipelineReadOnlyRoleBindingName,
 				Namespace: buildServiceNamespace,
 			}
 
@@ -691,7 +697,7 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
 			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
 
-			crNN := types.NamespacedName{Name: "appstudio-pipelines-runner"}
+			crNN := types.NamespacedName{Name: pipelinesRunnerClusterRoleName}
 
 			By("waiting for initial ClusterRole creation")
 			Eventually(func(g Gomega) {
@@ -723,7 +729,7 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
 			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
 
-			crbNN := types.NamespacedName{Name: "build-pipeline-runner-rolebinding"}
+			crbNN := types.NamespacedName{Name: pipelinesRunnerClusterRoleBindingName}
 
 			By("waiting for initial ClusterRoleBinding creation")
 			Eventually(func(g Gomega) {
@@ -822,6 +828,378 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: sccName}, &securityv1.SecurityContextConstraints{})
 				g.Expect(errors.IsNotFound(err)).To(BeTrue())
 			}, 5*time.Second, time.Second).Should(Succeed())
+		})
+	})
+
+	Context("Drift correction", func() {
+		It("restores Deployment image when modified", func(ctx context.Context) {
+			startManagerWithClusterInfo(nil)
+
+			buildService := &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+
+			deploymentNN := types.NamespacedName{
+				Name:      buildControllerManagerDeploymentName,
+				Namespace: buildServiceNamespace,
+			}
+
+			By("waiting for initial Deployment creation")
+			var originalImage string
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, deploymentNN, dep)).To(Succeed())
+				manager := testutil.FindContainer(dep.Spec.Template.Spec.Containers, buildManagerContainerName)
+				g.Expect(manager).NotTo(BeNil())
+				originalImage = manager.Image
+				g.Expect(originalImage).NotTo(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the Deployment image")
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, deploymentNN, dep)).To(Succeed())
+				manager := testutil.FindContainer(dep.Spec.Template.Spec.Containers, buildManagerContainerName)
+				g.Expect(manager).NotTo(BeNil())
+				manager.Image = "tampered-image:latest"
+				g.Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Deployment image is restored")
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, deploymentNN, dep)).To(Succeed())
+				m := testutil.FindContainer(dep.Spec.Template.Spec.Containers, buildManagerContainerName)
+				g.Expect(m).NotTo(BeNil())
+				g.Expect(m.Image).To(Equal(originalImage))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores ServiceAccount labels when stripped", func(ctx context.Context) {
+			startManagerWithClusterInfo(nil)
+
+			buildService := &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+
+			saNN := types.NamespacedName{
+				Name:      buildControllerManagerDeploymentName,
+				Namespace: buildServiceNamespace,
+			}
+
+			By("waiting for initial ServiceAccount creation")
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, saNN, sa)).To(Succeed())
+				g.Expect(sa.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("stripping ownership labels from the ServiceAccount")
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, saNN, sa)).To(Succeed())
+				delete(sa.Labels, constant.KonfluxOwnerLabel)
+				delete(sa.Labels, constant.KonfluxComponentLabel)
+				g.Expect(k8sClient.Update(ctx, sa)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the ServiceAccount labels are restored")
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, saNN, sa)).To(Succeed())
+				g.Expect(sa.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+				g.Expect(sa.Labels).To(HaveKey(constant.KonfluxComponentLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores Service labels when stripped", func(ctx context.Context) {
+			startManagerWithClusterInfo(nil)
+
+			buildService := &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+
+			svcNN := types.NamespacedName{
+				Name:      metricsServiceName,
+				Namespace: buildServiceNamespace,
+			}
+
+			By("waiting for initial Service creation with ownership labels")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("stripping ownership labels from the Service")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				delete(svc.Labels, constant.KonfluxOwnerLabel)
+				delete(svc.Labels, constant.KonfluxComponentLabel)
+				g.Expect(k8sClient.Update(ctx, svc)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Service labels are restored")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+				g.Expect(svc.Labels).To(HaveKey(constant.KonfluxComponentLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores ConfigMap data when modified", func(ctx context.Context) {
+			startManagerWithClusterInfo(nil)
+
+			buildService := &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+
+			cmNN := types.NamespacedName{
+				Name:      pipelineConfigMapName,
+				Namespace: buildServiceNamespace,
+			}
+
+			By("waiting for initial ConfigMap creation")
+			var originalData map[string]string
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+				g.Expect(cm.Data).NotTo(BeEmpty())
+				originalData = cm.Data
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the ConfigMap data")
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+				cm.Data = map[string]string{"config.yaml": "tampered"}
+				g.Expect(k8sClient.Update(ctx, cm)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the ConfigMap data is restored")
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+				g.Expect(cm.Data).To(Equal(originalData))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores Namespace labels when stripped", func(ctx context.Context) {
+			startManagerWithClusterInfo(nil)
+
+			buildService := &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+
+			nsNN := types.NamespacedName{Name: buildServiceNamespace}
+
+			By("waiting for initial Namespace creation with ownership labels")
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsNN, ns)).To(Succeed())
+				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("stripping ownership labels from the Namespace")
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsNN, ns)).To(Succeed())
+				delete(ns.Labels, constant.KonfluxOwnerLabel)
+				delete(ns.Labels, constant.KonfluxComponentLabel)
+				g.Expect(k8sClient.Update(ctx, ns)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Namespace labels are restored")
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsNN, ns)).To(Succeed())
+				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxComponentLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores Role rules when modified", func(ctx context.Context) {
+			startManagerWithClusterInfo(nil)
+
+			buildService := &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+
+			roleNN := types.NamespacedName{
+				Name:      pipelineReadOnlyRoleName,
+				Namespace: buildServiceNamespace,
+			}
+
+			By("waiting for initial Role creation")
+			var originalRules []rbacv1.PolicyRule
+			Eventually(func(g Gomega) {
+				role := &rbacv1.Role{}
+				g.Expect(k8sClient.Get(ctx, roleNN, role)).To(Succeed())
+				g.Expect(role.Rules).NotTo(BeEmpty())
+				originalRules = role.Rules
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the Role rules")
+			Eventually(func(g Gomega) {
+				role := &rbacv1.Role{}
+				g.Expect(k8sClient.Get(ctx, roleNN, role)).To(Succeed())
+				role.Rules = []rbacv1.PolicyRule{{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"delete"},
+				}}
+				g.Expect(k8sClient.Update(ctx, role)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Role rules are restored")
+			Eventually(func(g Gomega) {
+				role := &rbacv1.Role{}
+				g.Expect(k8sClient.Get(ctx, roleNN, role)).To(Succeed())
+				g.Expect(role.Rules).To(Equal(originalRules))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores RoleBinding subjects when modified", func(ctx context.Context) {
+			startManagerWithClusterInfo(nil)
+
+			buildService := &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+
+			rbNN := types.NamespacedName{
+				Name:      pipelineReadOnlyRoleBindingName,
+				Namespace: buildServiceNamespace,
+			}
+
+			By("waiting for initial RoleBinding creation")
+			var originalSubjects []rbacv1.Subject
+			Eventually(func(g Gomega) {
+				rb := &rbacv1.RoleBinding{}
+				g.Expect(k8sClient.Get(ctx, rbNN, rb)).To(Succeed())
+				g.Expect(rb.Subjects).NotTo(BeEmpty())
+				originalSubjects = rb.Subjects
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the RoleBinding subjects")
+			Eventually(func(g Gomega) {
+				rb := &rbacv1.RoleBinding{}
+				g.Expect(k8sClient.Get(ctx, rbNN, rb)).To(Succeed())
+				rb.Subjects = []rbacv1.Subject{{
+					Kind:     "User",
+					Name:     "tampered-user",
+					APIGroup: "rbac.authorization.k8s.io",
+				}}
+				g.Expect(k8sClient.Update(ctx, rb)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the RoleBinding subjects are restored")
+			Eventually(func(g Gomega) {
+				rb := &rbacv1.RoleBinding{}
+				g.Expect(k8sClient.Get(ctx, rbNN, rb)).To(Succeed())
+				g.Expect(rb.Subjects).To(Equal(originalSubjects))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores ClusterRole rules when modified", func(ctx context.Context) {
+			startManagerWithClusterInfo(nil)
+
+			buildService := &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+
+			crNN := types.NamespacedName{Name: pipelinesRunnerClusterRoleName}
+
+			By("waiting for initial ClusterRole creation")
+			var originalRules []rbacv1.PolicyRule
+			Eventually(func(g Gomega) {
+				cr := &rbacv1.ClusterRole{}
+				g.Expect(k8sClient.Get(ctx, crNN, cr)).To(Succeed())
+				g.Expect(cr.Rules).NotTo(BeEmpty())
+				originalRules = cr.Rules
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
+			})
+
+			By("modifying the ClusterRole rules")
+			Eventually(func(g Gomega) {
+				cr := &rbacv1.ClusterRole{}
+				g.Expect(k8sClient.Get(ctx, crNN, cr)).To(Succeed())
+				cr.Rules = []rbacv1.PolicyRule{{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"delete"},
+				}}
+				g.Expect(k8sClient.Update(ctx, cr)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the ClusterRole rules are restored")
+			Eventually(func(g Gomega) {
+				cr := &rbacv1.ClusterRole{}
+				g.Expect(k8sClient.Get(ctx, crNN, cr)).To(Succeed())
+				g.Expect(cr.Rules).To(Equal(originalRules))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores ClusterRoleBinding subjects when modified", func(ctx context.Context) {
+			startManagerWithClusterInfo(nil)
+
+			buildService := &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+
+			crbNN := types.NamespacedName{Name: pipelinesRunnerClusterRoleBindingName}
+
+			By("waiting for initial ClusterRoleBinding creation")
+			var originalSubjects []rbacv1.Subject
+			Eventually(func(g Gomega) {
+				crb := &rbacv1.ClusterRoleBinding{}
+				g.Expect(k8sClient.Get(ctx, crbNN, crb)).To(Succeed())
+				g.Expect(crb.Subjects).NotTo(BeEmpty())
+				originalSubjects = crb.Subjects
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: crbNN.Name},
+			})
+
+			By("modifying the ClusterRoleBinding subjects")
+			Eventually(func(g Gomega) {
+				crb := &rbacv1.ClusterRoleBinding{}
+				g.Expect(k8sClient.Get(ctx, crbNN, crb)).To(Succeed())
+				crb.Subjects = []rbacv1.Subject{{
+					Kind:      "ServiceAccount",
+					Name:      "tampered-sa",
+					Namespace: "default",
+				}}
+				g.Expect(k8sClient.Update(ctx, crb)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the ClusterRoleBinding subjects are restored")
+			Eventually(func(g Gomega) {
+				crb := &rbacv1.ClusterRoleBinding{}
+				g.Expect(k8sClient.Get(ctx, crbNN, crb)).To(Succeed())
+				g.Expect(crb.Subjects).To(Equal(originalSubjects))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
Add comprehensive drift correction tests for all real owned resources in the build-service controller. Each test tampers with a resource field (image, labels, rules, subjects, data) and verifies the controller restores the original state via the Owns watch.

Self-healing (delete/recreate) tests:
- Deployment, ServiceAccount, Service, ConfigMap, Role, RoleBinding, ClusterRole, ClusterRoleBinding, SCC (already existed)

Drift correction (modify/restore) tests:
- Deployment (container image)
- ServiceAccount (ownership labels)
- Service (ownership labels)
- ConfigMap (data content)
- Namespace (ownership labels)
- Role (rules)
- RoleBinding (subjects)
- ClusterRole (rules)
- ClusterRoleBinding (subjects)

Namespace deletion self-healing is intentionally omitted because envtest does not run the Kubernetes namespace lifecycle controller — deleting a namespace sets DeletionTimestamp but it never leaves the Terminating state, making the test either pass trivially or hang.

Several Owns() declarations in this controller (e.g. Secret) are phantom watches — the controller never creates those resource types. These stale registrations add unnecessary informer overhead and will be cleaned up in a follow-up PR.

Assisted-by: Cursor + Opus 4.6