### PR TITLE
feat(skills): add OpenShift CI (Prow) support to debug-e2e-tests

### DIFF
--- a/skills/debug-e2e-tests/SKILL.md
+++ b/skills/debug-e2e-tests/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: debug-e2e-tests
-description: Debug failed Konflux e2e test runs by downloading logs and artifacts from GitHub Actions, analyzing test failures, and suggesting fixes. Use when the user asks to debug, investigate, or fix a failing e2e test, CI failure, or flaky test.
+description: Debug failed Konflux e2e test runs by downloading logs and artifacts from GitHub Actions or OpenShift CI (Prow), analyzing test failures, and suggesting fixes. Use when the user asks to debug, investigate, or fix a failing e2e test, CI failure, or flaky test.
 ---
 
 # Debug E2E Tests
 
-Debug failed e2e test runs from GitHub Actions. Downloads test logs and cluster artifacts, identifies root causes, and suggests fixes to this repo or upstream dependencies.
+Debug failed e2e test runs from **GitHub Actions** or **OpenShift CI (Prow)**. Downloads test logs and cluster artifacts, identifies root causes, and suggests fixes to this repo or upstream dependencies.
 
 **When this skill is activated, tell the user:** "Using the **debug-e2e-tests** skill to investigate this failure." Then show the checklist from the Workflow section below so the user can track progress.
 
 ## Prerequisites
 
 - `gh` CLI authenticated with access to `konflux-ci/konflux-ci`
+- `curl` available (for Prow artifact downloads)
 - `tar` and `unzip` available (standard on Linux/macOS)
 
 ## Workflow
@@ -19,7 +20,7 @@ Debug failed e2e test runs from GitHub Actions. Downloads test logs and cluster 
 Copy this checklist and track progress:
 
 ```
-- [ ] Step 1: Identify the failed run
+- [ ] Step 1: Identify the CI system and failed run
 - [ ] Step 2: Download artifacts
 - [ ] Step 3: Analyze test output (JUnit + Ginkgo logs)
 - [ ] Step 4: Analyze cluster logs
@@ -27,7 +28,19 @@ Copy this checklist and track progress:
 - [ ] Step 6: Determine root cause and suggest fix
 ```
 
-### Step 1: Identify the Failed Run
+### Step 1: Identify the CI System and Failed Run
+
+First, determine which CI system the failure is from:
+
+| Signal | CI System |
+|--------|-----------|
+| User provides a GitHub Actions run ID or PR number | **GitHub Actions** |
+| URL contains `prow.ci.openshift.org` | **OpenShift CI (Prow)** |
+| URL contains `gcsweb-ci.apps.ci` | **OpenShift CI (Prow)** |
+| Job name starts with `pull-ci-` or `periodic-ci-` | **OpenShift CI (Prow)** |
+| User mentions "Prow", "OpenShift CI", or "OCP e2e" | **OpenShift CI (Prow)** |
+
+#### GitHub Actions
 
 If the user provides a PR number, run ID, or branch name, use that. Otherwise, find recent failures:
 
@@ -55,12 +68,30 @@ The e2e workflow has these jobs:
 - **Run Operator E2E Tests (AMD64)** — main e2e on amd64
 - **Run Operator E2E Tests (ARM64)** — main e2e on arm64
 
+#### OpenShift CI (Prow)
+
+The user will typically provide a Prow URL like:
+```
+https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/konflux-ci_konflux-ci/<PR>/<job-name>/<build-id>
+```
+
+Key Prow jobs for this repo:
+- `pull-ci-konflux-ci-konflux-ci-main-konflux-e2e-v420-optional` — PR presubmit (OCP 4.20)
+- `periodic-ci-konflux-ci-konflux-ci-main-ocp420-konflux-e2e-v420` — periodic x86_64
+- `periodic-ci-konflux-ci-konflux-ci-main-ocp420-arm64-konflux-e2e-v420-arm64` — periodic ARM64
+
+You can view recent Prow job runs at:
+- [x86_64 periodic](https://prow.ci.openshift.org/?job=periodic-ci-konflux-ci-konflux-ci-main-ocp420-konflux-e2e-v420)
+- [ARM64 periodic](https://prow.ci.openshift.org/?job=periodic-ci-konflux-ci-konflux-ci-main-ocp420-arm64-konflux-e2e-v420-arm64)
+
 ### Step 2: Download Artifacts
+
+#### GitHub Actions
 
 Use the helper script to download and extract artifacts:
 
 ```bash
-bash .cursor/skills/debug-e2e-tests/scripts/download-logs.sh <run-id> [arch]
+bash skills/debug-e2e-tests/scripts/download-logs.sh <run-id> [arch]
 ```
 
 - `arch` defaults to `amd64`. Use `arm64` if that's the failing job.
@@ -88,6 +119,24 @@ gh api "repos/konflux-ci/konflux-ci/actions/runs/<run-id>/jobs" \
 gh api "repos/konflux-ci/konflux-ci/actions/jobs/<job-id>/logs" > "$WORKDIR/job.log"
 ```
 
+#### OpenShift CI (Prow)
+
+Use the Prow download script:
+
+```bash
+bash skills/debug-e2e-tests/scripts/download-prow-logs.sh <prow-url>
+```
+
+The script accepts:
+- A full Prow UI URL: `https://prow.ci.openshift.org/view/gs/...`
+- A GCS path: `gs://test-platform-results/pr-logs/...`
+- A gcsweb URL: `https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/...`
+
+Artifacts are extracted to `/tmp/prow-debug-<build-id>/`. See
+[prow-reference.md](prow-reference.md) for the full artifact directory layout,
+step descriptions, gather file listing, and gcsweb URL patterns for fetching
+additional files.
+
 ### Step 3: Analyze Test Output
 
 #### 3a. JUnit Report
@@ -95,24 +144,34 @@ gh api "repos/konflux-ci/konflux-ci/actions/jobs/<job-id>/logs" > "$WORKDIR/job.
 Check the JUnit XML first for a quick summary of which tests failed:
 
 ```bash
-# The JUnit file is at:
-# logs/junit/junit-conformance-amd64.xml  (or arm64)
+# GitHub Actions:
+#   logs/junit/junit-conformance-amd64.xml  (or arm64)
+#
+# Prow:
+#   junit/junit.xml
+#   (also: artifacts/junit_operator.xml for step-level pass/fail)
 ```
 
 Look for `<testcase>` elements with `<failure>` children. Extract test names and failure messages.
 
 #### 3b. Ginkgo Output
 
-The raw job log (`job.log`) or stdout contains full Ginkgo output. Search for:
+The test execution log contains full Ginkgo output. Search for:
 
 - `[FAILED]` — Ginkgo failure markers
 - `FAIL!` — Go test failure
 - `Timed out` or `context deadline exceeded` — timeout failures
 - `Expected` / `to equal` / `to succeed` — Gomega assertion failures
 
+Where to find it:
+- **GitHub Actions:** `job.log` (raw job log)
+- **Prow:** `steps/konflux-ci-e2e-tests/build-log.txt`
+
 The test suite is `Konflux Conformance` under `test/go-tests/tests/conformance/`. Cross-reference the failing test name with the source files there to understand what the test was doing.
 
 ### Step 4: Analyze Cluster Logs
+
+#### GitHub Actions artifacts
 
 The `logs/` directory (from `generate-err-logs.sh`) contains the cluster state at test failure time. Read files in this priority order:
 
@@ -138,6 +197,18 @@ For deeper analysis, check structured artifacts under `logs/artifacts/`:
 
 For details on log structure, see [reference.md](reference.md).
 
+#### Prow artifacts
+
+For Prow jobs, cluster state is collected by the `redhat-appstudio-gather` step.
+Start with `artifacts/junit_operator.xml` to see which multi-stage test steps
+passed/failed — if the install step failed, the test never ran. Then check
+step logs under `steps/<step-name>/build-log.txt` and gathered resources under
+`gather/`.
+
+See [prow-reference.md](prow-reference.md) for the complete artifact layout,
+step descriptions, gather file listing, failure pattern table, and a mapping
+of Prow artifacts to their GitHub Actions equivalents.
+
 #### 4a. "No PipelineRun found" failures — PaC webhook chain
 
 When the failure is **"no pipelinerun found for component …"**, read
@@ -150,6 +221,8 @@ This step is not always needed. Use it when the logs from Steps 3–4 suggest a 
 
 #### 5a. Get the head commit and base branch from the run
 
+**GitHub Actions:**
+
 ```bash
 # Show the head SHA, branch, and associated PR for the run
 gh run view <run-id> --repo konflux-ci/konflux-ci --json headSha,headBranch \
@@ -159,6 +232,22 @@ gh run view <run-id> --repo konflux-ci/konflux-ci --json headSha,headBranch \
 gh pr list --repo konflux-ci/konflux-ci --head <branch> --json number,baseRefName \
   --jq '.[0] | "PR #\(.number) → base: \(.baseRefName)"'
 ```
+
+**Prow:**
+
+The commit info is in `started.json` and `prowjob.json` (downloaded in Step 2):
+
+```bash
+# From started.json — shows the PR refs
+cat /tmp/prow-debug-<build-id>/started.json | python3 -m json.tool
+
+# From prowjob.json — contains full refs spec
+cat /tmp/prow-debug-<build-id>/prowjob.json | \
+  python3 -c "import json,sys; d=json.load(sys.stdin); r=d['spec'].get('refs') or d['spec']['extra_refs'][0]; print(f\"org: {r['org']}\nrepo: {r['repo']}\nbase: {r['base_ref']}\nSHA: {r['base_sha']}\nPR pulls: {r.get('pulls', [])}\")"
+```
+
+For presubmit (PR) jobs, the `pulls` array contains the PR number and head SHA.
+For periodic jobs, `base_sha` is the commit tested from the base branch.
 
 #### 5b. Check out and inspect the diff
 

--- a/skills/debug-e2e-tests/prow-reference.md
+++ b/skills/debug-e2e-tests/prow-reference.md
@@ -1,0 +1,177 @@
+# Reference: OpenShift CI (Prow) Artifact Structure
+
+## GCS URL Pattern
+
+All Prow job artifacts are stored in public GCS buckets accessible via HTTP
+through gcsweb (no auth required).
+
+**Presubmit (PR) jobs:**
+```
+gs://test-platform-results/pr-logs/pull/<org>_<repo>/<PR-number>/<job-name>/<build-id>/
+```
+
+**Periodic jobs:**
+```
+gs://test-platform-results/logs/<job-name>/<build-id>/
+```
+
+**HTTP access via gcsweb:**
+```
+https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/<bucket-relative-path>
+```
+
+## Top-Level Files
+
+| File | Description |
+|------|-------------|
+| `build-log.txt` | ci-operator top-level log (step orchestration, image builds) |
+| `started.json` | Job start time, PR number, repo refs, commit SHAs |
+| `finished.json` | Job result (`passed`/`failed`), completion timestamp |
+| `prowjob.json` | Full ProwJob CR: job name, refs, labels, spec |
+| `prowjob_junit.xml` | Single JUnit test: "Job run should complete before timeout" |
+| `sidecar-logs.json` | Prow sidecar upload/censoring logs |
+
+## Artifacts Directory
+
+```
+artifacts/
+├── ci-operator.log              # Detailed ci-operator execution log
+├── ci-operator-step-graph.json  # Full step dependency graph with timing
+├── ci-operator-metrics.json     # Step durations and success/failure
+├── junit_operator.xml           # JUnit for ALL multi-stage steps (key file!)
+├── metadata.json                # Repo, PR, commit, pod name, namespace
+├── build-logs/                  # Source compilation logs
+├── build-resources/             # K8s objects from build namespace
+│   ├── builds.json
+│   ├── events.json
+│   ├── pods.json
+│   └── imagestreams.json
+├── release/                     # Release ImageStream
+└── <workflow-name>/             # Test workflow steps (see below)
+```
+
+## Workflow Steps Directory
+
+For Konflux e2e jobs, the workflow directory is named after the test
+(e.g., `konflux-e2e-v420-optional`). Each step directory contains:
+
+```
+<workflow-name>/
+├── <step-name>/
+│   ├── build-log.txt       # Step's stdout/stderr
+│   ├── finished.json       # Step result
+│   ├── sidecar-logs.json   # Upload logs
+│   └── artifacts/          # Files written to $ARTIFACT_DIR by the step
+└── ...
+```
+
+### Konflux-specific Steps
+
+| Step | Purpose | Key artifacts |
+|------|---------|---------------|
+| `ipi-install-rbac` | Cluster RBAC setup | (rarely relevant) |
+| `redhat-appstudio-health-check` | Pre-test cluster health validation | `build-log.txt`, `artifacts/` |
+| `konflux-ci-install-operator` | Deploys Konflux operator + CRs | `build-log.txt` (deployment log) |
+| `konflux-ci-e2e-tests` | Runs the Ginkgo test suite | `build-log.txt` (test output) |
+| `redhat-appstudio-gather` | Collects cluster state post-test | `artifacts/` (main debug data) |
+| `redhat-appstudio-report` | Generates JUnit reports | `artifacts/junit.xml`, `junit-rp.xml` |
+| `gather-extra` | Additional cluster diagnostics | `artifacts/` (pod logs under `artifacts/pods/`) |
+| `gather-audit-logs` | Kubernetes audit logs | `artifacts/` |
+| `gather-must-gather` | OpenShift must-gather | `artifacts/` (large tarball) |
+| `konflux-ci-unregister-sprayproxy` | Cleanup sprayproxy registration | `build-log.txt` |
+
+## redhat-appstudio-gather Artifacts
+
+The gather step dumps all Konflux-related cluster resources as JSON files.
+These are the primary debugging data source:
+
+```
+redhat-appstudio-gather/artifacts/
+├── must-gather-appstudio/           # oc adm must-gather output (tarball)
+├── must-gather-network-appstudio/   # Network diagnostics must-gather
+├── applications_appstudio.json      # HAS Application CRs
+├── components.json                  # HAS Component CRs
+├── componentdetectionqueries.json   # CDQ CRs
+├── snapshots.json                   # Snapshot CRs
+├── integrationtestscenarios.json    # ITS CRs
+├── pipelineruns.json                # Tekton PipelineRuns
+├── taskruns.json                    # Tekton TaskRuns
+├── pipelines.json                   # Tekton Pipeline definitions
+├── tasks.json                       # Tekton Task definitions
+├── repositories.json                # PipelinesAsCode Repository CRs
+├── releases.json                    # Release CRs
+├── releaseplans.json                # ReleasePlan CRs
+├── releaseplanadmissions.json       # ReleasePlanAdmission CRs
+├── enterprisecontractpolicies.json  # EC policy CRs
+├── environments.json                # Environment CRs
+├── promotionruns.json               # PromotionRun CRs
+├── tektonconfigs.json               # TektonConfig CRs
+├── tektonpipelines.json             # TektonPipeline CRs
+├── tektonchains.json                # TektonChain CRs
+├── clusterinterceptors.json         # Tekton ClusterInterceptors
+├── eventlisteners.json              # Tekton EventListeners
+├── triggerbindings.json             # Tekton TriggerBindings
+├── triggertemplates.json            # Tekton TriggerTemplates
+├── triggers.json                    # Tekton Triggers
+├── resolutionrequests.json          # Tekton ResolutionRequests
+└── ...                              # Many more CR types (see actual listing)
+```
+
+## gather-extra Artifacts
+
+The `gather-extra` step collects additional cluster diagnostics not covered by
+`redhat-appstudio-gather`. Its `artifacts/` directory contains useful cluster
+state, including pod logs from the test cluster:
+
+```
+gather-extra/artifacts/
+├── pods/                   # Pod logs from the test cluster
+│   ├── <namespace>_<pod>.log
+│   └── ...
+└── ...                     # Other cluster diagnostic files
+```
+
+The `pods/` directory is especially useful when you need container-level logs
+that are not included in the `redhat-appstudio-gather` JSON dumps.
+
+## Mapping Prow Artifacts to GitHub Actions Artifacts
+
+| Analysis need | GitHub Actions file | Prow equivalent |
+|---------------|--------------------|-----------------| 
+| Test JUnit results | `logs/junit/junit-conformance-*.xml` | `junit/junit.xml` |
+| Test Ginkgo output | `job.log` | `steps/konflux-ci-e2e-tests/build-log.txt` |
+| Operator deploy log | `logs/operator-logs.log` | `steps/konflux-ci-install-operator/build-log.txt` |
+| PipelineRun details | `logs/artifacts/pipelineruns.json` | `gather/pipelineruns.json` |
+| TaskRun details | `logs/artifacts/taskruns.json` | `gather/taskruns.json` |
+| Component CRs | `logs/artifacts/components.json` | `gather/components.json` |
+| Repository CRs | `logs/artifacts/repositories.json` | `gather/repositories.json` |
+| Cluster events | `logs/artifacts/events.json` | (in must-gather tarball) |
+| Pod logs | `logs/artifacts/pods/*.log` | `gather-extra/artifacts/pods/` |
+| Node/resource pressure | `logs/cluster-resources.log` | (in must-gather or gather-extra) |
+
+## Accessing Additional Files
+
+The download script fetches the most commonly needed files. For deeper analysis,
+fetch additional files directly:
+
+```bash
+GCSWEB="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs"
+BASE="test-platform-results/pr-logs/pull/konflux-ci_konflux-ci/<PR>/<job>/<build-id>"
+
+# Browse available files (returns HTML directory listing):
+curl -s "${GCSWEB}/${BASE}/artifacts/<workflow>/redhat-appstudio-gather/artifacts/"
+
+# Download a specific file:
+curl -sfL "${GCSWEB}/${BASE}/artifacts/<workflow>/redhat-appstudio-gather/artifacts/<file>.json" -o <local-path>
+```
+
+## Common Prow-Specific Failure Patterns
+
+| Pattern | Likely cause | Where to look |
+|---------|-------------|---------------|
+| `konflux-ci-install-operator` step failed | Operator deploy issue, OCP incompatibility | `steps/konflux-ci-install-operator/build-log.txt` |
+| `redhat-appstudio-health-check` step failed | Cluster not ready, missing prerequisites | `steps/redhat-appstudio-health-check/build-log.txt` |
+| Step timeout in `junit_operator.xml` | Step exceeded its time limit | `artifacts/ci-operator-step-graph.json` for timing |
+| `ipi-install-*` failure | Cluster provisioning failed (infra) | Not a Konflux code issue |
+| All steps pass but `konflux-ci-e2e-tests` fails | Test-level failure (same as GHA) | `steps/konflux-ci-e2e-tests/build-log.txt` |
+| `gather` step failed | Cluster in bad state, gather script error | Usually ignorable for root cause |

--- a/skills/debug-e2e-tests/reference.md
+++ b/skills/debug-e2e-tests/reference.md
@@ -1,8 +1,10 @@
-# Reference: E2E Debug Skill
+# Reference: E2E Debug Skill (GitHub Actions)
+
+For OpenShift CI (Prow) artifact structure, see [prow-reference.md](prow-reference.md).
 
 ## Log Directory Structure
 
-After downloading artifacts from a failed run, the `logs/` directory contains:
+After downloading artifacts from a failed GitHub Actions run, the `logs/` directory contains:
 
 ```
 logs/

--- a/skills/debug-e2e-tests/scripts/download-prow-logs.sh
+++ b/skills/debug-e2e-tests/scripts/download-prow-logs.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+#
+# Download and extract e2e test artifacts from an OpenShift CI (Prow) job.
+#
+# Usage: download-prow-logs.sh <prow-url-or-gcs-path>
+#
+# Accepts either:
+#   - A full Prow UI URL, e.g.:
+#     https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/konflux-ci_konflux-ci/7309/pull-ci-konflux-ci-konflux-ci-main-konflux-e2e-v420-optional/2069007573985529856
+#   - A GCS path, e.g.:
+#     gs://test-platform-results/pr-logs/pull/konflux-ci_konflux-ci/7309/pull-ci-konflux-ci-konflux-ci-main-konflux-e2e-v420-optional/2069007573985529856
+#
+# Output directory: /tmp/prow-debug-<build-id>/
+#
+# Requirements: curl (no gsutil or gcloud auth needed — uses public gcsweb HTTP)
+# Optional:     python3 (for parsing junit_operator.xml step results)
+
+set -euo pipefail
+
+GCSWEB_BASE="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs"
+
+input="${1:?Usage: download-prow-logs.sh <prow-url-or-gcs-path>}"
+
+# Parse the input into a GCS bucket-relative path
+if [[ "$input" == gs://* ]]; then
+  # gs://test-platform-results/pr-logs/pull/...
+  gcs_path="${input#gs://}"
+elif [[ "$input" == *"prow.ci.openshift.org/view/gs/"* ]]; then
+  # https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/...
+  gcs_path="${input#*prow.ci.openshift.org/view/gs/}"
+elif [[ "$input" == *"gcsweb-ci.apps.ci"*"/gcs/"* ]]; then
+  # https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/...
+  gcs_path="${input#*/gcs/}"
+else
+  echo "ERROR: Cannot parse input URL. Provide a Prow UI URL or gs:// path." >&2
+  exit 1
+fi
+
+# Remove trailing slash
+gcs_path="${gcs_path%/}"
+
+# Extract build ID (last path component) for workdir naming
+build_id="${gcs_path##*/}"
+workdir="/tmp/prow-debug-${build_id}"
+mkdir -p "$workdir"
+
+echo "Prow job artifacts: ${GCSWEB_BASE}/${gcs_path}/" >&2
+echo "Output directory:   ${workdir}" >&2
+echo "" >&2
+
+# Helper: download a single file from gcsweb.
+# gcsweb returns 200 for non-existent paths (showing an HTML directory listing),
+# so we verify the response is not HTML before accepting it — unless the file
+# itself is supposed to be HTML (e.g. .html extension).
+download_file() {
+  local remote_path="$1"
+  local local_path="$2"
+  mkdir -p "$(dirname "$local_path")"
+  if curl -sfL "${GCSWEB_BASE}/${remote_path}" -o "$local_path" 2>/dev/null; then
+    # Skip HTML check for files with .html extension (they're legitimately HTML)
+    if [[ "$local_path" != *.html ]]; then
+      if head -1 "$local_path" 2>/dev/null | grep -Eqi '<!doctype|<html'; then
+        rm -f "$local_path"
+        return 1
+      fi
+    fi
+    return 0
+  else
+    return 1
+  fi
+}
+
+# --- Top-level metadata ---
+echo "==> Downloading top-level metadata..." >&2
+for f in build-log.txt finished.json started.json prowjob.json; do
+  if download_file "${gcs_path}/${f}" "${workdir}/${f}"; then
+    echo "  ✓ ${f}" >&2
+  fi
+done
+
+# --- ci-operator.log and junit_operator.xml ---
+echo "==> Downloading ci-operator artifacts..." >&2
+for f in ci-operator.log junit_operator.xml ci-operator-step-graph.json metadata.json; do
+  if download_file "${gcs_path}/artifacts/${f}" "${workdir}/artifacts/${f}"; then
+    echo "  ✓ artifacts/${f}" >&2
+  fi
+done
+
+# --- Detect the test workflow name (e.g. "konflux-e2e-v420-optional") ---
+# Parse from the GCS path: .../<job-name>/<build-id>
+# The job name often matches the workflow directory under artifacts/
+path_without_build="${gcs_path%/*}"
+job_full_name="${path_without_build##*/}"
+# Try common workflow directory name patterns (shorter/stripped names first,
+# since gcsweb always returns 200 we must verify with a real file probe)
+workflow_dir=""
+candidate_pull="${job_full_name#pull-ci-konflux-ci-konflux-ci-main-}"
+candidate_periodic="${job_full_name#periodic-ci-konflux-ci-konflux-ci-main-}"
+candidate_periodic_trim1="${candidate_periodic#*-}"
+candidate_periodic_trim2="${candidate_periodic_trim1#*-}"
+for candidate in \
+  "$candidate_pull" \
+  "$candidate_periodic_trim2" \
+  "$candidate_periodic_trim1" \
+  "$candidate_periodic" \
+  "$job_full_name"; do
+  # Probe for a known step's build-log.txt to verify the directory is real
+  probe_url="${GCSWEB_BASE}/${gcs_path}/artifacts/${candidate}/konflux-ci-e2e-tests/build-log.txt"
+  probe_content=$(curl -sfL "$probe_url" 2>/dev/null | head -c 512 || true)
+  if [[ -n "$probe_content" ]] && ! echo "$probe_content" | grep -Eqi '<!doctype|<html'; then
+    workflow_dir="$candidate"
+    break
+  fi
+  # Also try redhat-appstudio-report as fallback probe (in case e2e-tests step didn't run)
+  probe_url="${GCSWEB_BASE}/${gcs_path}/artifacts/${candidate}/redhat-appstudio-report/build-log.txt"
+  probe_content=$(curl -sfL "$probe_url" 2>/dev/null | head -c 512 || true)
+  if [[ -n "$probe_content" ]] && ! echo "$probe_content" | grep -Eqi '<!doctype|<html'; then
+    workflow_dir="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$workflow_dir" ]]; then
+  echo "WARNING: Could not auto-detect workflow directory under artifacts/." >&2
+  echo "  Tried: ${job_full_name} and variants." >&2
+  echo "  You may need to browse: ${GCSWEB_BASE}/${gcs_path}/artifacts/" >&2
+  echo "" >&2
+  echo "${workdir}"
+  exit 0
+fi
+
+echo "==> Detected workflow directory: ${workflow_dir}" >&2
+echo "" >&2
+
+# --- Download step-level build-logs ---
+# Key steps for Konflux e2e:
+#   konflux-ci-install-operator — operator deployment log
+#   konflux-ci-e2e-tests — test execution log
+#   redhat-appstudio-gather — cluster state dump (most important)
+#   redhat-appstudio-report — JUnit results
+#   redhat-appstudio-health-check — pre-test health check
+
+steps=(
+  "konflux-ci-install-operator"
+  "konflux-ci-e2e-tests"
+  "redhat-appstudio-gather"
+  "redhat-appstudio-report"
+  "redhat-appstudio-health-check"
+  "gather-extra"
+  "gather-audit-logs"
+)
+
+step_base="${gcs_path}/artifacts/${workflow_dir}"
+
+echo "==> Downloading step build-logs..." >&2
+for step in "${steps[@]}"; do
+  if download_file "${step_base}/${step}/build-log.txt" "${workdir}/steps/${step}/build-log.txt"; then
+    echo "  ✓ ${step}/build-log.txt" >&2
+  fi
+  # Also grab finished.json to check pass/fail
+  download_file "${step_base}/${step}/finished.json" "${workdir}/steps/${step}/finished.json" 2>/dev/null || true
+done
+
+# --- Download JUnit from redhat-appstudio-report ---
+echo "" >&2
+echo "==> Downloading JUnit reports..." >&2
+for f in junit.xml junit-rp.xml junit-summary.html; do
+  if download_file "${step_base}/redhat-appstudio-report/artifacts/${f}" "${workdir}/junit/${f}"; then
+    echo "  ✓ junit/${f}" >&2
+  fi
+done
+
+# --- Download gather artifacts (cluster state) ---
+echo "" >&2
+echo "==> Downloading redhat-appstudio-gather artifacts (cluster state)..." >&2
+echo "    (This may take a moment for large files...)" >&2
+
+gather_base="${step_base}/redhat-appstudio-gather/artifacts"
+
+# Key JSON dumps from the gather step
+gather_files=(
+  "components.json"
+  "applications_appstudio.json"
+  "pipelineruns.json"
+  "taskruns.json"
+  "snapshots.json"
+  "integrationtestscenarios.json"
+  "releases.json"
+  "releaseplans.json"
+  "releaseplanadmissions.json"
+  "enterprisecontractpolicies.json"
+  "repositories.json"
+  "pipelines.json"
+  "tasks.json"
+  "tektonconfigs.json"
+  "tektonpipelines.json"
+  "tektonchains.json"
+  "clusterinterceptors.json"
+)
+
+gathered=0
+for f in "${gather_files[@]}"; do
+  if download_file "${gather_base}/${f}" "${workdir}/gather/${f}"; then
+    # Skip empty files (0 bytes)
+    if [[ -s "${workdir}/gather/${f}" ]]; then
+      gathered=$((gathered + 1))
+    else
+      rm -f "${workdir}/gather/${f}"
+    fi
+  fi
+done
+echo "  Downloaded ${gathered} non-empty gather artifacts" >&2
+
+# --- Summary ---
+echo "" >&2
+echo "=== Download complete ===" >&2
+echo "" >&2
+echo "Key files:" >&2
+echo "  Build log:        ${workdir}/build-log.txt" >&2
+echo "  Operator install: ${workdir}/steps/konflux-ci-install-operator/build-log.txt" >&2
+echo "  Test execution:   ${workdir}/steps/konflux-ci-e2e-tests/build-log.txt" >&2
+echo "  JUnit XML:        ${workdir}/junit/junit.xml" >&2
+echo "  Gather artifacts: ${workdir}/gather/" >&2
+echo "" >&2
+
+# Show step pass/fail status from junit_operator.xml if available
+junit_op="${workdir}/artifacts/junit_operator.xml"
+if [[ -f "$junit_op" ]]; then
+  echo "Step results (from junit_operator.xml):" >&2
+  python3 - "$junit_op" "$workflow_dir" <<'PYEOF' || echo "  (could not parse junit_operator.xml)" >&2
+import xml.etree.ElementTree as ET, sys
+tree = ET.parse(sys.argv[1])
+wf_prefix = sys.argv[2] + '-'
+for tc in tree.iter('testcase'):
+    name = tc.get('name', '')
+    if not name:
+        continue
+    failed = tc.find('failure') is not None
+    short = name
+    if 'Run multi-stage test' in name and ' - ' in name:
+        short = name.split(' - ', 1)[1].replace(' container test', '')
+        if short.startswith(wf_prefix):
+            short = short[len(wf_prefix):]
+    mark = '\u2717' if failed else '\u2713'
+    suffix = ' (FAILED)' if failed else ''
+    print(f'  {mark} {short}{suffix}', file=sys.stderr)
+PYEOF
+else
+  echo "Step results: (junit_operator.xml not available)" >&2
+fi
+
+echo "" >&2
+echo "${workdir}"


### PR DESCRIPTION
## Summary

- Extend the `debug-e2e-tests` skill to handle failures from **OpenShift CI (Prow)** in addition to GitHub Actions
- Add `prow-reference.md` documenting the full Prow artifact structure, step descriptions, gather file listing, failure patterns, and a mapping table to GHA equivalents
- Add `download-prow-logs.sh` script for fetching Prow job artifacts from gcsweb
- Deduplicate inline Prow content from `SKILL.md` into cross-references to `prow-reference.md`
- Clarify `reference.md` title as GitHub Actions-specific and add cross-reference to the new Prow reference

## Test plan

- [ ] Verify `SKILL.md` renders correctly and all cross-reference links resolve
- [ ] Verify `prow-reference.md` renders correctly
- [ ] Test `download-prow-logs.sh` against a real Prow job URL


Made with [Cursor](https://cursor.com)