### PR TITLE
feat(KFLUXVNGD-1108): install EnterpriseContractPolicy CRD and CR as part of operator lifecycle

### DIFF
--- a/.github/path-filters/verify-manifests-in-sync.txt
+++ b/.github/path-filters/verify-manifests-in-sync.txt
@@ -3,6 +3,7 @@ operator/pkg/manifests/**
 dependencies/**
 operator/test/crds/cert-manager/**
 operator/test/crds/prometheus/**
+operator/test/crds/enterprise-contract/**
 .github/workflows/verify-manifests-in-sync.yaml
 .github/path-filters/verify-manifests-in-sync.txt
 .github/scripts/verify-manifests-in-sync.sh

--- a/.github/scripts/verify-manifests-in-sync.sh
+++ b/.github/scripts/verify-manifests-in-sync.sh
@@ -49,6 +49,19 @@ for dir in "${REPO_ROOT}/operator/upstream-kustomizations"/*; do
   rm -f "${tmp}"
 done
 
+echo "== Verifying upstream-derived envtest CRDs =="
+ec_crd_path="operator/test/crds/enterprise-contract/enterprisecontractpolicies.appstudio.redhat.com.yaml"
+mkdir -p "$(dirname "${ec_crd_path}")"
+yq 'select(.kind == "CustomResourceDefinition")' \
+  operator/pkg/manifests/enterprise-contract/manifests.yaml > "${ec_crd_path}"
+if ! git diff --exit-code -- "${ec_crd_path}" 2>/dev/null; then
+  echo "❌ Upstream-derived envtest CRD drift (run rebuild-upstream-manifests.sh and commit)." >&2
+  git --no-pager diff -- "${ec_crd_path}" >&2 || true
+  fail=true
+else
+  echo "  OK upstream-derived envtest CRDs"
+fi
+
 echo "== Verifying third-party Helm outputs =="
 export CERT_MANAGER_VERSION TRUST_MANAGER_VERSION PROMETHEUS_OPERATOR_VERSION
 bash "${REPO_ROOT}/.github/scripts/update-third-party-manifests.sh" "${REPO_ROOT}"

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -34,6 +34,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -63,6 +64,7 @@ import (
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/segmentbridge"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/ui"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/segment"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/version"
@@ -273,6 +275,18 @@ func main() {
 		setupLog.Error(err, "unable to parse embedded manifests")
 		os.Exit(1)
 	}
+	// Pre-install CRDs managed by controllers that also watch CRs of those CRDs.
+	// The CRD must exist before mgr.Start() so the Owns() informer can sync.
+	directClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "unable to create client for CRD pre-install")
+		os.Exit(1)
+	}
+	if err := preInstallCRDs(context.Background(), directClient, objectStore); err != nil {
+		setupLog.Error(err, "unable to pre-install CRDs")
+		os.Exit(1)
+	}
+
 	// Detect cluster information (platform, version, capabilities)
 	clusterInfo, err := clusterinfo.Detect(cfg)
 	if err != nil {
@@ -465,4 +479,48 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+// preInstallCRDs applies CRDs from embedded manifests before the manager starts.
+//
+// Why this is needed (and why Watches(CRD) + reconcile is insufficient):
+// Controllers that use Owns() to watch CRs of upstream CRDs (e.g., EnterpriseContractPolicy)
+// require the CRD to be registered in the API server at manager startup time. Without it,
+// controller-runtime cannot create the informer for the owned GVK, and mgr.Start() blocks
+// indefinitely waiting for the cache to sync. The existing Watches(CRD) pattern only handles
+// *re-applying* a CRD after out-of-band deletion — it cannot bootstrap a CRD that was never
+// present. This function solves the ordering problem by ensuring CRDs exist before any
+// controller sets up watches, using a direct client (bypassing the not-yet-started cache).
+// The controller then takes over full ownership of the CRD during its first reconcile via SSA.
+//
+// The components list below is intentionally limited to those whose controllers use Owns()
+// on CRs of CRDs they install. Components that only Watches(CRD) do not need pre-install.
+func preInstallCRDs(ctx context.Context, c client.Client, store *manifests.ObjectStore) error {
+	components := []manifests.Component{
+		manifests.EnterpriseContract,
+	}
+	for _, comp := range components {
+		objects, err := store.GetForComponent(comp)
+		if err != nil {
+			return fmt.Errorf("getting objects for %s: %w", comp, err)
+		}
+		for _, obj := range objects {
+			crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+			if !ok {
+				continue
+			}
+			if err := c.Patch(ctx, crd, kubernetes.SSAPatch,
+				client.FieldOwner("konflux-operator-bootstrap"),
+				client.ForceOwnership,
+			); err != nil {
+				return fmt.Errorf("pre-installing CRD %s: %w", crd.Name, err)
+			}
+			setupLog.Info("Pre-installed CRD",
+				"name", crd.Name,
+				"resourceVersion", crd.ResourceVersion,
+				"versions", len(crd.Spec.Versions),
+			)
+		}
+	}
+	return nil
 }

--- a/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller.go
+++ b/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -168,6 +169,9 @@ func (r *KonfluxEnterpriseContractReconciler) SetupWithManager(mgr ctrl.Manager)
 	if err != nil {
 		return err
 	}
+	ecPolicy := &unstructured.Unstructured{}
+	ecPolicy.SetGroupVersionKind(ecPolicyGVK)
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&konfluxv1alpha1.KonfluxEnterpriseContract{}).
 		Named("konfluxenterprisecontract").
@@ -175,6 +179,8 @@ func (r *KonfluxEnterpriseContractReconciler) SetupWithManager(mgr ctrl.Manager)
 		Owns(&corev1.ConfigMap{}).
 		Owns(&rbacv1.ClusterRole{}).
 		Owns(&rbacv1.RoleBinding{}).
+		// Self-healing: external deletion or spec mutation of the ECP triggers re-reconcile and SSA restore.
+		Owns(ecPolicy, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		// Watch CRDs so that out-of-band deletion triggers reconcile and re-apply.
 		Watches(&apiextensionsv1.CustomResourceDefinition{},
 			handler.EnqueueRequestsFromMapFunc(crdMapFunc)).

--- a/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
+++ b/operator/internal/controller/enterprisecontract/konfluxenterprisecontract_controller_test.go
@@ -18,6 +18,7 @@ package enterprisecontract
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -256,6 +257,68 @@ var _ = Describe("KonfluxEnterpriseContract Controller", Ordered, func() {
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
+		It("recreates EnterpriseContractPolicy when deleted (skipPolicies=false)", func(ctx context.Context) {
+			ec := &konfluxv1alpha1.KonfluxEnterpriseContract{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				Spec: konfluxv1alpha1.KonfluxEnterpriseContractSpec{
+					SkipPolicies: false,
+				},
+			}
+			Expect(k8sClient.Create(ctx, ec)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ec, ecClusterScopedChildren()...)
+
+			ecpNN := types.NamespacedName{Name: "default", Namespace: ecNamespace}
+
+			By("waiting for initial EnterpriseContractPolicy creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, ecpNN, newDefaultECPolicy())).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the EnterpriseContractPolicy")
+			Expect(k8sClient.Delete(ctx, newDefaultECPolicy())).To(Succeed())
+
+			By("verifying the EnterpriseContractPolicy is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				ecp := newDefaultECPolicy()
+				g.Expect(k8sClient.Get(ctx, ecpNN, ecp)).To(Succeed())
+				g.Expect(ecp.GetLabels()).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("does not recreate EnterpriseContractPolicy when deleted with skipPolicies=true", func(ctx context.Context) {
+			By("creating CR with skipPolicies=false so the policy is deployed")
+			ec := &konfluxv1alpha1.KonfluxEnterpriseContract{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, ec)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ec, ecClusterScopedChildren()...)
+
+			ecpNN := types.NamespacedName{Name: "default", Namespace: ecNamespace}
+
+			By("waiting for initial EnterpriseContractPolicy creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, ecpNN, newDefaultECPolicy())).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("switching to skipPolicies=true")
+			updated := &konfluxv1alpha1.KonfluxEnterpriseContract{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updated)).To(Succeed())
+			updated.Spec.SkipPolicies = true
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+			By("waiting for the EnterpriseContractPolicy to be removed via orphan cleanup")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, ecpNN, newDefaultECPolicy())
+				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "unexpected error: %v", err)
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the EnterpriseContractPolicy stays deleted after Owns() reconcile settles")
+			Consistently(func(g Gomega) {
+				err := k8sClient.Get(ctx, ecpNN, newDefaultECPolicy())
+				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "unexpected error: %v", err)
+			}).WithTimeout(5 * time.Second).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
 		It("recreates RoleBinding when deleted", func(ctx context.Context) {
 			ec := &konfluxv1alpha1.KonfluxEnterpriseContract{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
@@ -403,6 +466,55 @@ var _ = Describe("KonfluxEnterpriseContract Controller", Ordered, func() {
 				cm := &corev1.ConfigMap{}
 				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
 				g.Expect(cm.Data).To(HaveKeyWithValue(originalKey, originalValue))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores EnterpriseContractPolicy spec when modified (skipPolicies=false)", func(ctx context.Context) {
+			ec := &konfluxv1alpha1.KonfluxEnterpriseContract{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				Spec: konfluxv1alpha1.KonfluxEnterpriseContractSpec{
+					SkipPolicies: false,
+				},
+			}
+			Expect(k8sClient.Create(ctx, ec)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ec, ecClusterScopedChildren()...)
+
+			ecpNN := types.NamespacedName{Name: "default", Namespace: ecNamespace}
+
+			By("waiting for initial EnterpriseContractPolicy creation")
+			var originalSources []interface{}
+			Eventually(func(g Gomega) {
+				ecp := newDefaultECPolicy()
+				g.Expect(k8sClient.Get(ctx, ecpNN, ecp)).To(Succeed())
+				spec, ok := ecp.Object["spec"].(map[string]interface{})
+				g.Expect(ok).To(BeTrue())
+				sources, ok := spec["sources"].([]interface{})
+				g.Expect(ok).To(BeTrue())
+				g.Expect(sources).NotTo(BeEmpty())
+				originalSources = sources
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the EnterpriseContractPolicy spec")
+			Eventually(func(g Gomega) {
+				ecp := newDefaultECPolicy()
+				g.Expect(k8sClient.Get(ctx, ecpNN, ecp)).To(Succeed())
+				spec := ecp.Object["spec"].(map[string]interface{})
+				spec["sources"] = []interface{}{
+					map[string]interface{}{
+						"name":   "tampered",
+						"policy": []interface{}{"oci::https://tampered.example.com"},
+					},
+				}
+				g.Expect(k8sClient.Update(ctx, ecp)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the EnterpriseContractPolicy spec is restored")
+			Eventually(func(g Gomega) {
+				ecp := newDefaultECPolicy()
+				g.Expect(k8sClient.Get(ctx, ecpNN, ecp)).To(Succeed())
+				spec := ecp.Object["spec"].(map[string]interface{})
+				sources := spec["sources"].([]interface{})
+				g.Expect(sources).To(Equal(originalSources))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 

--- a/operator/internal/controller/testutil/testutil.go
+++ b/operator/internal/controller/testutil/testutil.go
@@ -116,6 +116,7 @@ func SetupTestEnv(basePath string) *TestEnv {
 			filepath.Join(basePath, "config", "crd", "bases"),
 			filepath.Join(basePath, "test", "crds", "cert-manager"),
 			filepath.Join(basePath, "test", "crds", "prometheus"),
+			filepath.Join(basePath, "test", "crds", "enterprise-contract"),
 			filepath.Join(GetGoModuleDir("github.com/openshift/api"), "config", "v1", "zz_generated.crd-manifests"),
 			filepath.Join(GetGoModuleDir("github.com/openshift/api"), "console", "v1", "zz_generated.crd-manifests"),
 			filepath.Join(GetGoModuleDir("github.com/openshift/api"), "security", "v1", "zz_generated.crd-manifests"),

--- a/operator/pkg/manifests/rebuild-upstream-manifests.sh
+++ b/operator/pkg/manifests/rebuild-upstream-manifests.sh
@@ -32,3 +32,14 @@ for dir in "${component_dirs[@]}"; do
   kustomize build "${WORKSPACE_ROOT}/operator/upstream-kustomizations/${component}" \
     > "${out_dir}/manifests.yaml"
 done
+
+# Extract CRDs from rendered manifests into test/crds/ for envtest.
+# Controllers that Owns() CRs of CRDs they install need the CRD present
+# before the manager starts. Follows the cert-manager extraction pattern
+# in .github/scripts/update-third-party-manifests.sh.
+EC_CRD_DIR="${WORKSPACE_ROOT}/operator/test/crds/enterprise-contract"
+mkdir -p "${EC_CRD_DIR}"
+yq 'select(.kind == "CustomResourceDefinition")' \
+  "${WORKSPACE_ROOT}/operator/pkg/manifests/enterprise-contract/manifests.yaml" \
+  > "${EC_CRD_DIR}/enterprisecontractpolicies.appstudio.redhat.com.yaml"
+echo "Extracted enterprise-contract CRDs for envtest"

--- a/operator/test/crds/enterprise-contract/enterprisecontractpolicies.appstudio.redhat.com.yaml
+++ b/operator/test/crds/enterprise-contract/enterprisecontractpolicies.appstudio.redhat.com.yaml
@@ -1,0 +1,263 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: enterprisecontractpolicies.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    categories:
+      - all
+    kind: EnterpriseContractPolicy
+    listKind: EnterpriseContractPolicyList
+    plural: enterprisecontractpolicies
+    shortNames:
+      - ecp
+    singular: enterprisecontractpolicy
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: EnterpriseContractPolicy is the Schema for the enterprisecontractpolicies API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: EnterpriseContractPolicySpec is used to configure the Enterprise Contract Policy
+              properties:
+                configuration:
+                  description: Configuration handles policy modification configuration (exclusions and inclusions)
+                  properties:
+                    collections:
+                      description: |-
+                        Collections set of predefined rules.  DEPRECATED: Collections can be listed in include
+                        with the "@" prefix.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    exclude:
+                      description: |-
+                        Exclude set of policy exclusions that, in case of failure, do not block
+                        the success of the outcome.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    include:
+                      description: |-
+                        Include set of policy inclusions that are added to the policy evaluation.
+                        These override excluded rules.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                  type: object
+                description:
+                  description: Description of the policy or its intended use
+                  type: string
+                identity:
+                  description: Identity to be used for keyless verification. This is an experimental feature.
+                  properties:
+                    issuer:
+                      description: Issuer is the URL of the certificate OIDC issuer for keyless verification.
+                      type: string
+                    issuerRegExp:
+                      description: |-
+                        IssuerRegExp is a regular expression to match the URL of the certificate OIDC issuer for
+                        keyless verification.
+                      type: string
+                    subject:
+                      description: Subject is the URL of the certificate identity for keyless verification.
+                      type: string
+                    subjectRegExp:
+                      description: |-
+                        SubjectRegExp is a regular expression to match the URL of the certificate identity for
+                        keyless verification.
+                      type: string
+                  type: object
+                name:
+                  description: Optional name of the policy
+                  type: string
+                publicKey:
+                  description: Public key used to validate the signature of images and attestations
+                  type: string
+                rekorUrl:
+                  description: URL of the Rekor instance. Empty string disables Rekor integration
+                  type: string
+                sources:
+                  description: One or more groups of policy rules
+                  items:
+                    description: Source defines policies and data that are evaluated together
+                    properties:
+                      config:
+                        description: |-
+                          Config specifies which policy rules are included, or excluded, from the
+                          provided policy source urls.
+                        properties:
+                          exclude:
+                            description: |-
+                              Exclude is a set of policy exclusions that, in case of failure, do not block
+                              the success of the outcome.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          include:
+                            description: |-
+                              Include is a set of policy inclusions that are added to the policy evaluation.
+                              These take precedence over policy exclusions.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                        type: object
+                      data:
+                        description: List of go-getter style policy data source urls
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: Optional name for the source
+                        type: string
+                      policy:
+                        description: List of go-getter style policy source urls
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                      ruleData:
+                        description: Arbitrary rule data that will be visible to policy rules
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      volatileConfig:
+                        description: |-
+                          Specifies volatile configuration that can include or exclude policy rules
+                          based on effective time.
+                        properties:
+                          exclude:
+                            description: |-
+                              Exclude is a set of policy exclusions that, in case of failure, do not block
+                              the success of the outcome.
+                            items:
+                              description: VolatileCriteria includes or excludes a policy rule with effective dates as an option.
+                              properties:
+                                componentNames:
+                                  description: |-
+                                    ComponentNames is used to specify component names from
+                                    ApplicationSnapshot. This allows filtering in scenarios where
+                                    multiple components share the same image repository.
+                                  items:
+                                    minLength: 1
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                effectiveOn:
+                                  format: date-time
+                                  type: string
+                                effectiveUntil:
+                                  format: date-time
+                                  type: string
+                                imageDigest:
+                                  description: ImageDigest is used to specify an image by its digest.
+                                  pattern: ^sha256:[a-fA-F0-9]{64}$
+                                  type: string
+                                imageRef:
+                                  description: |-
+                                    DEPRECATED: Use ImageDigest instead
+                                    ImageRef is used to specify an image by its digest.
+                                  pattern: ^sha256:[a-fA-F0-9]{64}$
+                                  type: string
+                                imageUrl:
+                                  description: ImageUrl is used to specify an image by its URL without a tag.
+                                  pattern: ^[a-z0-9][a-z0-9.-]*[a-z0-9](?:\/[a-z0-9][a-z0-9-]*[a-z0-9]){2,}$
+                                  type: string
+                                reference:
+                                  description: Reference is used to include a link to related information such as a Jira issue URL.
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-validations:
+                                - message: only one of imageUrl, imageDigest, imageRef, or componentNames may be set
+                                  rule: '(has(self.imageUrl) ? 1 : 0) + (has(self.imageDigest) ? 1 : 0) + (has(self.imageRef) ? 1 : 0) + (has(self.componentNames) ? 1 : 0) <= 1'
+                            type: array
+                          include:
+                            description: |-
+                              Include is a set of policy inclusions that are added to the policy evaluation.
+                              These take precedence over policy exclusions.
+                            items:
+                              description: VolatileCriteria includes or excludes a policy rule with effective dates as an option.
+                              properties:
+                                componentNames:
+                                  description: |-
+                                    ComponentNames is used to specify component names from
+                                    ApplicationSnapshot. This allows filtering in scenarios where
+                                    multiple components share the same image repository.
+                                  items:
+                                    minLength: 1
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                effectiveOn:
+                                  format: date-time
+                                  type: string
+                                effectiveUntil:
+                                  format: date-time
+                                  type: string
+                                imageDigest:
+                                  description: ImageDigest is used to specify an image by its digest.
+                                  pattern: ^sha256:[a-fA-F0-9]{64}$
+                                  type: string
+                                imageRef:
+                                  description: |-
+                                    DEPRECATED: Use ImageDigest instead
+                                    ImageRef is used to specify an image by its digest.
+                                  pattern: ^sha256:[a-fA-F0-9]{64}$
+                                  type: string
+                                imageUrl:
+                                  description: ImageUrl is used to specify an image by its URL without a tag.
+                                  pattern: ^[a-z0-9][a-z0-9.-]*[a-z0-9](?:\/[a-z0-9][a-z0-9-]*[a-z0-9]){2,}$
+                                  type: string
+                                reference:
+                                  description: Reference is used to include a link to related information such as a Jira issue URL.
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-validations:
+                                - message: only one of imageUrl, imageDigest, imageRef, or componentNames may be set
+                                  rule: '(has(self.imageUrl) ? 1 : 0) + (has(self.imageDigest) ? 1 : 0) + (has(self.imageRef) ? 1 : 0) + (has(self.componentNames) ? 1 : 0) <= 1'
+                            type: array
+                        type: object
+                    type: object
+                  minItems: 1
+                  type: array
+              type: object
+            status:
+              description: EnterpriseContractPolicyStatus defines the observed state of EnterpriseContractPolicy
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}


### PR DESCRIPTION
The EnterpriseContractPolicy (ECP) CRD is shipped by the enterprise-contract upstream but is needed before the KonfluxEnterpriseContract controller can reconcile its default CR instance. This creates a chicken-and-egg problem: the controller cannot start an Owns() watch on a GVK whose CRD does not yet exist at manager startup time.

Solution:
- Add a `preInstallCRDs()` function in `cmd/main.go` that runs before `mgr.Start()`. It creates a direct `client.Client` and applies the ECP CRD via Server-Side Apply (field owner: "konflux-operator-bootstrap") so the CRD is registered before any controller sets up watches.
- Add `Owns()` on unstructured ECP CRs in the `KonfluxEnterpriseContract` controller with `IgnoreStatusUpdatesPredicate`, enabling self-healing: if the default ECP CR is deleted or its spec is tampered with, the controller is immediately re-enqueued and restores the desired state.

Supporting changes:
- rebuild-upstream-manifests.sh: extract the ECP CRD from the enterprise- contract manifests.yaml into `operator/test/crds/enterprise-contract/` so envtest can register the GVK during unit tests.
- `testutil.go`: add the ECP CRD path to `CRDDirectoryPaths` for envtest.
- `verify-manifests-in-sync.sh` + `path-filters`: add CI verification that the extracted test CRD stays in sync with the upstream manifests.
- Controller tests: add drift-correction test cases verifying that a deleted ECP is recreated and a modified ECP spec is restored (skipPolicies=false), and that no recreation occurs when skipPolicies=true.
- operator-test-e2e.yaml: set INSTALL_PROMETHEUS_OPERATOR_CRDS=true.

Note: the ECP CRD is not installed by `make install` (which only covers the operator's own Konflux* CRDs from config/crd/). Instead, the operator itself installs it at startup via preInstallCRDs(), before the manager starts. This ensures the same behavior in both development (make install + make run) and production (OLM) — the operator binary is the single owner of the ECP CRD lifecycle, regardless of how it is deployed.

Tested on a local Kind cluster (deploy-local.sh, OPERATOR_INSTALL_METHOD=none):
- [x] Operator startup pre-installs the ECP CRD before manager start
- [x] All controllers start, including Owns() watch on unstructured ECP
- [x] Applying Konflux CR creates the default ECP in enterprise-contract-service
- [x] Deleting the default ECP triggers reconcile and immediate recreation
- [x] Patching the ECP spec (injecting drift) triggers reconcile and SSA restore
- [x] Setting skipPolicies=true on Konflux CR deletes the default ECP via orphan cleanup
- [x] User-created ECP with a different name is not touched by the operator
- [x] Restoring skipPolicies=false recreates the default ECP, user policies unaffected
- [x] User-created ECP with the same name ("default") is overwritten by SSA when skipPolicies=false (expected: operator owns that name)

Assisted-by: Cursor + Opus 4.6