### PR TITLE
fix(KONFLUX-14569): add comprehensive spec drift tests for all owned resources

### DIFF
--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
@@ -953,6 +953,47 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
+		It("restores Service spec when modified", func(ctx context.Context) {
+			startManagerWithClusterInfo(nil)
+
+			buildService := &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+
+			svcNN := types.NamespacedName{
+				Name:      metricsServiceName,
+				Namespace: buildServiceNamespace,
+			}
+
+			By("waiting for initial Service creation")
+			var originalTargetPort int32
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Spec.Ports).NotTo(BeEmpty())
+				originalTargetPort = svc.Spec.Ports[0].TargetPort.IntVal
+				g.Expect(originalTargetPort).NotTo(BeZero())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the Service target port")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				svc.Spec.Ports[0].TargetPort.IntVal = 9999
+				g.Expect(k8sClient.Update(ctx, svc)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Service target port is restored")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Spec.Ports).NotTo(BeEmpty())
+				g.Expect(svc.Spec.Ports[0].TargetPort.IntVal).To(Equal(originalTargetPort))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
 		It("restores ConfigMap data when modified", func(ctx context.Context) {
 			startManagerWithClusterInfo(nil)
 
@@ -1195,6 +1236,52 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 				crb := &rbacv1.ClusterRoleBinding{}
 				g.Expect(k8sClient.Get(ctx, crbNN, crb)).To(Succeed())
 				g.Expect(crb.Subjects).To(Equal(originalSubjects))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores SecurityContextConstraints spec when modified", func(ctx context.Context) {
+			openShiftClusterInfo, err := clusterinfo.DetectWithClient(&buildServiceMockDiscoveryClient{
+				resources: map[string]*metav1.APIResourceList{
+					"config.openshift.io/v1": {
+						APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}},
+					},
+				},
+				serverVersion: &version.Info{GitVersion: "v1.29.0"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			startManagerWithClusterInfo(openShiftClusterInfo)
+
+			buildService := &konfluxv1alpha1.KonfluxBuildService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, buildService, &securityv1.SecurityContextConstraints{
+				ObjectMeta: metav1.ObjectMeta{Name: sccName},
+			})
+
+			sccNN := types.NamespacedName{Name: sccName}
+
+			By("waiting for initial SCC creation")
+			Eventually(func(g Gomega) {
+				scc := &securityv1.SecurityContextConstraints{}
+				g.Expect(k8sClient.Get(ctx, sccNN, scc)).To(Succeed())
+				g.Expect(scc.RunAsUser.Type).To(Equal(securityv1.RunAsUserStrategyRunAsAny))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the SCC RunAsUser strategy")
+			Eventually(func(g Gomega) {
+				scc := &securityv1.SecurityContextConstraints{}
+				g.Expect(k8sClient.Get(ctx, sccNN, scc)).To(Succeed())
+				scc.RunAsUser.Type = securityv1.RunAsUserStrategyMustRunAsRange
+				g.Expect(k8sClient.Update(ctx, scc)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the SCC RunAsUser strategy is restored")
+			Eventually(func(g Gomega) {
+				scc := &securityv1.SecurityContextConstraints{}
+				g.Expect(k8sClient.Get(ctx, sccNN, scc)).To(Succeed())
+				g.Expect(scc.RunAsUser.Type).To(Equal(securityv1.RunAsUserStrategyRunAsAny))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})

--- a/operator/internal/controller/certmanager/konfluxcertmanager_controller_test.go
+++ b/operator/internal/controller/certmanager/konfluxcertmanager_controller_test.go
@@ -42,6 +42,7 @@ const (
 	bootstrapIssuerName  = "konflux-bootstrap-issuer"
 	issuerName           = "konflux-issuer"
 	certificateName      = "konflux-ca"
+	caSecretName         = "konflux-ca-secret"
 )
 
 // clusterIssuerGVK is the GVK for cert-manager ClusterIssuer resources.
@@ -308,6 +309,108 @@ var _ = Describe("KonfluxCertManager Controller", Ordered, func() {
 					labels, _, _ := unstructured.NestedStringMap(obj.Object, "metadata", "labels")
 					g.Expect(labels).To(HaveKey(constant.KonfluxOwnerLabel))
 					g.Expect(labels).To(HaveKey(constant.KonfluxComponentLabel))
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			})
+
+			It("restores ClusterIssuer spec when modified", func(ctx context.Context) {
+				cm := &konfluxv1alpha1.KonfluxCertManager{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+				testutil.DeferCleanupParentAndChildren(k8sClient, cm, certManagerChildren()...)
+
+				By("waiting for initial ClusterIssuer creation")
+				Eventually(func(g Gomega) {
+					obj := newClusterIssuer(issuerName)
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: issuerName}, obj)).To(Succeed())
+					secretName, _, _ := unstructured.NestedString(obj.Object, "spec", "ca", "secretName")
+					g.Expect(secretName).To(Equal(caSecretName))
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("modifying the ClusterIssuer CA secret name")
+				Eventually(func(g Gomega) {
+					obj := newClusterIssuer(issuerName)
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: issuerName}, obj)).To(Succeed())
+					g.Expect(unstructured.SetNestedField(obj.Object, "tampered-secret", "spec", "ca", "secretName")).To(Succeed())
+					g.Expect(k8sClient.Update(ctx, obj)).To(Succeed())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("verifying the ClusterIssuer CA secret name is restored")
+				Eventually(func(g Gomega) {
+					obj := newClusterIssuer(issuerName)
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: issuerName}, obj)).To(Succeed())
+					secretName, _, _ := unstructured.NestedString(obj.Object, "spec", "ca", "secretName")
+					g.Expect(secretName).To(Equal(caSecretName))
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			})
+
+			It("restores bootstrap ClusterIssuer spec when modified", func(ctx context.Context) {
+				cm := &konfluxv1alpha1.KonfluxCertManager{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+				testutil.DeferCleanupParentAndChildren(k8sClient, cm, certManagerChildren()...)
+
+				By("waiting for initial bootstrap ClusterIssuer creation")
+				Eventually(func(g Gomega) {
+					obj := newClusterIssuer(bootstrapIssuerName)
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: bootstrapIssuerName}, obj)).To(Succeed())
+					_, found, _ := unstructured.NestedMap(obj.Object, "spec", "selfSigned")
+					g.Expect(found).To(BeTrue())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("replacing selfSigned with a CA spec")
+				Eventually(func(g Gomega) {
+					obj := newClusterIssuer(bootstrapIssuerName)
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: bootstrapIssuerName}, obj)).To(Succeed())
+					unstructured.RemoveNestedField(obj.Object, "spec", "selfSigned")
+					g.Expect(unstructured.SetNestedField(obj.Object, "fake-secret", "spec", "ca", "secretName")).To(Succeed())
+					g.Expect(k8sClient.Update(ctx, obj)).To(Succeed())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("verifying the bootstrap ClusterIssuer selfSigned spec is restored")
+				Eventually(func(g Gomega) {
+					obj := newClusterIssuer(bootstrapIssuerName)
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: bootstrapIssuerName}, obj)).To(Succeed())
+					_, found, _ := unstructured.NestedMap(obj.Object, "spec", "selfSigned")
+					g.Expect(found).To(BeTrue())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			})
+
+			It("restores Certificate spec when modified", func(ctx context.Context) {
+				cm := &konfluxv1alpha1.KonfluxCertManager{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+				testutil.DeferCleanupParentAndChildren(k8sClient, cm, certManagerChildren()...)
+
+				certNN := types.NamespacedName{
+					Name:      certificateName,
+					Namespace: certManagerNamespace,
+				}
+
+				By("waiting for initial Certificate creation")
+				Eventually(func(g Gomega) {
+					obj := newCertificate(certNN.Name, certNN.Namespace)
+					g.Expect(k8sClient.Get(ctx, certNN, obj)).To(Succeed())
+					issuer, _, _ := unstructured.NestedString(obj.Object, "spec", "issuerRef", "name")
+					g.Expect(issuer).To(Equal(bootstrapIssuerName))
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("modifying the Certificate issuerRef name")
+				Eventually(func(g Gomega) {
+					obj := newCertificate(certNN.Name, certNN.Namespace)
+					g.Expect(k8sClient.Get(ctx, certNN, obj)).To(Succeed())
+					g.Expect(unstructured.SetNestedField(obj.Object, "tampered-issuer", "spec", "issuerRef", "name")).To(Succeed())
+					g.Expect(k8sClient.Update(ctx, obj)).To(Succeed())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("verifying the Certificate issuerRef name is restored")
+				Eventually(func(g Gomega) {
+					obj := newCertificate(certNN.Name, certNN.Namespace)
+					g.Expect(k8sClient.Get(ctx, certNN, obj)).To(Succeed())
+					issuer, _, _ := unstructured.NestedString(obj.Object, "spec", "issuerRef", "name")
+					g.Expect(issuer).To(Equal(bootstrapIssuerName))
 				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 			})
 		})

--- a/operator/internal/controller/imagecontroller/konfluximagecontroller_controller_test.go
+++ b/operator/internal/controller/imagecontroller/konfluximagecontroller_controller_test.go
@@ -497,6 +497,45 @@ var _ = Describe("KonfluxImageController Controller", func() {
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
+		It("restores Service spec when modified", func(ctx context.Context) {
+			imageController := &konfluxv1alpha1.KonfluxImageController{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, imageController)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, imageController)
+
+			svcNN := types.NamespacedName{
+				Name:      metricsServiceName,
+				Namespace: imageControllerNamespace,
+			}
+
+			By("waiting for initial Service creation")
+			var originalTargetPort int32
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Spec.Ports).NotTo(BeEmpty())
+				originalTargetPort = svc.Spec.Ports[0].TargetPort.IntVal
+				g.Expect(originalTargetPort).NotTo(BeZero())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the Service target port")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				svc.Spec.Ports[0].TargetPort.IntVal = 9999
+				g.Expect(k8sClient.Update(ctx, svc)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Service target port is restored")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Spec.Ports).NotTo(BeEmpty())
+				g.Expect(svc.Spec.Ports[0].TargetPort.IntVal).To(Equal(originalTargetPort))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
 		It("restores ConfigMap data when modified", func(ctx context.Context) {
 			imageController := &konfluxv1alpha1.KonfluxImageController{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_test.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_test.go
@@ -665,6 +665,45 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
+		It("restores Service spec when modified", func(ctx context.Context) {
+			integrationService := &konfluxv1alpha1.KonfluxIntegrationService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, integrationService)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, integrationService)
+
+			svcNN := types.NamespacedName{
+				Name:      metricsServiceName,
+				Namespace: integrationServiceNamespace,
+			}
+
+			By("waiting for initial Service creation")
+			var originalTargetPort int32
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Spec.Ports).NotTo(BeEmpty())
+				originalTargetPort = svc.Spec.Ports[0].TargetPort.IntVal
+				g.Expect(originalTargetPort).NotTo(BeZero())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the Service target port")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				svc.Spec.Ports[0].TargetPort.IntVal = 9999
+				g.Expect(k8sClient.Update(ctx, svc)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Service target port is restored")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Spec.Ports).NotTo(BeEmpty())
+				g.Expect(svc.Spec.Ports[0].TargetPort.IntVal).To(Equal(originalTargetPort))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
 		It("restores ConfigMap data when modified", func(ctx context.Context) {
 			integrationService := &konfluxv1alpha1.KonfluxIntegrationService{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
@@ -1048,6 +1087,128 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 				g.Expect(k8sClient.Get(ctx, mwcNN, mwc)).To(Succeed())
 				g.Expect(mwc.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
 				g.Expect(mwc.Labels).To(HaveKey(constant.KonfluxComponentLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores Issuer spec when modified", func(ctx context.Context) {
+			integrationService := &konfluxv1alpha1.KonfluxIntegrationService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, integrationService)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, integrationService)
+
+			issuerNN := types.NamespacedName{
+				Name:      selfsignedIssuerName,
+				Namespace: integrationServiceNamespace,
+			}
+
+			By("waiting for initial Issuer creation with self-signed config")
+			Eventually(func(g Gomega) {
+				issuer := &certmanagerv1.Issuer{}
+				g.Expect(k8sClient.Get(ctx, issuerNN, issuer)).To(Succeed())
+				g.Expect(issuer.Spec.SelfSigned).NotTo(BeNil())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("replacing selfSigned with a CA spec")
+			Eventually(func(g Gomega) {
+				issuer := &certmanagerv1.Issuer{}
+				g.Expect(k8sClient.Get(ctx, issuerNN, issuer)).To(Succeed())
+				issuer.Spec.SelfSigned = nil
+				issuer.Spec.CA = &certmanagerv1.CAIssuer{SecretName: "tampered-secret"}
+				g.Expect(k8sClient.Update(ctx, issuer)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Issuer selfSigned spec is restored")
+			Eventually(func(g Gomega) {
+				issuer := &certmanagerv1.Issuer{}
+				g.Expect(k8sClient.Get(ctx, issuerNN, issuer)).To(Succeed())
+				g.Expect(issuer.Spec.SelfSigned).NotTo(BeNil())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores ValidatingWebhookConfiguration spec when modified", func(ctx context.Context) {
+			integrationService := &konfluxv1alpha1.KonfluxIntegrationService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, integrationService)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, integrationService,
+				&admissionregistrationv1.ValidatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: validatingWebhookName},
+				},
+			)
+
+			vwcNN := types.NamespacedName{Name: validatingWebhookName}
+
+			By("waiting for initial ValidatingWebhookConfiguration creation")
+			var originalPath string
+			Eventually(func(g Gomega) {
+				vwc := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+				g.Expect(k8sClient.Get(ctx, vwcNN, vwc)).To(Succeed())
+				g.Expect(vwc.Webhooks).NotTo(BeEmpty())
+				g.Expect(vwc.Webhooks[0].ClientConfig.Service).NotTo(BeNil())
+				originalPath = *vwc.Webhooks[0].ClientConfig.Service.Path
+				g.Expect(originalPath).NotTo(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the webhook path")
+			Eventually(func(g Gomega) {
+				vwc := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+				g.Expect(k8sClient.Get(ctx, vwcNN, vwc)).To(Succeed())
+				tampered := "/tampered-path"
+				vwc.Webhooks[0].ClientConfig.Service.Path = &tampered
+				g.Expect(k8sClient.Update(ctx, vwc)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the webhook path is restored")
+			Eventually(func(g Gomega) {
+				vwc := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+				g.Expect(k8sClient.Get(ctx, vwcNN, vwc)).To(Succeed())
+				g.Expect(vwc.Webhooks).NotTo(BeEmpty())
+				g.Expect(vwc.Webhooks[0].ClientConfig.Service).NotTo(BeNil())
+				g.Expect(*vwc.Webhooks[0].ClientConfig.Service.Path).To(Equal(originalPath))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores MutatingWebhookConfiguration spec when modified", func(ctx context.Context) {
+			integrationService := &konfluxv1alpha1.KonfluxIntegrationService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, integrationService)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, integrationService,
+				&admissionregistrationv1.MutatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: mutatingWebhookName},
+				},
+			)
+
+			mwcNN := types.NamespacedName{Name: mutatingWebhookName}
+
+			By("waiting for initial MutatingWebhookConfiguration creation")
+			var originalPath string
+			Eventually(func(g Gomega) {
+				mwc := &admissionregistrationv1.MutatingWebhookConfiguration{}
+				g.Expect(k8sClient.Get(ctx, mwcNN, mwc)).To(Succeed())
+				g.Expect(mwc.Webhooks).NotTo(BeEmpty())
+				g.Expect(mwc.Webhooks[0].ClientConfig.Service).NotTo(BeNil())
+				originalPath = *mwc.Webhooks[0].ClientConfig.Service.Path
+				g.Expect(originalPath).NotTo(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the webhook path")
+			Eventually(func(g Gomega) {
+				mwc := &admissionregistrationv1.MutatingWebhookConfiguration{}
+				g.Expect(k8sClient.Get(ctx, mwcNN, mwc)).To(Succeed())
+				tampered := "/tampered-path"
+				mwc.Webhooks[0].ClientConfig.Service.Path = &tampered
+				g.Expect(k8sClient.Update(ctx, mwc)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the webhook path is restored")
+			Eventually(func(g Gomega) {
+				mwc := &admissionregistrationv1.MutatingWebhookConfiguration{}
+				g.Expect(k8sClient.Get(ctx, mwcNN, mwc)).To(Succeed())
+				g.Expect(mwc.Webhooks).NotTo(BeEmpty())
+				g.Expect(mwc.Webhooks[0].ClientConfig.Service).NotTo(BeNil())
+				g.Expect(*mwc.Webhooks[0].ClientConfig.Service.Path).To(Equal(originalPath))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})

--- a/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
+++ b/operator/internal/controller/namespacelister/konfluxnamespacelister_controller_test.go
@@ -442,6 +442,45 @@ var _ = Describe("KonfluxNamespaceLister Controller", func() {
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
+		It("restores Service spec when modified", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			svcNN := types.NamespacedName{
+				Name:      namespaceListerNamespace,
+				Namespace: namespaceListerNamespace,
+			}
+
+			By("waiting for initial Service creation")
+			var originalTargetPort int32
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Spec.Ports).NotTo(BeEmpty())
+				originalTargetPort = svc.Spec.Ports[0].TargetPort.IntVal
+				g.Expect(originalTargetPort).NotTo(BeZero())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the Service target port")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				svc.Spec.Ports[0].TargetPort.IntVal = 9999
+				g.Expect(k8sClient.Update(ctx, svc)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Service target port is restored")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Spec.Ports).NotTo(BeEmpty())
+				g.Expect(svc.Spec.Ports[0].TargetPort.IntVal).To(Equal(originalTargetPort))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
 		It("restores Namespace labels when stripped", func(ctx context.Context) {
 			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
@@ -627,6 +666,111 @@ var _ = Describe("KonfluxNamespaceLister Controller", func() {
 				g.Expect(k8sClient.Get(ctx, certNN, cert)).To(Succeed())
 				g.Expect(cert.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
 				g.Expect(cert.Labels).To(HaveKey(constant.KonfluxComponentLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores ingress NetworkPolicy spec when modified", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			npNN := types.NamespacedName{
+				Name:      networkPolicyAllowFromKonfluxUIName,
+				Namespace: namespaceListerNamespace,
+			}
+
+			By("waiting for initial ingress NetworkPolicy creation")
+			Eventually(func(g Gomega) {
+				np := &networkingv1.NetworkPolicy{}
+				g.Expect(k8sClient.Get(ctx, npNN, np)).To(Succeed())
+				g.Expect(np.Spec.Ingress).NotTo(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the NetworkPolicy ingress rules")
+			Eventually(func(g Gomega) {
+				np := &networkingv1.NetworkPolicy{}
+				g.Expect(k8sClient.Get(ctx, npNN, np)).To(Succeed())
+				np.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{}
+				g.Expect(k8sClient.Update(ctx, np)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the NetworkPolicy ingress rules are restored")
+			Eventually(func(g Gomega) {
+				np := &networkingv1.NetworkPolicy{}
+				g.Expect(k8sClient.Get(ctx, npNN, np)).To(Succeed())
+				g.Expect(np.Spec.Ingress).NotTo(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores egress NetworkPolicy spec when modified", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			npNN := types.NamespacedName{
+				Name:      networkPolicyAllowToAPIServerName,
+				Namespace: namespaceListerNamespace,
+			}
+
+			By("waiting for initial egress NetworkPolicy creation")
+			Eventually(func(g Gomega) {
+				np := &networkingv1.NetworkPolicy{}
+				g.Expect(k8sClient.Get(ctx, npNN, np)).To(Succeed())
+				g.Expect(np.Spec.Egress).NotTo(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the NetworkPolicy egress rules")
+			Eventually(func(g Gomega) {
+				np := &networkingv1.NetworkPolicy{}
+				g.Expect(k8sClient.Get(ctx, npNN, np)).To(Succeed())
+				np.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{}
+				g.Expect(k8sClient.Update(ctx, np)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the NetworkPolicy egress rules are restored")
+			Eventually(func(g Gomega) {
+				np := &networkingv1.NetworkPolicy{}
+				g.Expect(k8sClient.Get(ctx, npNN, np)).To(Succeed())
+				g.Expect(np.Spec.Egress).NotTo(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores Certificate spec when modified", func(ctx context.Context) {
+			namespaceLister := &konfluxv1alpha1.KonfluxNamespaceLister{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, namespaceLister)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, namespaceLister)
+
+			certNN := types.NamespacedName{
+				Name:      namespaceListerNamespace,
+				Namespace: namespaceListerNamespace,
+			}
+
+			By("waiting for initial Certificate creation")
+			Eventually(func(g Gomega) {
+				cert := &certmanagerv1.Certificate{}
+				g.Expect(k8sClient.Get(ctx, certNN, cert)).To(Succeed())
+				g.Expect(cert.Spec.DNSNames).NotTo(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the Certificate DNS names")
+			Eventually(func(g Gomega) {
+				cert := &certmanagerv1.Certificate{}
+				g.Expect(k8sClient.Get(ctx, certNN, cert)).To(Succeed())
+				cert.Spec.DNSNames = []string{"tampered.example.com"}
+				g.Expect(k8sClient.Update(ctx, cert)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Certificate DNS names are restored")
+			Eventually(func(g Gomega) {
+				cert := &certmanagerv1.Certificate{}
+				g.Expect(k8sClient.Get(ctx, certNN, cert)).To(Succeed())
+				g.Expect(cert.Spec.DNSNames).To(ContainElement(namespaceListerNamespace + "." + namespaceListerNamespace + ".svc"))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})

--- a/operator/internal/controller/ui/konfluxui_controller_test.go
+++ b/operator/internal/controller/ui/konfluxui_controller_test.go
@@ -1421,6 +1421,42 @@ var _ = Describe("KonfluxUI Controller", func() {
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
+		It("restores Service spec when modified", func(ctx context.Context) {
+			startManager(noDefaultSegmentKey, nil)
+
+			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, ui)
+
+			svcNN := types.NamespacedName{Name: proxyServiceName, Namespace: uiNamespace}
+
+			By("waiting for initial Service creation")
+			var originalTargetPort string
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Spec.Ports).NotTo(BeEmpty())
+				originalTargetPort = svc.Spec.Ports[0].TargetPort.StrVal
+				g.Expect(originalTargetPort).NotTo(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the Service target port")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				svc.Spec.Ports[0].TargetPort.StrVal = "tampered"
+				g.Expect(k8sClient.Update(ctx, svc)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Service target port is restored")
+			Eventually(func(g Gomega) {
+				svc := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, svcNN, svc)).To(Succeed())
+				g.Expect(svc.Spec.Ports).NotTo(BeEmpty())
+				g.Expect(svc.Spec.Ports[0].TargetPort.StrVal).To(Equal(originalTargetPort))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
 		It("restores Namespace labels when stripped", func(ctx context.Context) {
 			startManager(noDefaultSegmentKey, nil)
 
@@ -1665,6 +1701,144 @@ var _ = Describe("KonfluxUI Controller", func() {
 				issuer := &certmanagerv1.Issuer{}
 				g.Expect(k8sClient.Get(ctx, issuerNN, issuer)).To(Succeed())
 				g.Expect(issuer.Spec.CA.SecretName).To(Equal(originalSecretName))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores dex Deployment image when modified", func(ctx context.Context) {
+			startManager(noDefaultSegmentKey, nil)
+
+			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
+			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, ui)
+
+			deploymentNN := types.NamespacedName{Name: dexDeploymentName, Namespace: uiNamespace}
+
+			By("waiting for initial dex Deployment creation")
+			var originalImage string
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, deploymentNN, dep)).To(Succeed())
+				container := testutil.FindContainer(dep.Spec.Template.Spec.Containers, dexContainerName)
+				g.Expect(container).NotTo(BeNil())
+				originalImage = container.Image
+				g.Expect(originalImage).NotTo(BeEmpty())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the dex Deployment image")
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, deploymentNN, dep)).To(Succeed())
+				container := testutil.FindContainer(dep.Spec.Template.Spec.Containers, dexContainerName)
+				g.Expect(container).NotTo(BeNil())
+				container.Image = "tampered-image:latest"
+				g.Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the dex Deployment image is restored")
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, deploymentNN, dep)).To(Succeed())
+				container := testutil.FindContainer(dep.Spec.Template.Spec.Containers, dexContainerName)
+				g.Expect(container).NotTo(BeNil())
+				g.Expect(container.Image).To(Equal(originalImage))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores Ingress spec when modified", func(ctx context.Context) {
+			startManager(noDefaultSegmentKey, nil)
+
+			ui := &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				Spec: konfluxv1alpha1.KonfluxUISpec{
+					Ingress: &konfluxv1alpha1.IngressSpec{
+						Enabled: ptr.To(true),
+						Host:    "drift-test.example.com",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ui,
+				&networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}},
+			)
+
+			ingressNN := types.NamespacedName{Name: ingress.IngressName, Namespace: uiNamespace}
+
+			By("waiting for initial Ingress creation")
+			Eventually(func(g Gomega) {
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, ingressNN, ing)).To(Succeed())
+				g.Expect(ing.Spec.Rules).NotTo(BeEmpty())
+				g.Expect(ing.Spec.Rules[0].Host).To(Equal("drift-test.example.com"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the Ingress host")
+			Eventually(func(g Gomega) {
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, ingressNN, ing)).To(Succeed())
+				ing.Spec.Rules[0].Host = "tampered.example.com"
+				g.Expect(k8sClient.Update(ctx, ing)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Ingress host is restored")
+			Eventually(func(g Gomega) {
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, ingressNN, ing)).To(Succeed())
+				g.Expect(ing.Spec.Rules).NotTo(BeEmpty())
+				g.Expect(ing.Spec.Rules[0].Host).To(Equal("drift-test.example.com"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores ConsoleLink spec when modified", func(ctx context.Context) {
+			openShiftClusterInfo, err := clusterinfo.DetectWithClient(&mockDiscoveryClient{
+				resources: map[string]*metav1.APIResourceList{
+					"config.openshift.io/v1": {
+						APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}},
+					},
+				},
+				serverVersion: &version.Info{GitVersion: "v1.29.0"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+
+			ui := &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				Spec: konfluxv1alpha1.KonfluxUISpec{
+					Ingress: &konfluxv1alpha1.IngressSpec{
+						Enabled: ptr.To(true),
+						Host:    "consolelink-drift.example.com",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ui,
+				&consolev1.ConsoleLink{ObjectMeta: metav1.ObjectMeta{Name: consolelink.ConsoleLinkName}},
+			)
+
+			consoleLinkNN := types.NamespacedName{Name: consolelink.ConsoleLinkName}
+
+			By("waiting for initial ConsoleLink creation")
+			Eventually(func(g Gomega) {
+				cl := &consolev1.ConsoleLink{}
+				g.Expect(k8sClient.Get(ctx, consoleLinkNN, cl)).To(Succeed())
+				g.Expect(cl.Spec.Href).To(Equal("https://consolelink-drift.example.com"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the ConsoleLink href")
+			Eventually(func(g Gomega) {
+				cl := &consolev1.ConsoleLink{}
+				g.Expect(k8sClient.Get(ctx, consoleLinkNN, cl)).To(Succeed())
+				cl.Spec.Href = "https://tampered.example.com"
+				g.Expect(k8sClient.Update(ctx, cl)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the ConsoleLink href is restored")
+			Eventually(func(g Gomega) {
+				cl := &consolev1.ConsoleLink{}
+				g.Expect(k8sClient.Get(ctx, consoleLinkNN, cl)).To(Succeed())
+				g.Expect(cl.Spec.Href).To(Equal("https://consolelink-drift.example.com"))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
Following https://github.com/konflux-ci/konflux-ci/pull/7455 which removed IgnoreStatusUpdatesPredicate from Service and Secret watches, this adds spec drift tests to validate that controllers correctly restore resources when they are tampered externally.

Together with #7455, this closes https://github.com/konflux-ci/konflux-ci/issues/7379 by both fixing the root cause (predicate filtering out spec-change events for generation-exempt resources) and adding comprehensive test coverage that would immediately catch any regression.

New spec drift tests added:

- Service spec (ports/targetPort): buildservice, imagecontroller, integrationservice, namespacelister, ui
- certmanager: ClusterIssuer spec (tamper spec.ca.secretName), bootstrap ClusterIssuer spec (replace spec.selfSigned with spec.ca), Certificate spec (tamper spec.issuerRef.name)
- integrationservice: Issuer spec (replace spec.selfSigned with spec.ca), ValidatingWebhookConfiguration spec (tamper webhooks[0] service path), MutatingWebhookConfiguration spec (tamper webhooks[0] service path)
- namespacelister: ingress NetworkPolicy spec (clear spec.ingress rules), egress NetworkPolicy spec (clear spec.egress rules), Certificate spec (tamper spec.dnsNames)
- ui: dex Deployment image, Ingress spec (tamper host), ConsoleLink spec (tamper href, requires OpenShift mock)
- buildservice: SecurityContextConstraints spec (tamper RunAsUser strategy, requires OpenShift mock)

Resources intentionally not tested for spec drift:
- Secrets (ui oauth2-proxy, internalregistry credentials): create-once semantics — controller only generates random values when data keys are empty, does not restore tampered values by design
- ConfigMap (ui dex): content-hashed name — already covered by existing deletion/recreation drift test

Assisted-by: Cursor + Opus 4.6