### PR TITLE
feat(KFLUXVNGD-1089): add drift correction tests for namespace-lister controller

### DIFF
--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
@@ -37,6 +37,7 @@ import (
 
 const (
 	namespaceListerNamespace            = "namespace-lister"
+	authorizerClusterRoleName           = "namespace-lister-authorizer"
 	networkPolicyAllowFromKonfluxUIName = "namespace-lister-allow-from-konfluxui"
 	networkPolicyAllowToAPIServerName   = "namespace-lister-allow-to-apiserver"
 )
@@ -271,7 +272,7 @@ var _ = Describe("KonfluxNamespaceLister Controller", func() {
 			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
 			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
 
-			crNN := types.NamespacedName{Name: "namespace-lister-authorizer"}
+			crNN := types.NamespacedName{Name: authorizerClusterRoleName}
 
 			By("waiting for initial ClusterRole creation")
 			Eventually(func(g Gomega) {
@@ -301,7 +302,7 @@ var _ = Describe("KonfluxNamespaceLister Controller", func() {
 			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
 			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
 
-			crbNN := types.NamespacedName{Name: "namespace-lister-authorizer"}
+			crbNN := types.NamespacedName{Name: authorizerClusterRoleName}
 
 			By("waiting for initial ClusterRoleBinding creation")
 			Eventually(func(g Gomega) {
@@ -321,6 +322,315 @@ var _ = Describe("KonfluxNamespaceLister Controller", func() {
 				crb := &rbacv1.ClusterRoleBinding{}
 				g.Expect(k8sClient.Get(ctx, crbNN, crb)).To(Succeed())
 				g.Expect(crb.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+	})
+
+	Context("Drift correction", func() {
+		It("restores Deployment image when modified", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			deploymentNN := types.NamespacedName{
+				Name:      namespaceListerNamespace,
+				Namespace: namespaceListerNamespace,
+			}
+
+			By("waiting for initial Deployment creation")
+			var originalImage string
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, deploymentNN, dep)).To(Succeed())
+				container := testutil.FindContainer(dep.Spec.Template.Spec.Containers, namespaceListerContainerName)
+				g.Expect(container).NotTo(BeNil())
+				originalImage = container.Image
+				g.Expect(originalImage).NotTo(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the Deployment image")
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, deploymentNN, dep)).To(Succeed())
+				container := testutil.FindContainer(dep.Spec.Template.Spec.Containers, namespaceListerContainerName)
+				g.Expect(container).NotTo(BeNil())
+				container.Image = "tampered-image:latest"
+				g.Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Deployment image is restored")
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, deploymentNN, dep)).To(Succeed())
+				container := testutil.FindContainer(dep.Spec.Template.Spec.Containers, namespaceListerContainerName)
+				g.Expect(container).NotTo(BeNil())
+				g.Expect(container.Image).To(Equal(originalImage))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores ServiceAccount labels when stripped", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			saNN := types.NamespacedName{
+				Name:      namespaceListerNamespace,
+				Namespace: namespaceListerNamespace,
+			}
+
+			By("waiting for initial ServiceAccount creation with ownership labels")
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, saNN, sa)).To(Succeed())
+				g.Expect(sa.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("stripping ownership labels from the ServiceAccount")
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, saNN, sa)).To(Succeed())
+				delete(sa.Labels, constant.KonfluxOwnerLabel)
+				delete(sa.Labels, constant.KonfluxComponentLabel)
+				g.Expect(k8sClient.Update(ctx, sa)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the ServiceAccount labels are restored")
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, saNN, sa)).To(Succeed())
+				g.Expect(sa.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+				g.Expect(sa.Labels).To(HaveKey(constant.KonfluxComponentLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores Service labels when stripped", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			svcNN := types.NamespacedName{
+				Name:      namespaceListerNamespace,
+				Namespace: namespaceListerNamespace,
+			}
+
+			By("waiting for initial Service creation with ownership labels")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("stripping ownership labels from the Service")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				delete(svc.Labels, constant.KonfluxOwnerLabel)
+				delete(svc.Labels, constant.KonfluxComponentLabel)
+				g.Expect(k8sClient.Update(ctx, svc)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Service labels are restored")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+				g.Expect(svc.Labels).To(HaveKey(constant.KonfluxComponentLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores Namespace labels when stripped", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			nsNN := types.NamespacedName{Name: namespaceListerNamespace}
+
+			By("waiting for initial Namespace creation with ownership labels")
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsNN, ns)).To(Succeed())
+				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("stripping ownership labels from the Namespace")
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsNN, ns)).To(Succeed())
+				delete(ns.Labels, constant.KonfluxOwnerLabel)
+				delete(ns.Labels, constant.KonfluxComponentLabel)
+				g.Expect(k8sClient.Update(ctx, ns)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Namespace labels are restored")
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsNN, ns)).To(Succeed())
+				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxComponentLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores ClusterRole rules when modified", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			crNN := types.NamespacedName{Name: authorizerClusterRoleName}
+
+			By("waiting for initial ClusterRole creation")
+			var originalRules []rbacv1.PolicyRule
+			Eventually(func(g Gomega) {
+				cr := &rbacv1.ClusterRole{}
+				g.Expect(k8sClient.Get(ctx, crNN, cr)).To(Succeed())
+				g.Expect(cr.Rules).NotTo(BeEmpty())
+				originalRules = cr.Rules
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
+			})
+
+			By("modifying the ClusterRole rules")
+			Eventually(func(g Gomega) {
+				cr := &rbacv1.ClusterRole{}
+				g.Expect(k8sClient.Get(ctx, crNN, cr)).To(Succeed())
+				cr.Rules = []rbacv1.PolicyRule{{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"delete"},
+				}}
+				g.Expect(k8sClient.Update(ctx, cr)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the ClusterRole rules are restored")
+			Eventually(func(g Gomega) {
+				cr := &rbacv1.ClusterRole{}
+				g.Expect(k8sClient.Get(ctx, crNN, cr)).To(Succeed())
+				g.Expect(cr.Rules).To(Equal(originalRules))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores ClusterRoleBinding subjects when modified", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			crbNN := types.NamespacedName{Name: authorizerClusterRoleName}
+
+			By("waiting for initial ClusterRoleBinding creation")
+			var originalSubjects []rbacv1.Subject
+			Eventually(func(g Gomega) {
+				crb := &rbacv1.ClusterRoleBinding{}
+				g.Expect(k8sClient.Get(ctx, crbNN, crb)).To(Succeed())
+				g.Expect(crb.Subjects).NotTo(BeEmpty())
+				originalSubjects = crb.Subjects
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: crbNN.Name},
+			})
+
+			By("modifying the ClusterRoleBinding subjects")
+			Eventually(func(g Gomega) {
+				crb := &rbacv1.ClusterRoleBinding{}
+				g.Expect(k8sClient.Get(ctx, crbNN, crb)).To(Succeed())
+				crb.Subjects = []rbacv1.Subject{{
+					Kind:      "ServiceAccount",
+					Name:      "tampered-sa",
+					Namespace: "default",
+				}}
+				g.Expect(k8sClient.Update(ctx, crb)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the ClusterRoleBinding subjects are restored")
+			Eventually(func(g Gomega) {
+				crb := &rbacv1.ClusterRoleBinding{}
+				g.Expect(k8sClient.Get(ctx, crbNN, crb)).To(Succeed())
+				g.Expect(crb.Subjects).To(Equal(originalSubjects))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores NetworkPolicy labels when stripped", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			npNN := types.NamespacedName{
+				Name:      networkPolicyAllowFromKonfluxUIName,
+				Namespace: namespaceListerNamespace,
+			}
+
+			By("waiting for initial NetworkPolicy creation with ownership labels")
+			Eventually(func(g Gomega) {
+				np := &networkingv1.NetworkPolicy{}
+				g.Expect(k8sClient.Get(ctx, npNN, np)).To(Succeed())
+				g.Expect(np.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("stripping ownership labels from the NetworkPolicy")
+			Eventually(func(g Gomega) {
+				np := &networkingv1.NetworkPolicy{}
+				g.Expect(k8sClient.Get(ctx, npNN, np)).To(Succeed())
+				delete(np.Labels, constant.KonfluxOwnerLabel)
+				delete(np.Labels, constant.KonfluxComponentLabel)
+				g.Expect(k8sClient.Update(ctx, np)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the NetworkPolicy labels are restored")
+			Eventually(func(g Gomega) {
+				np := &networkingv1.NetworkPolicy{}
+				g.Expect(k8sClient.Get(ctx, npNN, np)).To(Succeed())
+				g.Expect(np.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+				g.Expect(np.Labels).To(HaveKey(constant.KonfluxComponentLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores Certificate labels when stripped", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			certNN := types.NamespacedName{
+				Name:      namespaceListerNamespace,
+				Namespace: namespaceListerNamespace,
+			}
+
+			By("waiting for initial Certificate creation with ownership labels")
+			Eventually(func(g Gomega) {
+				cert := &certmanagerv1.Certificate{}
+				g.Expect(k8sClient.Get(ctx, certNN, cert)).To(Succeed())
+				g.Expect(cert.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("stripping ownership labels from the Certificate")
+			Eventually(func(g Gomega) {
+				cert := &certmanagerv1.Certificate{}
+				g.Expect(k8sClient.Get(ctx, certNN, cert)).To(Succeed())
+				delete(cert.Labels, constant.KonfluxOwnerLabel)
+				delete(cert.Labels, constant.KonfluxComponentLabel)
+				g.Expect(k8sClient.Update(ctx, cert)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Certificate labels are restored")
+			Eventually(func(g Gomega) {
+				cert := &certmanagerv1.Certificate{}
+				g.Expect(k8sClient.Get(ctx, certNN, cert)).To(Succeed())
+				g.Expect(cert.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+				g.Expect(cert.Labels).To(HaveKey(constant.KonfluxComponentLabel))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
Add drift correction (modify/restore) tests for all real owned resource types in the KonfluxNamespaceLister controller. Self-healing tests for all 8 real types were already in place.

Drift correction tests added for all 8 real owned types:
- Deployment (image tampering)
- ServiceAccount (label stripping)
- Service (label stripping)
- Namespace (label stripping)
- ClusterRole (rules modification)
- ClusterRoleBinding (subjects modification)
- NetworkPolicy (label stripping)
- Certificate (label stripping)

Also extracted the hardcoded "namespace-lister-authorizer" string to the authorizerClusterRoleName constant for consistency.

Namespace self-healing (deletion) is intentionally omitted because envtest does not run Kubernetes' namespace lifecycle controller — a deleted namespace enters Terminating state but never actually disappears, causing the test to hang indefinitely. Namespace drift (label stripping/restoration) is still fully covered.

ConfigMap, Secret, Role, and RoleBinding are declared in Owns() but are never created by the controller (neither in manifests nor programmatically). These phantom Owns() will be removed in upcoming tasks to reduce unnecessary informer overhead.

Assisted-by: Cursor + Opus 4.6