### PR TITLE
feat(KFLUXVNGD-1107): add Owns() watch for ReleaseServiceConfig to enable self-healing

### DIFF
--- a/.github/path-filters/verify-manifests-in-sync.txt
+++ b/.github/path-filters/verify-manifests-in-sync.txt
@@ -4,6 +4,7 @@ dependencies/**
 operator/test/crds/cert-manager/**
 operator/test/crds/prometheus/**
 operator/test/crds/enterprise-contract/**
+operator/test/crds/release/**
 .github/workflows/verify-manifests-in-sync.yaml
 .github/path-filters/verify-manifests-in-sync.txt
 .github/scripts/verify-manifests-in-sync.sh

--- a/.github/scripts/renovate-manifest-companion.sh
+++ b/.github/scripts/renovate-manifest-companion.sh
@@ -127,10 +127,9 @@ bash "${REPO_ROOT}/.github/scripts/update-third-party-manifests.sh" "${REPO_ROOT
 
 git add \
   operator/pkg/manifests \
+  operator/test/crds \
   dependencies/cert-manager/cert-manager.yaml \
   dependencies/trust-manager/trust-manager.yaml \
-  operator/test/crds/cert-manager/cert-manager.crds.yaml \
-  operator/test/crds/prometheus/servicemonitors.monitoring.coreos.com.yaml \
   dependencies/prometheus-operator-crds/servicemonitors.monitoring.coreos.com.yaml
 
 if git diff --cached --quiet; then

--- a/.github/scripts/verify-manifests-in-sync.sh
+++ b/.github/scripts/verify-manifests-in-sync.sh
@@ -52,11 +52,18 @@ done
 echo "== Verifying upstream-derived envtest CRDs =="
 ec_crd_path="operator/test/crds/enterprise-contract/enterprisecontractpolicies.appstudio.redhat.com.yaml"
 mkdir -p "$(dirname "${ec_crd_path}")"
-yq 'select(.kind == "CustomResourceDefinition")' \
+yq 'select(.kind == "CustomResourceDefinition" and .metadata.name == "enterprisecontractpolicies.appstudio.redhat.com")' \
   operator/pkg/manifests/enterprise-contract/manifests.yaml > "${ec_crd_path}"
-if ! git diff --exit-code -- "${ec_crd_path}" 2>/dev/null; then
+# Release has multiple CRDs; only extract the one needed by envtest (Owns() watch target).
+release_crd_path="operator/test/crds/release/releaseserviceconfigs.appstudio.redhat.com.yaml"
+mkdir -p "$(dirname "${release_crd_path}")"
+yq 'select(.kind == "CustomResourceDefinition" and .metadata.name == "releaseserviceconfigs.appstudio.redhat.com")' \
+  operator/pkg/manifests/release/manifests.yaml > "${release_crd_path}"
+
+envtest_crd_paths=("${ec_crd_path}" "${release_crd_path}")
+if ! git diff --exit-code -- "${envtest_crd_paths[@]}" 2>/dev/null; then
   echo "❌ Upstream-derived envtest CRD drift (run rebuild-upstream-manifests.sh and commit)." >&2
-  git --no-pager diff -- "${ec_crd_path}" >&2 || true
+  git --no-pager diff -- "${envtest_crd_paths[@]}" >&2 || true
   fail=true
 else
   echo "  OK upstream-derived envtest CRDs"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,10 @@ Those files must match `kustomize build` for the same pins; CI enforces that via
 Helm-rendered **cert-manager** and **trust-manager** manifests under
 `dependencies/` (and extracted envtest CRDs) must match the chart versions in
 `.github/scripts/export-third-party-chart-env.sh`, which MintMaker/Renovate
-updates alongside the scheduled update workflow.
+updates alongside the scheduled update workflow. Upstream-derived envtest CRDs
+(e.g., enterprise-contract, release) are extracted from
+`operator/pkg/manifests/` by `rebuild-upstream-manifests.sh` into
+`operator/test/crds/`; CI also verifies these stay in sync.
 
 When **MintMaker** or **Renovate** opens a PR that only bumps digests or chart
 versions, a **companion PR** may be opened automatically

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -481,6 +481,15 @@ func main() {
 	}
 }
 
+// ownsWatchCRDs maps each component to the specific CRD names required by its
+// controller's Owns() watches. Only these CRDs are pre-installed — other CRDs
+// from the same component are applied during normal reconciliation and do not
+// need to exist at startup.
+var ownsWatchCRDs = map[manifests.Component][]string{
+	manifests.EnterpriseContract: {"enterprisecontractpolicies.appstudio.redhat.com"},
+	manifests.Release:            {"releaseserviceconfigs.appstudio.redhat.com"},
+}
+
 // preInstallCRDs applies CRDs from embedded manifests before the manager starts.
 //
 // Why this is needed (and why Watches(CRD) + reconcile is insufficient):
@@ -492,21 +501,23 @@ func main() {
 // present. This function solves the ordering problem by ensuring CRDs exist before any
 // controller sets up watches, using a direct client (bypassing the not-yet-started cache).
 // The controller then takes over full ownership of the CRD during its first reconcile via SSA.
-//
-// The components list below is intentionally limited to those whose controllers use Owns()
-// on CRs of CRDs they install. Components that only Watches(CRD) do not need pre-install.
 func preInstallCRDs(ctx context.Context, c client.Client, store *manifests.ObjectStore) error {
-	components := []manifests.Component{
-		manifests.EnterpriseContract,
-	}
-	for _, comp := range components {
+	for comp, crdNames := range ownsWatchCRDs {
 		objects, err := store.GetForComponent(comp)
 		if err != nil {
 			return fmt.Errorf("getting objects for %s: %w", comp, err)
 		}
+		wanted := make(map[string]bool, len(crdNames))
+		for _, name := range crdNames {
+			wanted[name] = true
+		}
+		installed := make(map[string]bool, len(crdNames))
 		for _, obj := range objects {
 			crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
 			if !ok {
+				continue
+			}
+			if !wanted[crd.Name] {
 				continue
 			}
 			if err := c.Patch(ctx, crd, kubernetes.SSAPatch,
@@ -515,11 +526,17 @@ func preInstallCRDs(ctx context.Context, c client.Client, store *manifests.Objec
 			); err != nil {
 				return fmt.Errorf("pre-installing CRD %s: %w", crd.Name, err)
 			}
+			installed[crd.Name] = true
 			setupLog.Info("Pre-installed CRD",
 				"name", crd.Name,
 				"resourceVersion", crd.ResourceVersion,
 				"versions", len(crd.Spec.Versions),
 			)
+		}
+		for _, name := range crdNames {
+			if !installed[name] {
+				return fmt.Errorf("CRD %s not found in %s manifests", name, comp)
+			}
 		}
 	}
 	return nil

--- a/operator/internal/controller/releaseservice/konfluxreleaseservice_controller.go
+++ b/operator/internal/controller/releaseservice/konfluxreleaseservice_controller.go
@@ -64,6 +64,9 @@ const (
 	releaseServiceConfigGroup = "appstudio.redhat.com"
 )
 
+// releaseServiceConfigGVK is the GVK for ReleaseServiceConfig resources.
+var releaseServiceConfigGVK = schema.GroupVersionKind{Group: releaseServiceConfigGroup, Version: "v1alpha1", Kind: releaseServiceConfigKind}
+
 // ReleaseServiceCleanupGVKs defines which resource types should be cleaned up when they are
 // no longer part of the desired state. All resources managed by this controller are always
 // applied, so no cleanup GVKs are needed (they're always tracked and never become orphans).
@@ -261,6 +264,9 @@ func (r *KonfluxReleaseServiceReconciler) SetupWithManager(mgr ctrl.Manager) err
 	if err != nil {
 		return err
 	}
+	rsc := &unstructured.Unstructured{}
+	rsc.SetGroupVersionKind(releaseServiceConfigGVK)
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&konfluxv1alpha1.KonfluxReleaseService{}).
 		Named("konfluxreleaseservice").
@@ -279,10 +285,7 @@ func (r *KonfluxReleaseServiceReconciler) SetupWithManager(mgr ctrl.Manager) err
 		Owns(&certmanagerv1.Issuer{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		Owns(&admissionregistrationv1.MutatingWebhookConfiguration{}).
 		Owns(&admissionregistrationv1.ValidatingWebhookConfiguration{}).
-		// TODO(KFLUXVNGD-892): Add Owns() watch for ReleaseServiceConfig (unstructured)
-		// so that out-of-band deletion/mutation triggers reconcile and re-apply.
-		// Requires adding the upstream CRD to test/crds/ with a sync mechanism.
-		//
+		Owns(rsc, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		// Watch CRDs so that out-of-band deletion triggers reconcile and re-apply.
 		Watches(&apiextensionsv1.CustomResourceDefinition{},
 			handler.EnqueueRequestsFromMapFunc(crdMapFunc)).

--- a/operator/internal/controller/releaseservice/konfluxreleaseservice_controller_test.go
+++ b/operator/internal/controller/releaseservice/konfluxreleaseservice_controller_test.go
@@ -29,12 +29,14 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -50,7 +52,27 @@ const (
 	selfsignedIssuerName          = "selfsigned-issuer"
 	validatingWebhookName         = "release-service-validating-webhook-configuration"
 	mutatingWebhookName           = "release-service-mutating-webhook-configuration"
+	releaseServiceConfigName      = "release-service-config"
 )
+
+func newReleaseServiceConfig() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(releaseServiceConfigGVK)
+	obj.SetName(releaseServiceConfigName)
+	obj.SetNamespace(releaseServiceNamespace)
+	return obj
+}
+
+// rsClusterScopedChildren returns all cluster-scoped resources that the reconciler creates.
+// envtest has no garbage collector, so these must be explicitly cleaned up after each test.
+func rsClusterScopedChildren() []client.Object {
+	return []client.Object{
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: managerClusterRoleName}},
+		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: managerClusterRoleBindingName}},
+		&admissionregistrationv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: validatingWebhookName}},
+		&admissionregistrationv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: mutatingWebhookName}},
+	}
+}
 
 type rsCRDInfo struct {
 	name string
@@ -463,6 +485,36 @@ var _ = Describe("KonfluxReleaseService Controller", func() {
 				mwc := &admissionregistrationv1.MutatingWebhookConfiguration{}
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mutatingWebhookName}, mwc)).To(Succeed())
 				g.Expect(mwc.Labels).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("recreates ReleaseServiceConfig when deleted", func(ctx context.Context) {
+			cr := &konfluxv1alpha1.KonfluxReleaseService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, rsClusterScopedChildren()...)
+
+			rscNN := types.NamespacedName{
+				Name:      releaseServiceConfigName,
+				Namespace: releaseServiceNamespace,
+			}
+
+			By("waiting for initial ReleaseServiceConfig creation")
+			Eventually(func(g Gomega) {
+				rsc := newReleaseServiceConfig()
+				g.Expect(k8sClient.Get(ctx, rscNN, rsc)).To(Succeed())
+				g.Expect(rsc.GetLabels()).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the ReleaseServiceConfig")
+			Expect(k8sClient.Delete(ctx, newReleaseServiceConfig())).To(Succeed())
+
+			By("verifying the ReleaseServiceConfig is recreated with ownership labels")
+			Eventually(func(g Gomega) {
+				rsc := newReleaseServiceConfig()
+				g.Expect(k8sClient.Get(ctx, rscNN, rsc)).To(Succeed())
+				g.Expect(rsc.GetLabels()).To(HaveKey(constant.KonfluxOwnerLabel))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
@@ -1182,6 +1234,48 @@ var _ = Describe("KonfluxReleaseService Controller", func() {
 				g.Expect(mwc.Webhooks).NotTo(BeEmpty())
 				g.Expect(mwc.Webhooks[0].ClientConfig.Service).NotTo(BeNil())
 				g.Expect(*mwc.Webhooks[0].ClientConfig.Service.Path).To(Equal(originalPath))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores ReleaseServiceConfig spec when modified", func(ctx context.Context) {
+			cr := &konfluxv1alpha1.KonfluxReleaseService{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, rsClusterScopedChildren()...)
+
+			rscNN := types.NamespacedName{
+				Name:      releaseServiceConfigName,
+				Namespace: releaseServiceNamespace,
+			}
+
+			By("waiting for initial ReleaseServiceConfig creation")
+			var originalDebug interface{}
+			Eventually(func(g Gomega) {
+				rsc := newReleaseServiceConfig()
+				g.Expect(k8sClient.Get(ctx, rscNN, rsc)).To(Succeed())
+				spec, ok := rsc.Object["spec"].(map[string]interface{})
+				g.Expect(ok).To(BeTrue())
+				originalDebug = spec["debug"]
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the ReleaseServiceConfig spec")
+			Eventually(func(g Gomega) {
+				rsc := newReleaseServiceConfig()
+				g.Expect(k8sClient.Get(ctx, rscNN, rsc)).To(Succeed())
+				spec := rsc.Object["spec"].(map[string]interface{})
+				spec["debug"] = true
+				spec["tampered"] = "injected-field"
+				g.Expect(k8sClient.Update(ctx, rsc)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the ReleaseServiceConfig spec is restored")
+			Eventually(func(g Gomega) {
+				rsc := newReleaseServiceConfig()
+				g.Expect(k8sClient.Get(ctx, rscNN, rsc)).To(Succeed())
+				spec := rsc.Object["spec"].(map[string]interface{})
+				g.Expect(spec["debug"]).To(Equal(originalDebug))
+				g.Expect(spec).NotTo(HaveKey("tampered"))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 

--- a/operator/internal/controller/testutil/testutil.go
+++ b/operator/internal/controller/testutil/testutil.go
@@ -117,6 +117,7 @@ func SetupTestEnv(basePath string) *TestEnv {
 			filepath.Join(basePath, "test", "crds", "cert-manager"),
 			filepath.Join(basePath, "test", "crds", "prometheus"),
 			filepath.Join(basePath, "test", "crds", "enterprise-contract"),
+			filepath.Join(basePath, "test", "crds", "release"),
 			filepath.Join(GetGoModuleDir("github.com/openshift/api"), "config", "v1", "zz_generated.crd-manifests"),
 			filepath.Join(GetGoModuleDir("github.com/openshift/api"), "console", "v1", "zz_generated.crd-manifests"),
 			filepath.Join(GetGoModuleDir("github.com/openshift/api"), "security", "v1", "zz_generated.crd-manifests"),

--- a/operator/pkg/manifests/process-component.sh
+++ b/operator/pkg/manifests/process-component.sh
@@ -83,16 +83,37 @@ else
     exit 1
 fi
 set -e
+
+# Extract upstream-derived envtest CRDs for components that use Owns() watches.
+# Must stay in sync with rebuild-upstream-manifests.sh extraction logic.
+case "${COMPONENT}" in
+    enterprise-contract)
+        mkdir -p "${WORKSPACE_ROOT}/operator/test/crds/enterprise-contract"
+        yq 'select(.kind == "CustomResourceDefinition" and .metadata.name == "enterprisecontractpolicies.appstudio.redhat.com")' \
+            "${output_subdir}/manifests.yaml" \
+            > "${WORKSPACE_ROOT}/operator/test/crds/enterprise-contract/enterprisecontractpolicies.appstudio.redhat.com.yaml"
+        echo "  Extracted enterprise-contract envtest CRD"
+        ;;
+    release)
+        mkdir -p "${WORKSPACE_ROOT}/operator/test/crds/release"
+        yq 'select(.kind == "CustomResourceDefinition" and .metadata.name == "releaseserviceconfigs.appstudio.redhat.com")' \
+            "${output_subdir}/manifests.yaml" \
+            > "${WORKSPACE_ROOT}/operator/test/crds/release/releaseserviceconfigs.appstudio.redhat.com.yaml"
+        echo "  Extracted release envtest CRD"
+        ;;
+esac
+
 cd "${WORKSPACE_ROOT}"
 
 # Step 3: Check for changes specific to this component
 echo "Step 3: Checking for changes..."
 component_changes=false
 
-# Check for changes in component-specific files
+# Check for changes in component-specific files (includes derived envtest CRDs)
 if git diff --quiet --exit-code \
         "operator/upstream-kustomizations/${COMPONENT}/" \
-        "operator/pkg/manifests/${COMPONENT}/" 2>/dev/null; then
+        "operator/pkg/manifests/${COMPONENT}/" \
+        "operator/test/crds/${COMPONENT}/" 2>/dev/null; then
     echo "  No changes detected for ${COMPONENT}"
 else
     echo "  Changes detected for ${COMPONENT}"
@@ -137,8 +158,9 @@ else
     git checkout -b "${BRANCH_NAME}" main
 fi
 
-# Add only component-specific changes
+# Add only component-specific changes (includes derived envtest CRDs if present)
 git add "operator/upstream-kustomizations/${COMPONENT}/" "operator/pkg/manifests/${COMPONENT}/" || true
+git add "operator/test/crds/${COMPONENT}/" 2>/dev/null || true
 
 # Check if there are actually changes to commit
 if git diff --cached --quiet; then

--- a/operator/pkg/manifests/rebuild-upstream-manifests.sh
+++ b/operator/pkg/manifests/rebuild-upstream-manifests.sh
@@ -39,7 +39,15 @@ done
 # in .github/scripts/update-third-party-manifests.sh.
 EC_CRD_DIR="${WORKSPACE_ROOT}/operator/test/crds/enterprise-contract"
 mkdir -p "${EC_CRD_DIR}"
-yq 'select(.kind == "CustomResourceDefinition")' \
+yq 'select(.kind == "CustomResourceDefinition" and .metadata.name == "enterprisecontractpolicies.appstudio.redhat.com")' \
   "${WORKSPACE_ROOT}/operator/pkg/manifests/enterprise-contract/manifests.yaml" \
   > "${EC_CRD_DIR}/enterprisecontractpolicies.appstudio.redhat.com.yaml"
 echo "Extracted enterprise-contract CRDs for envtest"
+
+# Release has multiple CRDs; only extract the one needed by envtest (Owns() watch target).
+RELEASE_CRD_DIR="${WORKSPACE_ROOT}/operator/test/crds/release"
+mkdir -p "${RELEASE_CRD_DIR}"
+yq 'select(.kind == "CustomResourceDefinition" and .metadata.name == "releaseserviceconfigs.appstudio.redhat.com")' \
+  "${WORKSPACE_ROOT}/operator/pkg/manifests/release/manifests.yaml" \
+  > "${RELEASE_CRD_DIR}/releaseserviceconfigs.appstudio.redhat.com.yaml"
+echo "Extracted release CRDs for envtest"

--- a/operator/test/crds/release/releaseserviceconfigs.appstudio.redhat.com.yaml
+++ b/operator/test/crds/release/releaseserviceconfigs.appstudio.redhat.com.yaml
@@ -1,0 +1,237 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: release-service/serving-cert
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: releaseserviceconfigs.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: ReleaseServiceConfig
+    listKind: ReleaseServiceConfigList
+    plural: releaseserviceconfigs
+    shortNames:
+      - rsc
+    singular: releaseserviceconfig
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ReleaseServiceConfig is the Schema for the releaseserviceconfigs API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ReleaseServiceConfigSpec defines the desired state of ReleaseServiceConfig.
+              properties:
+                EmptyDirOverrides:
+                  description: VolumeOverrides is a map containing the volume type for specific Pipeline git refs
+                  items:
+                    description: EmptyDirOverrides defines the values usually set in a PipelineRef using a git resolver.
+                    properties:
+                      pathInRepo:
+                        description: PathInRepo is the path within the git repository where the Pipeline definition can be found
+                        type: string
+                      revision:
+                        description: Revision is the git revision where the Pipeline definition can be found
+                        type: string
+                      url:
+                        description: Url is the url to the git repo
+                        type: string
+                    required:
+                      - pathInRepo
+                      - revision
+                      - url
+                    type: object
+                  type: array
+                debug:
+                  description: |-
+                    Debug is the boolean that specifies whether or not the Release Service should run
+                    in debug mode
+                  type: boolean
+                defaultTimeouts:
+                  description: |-
+                    DefaultTimeouts contain the default Tekton timeouts to be used in case they are
+                    not specified in the ReleasePlanAdmission resource.
+                  properties:
+                    finally:
+                      description: Finally sets the maximum allowed duration of this pipeline's finally
+                      type: string
+                    pipeline:
+                      description: Pipeline sets the maximum allowed duration for execution of the entire pipeline. The sum of individual timeouts for tasks and finally must not exceed this value.
+                      type: string
+                    tasks:
+                      description: Tasks sets the maximum allowed duration of this pipeline's tasks
+                      type: string
+                  type: object
+                retryablePipelines:
+                  description: RetryablePipelines is a list of pipelines that are safe to automatically retry on failure.
+                  items:
+                    description: RetryablePipeline is a pipeline that is safe to automatically retry on failure.
+                    properties:
+                      pathInRepo:
+                        description: |-
+                          PathInRepo is the path within the git repository where the Pipeline definition
+                          can be found.
+                        type: string
+                      retryPolicy:
+                        description: RetryPolicy defines how and when the pipeline is retried after a failure.
+                        properties:
+                          disableOn:
+                            description: DisableOn defines conditions that disable automatic retries.
+                            properties:
+                              tags:
+                                description: |-
+                                  Tags is a list of values which disable retries when present in the ReleasePlanAdmission
+                                  mapping data.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          maxRetries:
+                            description: MaxRetries is the maximum number of retries allowed for a pipeline.
+                            minimum: 0
+                            type: integer
+                          mitigations:
+                            description: Mitigations defines adjustment strategies to apply on retry based on failure type
+                            properties:
+                              oomKill:
+                                description: OOMKill defines adjustment for out-of-memory failures
+                                properties:
+                                  maxComputeResources:
+                                    description: MaxComputeResources sets a upper limit on resources across retries.
+                                    properties:
+                                      claims:
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+                                          This field depends on the
+                                          DynamicResourceAllocation feature gate.
+
+                                          This field is immutable. It can only be set for containers.
+                                        items:
+                                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                          properties:
+                                            name:
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
+                                              type: string
+                                            request:
+                                              description: |-
+                                                Request is the name chosen for a request in the referenced claim.
+                                                If empty, everything from the claim is made available, otherwise
+                                                only the result of this request.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                        type: object
+                                    type: object
+                                  multiplier:
+                                    description: Multiplier is a factor used to multiply memory limits on each retry
+                                    pattern: ^[0-9]+(\.[0-9]+)?$
+                                    type: string
+                                required:
+                                  - multiplier
+                                type: object
+                              timeout:
+                                description: Timeout defines adjustment for timeout failures.
+                                properties:
+                                  pipeline:
+                                    description: Pipeline defines the timeout adjustment for PipelineRun timeouts.
+                                    properties:
+                                      increment:
+                                        description: Increment is the duration to add to the timeout on each retry.
+                                        type: string
+                                      maxTimeout:
+                                        description: MaxTimeout is the maximum time allowed across retries.
+                                        type: string
+                                    required:
+                                      - increment
+                                    type: object
+                                  task:
+                                    description: Task defines the timeout adjustment for TaskRun timeouts.
+                                    properties:
+                                      increment:
+                                        description: Increment is the duration to add to the timeout on each retry.
+                                        type: string
+                                      maxTimeout:
+                                        description: MaxTimeout is the maximum time allowed across retries.
+                                        type: string
+                                    required:
+                                      - increment
+                                    type: object
+                                type: object
+                            type: object
+                        required:
+                          - maxRetries
+                        type: object
+                      revision:
+                        description: Revision is the git revision where the Pipeline definition can be found.
+                        type: string
+                      url:
+                        description: Url is the url to the git repo.
+                        type: string
+                    required:
+                      - pathInRepo
+                      - retryPolicy
+                      - revision
+                      - url
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: ReleaseServiceConfigStatus defines the observed state of ReleaseServiceConfig.
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/skills/dev-verify-loop/SKILL.md
+++ b/skills/dev-verify-loop/SKILL.md
@@ -46,7 +46,7 @@ The script finds the `go run ... ./cmd/main.go` process by its command line, kil
 bash operator/pkg/manifests/rebuild-upstream-manifests.sh .
 ```
 
-This runs `kustomize build` for each component and writes the result to `operator/pkg/manifests/<component>/manifests.yaml`. These YAML files are embedded into the operator binary via `//go:embed`, so the rebuild must happen before `make run` for changes to take effect.
+This runs `kustomize build` for each component and writes the result to `operator/pkg/manifests/<component>/manifests.yaml`, then extracts upstream-derived CRDs needed by envtest into `operator/test/crds/`. These YAML files are embedded into the operator binary via `//go:embed`, so the rebuild must happen before `make run` for changes to take effect.
 
 **Run `make manifests generate`** from `operator/` when ANY of these changed:
 

--- a/skills/update-upstream-deps/SKILL.md
+++ b/skills/update-upstream-deps/SKILL.md
@@ -40,7 +40,7 @@ Requires: `gh` CLI authenticated, `kustomize`
 ./operator/pkg/manifests/process-component.sh build-service "$(pwd)"
 ```
 
-In local mode: updates refs, rebuilds manifests, reports changes.
+In local mode: updates refs, rebuilds manifests, extracts envtest CRDs, reports changes.
 
 ### All Components
 


### PR DESCRIPTION
Based on https://github.com/konflux-ci/konflux-ci/pull/7718 (EnterpriseContractPolicy CRD/CR lifecycle). Will be rebased
once https://github.com/konflux-ci/konflux-ci/pull/7718 is merged.
The ReleaseServiceConfig CR is managed by the release-service controller but
previously had no Owns() watch, meaning out-of-band deletion or spec tampering
would not trigger a reconcile.

Solution:
- Add ReleaseServiceConfig to the ownsWatchCRDs map in preInstallCRDs() so
  the CRD is pre-installed via SSA before the manager starts, avoiding the
  informer startup deadlock.
- Add Owns() on unstructured ReleaseServiceConfig in SetupWithManager() with
  IgnoreStatusUpdatesPredicate, so deletion or spec mutation triggers
  immediate reconcile and SSA restore.
- Refactor preInstallCRDs() to use a map[Component][]CRDName instead of a
  flat component list, allowing selective CRD pre-install per component
  (e.g., only releaseserviceconfigs from the release component, not all 6).

Supporting changes:
- rebuild-upstream-manifests.sh: extract the ReleaseServiceConfig CRD into
  operator/test/crds/release/ for envtest.
- testutil.go: add the release CRD path to CRDDirectoryPaths.
- verify-manifests-in-sync.sh + path-filters: add CI verification that the
  extracted test CRD stays in sync with upstream manifests.
- Controller tests: add self-healing test (recreate on delete) and drift-
  correction test (restore spec on modification).
- CONTRIBUTING.md: document that upstream-derived envtest CRDs are extracted
  from operator/pkg/manifests/ into operator/test/crds/ by
  rebuild-upstream-manifests.sh, alongside the existing cert-manager/
  trust-manager CRDs from dependencies/.
- skills: update update-upstream-deps and dev-verify-loop skill docs to
  mention the envtest CRD extraction step.

Tested on a local Kind cluster (deploy-local.sh, OPERATOR_INSTALL_METHOD=none):
- [x] Operator startup pre-installs releaseserviceconfigs.appstudio.redhat.com
- [x] Owns() watch registered: *unstructured.Unstructured[ReleaseServiceConfig]
- [x] Default CR produces ReleaseServiceConfig with debug=false, no overrides
- [x] Custom CR with debug=true + emptyDirOverrides propagates to RSC spec
- [x] Deleting RSC triggers reconcile and recreates with customized values
- [x] Tampering RSC spec (debug, EmptyDirOverrides) is restored by SSA
- [x] Changing parent Konflux CR values propagates to RSC correctly
- [x] Ownership labels and ownerReferences survive all mutations

Note: unlike EnterpriseContractPolicy, ReleaseServiceConfig is always applied
(no skipPolicies equivalent). When drift is corrected, the operator restores
the spec to the admin's configured values (debug, emptyDirOverrides from the
Konflux CR), not just the raw embedded manifest. For example, if an admin sets
debug=true and someone tampers it to false, the operator restores debug=true.

Assisted-by: Cursor + Opus 4.6