### PR TITLE
feat(KFLUXVNGD-1104): add watch/own tests to RBAC resources

### DIFF
--- a/operator/internal/controller/rbac/konfluxrbac_controller_test.go
+++ b/operator/internal/controller/rbac/konfluxrbac_controller_test.go
@@ -24,11 +24,48 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 )
+
+const (
+	adminBatchClusterRole       = "konflux-admin-user-actions-batch"
+	adminCoreClusterRole        = "konflux-admin-user-actions-core"
+	adminExtraClusterRole       = "konflux-admin-user-actions-extra"
+	builderBotClusterRole       = "konflux-builder-bot-actions"
+	contributorCoreClusterRole  = "konflux-contributor-user-actions-core"
+	contributorExtraClusterRole = "konflux-contributor-user-actions-extra"
+	maintainerCoreClusterRole   = "konflux-maintainer-user-actions-core"
+	maintainerExtraClusterRole  = "konflux-maintainer-user-actions-extra"
+	releaserBotClusterRole      = "konflux-releaser-bot-actions"
+	selfAccessClusterRole       = "konflux-self-access-reviewer"
+	viewerCoreClusterRole       = "konflux-viewer-user-actions-core"
+	viewerExtraClusterRole      = "konflux-viewer-user-actions-extra"
+)
+
+// rbacClusterScopedChildren returns all cluster-scoped resources that the reconciler creates.
+// envtest has no garbage collector, so these must be explicitly cleaned up after each test.
+func rbacClusterScopedChildren() []client.Object {
+	return []client.Object{
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: adminBatchClusterRole}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: adminCoreClusterRole}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: adminExtraClusterRole}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: builderBotClusterRole}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: contributorCoreClusterRole}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: contributorExtraClusterRole}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: maintainerCoreClusterRole}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: maintainerExtraClusterRole}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: releaserBotClusterRole}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: selfAccessClusterRole}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: viewerCoreClusterRole}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: viewerExtraClusterRole}},
+	}
+}
 
 var _ = Describe("KonfluxRBAC Controller", func() {
 	Context("When reconciling a resource", func() {
@@ -37,7 +74,7 @@ var _ = Describe("KonfluxRBAC Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, rbacRes)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, rbacRes)
+			testutil.DeferCleanupParentAndChildren(k8sClient, rbacRes, rbacClusterScopedChildren()...)
 
 			// The rbac manifests contain only ClusterRoles — no Deployments — so
 			// Ready=True is a reliable sentinel.
@@ -48,9 +85,89 @@ var _ = Describe("KonfluxRBAC Controller", func() {
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 
 			By("verifying representative ClusterRoles were created")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-admin-user-actions-batch"}, &rbacv1.ClusterRole{})).To(Succeed())
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-builder-bot-actions"}, &rbacv1.ClusterRole{})).To(Succeed())
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "konflux-releaser-bot-actions"}, &rbacv1.ClusterRole{})).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: adminBatchClusterRole}, &rbacv1.ClusterRole{})).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: builderBotClusterRole}, &rbacv1.ClusterRole{})).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: releaserBotClusterRole}, &rbacv1.ClusterRole{})).To(Succeed())
 		})
+	})
+
+	Context("Self-healing", func() {
+		DescribeTable("recreates ClusterRole when deleted",
+			func(ctx context.Context, roleName string) {
+				rbacRes := &konfluxv1alpha1.KonfluxRBAC{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, rbacRes)).To(Succeed())
+				testutil.DeferCleanupParentAndChildren(k8sClient, rbacRes, rbacClusterScopedChildren()...)
+
+				crNN := types.NamespacedName{Name: roleName}
+
+				By("waiting for initial ClusterRole creation")
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, crNN, &rbacv1.ClusterRole{})).To(Succeed())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("deleting the ClusterRole")
+				Expect(k8sClient.Delete(ctx, &rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{Name: crNN.Name},
+				})).To(Succeed())
+
+				By("verifying the ClusterRole is recreated with ownership labels")
+				Eventually(func(g Gomega) {
+					cr := &rbacv1.ClusterRole{}
+					g.Expect(k8sClient.Get(ctx, crNN, cr)).To(Succeed())
+					g.Expect(cr.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
+					g.Expect(cr.Labels).To(HaveKeyWithValue(constant.KonfluxComponentLabel, string(manifests.RBAC)))
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			},
+			Entry("admin-user-actions-core", adminCoreClusterRole),
+			Entry("releaser-bot-actions", releaserBotClusterRole),
+			Entry("self-access-reviewer", selfAccessClusterRole),
+		)
+	})
+
+	Context("Drift correction", func() {
+		DescribeTable("restores ClusterRole rules when modified",
+			func(ctx context.Context, roleName string) {
+				rbacRes := &konfluxv1alpha1.KonfluxRBAC{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, rbacRes)).To(Succeed())
+				testutil.DeferCleanupParentAndChildren(k8sClient, rbacRes, rbacClusterScopedChildren()...)
+
+				crNN := types.NamespacedName{Name: roleName}
+
+				By("waiting for initial ClusterRole creation")
+				var originalRules []rbacv1.PolicyRule
+				Eventually(func(g Gomega) {
+					cr := &rbacv1.ClusterRole{}
+					g.Expect(k8sClient.Get(ctx, crNN, cr)).To(Succeed())
+					g.Expect(cr.Rules).NotTo(BeEmpty())
+					originalRules = cr.Rules
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("modifying the ClusterRole rules")
+				Eventually(func(g Gomega) {
+					cr := &rbacv1.ClusterRole{}
+					g.Expect(k8sClient.Get(ctx, crNN, cr)).To(Succeed())
+					cr.Rules = []rbacv1.PolicyRule{{
+						APIGroups: []string{""},
+						Resources: []string{"pods"},
+						Verbs:     []string{"delete"},
+					}}
+					g.Expect(k8sClient.Update(ctx, cr)).To(Succeed())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("verifying the ClusterRole rules are restored")
+				Eventually(func(g Gomega) {
+					cr := &rbacv1.ClusterRole{}
+					g.Expect(k8sClient.Get(ctx, crNN, cr)).To(Succeed())
+					g.Expect(cr.Rules).To(Equal(originalRules))
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			},
+			Entry("admin-user-actions-core", adminCoreClusterRole),
+			Entry("releaser-bot-actions", releaserBotClusterRole),
+			Entry("self-access-reviewer", selfAccessClusterRole),
+		)
 	})
 })


### PR DESCRIPTION
Add DescribeTable-based test suites for ClusterRole recreation after deletion and rules restoration after tampering. Tests cover a representative sample (3 of 12 ClusterRoles) since the reconcile logic is identical for all — one from each category: user-actions, bot, and utility.

Also fix existing test cleanup to pass all cluster-scoped children to DeferCleanupParentAndChildren, preventing orphaned ClusterRoles in envtest.

No changes in Owns or Watches are needed.

Assisted-by: Cursor + Opus 4.6