### PR TITLE
chore: increase renovate quotas

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,8 @@
     "konflux-ci/**"
   ],
   "rebaseWhen": "conflicted",
+  "prConcurrentLimit": 30,
+  "prHourlyLimit": 3,
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
This should hopefully help prevent starvation of renovate of some PRs that might have been affected by the PR volume (specifically, PAC).

Assisted-by: Cursor