### PR TITLE
fix(operator): fix flaky test cleanup with DeferCleanupParentAndChildren

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,20 @@ After changing APIs or RBAC annotations, run `make manifests generate` from `ope
 1. **Platform conformance** (`test/go-tests/tests/conformance/`) — end-to-end tests against a deployed Konflux instance, run via `test/e2e/run-e2e.sh`. Uses Ginkgo/Gomega with a shared `Framework` in `test/go-tests/pkg/framework/`.
 2. **Operator unit/integration** (`operator/`) — controller tests using controller-runtime **envtest** (no real cluster needed). **Prefer Gomega matchers** for assertions in unit and functional tests. Shared test utilities in `operator/internal/controller/testutil/`. Run via `make test` from `operator/`.
 
+**Test cleanup pattern — `DeferCleanupParentAndChildren`:**
+
+Controller tests that create a parent CR and verify reconciler-managed children (ClusterRoles, ClusterRoleBindings, sub-CRs, etc.) **must** use `testutil.DeferCleanupParentAndChildren` for cleanup:
+
+```go
+Expect(k8sClient.Create(ctx, parentCR)).To(Succeed())
+testutil.DeferCleanupParentAndChildren(k8sClient, parentCR,
+    &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "child-role"}},
+    &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "child-binding"}},
+)
+```
+
+Why: envtest has no garbage collector, so child resources must be cleaned manually. Ginkgo's `DeferCleanup` executes in LIFO order — registering children after the parent causes children to be deleted first, triggering the reconciler to recreate them (flaky timeout). `DeferCleanupParentAndChildren` deletes parent first (stopping reconciles), then children. The helper also re-issues deletes during polling to handle in-flight reconcile races.
+
 ```bash
 # Kube-linter (before PR)
 mkdir -p .kube-linter

--- a/operator/internal/controller/applicationapi/konfluxapplicationapi_controller_test.go
+++ b/operator/internal/controller/applicationapi/konfluxapplicationapi_controller_test.go
@@ -33,14 +33,11 @@ import (
 var _ = Describe("KonfluxApplicationAPI Controller", func() {
 	Context("When reconciling a resource", func() {
 		It("should successfully reconcile the resource", func(ctx context.Context) {
-			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxApplicationAPI{
+			appRes := &konfluxv1alpha1.KonfluxApplicationAPI{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
-			})).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxApplicationAPI{
-					ObjectMeta: metav1.ObjectMeta{Name: CRName},
-				})
-			})
+			}
+			Expect(k8sClient.Create(ctx, appRes)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, appRes)
 
 			Eventually(func(g Gomega) {
 				updated := &konfluxv1alpha1.KonfluxApplicationAPI{}

--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
@@ -695,7 +695,9 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+			testutil.DeferCleanupParentAndChildren(k8sClient, buildService, &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{Name: pipelinesRunnerClusterRoleName},
+			})
 
 			crNN := types.NamespacedName{Name: pipelinesRunnerClusterRoleName}
 
@@ -703,9 +705,6 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, crNN, &rbacv1.ClusterRole{})).To(Succeed())
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
-			})
 
 			By("deleting the ClusterRole")
 			Expect(k8sClient.Delete(ctx, &rbacv1.ClusterRole{
@@ -727,7 +726,9 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+			testutil.DeferCleanupParentAndChildren(k8sClient, buildService, &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: pipelinesRunnerClusterRoleBindingName},
+			})
 
 			crbNN := types.NamespacedName{Name: pipelinesRunnerClusterRoleBindingName}
 
@@ -735,9 +736,6 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, crbNN, &rbacv1.ClusterRoleBinding{})).To(Succeed())
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: crbNN.Name},
-			})
 
 			By("deleting the ClusterRoleBinding")
 			Expect(k8sClient.Delete(ctx, &rbacv1.ClusterRoleBinding{
@@ -1123,7 +1121,9 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+			testutil.DeferCleanupParentAndChildren(k8sClient, buildService, &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{Name: pipelinesRunnerClusterRoleName},
+			})
 
 			crNN := types.NamespacedName{Name: pipelinesRunnerClusterRoleName}
 
@@ -1135,9 +1135,6 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 				g.Expect(cr.Rules).NotTo(BeEmpty())
 				originalRules = cr.Rules
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
-			})
 
 			By("modifying the ClusterRole rules")
 			Eventually(func(g Gomega) {
@@ -1166,7 +1163,9 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+			testutil.DeferCleanupParentAndChildren(k8sClient, buildService, &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: pipelinesRunnerClusterRoleBindingName},
+			})
 
 			crbNN := types.NamespacedName{Name: pipelinesRunnerClusterRoleBindingName}
 
@@ -1178,9 +1177,6 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 				g.Expect(crb.Subjects).NotTo(BeEmpty())
 				originalSubjects = crb.Subjects
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: crbNN.Name},
-			})
 
 			By("modifying the ClusterRoleBinding subjects")
 			Eventually(func(g Gomega) {

--- a/operator/internal/controller/certmanager/konfluxcertmanager_controller_test.go
+++ b/operator/internal/controller/certmanager/konfluxcertmanager_controller_test.go
@@ -116,22 +116,23 @@ var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 			g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
 		}
 
-		// Clean up after each spec. DeleteAndWait is a no-op when the object is already absent,
-		// so all deletions are safe to run unconditionally.
-		// ClusterIssuers are cleaned up explicitly because envtest has no GC controller, so
-		// OwnerReferences do not trigger cascading deletion.
-		AfterEach(func(ctx context.Context) {
-			testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxCertManager{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
-			testutil.DeleteAndWait(ctx, k8sClient, newClusterIssuer(bootstrapIssuerName))
-			testutil.DeleteAndWait(ctx, k8sClient, newClusterIssuer(issuerName))
-			testutil.DeleteAndWait(ctx, k8sClient, newCertificate(certificateName, certManagerNamespace))
-		})
+		// certManagerChildren lists all cluster-scoped/namespaced children that envtest's
+		// missing GC won't cascade-delete when the parent CR is removed.
+		certManagerChildren := func() []client.Object {
+			return []client.Object{
+				newClusterIssuer(bootstrapIssuerName),
+				newClusterIssuer(issuerName),
+				newCertificate(certificateName, certManagerNamespace),
+			}
+		}
 
 		Context("with createClusterIssuer unset (defaults to enabled)", func() {
 			It("should successfully reconcile the resource and create ClusterIssuers", func(ctx context.Context) {
-				Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxCertManager{
+				cm := &konfluxv1alpha1.KonfluxCertManager{
 					ObjectMeta: metav1.ObjectMeta{Name: CRName},
-				})).To(Succeed())
+				}
+				Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+				testutil.DeferCleanupParentAndChildren(k8sClient, cm, certManagerChildren()...)
 				Eventually(waitForReady).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 				By("verifying ClusterIssuers were created")
@@ -143,10 +144,12 @@ var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 		Context("with createClusterIssuer explicitly enabled", func() {
 			It("should successfully reconcile the resource and create ClusterIssuers", func(ctx context.Context) {
 				enabled := true
-				Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxCertManager{
+				cm := &konfluxv1alpha1.KonfluxCertManager{
 					ObjectMeta: metav1.ObjectMeta{Name: CRName},
 					Spec:       konfluxv1alpha1.KonfluxCertManagerSpec{CreateClusterIssuer: &enabled},
-				})).To(Succeed())
+				}
+				Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+				testutil.DeferCleanupParentAndChildren(k8sClient, cm, certManagerChildren()...)
 				Eventually(waitForReady).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 				By("verifying ClusterIssuers were created")
@@ -158,10 +161,12 @@ var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 		Context("with createClusterIssuer disabled", func() {
 			It("should successfully reconcile the resource and not create ClusterIssuers", func(ctx context.Context) {
 				disabled := false
-				Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxCertManager{
+				cm := &konfluxv1alpha1.KonfluxCertManager{
 					ObjectMeta: metav1.ObjectMeta{Name: CRName},
 					Spec:       konfluxv1alpha1.KonfluxCertManagerSpec{CreateClusterIssuer: &disabled},
-				})).To(Succeed())
+				}
+				Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+				testutil.DeferCleanupParentAndChildren(k8sClient, cm, certManagerChildren()...)
 				Eventually(waitForReady).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 				By("verifying no ClusterIssuers were created")
@@ -174,9 +179,11 @@ var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 
 		Context("Self-healing", func() {
 			It("recreates ClusterIssuer when deleted", func(ctx context.Context) {
-				Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxCertManager{
+				cm := &konfluxv1alpha1.KonfluxCertManager{
 					ObjectMeta: metav1.ObjectMeta{Name: CRName},
-				})).To(Succeed())
+				}
+				Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+				testutil.DeferCleanupParentAndChildren(k8sClient, cm, certManagerChildren()...)
 
 				By("waiting for initial ClusterIssuer creation")
 				Eventually(func(g Gomega) {
@@ -196,9 +203,11 @@ var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 			})
 
 			It("recreates Certificate when deleted", func(ctx context.Context) {
-				Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxCertManager{
+				cm := &konfluxv1alpha1.KonfluxCertManager{
 					ObjectMeta: metav1.ObjectMeta{Name: CRName},
-				})).To(Succeed())
+				}
+				Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+				testutil.DeferCleanupParentAndChildren(k8sClient, cm, certManagerChildren()...)
 
 				certNN := types.NamespacedName{
 					Name:      certificateName,
@@ -226,9 +235,11 @@ var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 
 		Context("Drift correction", func() {
 			It("restores ClusterIssuer labels when stripped", func(ctx context.Context) {
-				Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxCertManager{
+				cm := &konfluxv1alpha1.KonfluxCertManager{
 					ObjectMeta: metav1.ObjectMeta{Name: CRName},
-				})).To(Succeed())
+				}
+				Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+				testutil.DeferCleanupParentAndChildren(k8sClient, cm, certManagerChildren()...)
 
 				By("waiting for initial ClusterIssuer creation with ownership labels")
 				Eventually(func(g Gomega) {
@@ -260,9 +271,11 @@ var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 			})
 
 			It("restores Certificate labels when stripped", func(ctx context.Context) {
-				Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxCertManager{
+				cm := &konfluxv1alpha1.KonfluxCertManager{
 					ObjectMeta: metav1.ObjectMeta{Name: CRName},
-				})).To(Succeed())
+				}
+				Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+				testutil.DeferCleanupParentAndChildren(k8sClient, cm, certManagerChildren()...)
 
 				certNN := types.NamespacedName{
 					Name:      certificateName,

--- a/operator/internal/controller/cli/konfluxcli_controller_test.go
+++ b/operator/internal/controller/cli/konfluxcli_controller_test.go
@@ -36,12 +36,11 @@ import (
 var _ = Describe("KonfluxCLI Controller", func() {
 	Context("When reconciling a resource", func() {
 		It("should successfully reconcile the resource", func(ctx context.Context) {
-			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxCLI{
+			cliRes := &konfluxv1alpha1.KonfluxCLI{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
-			})).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxCLI{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
-			})
+			}
+			Expect(k8sClient.Create(ctx, cliRes)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, cliRes)
 
 			// The CLI manifests contain no Deployments — only a Namespace, ConfigMaps, and
 			// RBAC resources — so Ready=True is a reliable sentinel that the full

--- a/operator/internal/controller/defaulttenant/konfluxdefaulttenant_controller_test.go
+++ b/operator/internal/controller/defaulttenant/konfluxdefaulttenant_controller_test.go
@@ -108,11 +108,7 @@ var _ = Describe("KonfluxDefaultTenant Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: internalregistry.CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(func() {
-				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxInternalRegistry{
-					ObjectMeta: metav1.ObjectMeta{Name: internalregistry.CRName},
-				})
-			})
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
 
 			Expect(k8sClient.Create(ctx, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{Name: RegistrySourceSecretNamespace},
@@ -129,14 +125,7 @@ var _ = Describe("KonfluxDefaultTenant Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, source)).To(Succeed())
-			DeferCleanup(func() {
-				testutil.DeleteAndWait(ctx, k8sClient, &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      RegistrySourceSecretName,
-						Namespace: RegistrySourceSecretNamespace,
-					},
-				})
-			})
+			testutil.DeferCleanupParentAndChildren(k8sClient, source)
 
 			// Source secret watch should enqueue KonfluxDefaultTenant reconcile.
 			Eventually(func(g Gomega) {

--- a/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
+++ b/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
@@ -54,16 +54,13 @@ var _ = Describe("KonfluxEnterpriseContract Controller", Ordered, func() {
 		}
 	}
 
-	AfterEach(func(ctx context.Context) {
-		testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxEnterpriseContract{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
-		testutil.DeleteAndWait(ctx, k8sClient, newDefaultECPolicy())
-	})
-
 	Context("with skipPolicies unset (defaults to deploying policies)", func() {
 		It("should successfully reconcile and create policies", func(ctx context.Context) {
-			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxEnterpriseContract{
+			ec := &konfluxv1alpha1.KonfluxEnterpriseContract{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
-			})).To(Succeed())
+			}
+			Expect(k8sClient.Create(ctx, ec)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ec, newDefaultECPolicy())
 
 			Eventually(waitForReady(ctx)).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
@@ -86,12 +83,14 @@ var _ = Describe("KonfluxEnterpriseContract Controller", Ordered, func() {
 
 	Context("with skipPolicies set to true", func() {
 		It("should reconcile without creating EnterpriseContractPolicy resources", func(ctx context.Context) {
-			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxEnterpriseContract{
+			ec := &konfluxv1alpha1.KonfluxEnterpriseContract{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 				Spec: konfluxv1alpha1.KonfluxEnterpriseContractSpec{
 					SkipPolicies: true,
 				},
-			})).To(Succeed())
+			}
+			Expect(k8sClient.Create(ctx, ec)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ec, newDefaultECPolicy())
 
 			Eventually(waitForReady(ctx)).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
@@ -118,6 +117,7 @@ var _ = Describe("KonfluxEnterpriseContract Controller", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, newDefaultECPolicy())
 
 			Eventually(waitForReady(ctx)).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
@@ -153,6 +153,7 @@ var _ = Describe("KonfluxEnterpriseContract Controller", Ordered, func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, newDefaultECPolicy())
 
 			Eventually(waitForReady(ctx)).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 

--- a/operator/internal/controller/imagecontroller/konfluximagecontroller_controller_test.go
+++ b/operator/internal/controller/imagecontroller/konfluximagecontroller_controller_test.go
@@ -286,7 +286,7 @@ var _ = Describe("KonfluxImageController Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, imageController)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, imageController)
+			testutil.DeferCleanupParentAndChildren(k8sClient, imageController, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: managerClusterRoleName}})
 
 			crNN := types.NamespacedName{Name: managerClusterRoleName}
 
@@ -294,9 +294,6 @@ var _ = Describe("KonfluxImageController Controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, crNN, &rbacv1.ClusterRole{})).To(Succeed())
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
-			})
 
 			By("deleting the ClusterRole")
 			Expect(k8sClient.Delete(ctx, &rbacv1.ClusterRole{
@@ -316,7 +313,7 @@ var _ = Describe("KonfluxImageController Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, imageController)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, imageController)
+			testutil.DeferCleanupParentAndChildren(k8sClient, imageController, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: managerClusterRoleBindingName}})
 
 			crbNN := types.NamespacedName{Name: managerClusterRoleBindingName}
 
@@ -324,9 +321,6 @@ var _ = Describe("KonfluxImageController Controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, crbNN, &rbacv1.ClusterRoleBinding{})).To(Succeed())
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: crbNN.Name},
-			})
 
 			By("deleting the ClusterRoleBinding")
 			Expect(k8sClient.Delete(ctx, &rbacv1.ClusterRoleBinding{
@@ -666,7 +660,7 @@ var _ = Describe("KonfluxImageController Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, imageController)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, imageController)
+			testutil.DeferCleanupParentAndChildren(k8sClient, imageController, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: managerClusterRoleName}})
 
 			crNN := types.NamespacedName{Name: managerClusterRoleName}
 
@@ -678,9 +672,6 @@ var _ = Describe("KonfluxImageController Controller", func() {
 				g.Expect(cr.Rules).NotTo(BeEmpty())
 				originalRules = cr.Rules
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
-			})
 
 			By("modifying the ClusterRole rules")
 			Eventually(func(g Gomega) {
@@ -707,7 +698,7 @@ var _ = Describe("KonfluxImageController Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, imageController)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, imageController)
+			testutil.DeferCleanupParentAndChildren(k8sClient, imageController, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: managerClusterRoleBindingName}})
 
 			crbNN := types.NamespacedName{Name: managerClusterRoleBindingName}
 
@@ -719,9 +710,6 @@ var _ = Describe("KonfluxImageController Controller", func() {
 				g.Expect(crb.Subjects).NotTo(BeEmpty())
 				originalSubjects = crb.Subjects
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: crbNN.Name},
-			})
 
 			By("modifying the ClusterRoleBinding subjects")
 			Eventually(func(g Gomega) {

--- a/operator/internal/controller/info/konfluxinfo_controller_test.go
+++ b/operator/internal/controller/info/konfluxinfo_controller_test.go
@@ -34,12 +34,11 @@ import (
 var _ = Describe("KonfluxInfo Controller", func() {
 	Context("When reconciling a resource", func() {
 		It("should successfully reconcile the resource", func(ctx context.Context) {
-			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxInfo{
+			infoRes := &konfluxv1alpha1.KonfluxInfo{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
-			})).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxInfo{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
-			})
+			}
+			Expect(k8sClient.Create(ctx, infoRes)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, infoRes)
 
 			Eventually(func(g Gomega) {
 				updated := &konfluxv1alpha1.KonfluxInfo{}
@@ -117,9 +116,7 @@ var _ = Describe("KonfluxInfo Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				testutil.DeleteAndWait(ctx, k8sClient, cr)
-			})
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr)
 		})
 	})
 })

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_test.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_test.go
@@ -450,7 +450,9 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, integrationService)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, integrationService)
+			testutil.DeferCleanupParentAndChildren(k8sClient, integrationService, &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{Name: managerClusterRoleName},
+			})
 
 			crNN := types.NamespacedName{Name: managerClusterRoleName}
 
@@ -458,9 +460,6 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, crNN, &rbacv1.ClusterRole{})).To(Succeed())
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
-			})
 
 			By("deleting the ClusterRole")
 			Expect(k8sClient.Delete(ctx, &rbacv1.ClusterRole{
@@ -480,7 +479,9 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, integrationService)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, integrationService)
+			testutil.DeferCleanupParentAndChildren(k8sClient, integrationService, &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: managerClusterRoleBindingName},
+			})
 
 			crbNN := types.NamespacedName{Name: managerClusterRoleBindingName}
 
@@ -488,9 +489,6 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, crbNN, &rbacv1.ClusterRoleBinding{})).To(Succeed())
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: crbNN.Name},
-			})
 
 			By("deleting the ClusterRoleBinding")
 			Expect(k8sClient.Delete(ctx, &rbacv1.ClusterRoleBinding{
@@ -830,7 +828,9 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, integrationService)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, integrationService)
+			testutil.DeferCleanupParentAndChildren(k8sClient, integrationService, &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{Name: managerClusterRoleName},
+			})
 
 			crNN := types.NamespacedName{Name: managerClusterRoleName}
 
@@ -842,9 +842,6 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 				g.Expect(cr.Rules).NotTo(BeEmpty())
 				originalRules = cr.Rules
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
-			})
 
 			By("modifying the ClusterRole rules")
 			Eventually(func(g Gomega) {
@@ -871,7 +868,9 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, integrationService)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, integrationService)
+			testutil.DeferCleanupParentAndChildren(k8sClient, integrationService, &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: managerClusterRoleBindingName},
+			})
 
 			crbNN := types.NamespacedName{Name: managerClusterRoleBindingName}
 
@@ -883,9 +882,6 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 				g.Expect(crb.Subjects).NotTo(BeEmpty())
 				originalSubjects = crb.Subjects
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: crbNN.Name},
-			})
 
 			By("modifying the ClusterRoleBinding subjects")
 			Eventually(func(g Gomega) {

--- a/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
+++ b/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
@@ -101,7 +101,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
 
 			deploymentNN := types.NamespacedName{
 				Name:      "registry",
@@ -134,7 +134,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
 
 			cmNN := types.NamespacedName{
 				Name:      "zot-config",
@@ -164,7 +164,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
 
 			svcNN := types.NamespacedName{
 				Name:      "registry-service",
@@ -194,7 +194,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
 
 			secretNN := types.NamespacedName{
 				Name:      HtpasswdSecretName,
@@ -224,7 +224,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
 
 			certNN := types.NamespacedName{
 				Name:      "registry-cert",
@@ -257,7 +257,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
 
 			deploymentNN := types.NamespacedName{
 				Name:      "registry",
@@ -300,7 +300,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
 
 			cmNN := types.NamespacedName{
 				Name:      "zot-config",
@@ -337,7 +337,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
 
 			svcNN := types.NamespacedName{
 				Name:      "registry-service",
@@ -376,7 +376,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
 
 			certNN := types.NamespacedName{
 				Name:      "registry-cert",
@@ -413,7 +413,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
 
 			secretNN := types.NamespacedName{
 				Name:      HtpasswdSecretName,
@@ -452,7 +452,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
 
 			nsNN := types.NamespacedName{
 				Name: internalRegistryNamespace,

--- a/operator/internal/controller/konflux/konflux_controller_certmanager_test.go
+++ b/operator/internal/controller/konflux/konflux_controller_certmanager_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Konflux Controller - Cert-Manager Dependency", func() {
 
 			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr)
 
 			Eventually(func(g Gomega) {
 				updated := &konfluxv1alpha1.Konflux{}
@@ -120,7 +120,7 @@ var _ = Describe("Konflux Controller - Cert-Manager Dependency", func() {
 
 			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr)
 
 			Eventually(func(g Gomega) {
 				updated := &konfluxv1alpha1.Konflux{}
@@ -139,7 +139,7 @@ var _ = Describe("Konflux Controller - Cert-Manager Dependency", func() {
 
 			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr)
 
 			// Wait for CertManagerAvailable=True to confirm reconcile ran.
 			Eventually(func(g Gomega) {
@@ -180,7 +180,7 @@ var _ = Describe("Konflux Controller - Cert-Manager Dependency", func() {
 
 			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr)
 
 			Eventually(func(g Gomega) {
 				updated := &konfluxv1alpha1.Konflux{}
@@ -199,7 +199,7 @@ var _ = Describe("Konflux Controller - Cert-Manager Dependency", func() {
 
 			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr)
 
 			// Wait for CertManagerAvailable=Unknown to confirm reconcile ran.
 			Eventually(func(g Gomega) {

--- a/operator/internal/controller/konflux/konflux_controller_test.go
+++ b/operator/internal/controller/konflux/konflux_controller_test.go
@@ -27,12 +27,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/applicationapi"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/buildservice"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/certmanager"
+	"github.com/konflux-ci/konflux-ci/operator/internal/controller/cli"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/defaulttenant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/enterprisecontract"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/imagecontroller"
@@ -49,6 +51,29 @@ import (
 )
 
 var _ = Describe("Konflux Controller", func() {
+	// allSubCRs returns every sub-CR the Konflux reconciler can create (unconditional + conditional).
+	// envtest has no GC, so these must be cleaned explicitly after each test.
+	// Conditional sub-CRs that were not created are safe to list: DeleteAndWait is a no-op when absent.
+	allSubCRs := func() []client.Object {
+		return []client.Object{
+			&konfluxv1alpha1.KonfluxApplicationAPI{ObjectMeta: metav1.ObjectMeta{Name: applicationapi.CRName}},
+			&konfluxv1alpha1.KonfluxBuildService{ObjectMeta: metav1.ObjectMeta{Name: buildservice.CRName}},
+			&konfluxv1alpha1.KonfluxIntegrationService{ObjectMeta: metav1.ObjectMeta{Name: integrationservice.CRName}},
+			&konfluxv1alpha1.KonfluxReleaseService{ObjectMeta: metav1.ObjectMeta{Name: releaseservice.CRName}},
+			&konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: uictrl.CRName}},
+			&konfluxv1alpha1.KonfluxRBAC{ObjectMeta: metav1.ObjectMeta{Name: rbac.CRName}},
+			&konfluxv1alpha1.KonfluxInfo{ObjectMeta: metav1.ObjectMeta{Name: info.CRName}},
+			&konfluxv1alpha1.KonfluxNamespaceLister{ObjectMeta: metav1.ObjectMeta{Name: namespacelister.CRName}},
+			&konfluxv1alpha1.KonfluxEnterpriseContract{ObjectMeta: metav1.ObjectMeta{Name: enterprisecontract.CRName}},
+			&konfluxv1alpha1.KonfluxCertManager{ObjectMeta: metav1.ObjectMeta{Name: certmanager.CRName}},
+			&konfluxv1alpha1.KonfluxDefaultTenant{ObjectMeta: metav1.ObjectMeta{Name: defaulttenant.CRName}},
+			&konfluxv1alpha1.KonfluxCLI{ObjectMeta: metav1.ObjectMeta{Name: cli.CRName}},
+			&konfluxv1alpha1.KonfluxInternalRegistry{ObjectMeta: metav1.ObjectMeta{Name: internalregistry.CRName}},
+			&konfluxv1alpha1.KonfluxSegmentBridge{ObjectMeta: metav1.ObjectMeta{Name: segmentbridge.CRName}},
+			&konfluxv1alpha1.KonfluxImageController{ObjectMeta: metav1.ObjectMeta{Name: imagecontroller.CRName}},
+		}
+	}
+
 	// startManager creates a per-test manager with the given ClusterInfo
 	// and registers a DeferCleanup to cancel it after the test.
 	// A per-test manager is required because each test wires the reconciler with a different
@@ -75,7 +100,7 @@ var _ = Describe("Konflux Controller", func() {
 
 			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			// The Ready condition is written only after the reconciler completes all apply/get/status steps
 			// without an early error return. Its presence (regardless of True/False) is therefore a reliable
@@ -120,7 +145,7 @@ var _ = Describe("Konflux Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: requiredKonfluxName},
 			}
 			Expect(k8sClient.Create(ctx, konflux)).To(Succeed(), "Creation with required name should be allowed")
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, konflux)
+			testutil.DeferCleanupParentAndChildren(k8sClient, konflux)
 
 			By("verifying the instance was created")
 			created := &konfluxv1alpha1.Konflux{}
@@ -144,7 +169,7 @@ var _ = Describe("Konflux Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: requiredKonfluxName},
 			}
 			Expect(k8sClient.Create(ctx, konflux)).To(Succeed(), "Failed to create Konflux instance")
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, konflux)
+			testutil.DeferCleanupParentAndChildren(k8sClient, konflux)
 
 			By("updating the instance")
 			updated := &konfluxv1alpha1.Konflux{}
@@ -166,7 +191,7 @@ var _ = Describe("Konflux Controller", func() {
 			By("creating Konflux CR without internalRegistry config")
 			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: resourceName}}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("waiting for reconcile to complete")
 			Eventually(func(g Gomega) {
@@ -193,7 +218,7 @@ var _ = Describe("Konflux Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("waiting for reconcile to complete")
 			Eventually(func(g Gomega) {
@@ -220,9 +245,7 @@ var _ = Describe("Konflux Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
-			DeferCleanup(testutil.DeleteAndWait, k8sClient,
-				&konfluxv1alpha1.KonfluxInternalRegistry{ObjectMeta: metav1.ObjectMeta{Name: internalregistry.CRName}})
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("verifying InternalRegistry CR was created")
 			registry := &konfluxv1alpha1.KonfluxInternalRegistry{}
@@ -244,7 +267,7 @@ var _ = Describe("Konflux Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("waiting for InternalRegistry CR to be created")
 			Eventually(func(g Gomega) {
@@ -277,9 +300,7 @@ var _ = Describe("Konflux Controller", func() {
 			By("creating Konflux CR without defaultTenant config")
 			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: resourceName}}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
-			DeferCleanup(testutil.DeleteAndWait, k8sClient,
-				&konfluxv1alpha1.KonfluxDefaultTenant{ObjectMeta: metav1.ObjectMeta{Name: defaulttenant.CRName}})
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("verifying DefaultTenant CR was created (enabled by default)")
 			tenant := &konfluxv1alpha1.KonfluxDefaultTenant{}
@@ -301,9 +322,7 @@ var _ = Describe("Konflux Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
-			DeferCleanup(testutil.DeleteAndWait, k8sClient,
-				&konfluxv1alpha1.KonfluxDefaultTenant{ObjectMeta: metav1.ObjectMeta{Name: defaulttenant.CRName}})
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("verifying DefaultTenant CR was created")
 			Eventually(func(g Gomega) {
@@ -324,7 +343,7 @@ var _ = Describe("Konflux Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("waiting for reconcile to complete")
 			Eventually(func(g Gomega) {
@@ -351,7 +370,7 @@ var _ = Describe("Konflux Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("waiting for DefaultTenant CR to be created")
 			Eventually(func(g Gomega) {
@@ -384,7 +403,7 @@ var _ = Describe("Konflux Controller", func() {
 			By("creating Konflux CR without telemetry config")
 			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: resourceName}}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("waiting for reconcile to complete")
 			Eventually(func(g Gomega) {
@@ -411,7 +430,7 @@ var _ = Describe("Konflux Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("waiting for reconcile to complete")
 			Eventually(func(g Gomega) {
@@ -438,9 +457,7 @@ var _ = Describe("Konflux Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
-			DeferCleanup(testutil.DeleteAndWait, k8sClient,
-				&konfluxv1alpha1.KonfluxSegmentBridge{ObjectMeta: metav1.ObjectMeta{Name: segmentbridge.CRName}})
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("verifying SegmentBridge CR was created")
 			sb := &konfluxv1alpha1.KonfluxSegmentBridge{}
@@ -462,7 +479,7 @@ var _ = Describe("Konflux Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("waiting for SegmentBridge CR to be created")
 			Eventually(func(g Gomega) {
@@ -501,9 +518,7 @@ var _ = Describe("Konflux Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
-			DeferCleanup(testutil.DeleteAndWait, k8sClient,
-				&konfluxv1alpha1.KonfluxImageController{ObjectMeta: metav1.ObjectMeta{Name: imagecontroller.CRName}})
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("verifying ImageController CR was created with empty spec")
 			ic := &konfluxv1alpha1.KonfluxImageController{}
@@ -533,9 +548,7 @@ var _ = Describe("Konflux Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
-			DeferCleanup(testutil.DeleteAndWait, k8sClient,
-				&konfluxv1alpha1.KonfluxImageController{ObjectMeta: metav1.ObjectMeta{Name: imagecontroller.CRName}})
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("verifying ImageController CR has the quayCABundle spec")
 			ic := &konfluxv1alpha1.KonfluxImageController{}
@@ -567,9 +580,7 @@ var _ = Describe("Konflux Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
-			DeferCleanup(testutil.DeleteAndWait, k8sClient,
-				&konfluxv1alpha1.KonfluxImageController{ObjectMeta: metav1.ObjectMeta{Name: imagecontroller.CRName}})
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("waiting for ImageController CR to be created with quayCABundle")
 			Eventually(func(g Gomega) {
@@ -604,9 +615,7 @@ var _ = Describe("Konflux Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
-			DeferCleanup(testutil.DeleteAndWait, k8sClient,
-				&konfluxv1alpha1.KonfluxEnterpriseContract{ObjectMeta: metav1.ObjectMeta{Name: enterprisecontract.CRName}})
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("verifying EnterpriseContract CR was created with skipPolicies=false")
 			ec := &konfluxv1alpha1.KonfluxEnterpriseContract{}
@@ -629,9 +638,7 @@ var _ = Describe("Konflux Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
-			DeferCleanup(testutil.DeleteAndWait, k8sClient,
-				&konfluxv1alpha1.KonfluxEnterpriseContract{ObjectMeta: metav1.ObjectMeta{Name: enterprisecontract.CRName}})
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("verifying EnterpriseContract CR has skipPolicies=true")
 			ec := &konfluxv1alpha1.KonfluxEnterpriseContract{}
@@ -654,9 +661,7 @@ var _ = Describe("Konflux Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
-			DeferCleanup(testutil.DeleteAndWait, k8sClient,
-				&konfluxv1alpha1.KonfluxEnterpriseContract{ObjectMeta: metav1.ObjectMeta{Name: enterprisecontract.CRName}})
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("waiting for EnterpriseContract CR to be created with skipPolicies=true")
 			Eventually(func(g Gomega) {
@@ -688,14 +693,14 @@ var _ = Describe("Konflux Controller", func() {
 				Spec:       konfluxv1alpha1.KonfluxEnterpriseContractSpec{SkipPolicies: true},
 			}
 			Expect(k8sClient.Create(ctx, preExisting)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, preExisting)
+			testutil.DeferCleanupParentAndChildren(k8sClient, preExisting)
 
 			By("creating Konflux CR without enterpriseContract config (defaults to skipPolicies=false)")
 			cr := &konfluxv1alpha1.Konflux{
 				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
 
 			By("verifying the Konflux controller resets skipPolicies to false via SSA")
 			Eventually(func(g Gomega) {

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
@@ -270,7 +270,9 @@ var _ = Describe("KonfluxNamespaceLister Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+			testutil.DeferCleanupParentAndChildren(k8sClient, namespaceLister,
+				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: authorizerClusterRoleName}},
+			)
 
 			crNN := types.NamespacedName{Name: authorizerClusterRoleName}
 
@@ -278,9 +280,6 @@ var _ = Describe("KonfluxNamespaceLister Controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, crNN, &rbacv1.ClusterRole{})).To(Succeed())
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
-			})
 
 			By("deleting the ClusterRole")
 			Expect(k8sClient.Delete(ctx, &rbacv1.ClusterRole{
@@ -300,7 +299,9 @@ var _ = Describe("KonfluxNamespaceLister Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+			testutil.DeferCleanupParentAndChildren(k8sClient, namespaceLister,
+				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: authorizerClusterRoleName}},
+			)
 
 			crbNN := types.NamespacedName{Name: authorizerClusterRoleName}
 
@@ -308,9 +309,6 @@ var _ = Describe("KonfluxNamespaceLister Controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, crbNN, &rbacv1.ClusterRoleBinding{})).To(Succeed())
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: crbNN.Name},
-			})
 
 			By("deleting the ClusterRoleBinding")
 			Expect(k8sClient.Delete(ctx, &rbacv1.ClusterRoleBinding{
@@ -483,7 +481,9 @@ var _ = Describe("KonfluxNamespaceLister Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+			testutil.DeferCleanupParentAndChildren(k8sClient, namespaceLister,
+				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: authorizerClusterRoleName}},
+			)
 
 			crNN := types.NamespacedName{Name: authorizerClusterRoleName}
 
@@ -495,9 +495,6 @@ var _ = Describe("KonfluxNamespaceLister Controller", func() {
 				g.Expect(cr.Rules).NotTo(BeEmpty())
 				originalRules = cr.Rules
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
-			})
 
 			By("modifying the ClusterRole rules")
 			Eventually(func(g Gomega) {
@@ -524,7 +521,9 @@ var _ = Describe("KonfluxNamespaceLister Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+			testutil.DeferCleanupParentAndChildren(k8sClient, namespaceLister,
+				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: authorizerClusterRoleName}},
+			)
 
 			crbNN := types.NamespacedName{Name: authorizerClusterRoleName}
 
@@ -536,9 +535,6 @@ var _ = Describe("KonfluxNamespaceLister Controller", func() {
 				g.Expect(crb.Subjects).NotTo(BeEmpty())
 				originalSubjects = crb.Subjects
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: crbNN.Name},
-			})
 
 			By("modifying the ClusterRoleBinding subjects")
 			Eventually(func(g Gomega) {

--- a/operator/internal/controller/rbac/konfluxrbac_controller_test.go
+++ b/operator/internal/controller/rbac/konfluxrbac_controller_test.go
@@ -33,12 +33,11 @@ import (
 var _ = Describe("KonfluxRBAC Controller", func() {
 	Context("When reconciling a resource", func() {
 		It("should successfully reconcile the resource", func(ctx context.Context) {
-			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxRBAC{
+			rbacRes := &konfluxv1alpha1.KonfluxRBAC{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
-			})).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxRBAC{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
-			})
+			}
+			Expect(k8sClient.Create(ctx, rbacRes)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, rbacRes)
 
 			// The rbac manifests contain only ClusterRoles — no Deployments — so
 			// Ready=True is a reliable sentinel.

--- a/operator/internal/controller/releaseservice/konfluxreleaseservice_controller_test.go
+++ b/operator/internal/controller/releaseservice/konfluxreleaseservice_controller_test.go
@@ -34,12 +34,11 @@ const releaseServiceNamespace = "release-service"
 var _ = Describe("KonfluxReleaseService Controller", func() {
 	Context("When reconciling a resource", func() {
 		It("should successfully reconcile the resource", func(ctx context.Context) {
-			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxReleaseService{
+			releaseRes := &konfluxv1alpha1.KonfluxReleaseService{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
-			})).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxReleaseService{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
-			})
+			}
+			Expect(k8sClient.Create(ctx, releaseRes)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, releaseRes)
 
 			// Wait for the Deployment rather than Ready=True: UpdateComponentStatuses
 			// gates Ready=True on ReadyReplicas == Replicas, which never happens in

--- a/operator/internal/controller/segmentbridge/konfluxsegmentbridge_controller_test.go
+++ b/operator/internal/controller/segmentbridge/konfluxsegmentbridge_controller_test.go
@@ -81,18 +81,14 @@ var _ = Describe("KonfluxSegmentBridge Controller", func() {
 	// createCR creates the KonfluxSegmentBridge CR and registers cleanup for both
 	// the CR and the Secret the controller will create.
 	createCR := func(ctx context.Context) {
-		Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxSegmentBridge{
+		segmentRes := &konfluxv1alpha1.KonfluxSegmentBridge{
 			ObjectMeta: metav1.ObjectMeta{Name: CRName},
-		})).To(Succeed())
-		DeferCleanup(func(ctx context.Context) {
-			testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxSegmentBridge{
-				ObjectMeta: metav1.ObjectMeta{Name: CRName},
-			})
-			testutil.DeleteAndWait(ctx, k8sClient, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-				Name:      segmentBridgeSecretName,
-				Namespace: segmentBridgeNamespace,
-			}})
-		})
+		}
+		Expect(k8sClient.Create(ctx, segmentRes)).To(Succeed())
+		testutil.DeferCleanupParentAndChildren(k8sClient, segmentRes, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name:      segmentBridgeSecretName,
+			Namespace: segmentBridgeNamespace,
+		}})
 	}
 
 	// waitForSecret polls until the Secret exists and the caller's check passes.

--- a/operator/internal/controller/testutil/testutil.go
+++ b/operator/internal/controller/testutil/testutil.go
@@ -258,9 +258,25 @@ func DeleteAndWait(ctx context.Context, c client.Client, obj client.Object) {
 		// Propagate unexpected errors (e.g. network failure, unauthorized) immediately
 		// rather than masking them as a generic timeout.
 		g.Expect(err).NotTo(HaveOccurred(), "unexpected error while waiting for deletion of %s", key)
-		// err == nil: object still exists — keep retrying.
+		// Re-issue delete in case an in-flight reconcile recreated the object.
+		// After the parent CR is gone no new reconciles trigger, so this converges.
+		_ = c.Delete(ctx, obj) //nolint:errcheck
 		g.Expect(false).To(BeTrue(), "object %s still exists, waiting for deletion", key)
-	}).WithTimeout(10 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
+	}).WithTimeout(20 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
+}
+
+// DeferCleanupParentAndChildren registers a single DeferCleanup that deletes the parent
+// CR first (stopping the reconciler), then deletes orphaned cluster-scoped children
+// that envtest's missing GC won't cascade-delete. This avoids the Ginkgo DeferCleanup
+// LIFO ordering issue where separate DeferCleanup calls would delete children first
+// while the reconciler is still active and recreating them.
+func DeferCleanupParentAndChildren(c client.Client, parent client.Object, children ...client.Object) {
+	DeferCleanup(func(ctx context.Context) {
+		DeleteAndWait(ctx, c, parent)
+		for _, child := range children {
+			DeleteAndWait(ctx, c, child)
+		}
+	})
 }
 
 // StartManagerWithContext starts mgr in a goroutine tied to the provided context and

--- a/operator/internal/controller/ui/konfluxui_controller_test.go
+++ b/operator/internal/controller/ui/konfluxui_controller_test.go
@@ -1173,7 +1173,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, ui)
+			testutil.DeferCleanupParentAndChildren(k8sClient, ui, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: dexClusterRoleName}})
 
 			crNN := types.NamespacedName{Name: dexClusterRoleName}
 
@@ -1181,9 +1181,6 @@ var _ = Describe("KonfluxUI Controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, crNN, &rbacv1.ClusterRole{})).To(Succeed())
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
-			})
 
 			By("deleting the ClusterRole")
 			Expect(k8sClient.Delete(ctx, &rbacv1.ClusterRole{
@@ -1203,7 +1200,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, ui)
+			testutil.DeferCleanupParentAndChildren(k8sClient, ui, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: dexClusterRoleBindingName}})
 
 			crbNN := types.NamespacedName{Name: dexClusterRoleBindingName}
 
@@ -1211,9 +1208,6 @@ var _ = Describe("KonfluxUI Controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, crbNN, &rbacv1.ClusterRoleBinding{})).To(Succeed())
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: crbNN.Name},
-			})
 
 			By("deleting the ClusterRoleBinding")
 			Expect(k8sClient.Delete(ctx, &rbacv1.ClusterRoleBinding{
@@ -1466,7 +1460,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, ui)
+			testutil.DeferCleanupParentAndChildren(k8sClient, ui, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: dexClusterRoleName}})
 
 			crNN := types.NamespacedName{Name: dexClusterRoleName}
 
@@ -1478,9 +1472,6 @@ var _ = Describe("KonfluxUI Controller", func() {
 				g.Expect(cr.Rules).NotTo(BeEmpty())
 				originalRules = cr.Rules
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
-			})
 
 			By("modifying the ClusterRole rules")
 			Eventually(func(g Gomega) {
@@ -1507,7 +1498,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, ui)
+			testutil.DeferCleanupParentAndChildren(k8sClient, ui, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: dexClusterRoleBindingName}})
 
 			crbNN := types.NamespacedName{Name: dexClusterRoleBindingName}
 
@@ -1519,9 +1510,6 @@ var _ = Describe("KonfluxUI Controller", func() {
 				g.Expect(crb.Subjects).NotTo(BeEmpty())
 				originalSubjects = crb.Subjects
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: crbNN.Name},
-			})
 
 			By("modifying the ClusterRoleBinding subjects")
 			Eventually(func(g Gomega) {


### PR DESCRIPTION
Operator envtest controller tests suffered from intermittent cleanup
timeouts on CI caused by two related issues:

1. **DeferCleanup LIFO ordering conflict**: Ginkgo's DeferCleanup
   executes in LIFO order. When parent CR and children (ClusterRoles,
   ClusterRoleBindings, sub-CRs) were registered separately, children
   were deleted first — while the reconciler was still active and
   recreating them from the live parent.

2. **In-flight reconcile race**: Even with correct ordering, a
   controller's already-queued reconciliation could recreate a child
   after it was deleted, causing the cleanup poll to time out.

Changes:

- Add `testutil.DeferCleanupParentAndChildren` helper that wraps
  cleanup in a single DeferCleanup: deletes parent first (stopping
  the reconciler), then deletes orphaned children sequentially.

- Modify `testutil.DeleteAndWait` to re-issue the Delete call on each
  poll iteration, converging even when an in-flight reconcile recreates
  the object. Also increase timeout from 10s to 20s for CI headroom.

- Convert all 17 controller test files to use the new helper,
  replacing ad-hoc DeferCleanup/AfterEach patterns with one
  consistent approach.

- Add `alwaysOnSubCRs()` helper in the Konflux controller tests to
  ensure all 11 unconditionally-created sub-CRs are cleaned up,
  preventing orphan pollution across tests.

- Add child arguments to deletion/transition tests as a safety net:
  if the test fails midway (before the reconciler deletes the child),
  cleanup still succeeds.

- Document the pattern in AGENTS.md under the Testing section.

Assisted-by: Cursor + Opus 4.6