### PR TITLE
feat(KFLUXVNGD-1100): Add self-healing and drift correction tests to enterprise-contract resources

### DIFF
--- a/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
+++ b/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
@@ -27,10 +27,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
+)
+
+const (
+	ecNamespace                = "enterprise-contract-service"
+	ecConfigMapName            = "ec-defaults"
+	configmapViewerClusterRole = "enterprisecontract-configmap-viewer-role"
+	policyEditorClusterRole    = "enterprisecontractpolicy-editor-role"
+	policyViewerClusterRole    = "enterprisecontractpolicy-viewer-role"
+	publicEcCmRoleBinding      = "public-ec-cm"
+	publicEcpRoleBinding       = "public-ecp"
 )
 
 // newDefaultECPolicy returns an unstructured object for the default EnterpriseContractPolicy.
@@ -40,6 +52,17 @@ func newDefaultECPolicy() *unstructured.Unstructured {
 	obj.SetName("default")
 	obj.SetNamespace("enterprise-contract-service")
 	return obj
+}
+
+// ecClusterScopedChildren returns all cluster-scoped resources that the reconciler creates.
+// envtest has no garbage collector, so these must be explicitly cleaned up after each test.
+func ecClusterScopedChildren() []client.Object {
+	return []client.Object{
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: configmapViewerClusterRole}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: policyEditorClusterRole}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: policyViewerClusterRole}},
+		newDefaultECPolicy(),
+	}
 }
 
 var _ = Describe("KonfluxEnterpriseContract Controller", Ordered, func() {
@@ -60,7 +83,7 @@ var _ = Describe("KonfluxEnterpriseContract Controller", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, ec)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, ec, newDefaultECPolicy())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ec, ecClusterScopedChildren()...)
 
 			Eventually(waitForReady(ctx)).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
@@ -90,7 +113,7 @@ var _ = Describe("KonfluxEnterpriseContract Controller", Ordered, func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, ec)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, ec, newDefaultECPolicy())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ec, ecClusterScopedChildren()...)
 
 			Eventually(waitForReady(ctx)).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
@@ -117,7 +140,7 @@ var _ = Describe("KonfluxEnterpriseContract Controller", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, cr, newDefaultECPolicy())
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, ecClusterScopedChildren()...)
 
 			Eventually(waitForReady(ctx)).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
@@ -153,7 +176,7 @@ var _ = Describe("KonfluxEnterpriseContract Controller", Ordered, func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, cr, newDefaultECPolicy())
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, ecClusterScopedChildren()...)
 
 			Eventually(waitForReady(ctx)).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
@@ -172,5 +195,248 @@ var _ = Describe("KonfluxEnterpriseContract Controller", Ordered, func() {
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: "enterprise-contract-service"}, newDefaultECPolicy())).To(Succeed())
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
+	})
+
+	Context("Self-healing", func() {
+		It("recreates ConfigMap when deleted", func(ctx context.Context) {
+			ec := &konfluxv1alpha1.KonfluxEnterpriseContract{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, ec)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ec, ecClusterScopedChildren()...)
+
+			cmNN := types.NamespacedName{Name: ecConfigMapName, Namespace: ecNamespace}
+
+			By("waiting for initial ConfigMap creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, cmNN, &corev1.ConfigMap{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the ConfigMap")
+			Expect(k8sClient.Delete(ctx, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: cmNN.Name, Namespace: cmNN.Namespace},
+			})).To(Succeed())
+
+			By("verifying the ConfigMap is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+				g.Expect(cm.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("recreates ClusterRole when deleted", func(ctx context.Context) {
+			ec := &konfluxv1alpha1.KonfluxEnterpriseContract{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, ec)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ec, ecClusterScopedChildren()...)
+
+			crNN := types.NamespacedName{Name: configmapViewerClusterRole}
+
+			By("waiting for initial ClusterRole creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, crNN, &rbacv1.ClusterRole{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the ClusterRole")
+			Expect(k8sClient.Delete(ctx, &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
+			})).To(Succeed())
+
+			By("verifying the ClusterRole is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				cr := &rbacv1.ClusterRole{}
+				g.Expect(k8sClient.Get(ctx, crNN, cr)).To(Succeed())
+				g.Expect(cr.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("recreates RoleBinding when deleted", func(ctx context.Context) {
+			ec := &konfluxv1alpha1.KonfluxEnterpriseContract{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, ec)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ec, ecClusterScopedChildren()...)
+
+			rbNN := types.NamespacedName{Name: publicEcCmRoleBinding, Namespace: ecNamespace}
+
+			By("waiting for initial RoleBinding creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, rbNN, &rbacv1.RoleBinding{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the RoleBinding")
+			Expect(k8sClient.Delete(ctx, &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: rbNN.Name, Namespace: rbNN.Namespace},
+			})).To(Succeed())
+
+			By("verifying the RoleBinding is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				rb := &rbacv1.RoleBinding{}
+				g.Expect(k8sClient.Get(ctx, rbNN, rb)).To(Succeed())
+				g.Expect(rb.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+	})
+
+	Context("Drift correction", func() {
+		It("restores Namespace labels when stripped", func(ctx context.Context) {
+			ec := &konfluxv1alpha1.KonfluxEnterpriseContract{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, ec)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ec, ecClusterScopedChildren()...)
+
+			nsNN := types.NamespacedName{Name: ecNamespace}
+
+			By("waiting for initial Namespace creation with ownership labels")
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsNN, ns)).To(Succeed())
+				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("stripping ownership labels from the Namespace")
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsNN, ns)).To(Succeed())
+				delete(ns.Labels, constant.KonfluxOwnerLabel)
+				delete(ns.Labels, constant.KonfluxComponentLabel)
+				g.Expect(k8sClient.Update(ctx, ns)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Namespace labels are restored")
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsNN, ns)).To(Succeed())
+				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxComponentLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores ConfigMap data when modified", func(ctx context.Context) {
+			ec := &konfluxv1alpha1.KonfluxEnterpriseContract{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, ec)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ec, ecClusterScopedChildren()...)
+
+			cmNN := types.NamespacedName{Name: ecConfigMapName, Namespace: ecNamespace}
+
+			By("waiting for initial ConfigMap creation")
+			var originalKey string
+			var originalValue string
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+				g.Expect(cm.Data).NotTo(BeEmpty())
+				for k, v := range cm.Data {
+					originalKey = k
+					originalValue = v
+					break
+				}
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying an existing ConfigMap data key")
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+				cm.Data[originalKey] = "tampered-content"
+				g.Expect(k8sClient.Update(ctx, cm)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the ConfigMap data is restored")
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+				g.Expect(cm.Data).To(HaveKeyWithValue(originalKey, originalValue))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		DescribeTable("restores ClusterRole rules when modified",
+			func(ctx context.Context, roleName string) {
+				ec := &konfluxv1alpha1.KonfluxEnterpriseContract{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, ec)).To(Succeed())
+				testutil.DeferCleanupParentAndChildren(k8sClient, ec, ecClusterScopedChildren()...)
+
+				crNN := types.NamespacedName{Name: roleName}
+
+				By("waiting for initial ClusterRole creation")
+				var originalRules []rbacv1.PolicyRule
+				Eventually(func(g Gomega) {
+					cr := &rbacv1.ClusterRole{}
+					g.Expect(k8sClient.Get(ctx, crNN, cr)).To(Succeed())
+					g.Expect(cr.Rules).NotTo(BeEmpty())
+					originalRules = cr.Rules
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("modifying the ClusterRole rules")
+				Eventually(func(g Gomega) {
+					cr := &rbacv1.ClusterRole{}
+					g.Expect(k8sClient.Get(ctx, crNN, cr)).To(Succeed())
+					cr.Rules = []rbacv1.PolicyRule{{
+						APIGroups: []string{""},
+						Resources: []string{"pods"},
+						Verbs:     []string{"delete"},
+					}}
+					g.Expect(k8sClient.Update(ctx, cr)).To(Succeed())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("verifying the ClusterRole rules are restored")
+				Eventually(func(g Gomega) {
+					cr := &rbacv1.ClusterRole{}
+					g.Expect(k8sClient.Get(ctx, crNN, cr)).To(Succeed())
+					g.Expect(cr.Rules).To(Equal(originalRules))
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			},
+			Entry("configmap-viewer", configmapViewerClusterRole),
+			Entry("policy-editor", policyEditorClusterRole),
+			Entry("policy-viewer", policyViewerClusterRole),
+		)
+
+		DescribeTable("restores RoleBinding subjects when modified",
+			func(ctx context.Context, bindingName string) {
+				ec := &konfluxv1alpha1.KonfluxEnterpriseContract{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, ec)).To(Succeed())
+				testutil.DeferCleanupParentAndChildren(k8sClient, ec, ecClusterScopedChildren()...)
+
+				rbNN := types.NamespacedName{Name: bindingName, Namespace: ecNamespace}
+
+				By("waiting for initial RoleBinding creation")
+				var originalSubjects []rbacv1.Subject
+				Eventually(func(g Gomega) {
+					rb := &rbacv1.RoleBinding{}
+					g.Expect(k8sClient.Get(ctx, rbNN, rb)).To(Succeed())
+					g.Expect(rb.Subjects).NotTo(BeEmpty())
+					originalSubjects = rb.Subjects
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("modifying the RoleBinding subjects")
+				Eventually(func(g Gomega) {
+					rb := &rbacv1.RoleBinding{}
+					g.Expect(k8sClient.Get(ctx, rbNN, rb)).To(Succeed())
+					rb.Subjects = []rbacv1.Subject{{
+						Kind:     "User",
+						Name:     "tampered-user",
+						APIGroup: "rbac.authorization.k8s.io",
+					}}
+					g.Expect(k8sClient.Update(ctx, rb)).To(Succeed())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("verifying the RoleBinding subjects are restored")
+				Eventually(func(g Gomega) {
+					rb := &rbacv1.RoleBinding{}
+					g.Expect(k8sClient.Get(ctx, rbNN, rb)).To(Succeed())
+					g.Expect(rb.Subjects).To(Equal(originalSubjects))
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			},
+			Entry("public-ec-cm", publicEcCmRoleBinding),
+			Entry("public-ecp", publicEcpRoleBinding),
+		)
 	})
 })


### PR DESCRIPTION
The EnterpriseContract controller already has correct Owns() wiring for all its manifest resources (Namespace, ConfigMap, ClusterRole, RoleBinding) but was missing tests to verify drift correction and self-healing behavior.

Add 10 new tests:

Self-healing (3):
- recreates ConfigMap (ec-defaults) when deleted
- recreates ClusterRole when deleted
- recreates RoleBinding when deleted

Drift correction (7):
- restores Namespace labels when stripped
- restores ConfigMap data when modified
- restores ClusterRole rules when modified (all 3: configmap-viewer, policy-editor, policy-viewer)
- restores RoleBinding subjects when modified (both: public-ec-cm, public-ecp)

Uses DescribeTable for parameterized ClusterRole and RoleBinding tests to reduce duplication. Introduces ecClusterScopedChildren() helper for consistent cluster-scoped resource cleanup across all tests.

Note: EnterpriseContractPolicy is not covered by Owns() because its CRD is installed by this same controller — a static informer would fail at startup if the CRD doesn't exist yet. A dynamic/unstructured watch is tracked in https://redhat.atlassian.net/browse/KFLUXVNGD-1108.

Assisted-by: Cursor + Opus 4.6