### PR TITLE
test(KFLUXVNGD-1081): default to not deploying test resources

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -296,6 +296,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           MY_GITHUB_ORG: ${{ secrets.GH_ORG }}
           E2E_APPLICATIONS_NAMESPACE: default-tenant
+          E2E_DEPLOY_TEST_RESOURCES: "true"
         run: |
           ./test/e2e/run-e2e.sh \
             -ginkgo.github-output \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,7 +239,10 @@ source test/e2e/e2e.env
 ./test/e2e/run-e2e.sh
 ```
 
-The script deploys test resources and runs the conformance suite.
+The script runs proxy integration tests and the conformance suite. Demo-user fixtures
+(`deploy-test-resources.sh`) are skipped unless `E2E_DEPLOY_TEST_RESOURCES=true` is set
+(for Kind Dex `proxy-dex` RBAC; see `test/e2e/e2e.env.template`). GHA and Tekton enable
+fixtures in CI; OpenShift overlay e2e does not need them.
 
 Note: The deploy step uses `scripts/deploy-local.env` (GitHub App, Quay for image-controller, Smee). The E2E step uses `test/e2e/e2e.env` (GitHub token for PaC flows). They are separate so you never load deploy secrets into the shell where you only run tests.
 

--- a/dependencies/kyverno/kustomization.yaml
+++ b/dependencies/kyverno/kustomization.yaml
@@ -54,6 +54,30 @@ patches:
     kind: Deployment
     name: kyverno-background-controller
     namespace: kyverno
+# OpenShift restricted-v2: upstream 1.18.1 sets runAsUser/runAsGroup 65534, which is outside the
+# namespace UID range. Remove so SCC (OCP) or the image default (Kind) can assign a non-root UID.
+- patch: |-
+    - op: remove
+      path: /spec/template/spec/initContainers/0/securityContext/runAsUser
+    - op: remove
+      path: /spec/template/spec/initContainers/0/securityContext/runAsGroup
+    - op: remove
+      path: /spec/template/spec/containers/0/securityContext/runAsUser
+    - op: remove
+      path: /spec/template/spec/containers/0/securityContext/runAsGroup
+  target:
+    kind: Deployment
+    name: kyverno-admission-controller
+    namespace: kyverno
+- patch: |-
+    - op: remove
+      path: /spec/template/spec/containers/0/securityContext/runAsUser
+    - op: remove
+      path: /spec/template/spec/containers/0/securityContext/runAsGroup
+  target:
+    kind: Deployment
+    name: kyverno-background-controller
+    namespace: kyverno
 - patch: |-
     - op: add
       path: /spec/jobTemplate/spec/template/spec/containers/0/resources

--- a/deploy-test-resources.sh
+++ b/deploy-test-resources.sh
@@ -38,6 +38,8 @@ deploy() {
     kubectl apply --server-side --force-conflicts -k "${script_path}/test/resources/demo-users/user/"
     wait_for_kyverno
 
+    # Sample onboarding manifests under demo-users/user/sample-components/ (optional).
+    # CI sets SKIP_SAMPLE_COMPONENTS=true; omit it for full local demo deploys.
     if [[ "${SKIP_SAMPLE_COMPONENTS:-}" != "true" ]]; then
         echo "Deploying sample components..." >&2
         kubectl apply --server-side --force-conflicts -k "${script_path}/test/resources/demo-users/user/sample-components/"

--- a/scripts/operator-e2e/README.md
+++ b/scripts/operator-e2e/README.md
@@ -50,10 +50,11 @@ Use **one token per flag** where possible (e.g. `-ginkgo.skip=Flaky`). Values wi
 
 ## Proxy integration tests
 
-`test/e2e/run-e2e.sh` runs `run-proxy-integration-tests.sh` before conformance. OpenShift OAuth (kubeadmin → Dex `id_token`) is implemented in Go (`test/go-tests/proxy_oauth_openshift.go`) and runs in proxy test `BeforeSuite` when `KONFLUX_PROXY_AUTH=openshift`. Useful env vars:
+`test/e2e/run-e2e.sh` runs `run-proxy-integration-tests.sh` before conformance. Demo-user fixtures (`deploy-test-resources.sh`) run only when `E2E_DEPLOY_TEST_RESOURCES=true` (set in GHA; Tekton calls `deploy-test-resources.sh` directly). OpenShift OAuth (kubeadmin → Dex `id_token`) is implemented in Go (`test/go-tests/proxy_oauth_openshift.go`) and runs in proxy test `BeforeSuite` when `KONFLUX_PROXY_AUTH=openshift`. Useful env vars:
 
 | Variable | Purpose |
 |----------|---------|
+| `E2E_DEPLOY_TEST_RESOURCES` | When `true`, run `deploy-test-resources.sh` before tests (Kind Dex `proxy-dex` RBAC; off by default in `run-e2e.sh`) |
 | `KONFLUX_PROXY_AUTH` | `openshift` or `dex` (default: infer — openshift when `OPENSHIFT_PASSWORD`, `KUBEADMIN_PASSWORD_FILE`, or `SHARED_DIR/kubeadmin-password` is set and `TEST_ENVIRONMENT!=upstream`, else dex) |
 | `KONFLUX_PROXY_AUTH_METHOD` | Set by the runner: `openshift-oauth` or `dex-password-grant` |
 | `OPENSHIFT_PASSWORD` / `KUBEADMIN_PASSWORD_FILE` / `SHARED_DIR/kubeadmin-password` | Kubeadmin password for OpenShift OAuth (same sources as infra-deployments `ci-common.sh`) |

--- a/test/e2e/e2e.env.template
+++ b/test/e2e/e2e.env.template
@@ -14,6 +14,10 @@
 # The release-service-catalog revision is embedded in that setup-release.sh as its default
 # (tracked by Renovate). The test calls setup-release.sh without overriding it, so local runs
 # match CI automatically.
+# Kind/local runs that need Dex proxy-dex RBAC (user-ns1/user-ns2 demo fixtures):
+# export E2E_DEPLOY_TEST_RESOURCES=true
+# CI sets SKIP_SAMPLE_COMPONENTS=true when calling deploy-test-resources.sh; omit for full sample onboarding.
+#
 # The build pipeline bundle (docker-build-oci-ta-min) is set from operator/pkg/manifests/build-service/manifests.yaml
 # when unset, so local runs match CI without a prep script. Override with CUSTOM_DOCKER_BUILD_OCI_TA_MIN_PIPELINE_BUNDLE.
 #

--- a/test/e2e/run-e2e.sh
+++ b/test/e2e/run-e2e.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
-# Deploy test resources, run proxy integration tests, then E2E conformance tests.
+# Deploy demo-user fixtures (opt-in), run proxy integration tests, then E2E conformance tests.
+# Set E2E_DEPLOY_TEST_RESOURCES=true to run deploy-test-resources.sh (required for Kind Dex proxy-dex tests).
 # Extra arguments are forwarded to the conformance "go test" only, e.g.:
 #   ./test/e2e/run-e2e.sh -ginkgo.focus="build" -ginkgo.junit-report=report.xml
 
@@ -23,8 +24,15 @@ if ! command -v kubectl &>/dev/null; then
     fi
 fi
 
-# Deploy test resources (idempotent — safe to run if already deployed)
-SKIP_SAMPLE_COMPONENTS="true" "${REPO_ROOT}/deploy-test-resources.sh"
+# Demo-user fixtures (user-ns1/user-ns2) for Dex proxy-dex tests — opt-in via E2E_DEPLOY_TEST_RESOURCES.
+case "${E2E_DEPLOY_TEST_RESOURCES:-}" in
+1 | true | yes | TRUE | YES)
+    SKIP_SAMPLE_COMPONENTS=true "${REPO_ROOT}/deploy-test-resources.sh"
+    ;;
+*)
+    echo "Skipping deploy-test-resources.sh (set E2E_DEPLOY_TEST_RESOURCES=true to enable)" >&2
+    ;;
+esac
 
 bash "${REPO_ROOT}/scripts/operator-e2e/run-proxy-integration-tests.sh" "${REPO_ROOT}"
 

--- a/test/go-tests/tests/conformance/README.md
+++ b/test/go-tests/tests/conformance/README.md
@@ -38,11 +38,14 @@ They run against an upstream Konflux instance deployed via scripts in the [konfl
    ```bash
    ./test/e2e/run-e2e.sh
    ```
-   This deploys test resources, runs proxy integration tests (`test/go-tests`), then runs this conformance suite.
+   This runs proxy integration tests (`test/go-tests`), then this conformance suite.
+   Demo-user fixtures (`deploy-test-resources.sh`) run only when
+   `E2E_DEPLOY_TEST_RESOURCES=true` (required for Kind Dex `proxy-dex` tests; set in
+   `test/e2e/e2e.env` — see `test/e2e/e2e.env.template`).
 
    You can also run `go test . -v` directly from this directory, but that
-   skips test resource deployment — you must ensure resources are already
-   deployed (e.g. via `deploy-test-resources.sh`).
+   skips the proxy suite and fixture deployment — deploy fixtures first if needed
+   (e.g. `E2E_DEPLOY_TEST_RESOURCES=true ./test/e2e/run-e2e.sh` or `./deploy-test-resources.sh`).
 
 ### Configuration
 


### PR DESCRIPTION
Only Kind deployments for CI actually use the test resources (for specific proxy tests only relevant in Kind).

This change make it so that we don't deploy test resources unless we specifically need those.

Assisted-by: Cursor