### PR TITLE
Add dev-verify-loop skill for operator development iteration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,3 +135,4 @@ Detailed guides live in `skills/` — each subdirectory contains a `SKILL.md` wi
 | [debug-e2e-tests](skills/debug-e2e-tests/SKILL.md) | Investigating failed e2e / OpenShift CI runs |
 | [update-upstream-deps](skills/update-upstream-deps/SKILL.md) | Bumping upstream SHAs or editing `upstream-kustomizations/` (triggers manifest rebuild) |
 | [local-dev-setup](skills/local-dev-setup/SKILL.md) | Local Kind / dev environment |
+| [dev-verify-loop](skills/dev-verify-loop/SKILL.md) | Iterative stop-rebuild-restart cycle for operator development |

--- a/skills/dev-verify-loop/SKILL.md
+++ b/skills/dev-verify-loop/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: dev-verify-loop
+description: Use when iteratively verifying operator changes in development — code edit, stop operator, optionally regenerate manifests or CRDs, restart operator, verify. Use when the user says "verify", "test this change", "restart the operator", or needs a stop-rebuild-run cycle.
+---
+
+# Local Dev Verification Loop
+
+Iterative stop-rebuild-restart cycle for the Konflux operator running outside the cluster via `make run`. Each iteration: stop the operator process, optionally regenerate/install manifests, restart, and verify.
+
+## When to Use
+
+- Verifying operator code changes against a running cluster
+- The operator is running outside the cluster via `make run` (development mode)
+- You need to stop and restart the operator between iterations
+
+**Prerequisites:** A Konflux environment is deployed and the operator is running via `make run` in a backgrounded terminal. For local Kind setup, see the `local-dev-setup` skill.
+
+## The Loop
+
+Each verification iteration follows these steps:
+
+1. **Stop the operator** — kill the `make run` process (see "Stopping the Operator" below)
+2. **If upstream kustomizations changed** (`operator/upstream-kustomizations/`) — rebuild the embedded manifests: `bash operator/pkg/manifests/rebuild-upstream-manifests.sh .`
+3. **If API types, RBAC markers, or webhook config changed** — run `cd operator && make manifests generate`
+4. **If CRD schema changed** (fields added/removed/renamed in `*_types.go`) — run `cd operator && make install`
+5. **Start the operator** — run `cd operator && make run` (run in the background)
+6. **Wait for startup** — poll logs for `"starting manager"` or controller registration messages
+7. **Verify the change** — check logs, inspect resources, confirm expected behavior
+8. **If not correct** — fix the code and go back to step 1
+
+## Stopping the Operator
+
+**Kill ONLY the operator process — nothing else. NEVER use `pkill`, `killall`, or any broad kill command.**
+
+```bash
+bash skills/dev-verify-loop/scripts/stop-operator.sh
+```
+
+The script finds the `go run ... ./cmd/main.go` process by its command line, kills it and its child processes (the compiled binary), and confirms everything stopped.
+
+## When to Regenerate / Rebuild
+
+**Rebuild upstream manifests** when files in `operator/upstream-kustomizations/` changed:
+
+```bash
+bash operator/pkg/manifests/rebuild-upstream-manifests.sh .
+```
+
+This runs `kustomize build` for each component and writes the result to `operator/pkg/manifests/<component>/manifests.yaml`. These YAML files are embedded into the operator binary via `//go:embed`, so the rebuild must happen before `make run` for changes to take effect.
+
+**Run `make manifests generate`** from `operator/` when ANY of these changed:
+
+- `operator/api/` — CRD types, marker comments
+- RBAC markers (`//+kubebuilder:rbac:...`) in controller files
+- Webhook configurations
+
+**Run `make install`** (which applies CRDs to the cluster) when:
+
+- CRD schema changed (fields added/removed/renamed in `*_types.go`)
+- New CRD added
+
+**Skip all of the above** when only controller logic, reconciler behavior, or non-API code changed.
+
+## Starting the Operator
+
+From the `operator/` directory, start `make run` as a background process:
+
+```bash
+make run
+```
+
+This is a long-running process — run it in the background. Then confirm startup by checking logs for `"starting manager"` or controller registration messages.
+
+## Verifying the Change
+
+Verification is context-dependent — the user will tell you what to check. Examples: run a specific test, inspect operator logs, check a resource with `kubectl get`, apply a CR, or anything else. Ask the user if they haven't specified a verification method.
+
+Always check operator logs for errors after restart — read the terminal running `make run`.
+
+## Quick Reference
+
+| Step | Command | When |
+|------|---------|------|
+| Stop operator | `bash skills/dev-verify-loop/scripts/stop-operator.sh` | Every iteration |
+| Rebuild upstream | `bash operator/pkg/manifests/rebuild-upstream-manifests.sh .` | Upstream kustomization changes |
+| Regen manifests | `cd operator && make manifests generate` | API/RBAC changes |
+| Install CRDs | `cd operator && make install` | CRD schema changes |
+| Start operator | `cd operator && make run` (background) | Every iteration |
+| Check startup | Poll logs for `"starting manager"` | After start |
+| Check logs | Read the `make run` terminal file | After start |
+| Konflux status | `kubectl get konflux konflux -o jsonpath='{.status.conditions}'` | When needed |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Using `pkill` or `killall` to stop operator | Always use the specific pid from the terminal file, or the helper script |
+| Editing upstream kustomizations without rebuilding | Run `bash operator/pkg/manifests/rebuild-upstream-manifests.sh .` — the YAML is embedded at compile time |
+| Forgetting `make install` after CRD changes | Operator will fail with validation errors — check logs |
+| Starting `make run` before previous one stopped | Kill the old process first; port conflicts cause silent failures |
+| Not waiting for startup before verifying | Poll for `"starting manager"` log line |
+| Running `make run` from repo root | Must run from `operator/` directory |

--- a/skills/dev-verify-loop/scripts/stop-operator.sh
+++ b/skills/dev-verify-loop/scripts/stop-operator.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stop the locally-running Konflux operator (started via "make run" in the
+# operator/ directory). Finds the process by its command line and kills only
+# that specific process.
+#
+# Usage:
+#   bash skills/dev-verify-loop/scripts/stop-operator.sh
+
+# "make run" executes: go run -ldflags "..." ./cmd/main.go
+# go run compiles the code into a temp binary and runs it as a child process.
+# We find the go run parent and also kill its children to ensure the compiled
+# binary is stopped too.
+ALL_PIDS=$(pgrep -f 'go run.*\./cmd/main\.go') || true
+
+if [ -z "${ALL_PIDS}" ]; then
+    echo "No running operator process found (looked for 'go run ... ./cmd/main.go')." >&2
+    exit 1
+fi
+
+PID_COUNT=$(echo "${ALL_PIDS}" | wc -l | tr -d ' ')
+if [ "${PID_COUNT}" -gt 1 ]; then
+    echo "WARNING: Found ${PID_COUNT} matching operator processes. Stopping all of them." >&2
+fi
+
+for FOUND_PID in ${ALL_PIDS}; do
+    echo "Found operator process: pid=${FOUND_PID}"
+
+    # Also kill child processes (the compiled binary spawned by go run)
+    mapfile -t CHILD_PIDS < <(pgrep -P "${FOUND_PID}" 2>/dev/null) || true
+
+    echo "Stopping operator (pid ${FOUND_PID})..."
+    if kill "${FOUND_PID}" "${CHILD_PIDS[@]}" 2>/dev/null; then
+        echo "Sent TERM to process ${FOUND_PID} and its children."
+    else
+        echo "Process ${FOUND_PID} is already stopped."
+        continue
+    fi
+
+    for _ in $(seq 1 10); do
+        if ! ps -p "${FOUND_PID}" > /dev/null 2>&1; then
+            echo "Operator stopped (pid ${FOUND_PID})."
+            break
+        fi
+        sleep 0.5
+    done
+
+    if ps -p "${FOUND_PID}" > /dev/null 2>&1; then
+        echo "WARNING: Process ${FOUND_PID} still running after 5s, sending SIGKILL..." >&2
+        kill -9 "${FOUND_PID}" "${CHILD_PIDS[@]}" 2>/dev/null || true
+        sleep 1
+        if ps -p "${FOUND_PID}" > /dev/null 2>&1; then
+            echo "ERROR: Failed to stop process ${FOUND_PID}" >&2
+            exit 1
+        fi
+        echo "Operator stopped (SIGKILL, pid ${FOUND_PID})."
+    fi
+done
+
+echo "All operator processes stopped."


### PR DESCRIPTION
Provides a stop-rebuild-restart verification loop for developing the operator outside the cluster via `make run`. Includes a helper script to safely stop only the operator process, and guidance on when to regenerate manifests, CRDs, or upstream kustomizations between iterations.

Assisted-by: Cursor