### PR TITLE
feat(KFLUXVNGD-1103): add watch/own to Info resources

### DIFF
--- a/operator/internal/controller/info/konfluxinfo_controller_test.go
+++ b/operator/internal/controller/info/konfluxinfo_controller_test.go
@@ -18,27 +18,59 @@ package info
 
 import (
 	"context"
+	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
+)
+
+const (
+	infoRoleName        = "konflux-public-info-view-role"
+	infoRoleBindingName = "konflux-public-info-view-rb"
 )
 
 var _ = Describe("KonfluxInfo Controller", func() {
+	// startManager starts a per-test manager with the given ClusterInfo
+	// and registers a DeferCleanup to stop it when the It block finishes.
+	// A per-test manager is needed because the OpenShift tests require a different
+	// ClusterInfo than the default (nil) tests.
+	startManager := func(clusterInfo *clusterinfo.Info) {
+		mgrCtx, mgrCancel := context.WithCancel(testEnv.Ctx)
+		mgr := testutil.NewTestManager(testEnv)
+		Expect((&KonfluxInfoReconciler{
+			Client:      mgr.GetClient(),
+			Scheme:      mgr.GetScheme(),
+			ObjectStore: objectStore,
+			ClusterInfo: clusterInfo,
+		}).SetupWithManager(mgr)).To(Succeed())
+		waitForStop := testutil.StartManagerWithContext(mgrCtx, mgr)
+		DeferCleanup(func() {
+			mgrCancel()
+			waitForStop()
+		})
+	}
+
 	Context("When reconciling a resource", func() {
 		It("should successfully reconcile the resource", func(ctx context.Context) {
+			startManager(nil)
+
 			infoRes := &konfluxv1alpha1.KonfluxInfo{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, infoRes)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, infoRes)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, infoRes)
 
 			Eventually(func(g Gomega) {
 				updated := &konfluxv1alpha1.KonfluxInfo{}
@@ -116,7 +148,355 @@ var _ = Describe("KonfluxInfo Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, cr)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+		})
+	})
+
+	Context("Self-healing", func() {
+		DescribeTable("recreates ConfigMap when deleted",
+			func(ctx context.Context, cmName string) {
+				startManager(nil)
+
+				cr := &konfluxv1alpha1.KonfluxInfo{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+				DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+				cmNN := types.NamespacedName{Name: cmName, Namespace: infoNamespace}
+
+				By("waiting for initial ConfigMap creation")
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, cmNN, &corev1.ConfigMap{})).To(Succeed())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("deleting the ConfigMap")
+				Expect(k8sClient.Delete(ctx, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: cmNN.Name, Namespace: cmNN.Namespace},
+				})).To(Succeed())
+
+				By("verifying the ConfigMap is recreated with ownership labels")
+				Eventually(func(g Gomega) {
+					cm := &corev1.ConfigMap{}
+					g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+					g.Expect(cm.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			},
+			Entry("info", infoConfigMapName),
+			Entry("banner", bannerConfigMapName),
+			Entry("cluster-config", clusterConfigMapName),
+		)
+
+		It("recreates Role when deleted", func(ctx context.Context) {
+			startManager(nil)
+
+			cr := &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			roleNN := types.NamespacedName{Name: infoRoleName, Namespace: infoNamespace}
+
+			By("waiting for initial Role creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, roleNN, &rbacv1.Role{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the Role")
+			Expect(k8sClient.Delete(ctx, &rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{Name: roleNN.Name, Namespace: roleNN.Namespace},
+			})).To(Succeed())
+
+			By("verifying the Role is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				role := &rbacv1.Role{}
+				g.Expect(k8sClient.Get(ctx, roleNN, role)).To(Succeed())
+				g.Expect(role.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("recreates RoleBinding when deleted", func(ctx context.Context) {
+			startManager(nil)
+
+			cr := &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			rbNN := types.NamespacedName{Name: infoRoleBindingName, Namespace: infoNamespace}
+
+			By("waiting for initial RoleBinding creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, rbNN, &rbacv1.RoleBinding{})).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the RoleBinding")
+			Expect(k8sClient.Delete(ctx, &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: rbNN.Name, Namespace: rbNN.Namespace},
+			})).To(Succeed())
+
+			By("verifying the RoleBinding is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				rb := &rbacv1.RoleBinding{}
+				g.Expect(k8sClient.Get(ctx, rbNN, rb)).To(Succeed())
+				g.Expect(rb.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+	})
+
+	Context("Drift correction", func() {
+		It("restores Namespace labels when stripped", func(ctx context.Context) {
+			startManager(nil)
+
+			cr := &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			nsNN := types.NamespacedName{Name: infoNamespace}
+
+			By("waiting for initial Namespace creation with ownership labels")
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsNN, ns)).To(Succeed())
+				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("stripping ownership labels from the Namespace")
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsNN, ns)).To(Succeed())
+				delete(ns.Labels, constant.KonfluxOwnerLabel)
+				delete(ns.Labels, constant.KonfluxComponentLabel)
+				g.Expect(k8sClient.Update(ctx, ns)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Namespace labels are restored")
+			Eventually(func(g Gomega) {
+				ns := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsNN, ns)).To(Succeed())
+				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxComponentLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		DescribeTable("restores ConfigMap data when modified",
+			func(ctx context.Context, cmName string) {
+				startManager(nil)
+
+				cr := &konfluxv1alpha1.KonfluxInfo{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+					Spec: konfluxv1alpha1.KonfluxInfoSpec{
+						ClusterConfig: &konfluxv1alpha1.ClusterConfig{
+							Data: &konfluxv1alpha1.ClusterConfigData{
+								DefaultOIDCIssuer: "https://oidc.example.com",
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+				DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+				cmNN := types.NamespacedName{Name: cmName, Namespace: infoNamespace}
+
+				By("waiting for initial ConfigMap creation")
+				var originalKey string
+				var originalValue string
+				Eventually(func(g Gomega) {
+					cm := &corev1.ConfigMap{}
+					g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+					g.Expect(cm.Data).NotTo(BeEmpty())
+					for k, v := range cm.Data {
+						originalKey = k
+						originalValue = v
+						break
+					}
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("modifying an existing ConfigMap data key")
+				Eventually(func(g Gomega) {
+					cm := &corev1.ConfigMap{}
+					g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+					cm.Data[originalKey] = "tampered-content"
+					g.Expect(k8sClient.Update(ctx, cm)).To(Succeed())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("verifying the ConfigMap data is restored")
+				Eventually(func(g Gomega) {
+					cm := &corev1.ConfigMap{}
+					g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+					g.Expect(cm.Data).To(HaveKeyWithValue(originalKey, originalValue))
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			},
+			Entry("info", infoConfigMapName),
+			Entry("banner", bannerConfigMapName),
+			Entry("cluster-config", clusterConfigMapName),
+		)
+
+		It("restores Role rules when modified", func(ctx context.Context) {
+			startManager(nil)
+
+			cr := &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			roleNN := types.NamespacedName{Name: infoRoleName, Namespace: infoNamespace}
+
+			By("waiting for initial Role creation")
+			var originalRules []rbacv1.PolicyRule
+			Eventually(func(g Gomega) {
+				role := &rbacv1.Role{}
+				g.Expect(k8sClient.Get(ctx, roleNN, role)).To(Succeed())
+				g.Expect(role.Rules).NotTo(BeEmpty())
+				originalRules = role.Rules
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the Role rules")
+			Eventually(func(g Gomega) {
+				role := &rbacv1.Role{}
+				g.Expect(k8sClient.Get(ctx, roleNN, role)).To(Succeed())
+				role.Rules = []rbacv1.PolicyRule{{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"delete"},
+				}}
+				g.Expect(k8sClient.Update(ctx, role)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Role rules are restored")
+			Eventually(func(g Gomega) {
+				role := &rbacv1.Role{}
+				g.Expect(k8sClient.Get(ctx, roleNN, role)).To(Succeed())
+				g.Expect(role.Rules).To(Equal(originalRules))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores RoleBinding subjects when modified", func(ctx context.Context) {
+			startManager(nil)
+
+			cr := &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			rbNN := types.NamespacedName{Name: infoRoleBindingName, Namespace: infoNamespace}
+
+			By("waiting for initial RoleBinding creation")
+			var originalSubjects []rbacv1.Subject
+			Eventually(func(g Gomega) {
+				rb := &rbacv1.RoleBinding{}
+				g.Expect(k8sClient.Get(ctx, rbNN, rb)).To(Succeed())
+				g.Expect(rb.Subjects).NotTo(BeEmpty())
+				originalSubjects = rb.Subjects
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the RoleBinding subjects")
+			Eventually(func(g Gomega) {
+				rb := &rbacv1.RoleBinding{}
+				g.Expect(k8sClient.Get(ctx, rbNN, rb)).To(Succeed())
+				rb.Subjects = []rbacv1.Subject{{
+					Kind:     "User",
+					Name:     "tampered-user",
+					APIGroup: "rbac.authorization.k8s.io",
+				}}
+				g.Expect(k8sClient.Update(ctx, rb)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the RoleBinding subjects are restored")
+			Eventually(func(g Gomega) {
+				rb := &rbacv1.RoleBinding{}
+				g.Expect(k8sClient.Get(ctx, rbNN, rb)).To(Succeed())
+				g.Expect(rb.Subjects).To(Equal(originalSubjects))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+	})
+
+	Context("OpenShift ClusterVersion watch", func() {
+		It("should not include cluster version info in info.json without ClusterInfo", func(ctx context.Context) {
+			startManager(nil)
+
+			cr := &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			cmNN := types.NamespacedName{Name: infoConfigMapName, Namespace: infoNamespace}
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+				g.Expect(cm.Data).To(HaveKey("info.json"))
+
+				var info map[string]interface{}
+				g.Expect(json.Unmarshal([]byte(cm.Data["info.json"]), &info)).To(Succeed())
+				g.Expect(info).NotTo(HaveKey("openshiftVersion"))
+				g.Expect(info).NotTo(HaveKey("kubernetesVersion"))
+				g.Expect(info).NotTo(HaveKey("clusterId"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("should include cluster version info in info.json on OpenShift", func(ctx context.Context) {
+			By("building OpenShift cluster info")
+			mockDiscovery := &MockDiscoveryClient{
+				resources: map[string]*metav1.APIResourceList{
+					"config.openshift.io/v1": {
+						APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}},
+					},
+				},
+			}
+			mockDiscovery.SetVersion("v1.29.0")
+			openShiftClusterInfo, err := clusterinfo.DetectWithClient(mockDiscovery)
+			Expect(err).NotTo(HaveOccurred())
+
+			startManager(openShiftClusterInfo)
+
+			By("creating the ClusterVersion resource")
+			clusterVersion := &configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{Name: "version"},
+				Spec: configv1.ClusterVersionSpec{
+					ClusterID: "test-cluster-id-12345",
+				},
+			}
+			Expect(k8sClient.Create(ctx, clusterVersion)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, clusterVersion)
+
+			clusterVersion.Status = configv1.ClusterVersionStatus{
+				History: []configv1.UpdateHistory{
+					{
+						State:       configv1.CompletedUpdate,
+						Version:     "4.15.0",
+						StartedTime: metav1.Now(),
+					},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, clusterVersion)).To(Succeed())
+
+			By("creating the KonfluxInfo CR")
+			cr := &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			By("verifying info.json contains OpenShift version info")
+			cmNN := types.NamespacedName{Name: infoConfigMapName, Namespace: infoNamespace}
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+				g.Expect(cm.Data).To(HaveKey("info.json"))
+
+				var info map[string]interface{}
+				g.Expect(json.Unmarshal([]byte(cm.Data["info.json"]), &info)).To(Succeed())
+				g.Expect(info["kubernetesVersion"]).To(Equal("v1.29.0"))
+				g.Expect(info["openshiftVersion"]).To(Equal("4.15.0"))
+				g.Expect(info["clusterId"]).To(Equal("test-cluster-id-12345"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})
 })

--- a/operator/internal/controller/info/mock_discovery_test.go
+++ b/operator/internal/controller/info/mock_discovery_test.go
@@ -29,9 +29,11 @@ import (
 
 // MockDiscoveryClient implements clusterinfo.DiscoveryClient and allows changing
 // the reported server version during a test (e.g. to simulate a cluster upgrade).
+// Set resources to simulate OpenShift API discovery (nil defaults to NotFound for all).
 type MockDiscoveryClient struct {
 	lock          sync.Mutex
 	serverVersion *version.Info
+	resources     map[string]*metav1.APIResourceList
 }
 
 // ServerVersion returns the currently set version. Safe for concurrent use.
@@ -49,9 +51,14 @@ func (m *MockDiscoveryClient) SetVersion(v string) {
 	m.serverVersion = &version.Info{GitVersion: v}
 }
 
-// ServerResourcesForGroupVersion returns NotFound for config.openshift.io/v1 so
-// clusterinfo.DetectWithClient treats the cluster as non-OpenShift and succeeds.
+// ServerResourcesForGroupVersion returns the configured resources for the group version,
+// or NotFound if not configured. Set resources map to simulate OpenShift API presence.
 func (m *MockDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	if m.resources != nil {
+		if r, ok := m.resources[groupVersion]; ok {
+			return r, nil
+		}
+	}
 	return nil, apierrors.NewNotFound(schema.GroupResource{Group: groupVersion}, "")
 }
 

--- a/operator/internal/controller/info/suite_test.go
+++ b/operator/internal/controller/info/suite_test.go
@@ -45,14 +45,6 @@ var _ = BeforeSuite(func() {
 	ctx = testEnv.Ctx
 	k8sClient = testEnv.K8sClient
 	objectStore = testEnv.ObjectStore
-
-	mgr := testutil.NewTestManager(testEnv)
-	Expect((&KonfluxInfoReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		ObjectStore: objectStore,
-	}).SetupWithManager(mgr)).To(Succeed())
-	testutil.StartManager(testEnv, mgr)
 })
 
 var _ = AfterSuite(func() {

--- a/operator/internal/controller/testutil/testutil.go
+++ b/operator/internal/controller/testutil/testutil.go
@@ -47,6 +47,7 @@ import (
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 )
@@ -103,6 +104,9 @@ func SetupTestEnv(basePath string) *TestEnv {
 	err = certmanagerv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = configv1.Install(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
 	objectStore, err := manifests.NewObjectStore(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -111,6 +115,7 @@ func SetupTestEnv(basePath string) *TestEnv {
 		CRDDirectoryPaths: []string{
 			filepath.Join(basePath, "config", "crd", "bases"),
 			filepath.Join(basePath, "test", "crds", "cert-manager"),
+			filepath.Join(GetGoModuleDir("github.com/openshift/api"), "config", "v1", "zz_generated.crd-manifests"),
 			filepath.Join(GetGoModuleDir("github.com/openshift/api"), "console", "v1", "zz_generated.crd-manifests"),
 			filepath.Join(GetGoModuleDir("github.com/openshift/api"), "security", "v1", "zz_generated.crd-manifests"),
 		},


### PR DESCRIPTION
The info controller manages a Namespace, 3 ConfigMaps, a Role, and a RoleBinding but had no tests verifying that these resources are recreated when deleted or restored when tampered with.

- Add self-healing tests that delete each owned resource and verify the controller recreates it.

- Add drift correction tests that modify resource content (Namespace labels, ConfigMap data, Role rules, RoleBinding subjects) and verify the controller restores the original values.

- ConfigMap tests use DescribeTable to cover all three programmatic ConfigMaps (info.json, banner, cluster-config).

- Add an OpenShift integration test that starts the controller with simulated OpenShift cluster info, creates a ClusterVersion resource, and verifies the info.json ConfigMap includes kubernetesVersion, openshiftVersion, and clusterId. This exercises the conditional ClusterVersion watch that was previously untested.

- To support different ClusterInfo per test (nil vs OpenShift), convert the suite from a shared manager to per-test managers, following the same pattern used by the buildservice and UI controllers. Register the OpenShift config/v1 scheme and reference its CRDs from the Go module cache so envtest can serve ClusterVersion resources.

Assisted-by: Cursor + Opus 4.6