### PR TITLE
feat: two-tier proxy endpoint testing for echo and real services

### DIFF
--- a/operator/config/samples/konflux_v1alpha1_konfluxui.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konfluxui.yaml
@@ -30,7 +30,7 @@ spec:
         # hostname: "custom-kite.namespace.svc.cluster.local"  # optional override
       kubearchive:
         enabled: true
-        # hostname: "kubearchive-api-server.kubearchive.svc.cluster.local"
+        # hostname: "kubearchive-api-server.product-kubearchive.svc.cluster.local"
       watson:
         enabled: false
         # hostname: "api.us-east.assistant.watson.cloud.ibm.com"  # optional override

--- a/operator/pkg/manifests/ui/manifests.yaml
+++ b/operator/pkg/manifests/ui/manifests.yaml
@@ -263,7 +263,7 @@ data:
 
     # Process kubearchive template
     if [ "${KUBEARCHIVE_ENABLED:-}" = "true" ] && [ -f "${TEMPLATES_DIR}/kubearchive.caddy" ]; then
-      hostname="${KUBEARCHIVE_HOSTNAME:-kubearchive-api-server.kubearchive.svc.cluster.local}"
+      hostname="${KUBEARCHIVE_HOSTNAME:-kubearchive-api-server.product-kubearchive.svc.cluster.local}"
       sed "s/__KUBEARCHIVE_HOSTNAME__/${hostname}/g" \
         "${TEMPLATES_DIR}/kubearchive.caddy" > "${SNIPPETS_DIR}/kubearchive.caddy"
       log "kubearchive endpoint enabled (${hostname})"
@@ -318,7 +318,7 @@ data:
     log "done"
 kind: ConfigMap
 metadata:
-  name: proxy-generate-config-c4c49hd24b
+  name: proxy-generate-config-thtfcb7h98
   namespace: konflux-ui
 ---
 apiVersion: v1
@@ -700,7 +700,7 @@ spec:
           items:
           - key: generate-proxy-config.sh
             path: generate-proxy-config.sh
-          name: proxy-generate-config-c4c49hd24b
+          name: proxy-generate-config-thtfcb7h98
         name: generate-proxy-config-script
       - name: kube-api-token
         projected:

--- a/operator/upstream-kustomizations/ui/core/proxy/generate-proxy-config.sh
+++ b/operator/upstream-kustomizations/ui/core/proxy/generate-proxy-config.sh
@@ -54,7 +54,7 @@ fi
 
 # Process kubearchive template
 if [ "${KUBEARCHIVE_ENABLED:-}" = "true" ] && [ -f "${TEMPLATES_DIR}/kubearchive.caddy" ]; then
-  hostname="${KUBEARCHIVE_HOSTNAME:-kubearchive-api-server.kubearchive.svc.cluster.local}"
+  hostname="${KUBEARCHIVE_HOSTNAME:-kubearchive-api-server.product-kubearchive.svc.cluster.local}"
   sed "s/__KUBEARCHIVE_HOSTNAME__/${hostname}/g" \
     "${TEMPLATES_DIR}/kubearchive.caddy" > "${SNIPPETS_DIR}/kubearchive.caddy"
   log "kubearchive endpoint enabled (${hostname})"

--- a/test/echo-server/main.go
+++ b/test/echo-server/main.go
@@ -118,7 +118,7 @@ func generateSelfSignedCert() (tls.Certificate, error) {
 		DNSNames: []string{
 			"localhost",
 			"*.konflux-kite.svc.cluster.local",
-			"*.kubearchive.svc.cluster.local",
+			"*.product-kubearchive.svc.cluster.local",
 			"*.test-echo-watson.svc.cluster.local",
 		},
 		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},

--- a/test/go-tests/echo_server_setup.go
+++ b/test/go-tests/echo_server_setup.go
@@ -10,8 +10,10 @@ import (
 	"runtime"
 	"time"
 
+	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -46,37 +48,73 @@ const (
 	openShiftServingCertAnnotation = "service.beta.openshift.io/serving-cert-secret-name"
 )
 
+type endpointTestMode string
+
+const (
+	modeEcho endpointTestMode = "echo"
+	modeReal endpointTestMode = "real"
+	modeSkip endpointTestMode = "skip"
+)
+
+type endpointModes struct {
+	Kite        endpointTestMode
+	KubeArchive endpointTestMode
+	Watson      endpointTestMode
+}
+
 type echoInstance struct {
+	endpointName   string
+	mode           *endpointTestMode
+	BasePath       string
 	Namespace      string
 	DeploymentName string
 	ServiceName    string
 	ServicePort    int32
 	ContainerPort  int32
+	isEnabled      func(*konfluxv1alpha1.ProxyEndpointsSpec) bool
 }
 
-var echoInstances = []echoInstance{
-	{
-		Namespace:      "konflux-kite",
-		DeploymentName: "konflux-kite",
-		ServiceName:    "konflux-kite",
-		ServicePort:    443,
-		ContainerPort:  8443,
-	},
-	{
-		Namespace:      "kubearchive",
-		DeploymentName: "kubearchive-api-server",
-		ServiceName:    "kubearchive-api-server",
-		ServicePort:    8081,
-		ContainerPort:  8081,
-	},
-	{
-		Namespace:      watsonEchoNamespace,
-		DeploymentName: "echo-watson",
-		ServiceName:    "echo-watson",
-		ServicePort:    443,
-		ContainerPort:  8443,
+var epModes endpointModes
+
+var kiteEndpoint = echoInstance{
+	endpointName:   "kite",
+	mode:           &epModes.Kite,
+	BasePath:       "/api/k8s/plugins/kite/",
+	Namespace:      "konflux-kite",
+	DeploymentName: "konflux-kite",
+	ServiceName:    "konflux-kite",
+	ServicePort:    443,
+	ContainerPort:  8443,
+	isEnabled:      func(ep *konfluxv1alpha1.ProxyEndpointsSpec) bool { return ep.Kite != nil && ep.Kite.Enabled },
+}
+
+var kubearchiveEndpoint = echoInstance{
+	endpointName:   "kubearchive",
+	mode:           &epModes.KubeArchive,
+	BasePath:       "/api/k8s/plugins/kubearchive/",
+	Namespace:      "product-kubearchive",
+	DeploymentName: "kubearchive-api-server",
+	ServiceName:    "kubearchive-api-server",
+	ServicePort:    8081,
+	ContainerPort:  8081,
+	isEnabled: func(ep *konfluxv1alpha1.ProxyEndpointsSpec) bool {
+		return ep.KubeArchive != nil && ep.KubeArchive.Enabled
 	},
 }
+
+var watsonEndpoint = echoInstance{
+	endpointName:   "watson",
+	mode:           &epModes.Watson,
+	BasePath:       "/api/chatbot/",
+	Namespace:      watsonEchoNamespace,
+	DeploymentName: "echo-watson",
+	ServiceName:    "echo-watson",
+	ServicePort:    443,
+	ContainerPort:  8443,
+	isEnabled:      func(ep *konfluxv1alpha1.ProxyEndpointsSpec) bool { return ep.Watson != nil && ep.Watson.Enabled },
+}
+
+var echoInstances = []*echoInstance{&kiteEndpoint, &kubearchiveEndpoint, &watsonEndpoint}
 
 func readEchoServerSource() string {
 	_, thisFile, _, ok := runtime.Caller(0)
@@ -88,11 +126,38 @@ func readEchoServerSource() string {
 	return string(data)
 }
 
-func deployEchoServers(ctx context.Context, cl crclient.Client) {
+func resolveEndpoints(k *konfluxv1alpha1.Konflux) *konfluxv1alpha1.ProxyEndpointsSpec {
+	if k.Spec.KonfluxUI == nil || k.Spec.KonfluxUI.Spec == nil {
+		return nil
+	}
+	return k.Spec.KonfluxUI.Spec.GetProxy().Endpoints
+}
+
+func setupEndpoints(ctx context.Context, cl crclient.Client, ep *konfluxv1alpha1.ProxyEndpointsSpec) {
 	src := readEchoServerSource()
 
 	for _, inst := range echoInstances {
-		By(fmt.Sprintf("Creating echo server in %s/%s", inst.Namespace, inst.DeploymentName))
+		if ep == nil || !inst.isEnabled(ep) {
+			*inst.mode = modeSkip
+			By(fmt.Sprintf("Skipping %s endpoint (not enabled in Konflux CR)", inst.endpointName))
+			continue
+		}
+
+		realDeploy := &appsv1.Deployment{}
+		err := cl.Get(ctx, crclient.ObjectKey{
+			Namespace: inst.Namespace,
+			Name:      inst.DeploymentName,
+		}, realDeploy)
+		if err == nil {
+			*inst.mode = modeReal
+			By(fmt.Sprintf("Using real %s service at %s/%s", inst.endpointName, inst.Namespace, inst.DeploymentName))
+			continue
+		}
+		Expect(errors.IsNotFound(err)).To(BeTrue(),
+			"unexpected error checking for real %s deployment: %v", inst.endpointName, err)
+
+		*inst.mode = modeEcho
+		By(fmt.Sprintf("Deploying echo server for %s in %s/%s", inst.endpointName, inst.Namespace, inst.DeploymentName))
 
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: inst.Namespace}}
 		Expect(cl.Create(ctx, ns)).To(Or(Succeed(), MatchError(ContainSubstring("already exists"))))
@@ -205,21 +270,26 @@ func deployEchoServers(ctx context.Context, cl crclient.Client) {
 		Expect(cl.Create(ctx, svc)).To(Or(Succeed(), MatchError(ContainSubstring("already exists"))))
 	}
 
-	By("Creating watson-config secret")
-	watsonBasicAuth := base64.StdEncoding.EncodeToString([]byte("apikey:" + watsonTestAPIKey))
-	watsonSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      watsonSecretName,
-			Namespace: proxyNamespace,
-		},
-		StringData: map[string]string{
-			"API_KEY": watsonBasicAuth,
-		},
+	if epModes.Watson == modeEcho {
+		By("Creating watson-config secret")
+		watsonBasicAuth := base64.StdEncoding.EncodeToString([]byte("apikey:" + watsonTestAPIKey))
+		watsonSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      watsonSecretName,
+				Namespace: proxyNamespace,
+			},
+			StringData: map[string]string{
+				"API_KEY": watsonBasicAuth,
+			},
+		}
+		Expect(cl.Create(ctx, watsonSecret)).To(Or(Succeed(), MatchError(ContainSubstring("already exists"))))
 	}
-	Expect(cl.Create(ctx, watsonSecret)).To(Or(Succeed(), MatchError(ContainSubstring("already exists"))))
 
 	By("Waiting for echo server deployments to be ready")
 	for _, inst := range echoInstances {
+		if *inst.mode != modeEcho {
+			continue
+		}
 		Eventually(func(g Gomega) {
 			deploy := &appsv1.Deployment{}
 			g.Expect(cl.Get(ctx, crclient.ObjectKey{
@@ -230,20 +300,24 @@ func deployEchoServers(ctx context.Context, cl crclient.Client) {
 				"echo server %s/%s not ready", inst.Namespace, inst.DeploymentName)
 		}).WithTimeout(echoDeployTimeout).WithPolling(echoDeployInterval).Should(Succeed())
 	}
-
 }
 
 func cleanupEchoServers(ctx context.Context, cl crclient.Client) {
 	for _, inst := range echoInstances {
+		if *inst.mode != modeEcho {
+			continue
+		}
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: inst.Namespace}}
 		_ = cl.Delete(ctx, ns)
 	}
 
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      watsonSecretName,
-			Namespace: proxyNamespace,
-		},
+	if epModes.Watson == modeEcho {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      watsonSecretName,
+				Namespace: proxyNamespace,
+			},
+		}
+		_ = cl.Delete(ctx, secret)
 	}
-	_ = cl.Delete(ctx, secret)
 }

--- a/test/go-tests/proxy_setup.go
+++ b/test/go-tests/proxy_setup.go
@@ -21,22 +21,24 @@ import (
 )
 
 const (
-	konfluxCRName               = "konflux"
-	defaultProxyTenantNamespace = "default-tenant"
-	konfluxReadyWaitTimeout     = 5 * time.Minute
-	konfluxHealthWaitTimeout    = 5 * time.Minute
-	konfluxReadyPollInterval    = 2 * time.Second
-	proxyHTTPRequestTimeout     = 30 * time.Second
+	konfluxCRName                 = "konflux"
+	defaultProxyTenantNamespace   = "default-tenant"
+	konfluxReadyWaitTimeout       = 5 * time.Minute
+	konfluxHealthWaitTimeout      = 5 * time.Minute
+	konfluxReadyPollInterval      = 2 * time.Second
+	proxyHTTPRequestTimeout       = 30 * time.Second
 	proxyAPITransientRetryTimeout = 2 * time.Minute
 )
 
 var (
-	proxyBase       *url.URL
-	proxyHome       string
-	tokenURL        string
+	proxyBase                *url.URL
+	proxyHome                string
+	tokenURL                 string
 	proxyHTTPClient          *http.Client
 	proxyWebSocketHTTPClient *http.Client
 	proxyClient              crclient.Client
+
+	proxyEndpointsCfg *konfluxv1alpha1.ProxyEndpointsSpec
 )
 
 var _ = BeforeSuite(func() {
@@ -91,7 +93,11 @@ var _ = BeforeSuite(func() {
 		}
 	}
 
-	deployEchoServers(ctx, proxyClient)
+	konflux := &konfluxv1alpha1.Konflux{}
+	Expect(proxyClient.Get(ctx, crclient.ObjectKey{Name: konfluxCRName}, konflux)).To(Succeed())
+	proxyEndpointsCfg = resolveEndpoints(konflux)
+
+	setupEndpoints(ctx, proxyClient, proxyEndpointsCfg)
 })
 
 var _ = AfterSuite(func() {

--- a/test/go-tests/proxy_test.go
+++ b/test/go-tests/proxy_test.go
@@ -291,23 +291,32 @@ var _ = Describe("Test Proxy endpoints", func() {
 	})
 
 	Describe("Test Kite endpoint", func() {
-		const kitePath = "/api/k8s/plugins/kite/echo"
+		kitePath := kiteEndpoint.BasePath
+
+		BeforeEach(func() {
+			if epModes.Kite == modeSkip {
+				Skip("Kite endpoint not enabled in Konflux CR")
+			}
+		})
 
 		It("should proxy authenticated requests with impersonation headers", func() {
 			token, err := ExtractToken(proxyClient)
 			Expect(err).NotTo(HaveOccurred())
 
-			headers := echoGet(kitePath, token)
-			Expect(headers).To(HaveKey("Authorization"),
-				"echo should receive Authorization header with kube_token")
-			Expect(headers["Authorization"]).To(HaveLen(1))
-			Expect(headers["Authorization"][0]).To(HavePrefix("Bearer "),
-				"Authorization should be a Bearer token (kube SA token)")
-
-			Expect(headers).To(HaveKey("Impersonate-User"),
-				"echo should receive Impersonate-User header")
-			Expect(headers["Impersonate-User"][0]).To(Equal(expectedImpersonateUser()),
-				"Impersonate-User should match the authenticated user")
+			if epModes.Kite == modeEcho {
+				headers := echoGet(kitePath+"echo", token)
+				Expect(headers).To(HaveKey("Authorization"),
+					"echo should receive Authorization header with kube_token")
+				Expect(headers["Authorization"]).To(HaveLen(1))
+				Expect(headers["Authorization"][0]).To(HavePrefix("Bearer "),
+					"Authorization should be a Bearer token (kube SA token)")
+				Expect(headers).To(HaveKey("Impersonate-User"),
+					"echo should receive Impersonate-User header")
+				Expect(headers["Impersonate-User"][0]).To(Equal(expectedImpersonateUser()),
+					"Impersonate-User should match the authenticated user")
+			} else {
+				expectEndpointRouted(kitePath, token)
+			}
 		})
 
 		It("should reject unauthenticated requests", func() {
@@ -321,20 +330,29 @@ var _ = Describe("Test Proxy endpoints", func() {
 	})
 
 	Describe("Test KubeArchive endpoint", func() {
-		const kubearchivePath = "/api/k8s/plugins/kubearchive/echo"
+		kubearchivePath := kubearchiveEndpoint.BasePath
+
+		BeforeEach(func() {
+			if epModes.KubeArchive == modeSkip {
+				Skip("KubeArchive endpoint not enabled in Konflux CR")
+			}
+		})
 
 		It("should proxy authenticated requests with impersonation headers", func() {
 			token, err := ExtractToken(proxyClient)
 			Expect(err).NotTo(HaveOccurred())
 
-			headers := echoGet(kubearchivePath, token)
-			Expect(headers).To(HaveKey("Authorization"),
-				"echo should receive Authorization header with kube_token")
-			Expect(headers["Authorization"][0]).To(HavePrefix("Bearer "))
-
-			Expect(headers).To(HaveKey("Impersonate-User"),
-				"echo should receive Impersonate-User header")
-			Expect(headers["Impersonate-User"][0]).To(Equal(expectedImpersonateUser()))
+			if epModes.KubeArchive == modeEcho {
+				headers := echoGet(kubearchivePath+"echo", token)
+				Expect(headers).To(HaveKey("Authorization"),
+					"echo should receive Authorization header with kube_token")
+				Expect(headers["Authorization"][0]).To(HavePrefix("Bearer "))
+				Expect(headers).To(HaveKey("Impersonate-User"),
+					"echo should receive Impersonate-User header")
+				Expect(headers["Impersonate-User"][0]).To(Equal(expectedImpersonateUser()))
+			} else {
+				expectEndpointRouted(kubearchivePath, token)
+			}
 		})
 
 		It("should reject unauthenticated requests", func() {
@@ -348,7 +366,13 @@ var _ = Describe("Test Proxy endpoints", func() {
 	})
 
 	Describe("Test Watson chatbot endpoint", func() {
-		const watsonPath = "/api/chatbot/echo"
+		watsonPath := watsonEndpoint.BasePath
+
+		BeforeEach(func() {
+			if epModes.Watson == modeSkip {
+				Skip("Watson endpoint not enabled in Konflux CR")
+			}
+		})
 
 		It("should proxy authenticated requests with Basic auth header", func() {
 			token, err := ExtractToken(proxyClient)
@@ -356,17 +380,14 @@ var _ = Describe("Test Proxy endpoints", func() {
 
 			expectedBasic := base64.StdEncoding.EncodeToString([]byte("apikey:" + watsonTestAPIKey))
 
-			// The watson-config Secret is projected as a volume and cached by
-			// file_watcher. Kubernetes may take up to ~60s to project a new
-			// Secret, so we poll until the auth value is populated.
 			var lastHeaders map[string][]string
 			Eventually(func(g Gomega) {
-				lastHeaders = echoGet(watsonPath, token)
+				lastHeaders = echoGet(watsonPath+"echo", token)
 				g.Expect(lastHeaders).To(HaveKey("Authorization"))
 				g.Expect(lastHeaders["Authorization"]).To(HaveLen(1))
 				g.Expect(lastHeaders["Authorization"][0]).To(Equal("Basic "+expectedBasic),
 					"Authorization should be Basic auth derived from watson API key")
-			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(Succeed())
+			}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 
 			Expect(lastHeaders).NotTo(HaveKey("Impersonate-User"),
 				"watson endpoint should NOT use impersonation")
@@ -389,8 +410,23 @@ type echoResponseBody struct {
 	Headers map[string][]string `json:"headers"`
 }
 
-// echoGet sends an authenticated GET to the proxy and parses the echo server JSON response.
-// Returns the headers map from the echo response.
+func expectEndpointRouted(path, token string) {
+	GinkgoHelper()
+	request, err := http.NewRequest("GET", proxyURL(path), nil)
+	Expect(err).NotTo(HaveOccurred())
+	request.Header.Set("Authorization", "Bearer "+token)
+
+	response, err := proxyHTTPClient.Do(request)
+	Expect(err).NotTo(HaveOccurred())
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(string(body)).NotTo(HavePrefix("<!doctype html>"),
+		"expected a backend service response, got the SPA HTML fallback — proxy may not be routing to the endpoint")
+}
+
 func echoGet(path, token string) map[string][]string {
 	request, err := http.NewRequest("GET", proxyURL(path), nil)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/go-tests/proxy_test.go
+++ b/test/go-tests/proxy_test.go
@@ -430,8 +430,8 @@ func expectEndpointRouted(path, token string) {
 	body, err := io.ReadAll(response.Body)
 	Expect(err).NotTo(HaveOccurred())
 
-	Expect(response.StatusCode).NotTo(Equal(http.StatusBadGateway),
-		"proxy returned 502 — backend service may be unreachable at %s", path)
+	Expect(response.StatusCode).To(BeNumerically("<", 500),
+		"backend at %s returned a server error (HTTP %d)", path, response.StatusCode)
 	Expect(string(body)).NotTo(HavePrefix("<!doctype html>"),
 		"expected a backend service response, got the SPA HTML fallback — proxy may not be routing to the endpoint")
 }

--- a/test/go-tests/proxy_test.go
+++ b/test/go-tests/proxy_test.go
@@ -378,19 +378,26 @@ var _ = Describe("Test Proxy endpoints", func() {
 			token, err := ExtractToken(proxyClient)
 			Expect(err).NotTo(HaveOccurred())
 
-			expectedBasic := base64.StdEncoding.EncodeToString([]byte("apikey:" + watsonTestAPIKey))
+			if epModes.Watson == modeEcho {
+				expectedBasic := base64.StdEncoding.EncodeToString([]byte("apikey:" + watsonTestAPIKey))
 
-			var lastHeaders map[string][]string
-			Eventually(func(g Gomega) {
-				lastHeaders = echoGet(watsonPath+"echo", token)
-				g.Expect(lastHeaders).To(HaveKey("Authorization"))
-				g.Expect(lastHeaders["Authorization"]).To(HaveLen(1))
-				g.Expect(lastHeaders["Authorization"][0]).To(Equal("Basic "+expectedBasic),
-					"Authorization should be Basic auth derived from watson API key")
-			}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+				// The watson-config Secret is projected as a volume and cached by
+				// file_watcher. Kubernetes may take up to ~60s to project a new
+				// Secret, so we poll until the auth value is populated.
+				var lastHeaders map[string][]string
+				Eventually(func(g Gomega) {
+					lastHeaders = echoGet(watsonPath+"echo", token)
+					g.Expect(lastHeaders).To(HaveKey("Authorization"))
+					g.Expect(lastHeaders["Authorization"]).To(HaveLen(1))
+					g.Expect(lastHeaders["Authorization"][0]).To(Equal("Basic "+expectedBasic),
+						"Authorization should be Basic auth derived from watson API key")
+				}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 
-			Expect(lastHeaders).NotTo(HaveKey("Impersonate-User"),
-				"watson endpoint should NOT use impersonation")
+				Expect(lastHeaders).NotTo(HaveKey("Impersonate-User"),
+					"watson endpoint should NOT use impersonation")
+			} else {
+				expectEndpointRouted(watsonPath, token)
+			}
 		})
 
 		It("should reject unauthenticated requests", func() {
@@ -423,6 +430,8 @@ func expectEndpointRouted(path, token string) {
 	body, err := io.ReadAll(response.Body)
 	Expect(err).NotTo(HaveOccurred())
 
+	Expect(response.StatusCode).NotTo(Equal(http.StatusBadGateway),
+		"proxy returned 502 — backend service may be unreachable at %s", path)
 	Expect(string(body)).NotTo(HavePrefix("<!doctype html>"),
 		"expected a backend service response, got the SPA HTML fallback — proxy may not be routing to the endpoint")
 }


### PR DESCRIPTION
## Summary

- Proxy endpoint E2E tests now adapt to the deployment environment: in konflux-ci (Kind), echo servers are deployed with full header verification (Authorization, Impersonate-User); in infra-deployments (OpenShift) where real Kite/KubeArchive services exist, tests verify routing without echo servers.
- The test reads the Konflux CR to determine which endpoints are enabled, then checks for an existing real Deployment to decide between `modeEcho` (deploy echo server), `modeReal` (lighter routing assertions), or `modeSkip` (endpoint not enabled).
- Updates the default KubeArchive proxy hostname to use the `product-kubearchive` namespace, matching the real service deployment in infra-deployments.

## Test plan

- [x] Verified on local Kind cluster: all 6 endpoint tests pass in `modeEcho` (Kite, KubeArchive, Watson — authenticated + unauthenticated)
- [x] Operator unit tests pass (`make test` from `operator/`)
- [x] Both `operator/` and `test/go-tests/` modules compile cleanly
- [ ] CI E2E tests pass on this PR


Made with [Cursor](https://cursor.com)