### PR TITLE
fix(KFLUXVNGD-1110): align test cleanup patterns

### DIFF
--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
@@ -767,15 +767,16 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+			testutil.DeferCleanupParentAndChildren(k8sClient, buildService,
+				&securityv1.SecurityContextConstraints{
+					ObjectMeta: metav1.ObjectMeta{Name: sccName},
+				},
+			)
 
 			By("waiting for initial SCC creation")
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: sccName}, &securityv1.SecurityContextConstraints{})).To(Succeed())
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &securityv1.SecurityContextConstraints{
-				ObjectMeta: metav1.ObjectMeta{Name: sccName},
-			})
 
 			By("deleting the SCC")
 			Expect(k8sClient.Delete(ctx, &securityv1.SecurityContextConstraints{

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_test.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_test.go
@@ -182,16 +182,17 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, integrationService)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, integrationService)
+			testutil.DeferCleanupParentAndChildren(k8sClient, integrationService,
+				&admissionregistrationv1.ValidatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: validatingWebhookName},
+				},
+			)
 
 			By("waiting for initial ValidatingWebhookConfiguration creation")
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: validatingWebhookName},
 					&admissionregistrationv1.ValidatingWebhookConfiguration{})).To(Succeed())
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &admissionregistrationv1.ValidatingWebhookConfiguration{
-				ObjectMeta: metav1.ObjectMeta{Name: validatingWebhookName},
-			})
 
 			By("deleting the ValidatingWebhookConfiguration")
 			Expect(k8sClient.Delete(ctx, &admissionregistrationv1.ValidatingWebhookConfiguration{
@@ -211,16 +212,17 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, integrationService)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, integrationService)
+			testutil.DeferCleanupParentAndChildren(k8sClient, integrationService,
+				&admissionregistrationv1.MutatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: mutatingWebhookName},
+				},
+			)
 
 			By("waiting for initial MutatingWebhookConfiguration creation")
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mutatingWebhookName},
 					&admissionregistrationv1.MutatingWebhookConfiguration{})).To(Succeed())
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &admissionregistrationv1.MutatingWebhookConfiguration{
-				ObjectMeta: metav1.ObjectMeta{Name: mutatingWebhookName},
-			})
 
 			By("deleting the MutatingWebhookConfiguration")
 			Expect(k8sClient.Delete(ctx, &admissionregistrationv1.MutatingWebhookConfiguration{
@@ -1021,7 +1023,11 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, integrationService)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, integrationService)
+			testutil.DeferCleanupParentAndChildren(k8sClient, integrationService,
+				&admissionregistrationv1.ValidatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: validatingWebhookName},
+				},
+			)
 
 			vwcNN := types.NamespacedName{Name: validatingWebhookName}
 
@@ -1031,9 +1037,6 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 				g.Expect(k8sClient.Get(ctx, vwcNN, vwc)).To(Succeed())
 				g.Expect(vwc.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &admissionregistrationv1.ValidatingWebhookConfiguration{
-				ObjectMeta: metav1.ObjectMeta{Name: vwcNN.Name},
-			})
 
 			By("stripping ownership labels from the ValidatingWebhookConfiguration")
 			Eventually(func(g Gomega) {
@@ -1058,7 +1061,11 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, integrationService)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, integrationService)
+			testutil.DeferCleanupParentAndChildren(k8sClient, integrationService,
+				&admissionregistrationv1.MutatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: mutatingWebhookName},
+				},
+			)
 
 			mwcNN := types.NamespacedName{Name: mutatingWebhookName}
 
@@ -1068,9 +1075,6 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 				g.Expect(k8sClient.Get(ctx, mwcNN, mwc)).To(Succeed())
 				g.Expect(mwc.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, &admissionregistrationv1.MutatingWebhookConfiguration{
-				ObjectMeta: metav1.ObjectMeta{Name: mwcNN.Name},
-			})
 
 			By("stripping ownership labels from the MutatingWebhookConfiguration")
 			Eventually(func(g Gomega) {

--- a/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
+++ b/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
@@ -101,7 +101,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
 
 			deploymentNN := types.NamespacedName{
 				Name:      "registry",
@@ -134,7 +134,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
 
 			cmNN := types.NamespacedName{
 				Name:      "zot-config",
@@ -164,7 +164,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
 
 			svcNN := types.NamespacedName{
 				Name:      "registry-service",
@@ -194,7 +194,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
 
 			secretNN := types.NamespacedName{
 				Name:      HtpasswdSecretName,
@@ -224,7 +224,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
 
 			certNN := types.NamespacedName{
 				Name:      "registry-cert",
@@ -257,7 +257,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
 
 			deploymentNN := types.NamespacedName{
 				Name:      "registry",
@@ -300,7 +300,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
 
 			cmNN := types.NamespacedName{
 				Name:      "zot-config",
@@ -337,7 +337,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
 
 			svcNN := types.NamespacedName{
 				Name:      "registry-service",
@@ -376,7 +376,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
 
 			certNN := types.NamespacedName{
 				Name:      "registry-cert",
@@ -413,7 +413,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
 
 			secretNN := types.NamespacedName{
 				Name:      HtpasswdSecretName,
@@ -452,7 +452,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, registry)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
 
 			nsNN := types.NamespacedName{
 				Name: internalRegistryNamespace,


### PR DESCRIPTION
Fix incorrect cleanup patterns identified during the review of PR #7564, applying the conventions now documented in AGENTS.md (see PR #7564).

**Bugs fixed (5 tests):** Replace dual `DeferCleanup(testutil.DeleteAndWait)` calls (one for parent CR, one for cluster-scoped child) with a single `testutil.DeferCleanupParentAndChildren` call. Ginkgo's LIFO ordering meant the child was deleted first while the reconciler was still active, causing it to be immediately recreated — leading to flaky cleanup timeouts.

- integration-service: VWC/MWC self-healing and label-drift tests (4)
- build-service: SCC self-healing test (1)

**Nits fixed (11 tests):** Replace `DeferCleanupParentAndChildren(k8sClient, cr)` with no children listed with `DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)` in internal-registry tests. These tests only manage namespaced resources and don't need the parent-and-children cleanup ordering.

The correct usage is documented in AGENTS.md (updated in #7564):
- `DeferCleanupParentAndChildren` — when tests create cluster-scoped children (ClusterRole, ClusterRoleBinding, VWC, MWC, SCC) that must be explicitly cleaned after the parent is deleted
- `DeferCleanup(testutil.DeleteAndWait, ...)` — when only the parent CR needs cleanup (namespaced children are overwritten by the next reconcile)

Assisted-by: Cursor + Opus 4.6