### PR TITLE
test(KFLUXVNGD-1109): add tests for CRD self-healing and drift correction

### DIFF
--- a/operator/internal/controller/applicationapi/konfluxapplicationapi_controller_test.go
+++ b/operator/internal/controller/applicationapi/konfluxapplicationapi_controller_test.go
@@ -21,14 +21,52 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
+	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 )
+
+type crdInfo struct {
+	name string
+	kind string
+}
+
+var managedCRDs = []crdInfo{
+	{"applications.appstudio.redhat.com", "Application"},
+	{"componentdetectionqueries.appstudio.redhat.com", "ComponentDetectionQuery"},
+	{"components.appstudio.redhat.com", "Component"},
+	{"deploymenttargetclaims.appstudio.redhat.com", "DeploymentTargetClaim"},
+	{"deploymenttargetclasses.appstudio.redhat.com", "DeploymentTargetClass"},
+	{"deploymenttargets.appstudio.redhat.com", "DeploymentTarget"},
+	{"environments.appstudio.redhat.com", "Environment"},
+	{"promotionruns.appstudio.redhat.com", "PromotionRun"},
+	{"snapshotenvironmentbindings.appstudio.redhat.com", "SnapshotEnvironmentBinding"},
+	{"snapshots.appstudio.redhat.com", "Snapshot"},
+}
+
+func crdEntries() []TableEntry {
+	entries := make([]TableEntry, len(managedCRDs))
+	for i, c := range managedCRDs {
+		entries[i] = Entry(c.kind, c.name, c.kind)
+	}
+	return entries
+}
+
+func crdEntriesNameOnly() []TableEntry {
+	entries := make([]TableEntry, len(managedCRDs))
+	for i, c := range managedCRDs {
+		entries[i] = Entry(c.kind, c.name)
+	}
+	return entries
+}
 
 var _ = Describe("KonfluxApplicationAPI Controller", func() {
 	Context("When reconciling a resource", func() {
@@ -37,7 +75,7 @@ var _ = Describe("KonfluxApplicationAPI Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, appRes)).To(Succeed())
-			testutil.DeferCleanupParentAndChildren(k8sClient, appRes)
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, appRes)
 
 			Eventually(func(g Gomega) {
 				updated := &konfluxv1alpha1.KonfluxApplicationAPI{}
@@ -47,5 +85,99 @@ var _ = Describe("KonfluxApplicationAPI Controller", func() {
 				g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
+	})
+
+	Context("Self-healing", func() {
+		DescribeTable("recreates CRD when deleted",
+			func(ctx context.Context, crdName, expectedKind string) {
+				cr := &konfluxv1alpha1.KonfluxApplicationAPI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+				DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+				crdNN := types.NamespacedName{Name: crdName}
+
+				By("waiting for CRD with owner labels")
+				var originalUID types.UID
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxComponentLabel, string(manifests.ApplicationAPI)))
+					originalUID = crd.UID
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("deleting the CRD and waiting for it to be gone")
+				Expect(k8sClient.Delete(ctx, &apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: crdNN.Name},
+				})).To(Succeed())
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					err := k8sClient.Get(ctx, crdNN, crd)
+					if err == nil {
+						if crd.DeletionTimestamp != nil && len(crd.Finalizers) > 0 {
+							crd.Finalizers = nil
+							g.Expect(k8sClient.Update(ctx, crd)).To(Succeed())
+						}
+						g.Expect(crd.UID).NotTo(Equal(originalUID), "old CRD still exists")
+						return
+					}
+					g.Expect(errors.IsNotFound(err)).To(BeTrue(), "unexpected error: %v", err)
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("verifying the CRD is recreated with correct spec and labels")
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.UID).NotTo(Equal(originalUID))
+					g.Expect(crd.Spec.Names.Kind).To(Equal(expectedKind))
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxComponentLabel, string(manifests.ApplicationAPI)))
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			},
+			crdEntries(),
+		)
+	})
+
+	Context("Drift correction", func() {
+		DescribeTable("restores CRD spec when version is disabled",
+			func(ctx context.Context, crdName string) {
+				cr := &konfluxv1alpha1.KonfluxApplicationAPI{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+				DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+				crdNN := types.NamespacedName{Name: crdName}
+
+				By("waiting for CRD creation with served=true")
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.Spec.Versions).NotTo(BeEmpty())
+					g.Expect(crd.Spec.Versions[0].Served).To(BeTrue())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("disabling the served version")
+				var afterTamperRV string
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					crd.Spec.Versions[0].Served = false
+					g.Expect(k8sClient.Update(ctx, crd)).To(Succeed())
+					afterTamperRV = crd.ResourceVersion
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("verifying SSA restores served=true")
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.ResourceVersion).NotTo(Equal(afterTamperRV), "controller has not reconciled yet")
+					g.Expect(crd.Spec.Versions[0].Served).To(BeTrue())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			},
+			crdEntriesNameOnly(),
+		)
 	})
 })

--- a/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
+++ b/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
@@ -23,6 +23,8 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -33,6 +35,7 @@ import (
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 )
 
 const (
@@ -43,6 +46,7 @@ const (
 	policyViewerClusterRole    = "enterprisecontractpolicy-viewer-role"
 	publicEcCmRoleBinding      = "public-ec-cm"
 	publicEcpRoleBinding       = "public-ecp"
+	ecCRDName                  = "enterprisecontractpolicies.appstudio.redhat.com"
 )
 
 // newDefaultECPolicy returns an unstructured object for the default EnterpriseContractPolicy.
@@ -278,6 +282,54 @@ var _ = Describe("KonfluxEnterpriseContract Controller", Ordered, func() {
 				g.Expect(rb.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
+
+		It("recreates CRD when deleted", func(ctx context.Context) {
+			ec := &konfluxv1alpha1.KonfluxEnterpriseContract{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, ec)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ec, ecClusterScopedChildren()...)
+
+			crdNN := types.NamespacedName{Name: ecCRDName}
+
+			By("waiting for CRD with owner labels")
+			var originalUID types.UID
+			Eventually(func(g Gomega) {
+				crd := &apiextensionsv1.CustomResourceDefinition{}
+				g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+				g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
+				g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxComponentLabel, string(manifests.EnterpriseContract)))
+				originalUID = crd.UID
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the CRD and waiting for it to be gone")
+			Expect(k8sClient.Delete(ctx, &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: crdNN.Name},
+			})).To(Succeed())
+			Eventually(func(g Gomega) {
+				crd := &apiextensionsv1.CustomResourceDefinition{}
+				err := k8sClient.Get(ctx, crdNN, crd)
+				if err == nil {
+					if crd.DeletionTimestamp != nil && len(crd.Finalizers) > 0 {
+						crd.Finalizers = nil
+						g.Expect(k8sClient.Update(ctx, crd)).To(Succeed())
+					}
+					g.Expect(crd.UID).NotTo(Equal(originalUID), "old CRD still exists")
+					return
+				}
+				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "unexpected error: %v", err)
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the CRD is recreated with correct spec and labels")
+			Eventually(func(g Gomega) {
+				crd := &apiextensionsv1.CustomResourceDefinition{}
+				g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+				g.Expect(crd.UID).NotTo(Equal(originalUID))
+				g.Expect(crd.Spec.Names.Kind).To(Equal("EnterpriseContractPolicy"))
+				g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
+				g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxComponentLabel, string(manifests.EnterpriseContract)))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
 	})
 
 	Context("Drift correction", func() {
@@ -438,5 +490,41 @@ var _ = Describe("KonfluxEnterpriseContract Controller", Ordered, func() {
 			Entry("public-ec-cm", publicEcCmRoleBinding),
 			Entry("public-ecp", publicEcpRoleBinding),
 		)
+
+		It("restores CRD spec when version is disabled", func(ctx context.Context) {
+			ec := &konfluxv1alpha1.KonfluxEnterpriseContract{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, ec)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ec, ecClusterScopedChildren()...)
+
+			crdNN := types.NamespacedName{Name: ecCRDName}
+
+			By("waiting for CRD creation with served=true")
+			Eventually(func(g Gomega) {
+				crd := &apiextensionsv1.CustomResourceDefinition{}
+				g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+				g.Expect(crd.Spec.Versions).NotTo(BeEmpty())
+				g.Expect(crd.Spec.Versions[0].Served).To(BeTrue())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("disabling the served version")
+			var afterTamperRV string
+			Eventually(func(g Gomega) {
+				crd := &apiextensionsv1.CustomResourceDefinition{}
+				g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+				crd.Spec.Versions[0].Served = false
+				g.Expect(k8sClient.Update(ctx, crd)).To(Succeed())
+				afterTamperRV = crd.ResourceVersion
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying SSA restores served=true")
+			Eventually(func(g Gomega) {
+				crd := &apiextensionsv1.CustomResourceDefinition{}
+				g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+				g.Expect(crd.ResourceVersion).NotTo(Equal(afterTamperRV), "controller has not reconciled yet")
+				g.Expect(crd.Spec.Versions[0].Served).To(BeTrue())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
 	})
 })

--- a/operator/internal/controller/imagecontroller/konfluximagecontroller_controller_test.go
+++ b/operator/internal/controller/imagecontroller/konfluximagecontroller_controller_test.go
@@ -25,12 +25,15 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 )
 
 const (
@@ -42,6 +45,32 @@ const (
 	managerClusterRoleName        = "image-controller-manager-role"
 	managerClusterRoleBindingName = "image-controller-manager-rolebinding"
 )
+
+type icCRDInfo struct {
+	name string
+	kind string
+}
+
+var icManagedCRDs = []icCRDInfo{
+	{"imagerepositories.appstudio.redhat.com", "ImageRepository"},
+	{"imagerepositories.konflux-ci.dev", "ImageRepository"},
+}
+
+func icCRDEntries() []TableEntry {
+	entries := make([]TableEntry, len(icManagedCRDs))
+	for i, c := range icManagedCRDs {
+		entries[i] = Entry(c.name, c.name, c.kind)
+	}
+	return entries
+}
+
+func icCRDEntriesNameOnly() []TableEntry {
+	entries := make([]TableEntry, len(icManagedCRDs))
+	for i, c := range icManagedCRDs {
+		entries[i] = Entry(c.name, c.name)
+	}
+	return entries
+}
 
 var _ = Describe("KonfluxImageController Controller", func() {
 	Context("When reconciling a resource", func() {
@@ -334,6 +363,57 @@ var _ = Describe("KonfluxImageController Controller", func() {
 				g.Expect(crb.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
+
+		DescribeTable("recreates CRD when deleted",
+			func(ctx context.Context, crdName string, expectedKind string) {
+				imageController := &konfluxv1alpha1.KonfluxImageController{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, imageController)).To(Succeed())
+				DeferCleanup(testutil.DeleteAndWait, k8sClient, imageController)
+
+				crdNN := types.NamespacedName{Name: crdName}
+
+				By("waiting for CRD with owner labels")
+				var originalUID types.UID
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxComponentLabel, string(manifests.ImageController)))
+					originalUID = crd.UID
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("deleting the CRD and waiting for it to be gone")
+				Expect(k8sClient.Delete(ctx, &apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: crdNN.Name},
+				})).To(Succeed())
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					err := k8sClient.Get(ctx, crdNN, crd)
+					if err == nil {
+						if crd.DeletionTimestamp != nil && len(crd.Finalizers) > 0 {
+							crd.Finalizers = nil
+							g.Expect(k8sClient.Update(ctx, crd)).To(Succeed())
+						}
+						g.Expect(crd.UID).NotTo(Equal(originalUID), "old CRD still exists")
+						return
+					}
+					g.Expect(errors.IsNotFound(err)).To(BeTrue(), "unexpected error: %v", err)
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("verifying the CRD is recreated with correct spec and labels")
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.UID).NotTo(Equal(originalUID))
+					g.Expect(crd.Spec.Names.Kind).To(Equal(expectedKind))
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxComponentLabel, string(manifests.ImageController)))
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			},
+			icCRDEntries(),
+		)
 	})
 
 	Context("Drift correction", func() {
@@ -769,6 +849,45 @@ var _ = Describe("KonfluxImageController Controller", func() {
 				g.Expect(crb.Subjects).To(Equal(originalSubjects))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
+
+		DescribeTable("restores CRD spec when version is disabled",
+			func(ctx context.Context, crdName string) {
+				imageController := &konfluxv1alpha1.KonfluxImageController{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, imageController)).To(Succeed())
+				DeferCleanup(testutil.DeleteAndWait, k8sClient, imageController)
+
+				crdNN := types.NamespacedName{Name: crdName}
+
+				By("waiting for CRD creation with served=true")
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.Spec.Versions).NotTo(BeEmpty())
+					g.Expect(crd.Spec.Versions[0].Served).To(BeTrue())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("disabling the served version")
+				var afterTamperRV string
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					crd.Spec.Versions[0].Served = false
+					g.Expect(k8sClient.Update(ctx, crd)).To(Succeed())
+					afterTamperRV = crd.ResourceVersion
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("verifying SSA restores served=true")
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.ResourceVersion).NotTo(Equal(afterTamperRV), "controller has not reconciled yet")
+					g.Expect(crd.Spec.Versions[0].Served).To(BeTrue())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			},
+			icCRDEntriesNameOnly(),
+		)
 	})
 
 	Context("Quay CA Bundle", func() {

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_test.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_test.go
@@ -27,12 +27,15 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 )
 
 const (
@@ -48,6 +51,33 @@ const (
 	managerClusterRoleName        = "integration-service-manager-role"
 	managerClusterRoleBindingName = "integration-service-manager-rolebinding"
 )
+
+type isCRDInfo struct {
+	name string
+	kind string
+}
+
+var isManagedCRDs = []isCRDInfo{
+	{"componentgroups.appstudio.redhat.com", "ComponentGroup"},
+	{"integrationtestscenarios.appstudio.redhat.com", "IntegrationTestScenario"},
+	{"nudgeconfigs.appstudio.redhat.com", "NudgeConfig"},
+}
+
+func isCRDEntries() []TableEntry {
+	entries := make([]TableEntry, len(isManagedCRDs))
+	for i, c := range isManagedCRDs {
+		entries[i] = Entry(c.kind, c.name, c.kind)
+	}
+	return entries
+}
+
+func isCRDEntriesNameOnly() []TableEntry {
+	entries := make([]TableEntry, len(isManagedCRDs))
+	for i, c := range isManagedCRDs {
+		entries[i] = Entry(c.kind, c.name)
+	}
+	return entries
+}
 
 var _ = Describe("KonfluxIntegrationService Controller", func() {
 	Context("When reconciling a resource", func() {
@@ -504,6 +534,57 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 				g.Expect(crb.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
+
+		DescribeTable("recreates CRD when deleted",
+			func(ctx context.Context, crdName string, expectedKind string) {
+				integrationService := &konfluxv1alpha1.KonfluxIntegrationService{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, integrationService)).To(Succeed())
+				DeferCleanup(testutil.DeleteAndWait, k8sClient, integrationService)
+
+				crdNN := types.NamespacedName{Name: crdName}
+
+				By("waiting for CRD with owner labels")
+				var originalUID types.UID
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxComponentLabel, string(manifests.Integration)))
+					originalUID = crd.UID
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("deleting the CRD and waiting for it to be gone")
+				Expect(k8sClient.Delete(ctx, &apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: crdNN.Name},
+				})).To(Succeed())
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					err := k8sClient.Get(ctx, crdNN, crd)
+					if err == nil {
+						if crd.DeletionTimestamp != nil && len(crd.Finalizers) > 0 {
+							crd.Finalizers = nil
+							g.Expect(k8sClient.Update(ctx, crd)).To(Succeed())
+						}
+						g.Expect(crd.UID).NotTo(Equal(originalUID), "old CRD still exists")
+						return
+					}
+					g.Expect(errors.IsNotFound(err)).To(BeTrue(), "unexpected error: %v", err)
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("verifying the CRD is recreated with correct spec and labels")
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.UID).NotTo(Equal(originalUID))
+					g.Expect(crd.Spec.Names.Kind).To(Equal(expectedKind))
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxComponentLabel, string(manifests.Integration)))
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			},
+			isCRDEntries(),
+		)
 	})
 
 	Context("Drift correction", func() {
@@ -1215,5 +1296,44 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 				g.Expect(*mwc.Webhooks[0].ClientConfig.Service.Path).To(Equal(originalPath))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
+
+		DescribeTable("restores CRD spec when version is disabled",
+			func(ctx context.Context, crdName string) {
+				integrationService := &konfluxv1alpha1.KonfluxIntegrationService{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, integrationService)).To(Succeed())
+				DeferCleanup(testutil.DeleteAndWait, k8sClient, integrationService)
+
+				crdNN := types.NamespacedName{Name: crdName}
+
+				By("waiting for CRD creation with served=true")
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.Spec.Versions).NotTo(BeEmpty())
+					g.Expect(crd.Spec.Versions[0].Served).To(BeTrue())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("disabling the served version")
+				var afterTamperRV string
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					crd.Spec.Versions[0].Served = false
+					g.Expect(k8sClient.Update(ctx, crd)).To(Succeed())
+					afterTamperRV = crd.ResourceVersion
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("verifying SSA restores served=true")
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.ResourceVersion).NotTo(Equal(afterTamperRV), "controller has not reconciled yet")
+					g.Expect(crd.Spec.Versions[0].Served).To(BeTrue())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			},
+			isCRDEntriesNameOnly(),
+		)
 	})
 })

--- a/operator/internal/controller/releaseservice/konfluxreleaseservice_controller_test.go
+++ b/operator/internal/controller/releaseservice/konfluxreleaseservice_controller_test.go
@@ -26,12 +26,15 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 )
 
 const (
@@ -48,6 +51,36 @@ const (
 	validatingWebhookName         = "release-service-validating-webhook-configuration"
 	mutatingWebhookName           = "release-service-mutating-webhook-configuration"
 )
+
+type rsCRDInfo struct {
+	name string
+	kind string
+}
+
+var rsManagedCRDs = []rsCRDInfo{
+	{"internalrequests.appstudio.redhat.com", "InternalRequest"},
+	{"internalservicesconfigs.appstudio.redhat.com", "InternalServicesConfig"},
+	{"releaseplanadmissions.appstudio.redhat.com", "ReleasePlanAdmission"},
+	{"releaseplans.appstudio.redhat.com", "ReleasePlan"},
+	{"releases.appstudio.redhat.com", "Release"},
+	{"releaseserviceconfigs.appstudio.redhat.com", "ReleaseServiceConfig"},
+}
+
+func rsCRDEntries() []TableEntry {
+	entries := make([]TableEntry, len(rsManagedCRDs))
+	for i, c := range rsManagedCRDs {
+		entries[i] = Entry(c.kind, c.name, c.kind)
+	}
+	return entries
+}
+
+func rsCRDEntriesNameOnly() []TableEntry {
+	entries := make([]TableEntry, len(rsManagedCRDs))
+	for i, c := range rsManagedCRDs {
+		entries[i] = Entry(c.kind, c.name)
+	}
+	return entries
+}
 
 var _ = Describe("KonfluxReleaseService Controller", func() {
 	Context("When reconciling a resource", func() {
@@ -432,6 +465,57 @@ var _ = Describe("KonfluxReleaseService Controller", func() {
 				g.Expect(mwc.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
+
+		DescribeTable("recreates CRD when deleted",
+			func(ctx context.Context, crdName string, expectedKind string) {
+				cr := &konfluxv1alpha1.KonfluxReleaseService{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+				DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+				crdNN := types.NamespacedName{Name: crdName}
+
+				By("waiting for CRD with owner labels")
+				var originalUID types.UID
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxComponentLabel, string(manifests.Release)))
+					originalUID = crd.UID
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("deleting the CRD and waiting for it to be gone")
+				Expect(k8sClient.Delete(ctx, &apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: crdNN.Name},
+				})).To(Succeed())
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					err := k8sClient.Get(ctx, crdNN, crd)
+					if err == nil {
+						if crd.DeletionTimestamp != nil && len(crd.Finalizers) > 0 {
+							crd.Finalizers = nil
+							g.Expect(k8sClient.Update(ctx, crd)).To(Succeed())
+						}
+						g.Expect(crd.UID).NotTo(Equal(originalUID), "old CRD still exists")
+						return
+					}
+					g.Expect(errors.IsNotFound(err)).To(BeTrue(), "unexpected error: %v", err)
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("verifying the CRD is recreated with correct spec and labels")
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.UID).NotTo(Equal(originalUID))
+					g.Expect(crd.Spec.Names.Kind).To(Equal(expectedKind))
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
+					g.Expect(crd.Labels).To(HaveKeyWithValue(constant.KonfluxComponentLabel, string(manifests.Release)))
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			},
+			rsCRDEntries(),
+		)
 	})
 
 	Context("Drift correction", func() {
@@ -1100,5 +1184,44 @@ var _ = Describe("KonfluxReleaseService Controller", func() {
 				g.Expect(*mwc.Webhooks[0].ClientConfig.Service.Path).To(Equal(originalPath))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
+
+		DescribeTable("restores CRD spec when version is disabled",
+			func(ctx context.Context, crdName string) {
+				cr := &konfluxv1alpha1.KonfluxReleaseService{
+					ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				}
+				Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+				DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+				crdNN := types.NamespacedName{Name: crdName}
+
+				By("waiting for CRD creation with served=true")
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.Spec.Versions).NotTo(BeEmpty())
+					g.Expect(crd.Spec.Versions[0].Served).To(BeTrue())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("disabling the served version")
+				var afterTamperRV string
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					crd.Spec.Versions[0].Served = false
+					g.Expect(k8sClient.Update(ctx, crd)).To(Succeed())
+					afterTamperRV = crd.ResourceVersion
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+				By("verifying SSA restores served=true")
+				Eventually(func(g Gomega) {
+					crd := &apiextensionsv1.CustomResourceDefinition{}
+					g.Expect(k8sClient.Get(ctx, crdNN, crd)).To(Succeed())
+					g.Expect(crd.ResourceVersion).NotTo(Equal(afterTamperRV), "controller has not reconciled yet")
+					g.Expect(crd.Spec.Versions[0].Served).To(BeTrue())
+				}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+			},
+			rsCRDEntriesNameOnly(),
+		)
 	})
 })


### PR DESCRIPTION
Add integration tests for the CRD watch path (Watches(&CRD{},
MapCRDToRequest)) across all three controllers that use it:
- applicationapi (10 CRDs)
- enterprisecontract (1 CRD)
- releaseservice (6 CRDs)
- imagecontroller (2 CRDs)
- integrationservice (3 CRDs)

Self-healing: delete each CRD, verify removal via UID check, then
assert recreation with correct spec.names.kind and ownership labels.

Drift correction: tamper spec.versions[0].served (set to false), then
verify SSA restores it. A ResourceVersion gate ensures the assertion
evaluates post-reconciliation state, preventing false passes from
matching the tampered value.

The served field was chosen because it is present on every CRD, mutable
after creation, and represents real operational damage — disabling it
breaks the API for all consumers. SSA manages it as part of the full
CRD spec, exercising the same restore path as any other spec field.

Assisted-by: Cursor + Opus 4.6