### PR TITLE
fix(KONFLUX-14569): remove IgnoreStatusUpdatesPredicate from Service and Secret watches

### DIFF
--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
@@ -354,7 +354,7 @@ func (r *KonfluxBuildServiceReconciler) SetupWithManager(mgr ctrl.Manager) error
 		// Use predicates to filter out unnecessary updates and prevent reconcile loops
 		// Deployments: watch spec changes AND readiness status changes
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).

--- a/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
+++ b/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
@@ -282,7 +282,7 @@ func (r *KonfluxImageControllerReconciler) SetupWithManager(mgr ctrl.Manager) er
 		// Deployments: watch spec changes AND readiness status changes
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
 		Owns(&batchv1.CronJob{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
@@ -312,7 +312,7 @@ func (r *KonfluxIntegrationServiceReconciler) SetupWithManager(mgr ctrl.Manager)
 		// Deployments: watch spec changes AND readiness status changes
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
 		Owns(&batchv1.CronJob{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).

--- a/operator/internal/controller/internalregistry/konfluxinternalregistry_controller.go
+++ b/operator/internal/controller/internalregistry/konfluxinternalregistry_controller.go
@@ -194,10 +194,10 @@ func (r *KonfluxInternalRegistryReconciler) SetupWithManager(mgr ctrl.Manager) e
 		For(&konfluxv1alpha1.KonfluxInternalRegistry{}).
 		Named("konfluxinternalregistry").
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.Service{}).
 		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		Owns(&corev1.ConfigMap{}).
-		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.Secret{}).
 		Owns(&certmanagerv1.Certificate{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		// NOTE: trust-manager Bundle (trust.cert-manager.io/v1alpha1) is not owned here
 		// because trust-manager's Go module pulls controller-runtime/k8s.io versions

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller.go
@@ -232,7 +232,7 @@ func (r *KonfluxNamespaceListerReconciler) SetupWithManager(mgr ctrl.Manager) er
 		// Use predicates to filter out unnecessary updates and prevent reconcile loops
 		// Deployments: watch spec changes AND readiness status changes
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.Service{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		Owns(&rbacv1.ClusterRole{}).

--- a/operator/internal/controller/releaseservice/konfluxreleaseservice_controller.go
+++ b/operator/internal/controller/releaseservice/konfluxreleaseservice_controller.go
@@ -265,7 +265,7 @@ func (r *KonfluxReleaseServiceReconciler) SetupWithManager(mgr ctrl.Manager) err
 		// Use predicates to filter out unnecessary updates and prevent reconcile loops
 		// Deployments: watch spec changes AND readiness status changes
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		Owns(&rbacv1.Role{}).

--- a/operator/internal/controller/ui/konfluxui_controller.go
+++ b/operator/internal/controller/ui/konfluxui_controller.go
@@ -697,7 +697,7 @@ func (r *KonfluxUIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Use predicates to filter out unnecessary updates and prevent reconcile loops
 		// Deployments: watch spec changes AND readiness status changes
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
-		Owns(&corev1.Service{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
+		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.ServiceAccount{}).

--- a/operator/internal/predicate/predicate.go
+++ b/operator/internal/predicate/predicate.go
@@ -48,6 +48,27 @@ func generationOrMetadataChanged(oldObj, newObj client.Object) bool {
 // IgnoreStatusUpdatesPredicate filters out status-only updates.
 // Reconciliation triggers on spec changes (generation bump), ownerReference
 // changes, and label/annotation changes.
+//
+// IMPORTANT: This predicate relies on metadata.generation incrementing on spec
+// changes. It must NOT be used on resources where generation is unreliable:
+//
+//   - Generation-exempt resources (hardcoded in kube-apiserver, generation
+//     always 0): Services, Namespaces, Nodes, PVs, PVCs, ResourceQuotas.
+//     Spec changes on these resources will NOT trigger reconciliation.
+//
+//   - Resources without a status subresource (Secrets, ConfigMaps,
+//     ServiceAccounts, RBAC resources). These never receive status-only
+//     updates, so the predicate provides no filtering benefit and can only
+//     block legitimate data changes.
+//
+// Safe to use on resources with a status subresource AND proper generation
+// tracking: Deployments (use DeploymentReadinessPredicate instead),
+// Certificates, Issuers, CronJobs, Ingresses, and all CRDs with /status.
+//
+// Exception: Namespaces keep this predicate because their spec only contains
+// .spec.finalizers (not managed by our controllers), and filtering
+// .status.phase transitions is desirable. Label/annotation drift is always
+// detected via the metadata comparison path regardless of generation.
 var IgnoreStatusUpdatesPredicate = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		if e.ObjectOld == nil || e.ObjectNew == nil {


### PR DESCRIPTION
Services and Secrets are on Kubernetes' hardcoded "generation-exempt" list (or lack a status subresource entirely), meaning metadata.generation always remains 0 and never increments on spec changes. IgnoreStatusUpdatesPredicate relies on generation bumps to pass update events through, so applying it to these resources silently blocks spec-drift reconciliation — the controller never sees the update event and only corrects the drift on the next unrelated requeue.

This caused flaky "restores Service spec when modified" test failures: the test mutates the Service spec and expects the controller to restore it, but the predicate filters out the update event because generation stays at 0.

Changes:
- Remove IgnoreStatusUpdatesPredicate from Owns(&corev1.Service{}) in all 7 controllers (buildservice, imagecontroller, integrationservice, internalregistry, namespacelister, releaseservice, ui)
- Remove IgnoreStatusUpdatesPredicate from Owns(&corev1.Secret{}) in internalregistry (Secrets have no status subresource — predicate is pointless and can only block legitimate data changes)
- Retain the predicate for Namespaces (spec is only .spec.finalizers which we don't manage; filtering status.phase transitions is still useful; label/annotation drift is detected via the metadata comparison path)
- Retain the predicate for Certificates, CronJobs, Ingresses, Issuers (proper generation tracking, frequent status updates worth filtering)
- Add documentation comment to predicate.go explaining generation-exempt resources and correct predicate usage

Note: Service and Secret drift tests will be updated to cover spec modification (in addition to existing label-stripping tests) in a follow-up PR once https://github.com/konflux-ci/konflux-ci/pull/7424 merges and the branch is rebased.

Assisted-by: Cursor + Opus 4.6