### PR TITLE
ci: add concurrency groups to e2e tests

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -148,6 +148,20 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: [check-prerequisites, check-changes]
     if: needs.check-changes.outputs.operator == 'true'
+    # Cancel superseded test jobs per PR/arch to reduce shared smee contention (#6551).
+    # Job-level (not workflow-level) so report-operator-e2e-status can finalize /allow
+    # Checks API runs when a superseded run's test job is cancelled.
+    # Group key (first match wins): pull_request.number, client_payload.pr_number,
+    # ref (merge queue), run_id; matrix.arch keeps AMD64/ARM64 from cancelling each other.
+    concurrency:
+      group: >-
+        operator-e2e-${{
+          github.event.pull_request.number
+          || github.event.client_payload.pr_number
+          || github.ref
+          || github.run_id
+        }}-${{ matrix.arch }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
We still have issues for CI runs affecting one another. We see it, at the moment, at least for GitHub rate limiting and potentially dropped smee webhooks.

With this change, we introduce concurrency groups to have earlier e2e workflows for a given PR canceled when new ones are triggered. This should reduce the number of concurrent runs and mitigate the issues we're seeing.

Assisted-by: Cursor

Closes: #6551