### PR TITLE
Increase PR limits in renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,8 +5,8 @@
     "konflux-ci/**"
   ],
   "rebaseWhen": "conflicted",
-  "prConcurrentLimit": 30,
-  "prHourlyLimit": 3,
+  "prConcurrentLimit": 50,
+  "prHourlyLimit": 20,
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
Temporarily increase renovate limits to see if some branches are starved.