### PR TITLE
Reduce prHourlyLimit from 20 to 7

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   ],
   "rebaseWhen": "conflicted",
   "prConcurrentLimit": 50,
-  "prHourlyLimit": 20,
+  "prHourlyLimit": 7,
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
We increased the some renovate limits to clear a backlog of PRs that were waiting to be opened.

If we have too many concurrent CI runs at once, e2e tests are starting to fail for GitHub rate limiting.

Reducing the hourly limit to 7 should allow at least 42 Mintmaker PRs opened a day (Mintmaker triggered every 4 hours), which is more that what we get today, and should also avoid hitting failures due to rate limiting.

I'm not changing the prConcurrentLimit for now, as I think it's worth having it as a buffer.