### PR TITLE
fix(KFLUXVNGD-1106): remove no-op IgnoreStatusUpdatesPredicate from ConsoleLink

### DIFF
--- a/operator/internal/controller/ui/konfluxui_controller.go
+++ b/operator/internal/controller/ui/konfluxui_controller.go
@@ -778,7 +778,7 @@ func (r *KonfluxUIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// ConsoleLink CRD only exists on OpenShift; skip watch on non-OpenShift clusters
 	// to avoid informer startup failures when the CRD is absent.
 	if r.ClusterInfo != nil && r.ClusterInfo.IsOpenShift() {
-		b = b.Owns(&consolev1.ConsoleLink{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate))
+		b = b.Owns(&consolev1.ConsoleLink{})
 	}
 
 	return b.Complete(r)


### PR DESCRIPTION
ConsoleLink (console.openshift.io/v1) has no status subresource, so IgnoreStatusUpdatesPredicate provides no filtering benefit and could block legitimate spec change events in production - the same class of bug previously fixed for Service and Secret.

Tests are already covering this.