### PR TITLE
feat(KONFLUX-14509): Migrate default ECP data source to konflux-operator-trusted-sources

### DIFF
--- a/operator/docs/content/docs/guides/conforma-policy-configuration.md
+++ b/operator/docs/content/docs/guides/conforma-policy-configuration.md
@@ -180,11 +180,10 @@ spec:
       policy:
         - oci::quay.io/conforma/release-policy:latest
       data:
-        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-        - github.com/release-engineering/rhtap-ec-policy//data
+        - github.com/konflux-ci/konflux-operator-trusted-sources//data
       config:
         include:
-          - "@slsa3"
+          - "@redhat"
         exclude:
           - hermetic_build_task.*
 ```
@@ -194,6 +193,13 @@ Apply it to the cluster:
 ```bash
 kubectl apply -f policy.yaml
 ```
+
+**Trusted task rules** — the data source above includes trusted task rules that
+determine which Tekton tasks are trusted based on OCI registry patterns. If you
+need to customize trust rules (e.g. trust tasks from your own registry), you can
+add a `ruleData` section to your source with `trusted_task_rules`. See
+[ADR 0053](https://github.com/konflux-ci/architecture/blob/main/ADR/0053-trusted-task-model.md)
+for details on the trust model.
 
 **Integration tests** — reference it as `<your-namespace>/my-custom-policy` in the
 `POLICY_CONFIGURATION` parameter of your `IntegrationTestScenario`.

--- a/operator/pkg/manifests/enterprise-contract/manifests.yaml
+++ b/operator/pkg/manifests/enterprise-contract/manifests.yaml
@@ -419,8 +419,7 @@ spec:
       include:
       - '@redhat'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:75bf04aa69efa7da761c75018bdc83f7e7ff21a171540cd6b3c0d107493d0d55
-    - github.com/redhat-appstudio/tsf-conforma-data//data?ref=1966f21842d507441a7a5e1c7de9071cf3f9ec53
+    - github.com/konflux-ci/konflux-operator-trusted-sources//data?ref=ddf0fb495b616175954f46e50bcbedfe37795bf5
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:latest@sha256:5a042dc4a99589fe2ff6f239fdf45429d9d44ac01147ab56c96930a2f68ccc6a

--- a/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
+++ b/operator/upstream-kustomizations/enterprise-contract/policies/enterprise-contract-service_appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_default.yaml
@@ -33,8 +33,7 @@ spec:
       include:
       - '@redhat'
     data:
-    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest@sha256:75bf04aa69efa7da761c75018bdc83f7e7ff21a171540cd6b3c0d107493d0d55
-    - github.com/redhat-appstudio/tsf-conforma-data//data?ref=1966f21842d507441a7a5e1c7de9071cf3f9ec53
+    - github.com/konflux-ci/konflux-operator-trusted-sources//data?ref=ddf0fb495b616175954f46e50bcbedfe37795bf5
     name: Default
     policy:
     - oci::quay.io/conforma/release-policy:latest@sha256:5a042dc4a99589fe2ff6f239fdf45429d9d44ac01147ab56c96930a2f68ccc6a

--- a/renovate.json
+++ b/renovate.json
@@ -187,22 +187,10 @@
         "operator/upstream-kustomizations/enterprise-contract/policies/.*\\.yaml$"
       ],
       "matchStrings": [
-        "- oci::(?<depName>quay\\.io/konflux-ci/tekton-catalog/data-acceptable-bundles):latest@(?<currentDigest>sha256:[a-f0-9]{64})"
+        "- github\\.com/konflux-ci/konflux-operator-trusted-sources//data\\?ref=(?<currentDigest>[a-f0-9]{40})"
       ],
-      "autoReplaceStringTemplate": "- oci::{{depName}}:latest@{{newDigest}}",
-      "datasourceTemplate": "docker",
-      "currentValueTemplate": "latest"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "operator/upstream-kustomizations/enterprise-contract/policies/.*\\.yaml$"
-      ],
-      "matchStrings": [
-        "- github\\.com/redhat-appstudio/tsf-conforma-data//data\\?ref=(?<currentDigest>[a-f0-9]{40})"
-      ],
-      "depNameTemplate": "https://github.com/redhat-appstudio/tsf-conforma-data",
-      "autoReplaceStringTemplate": "- github.com/redhat-appstudio/tsf-conforma-data//data?ref={{newDigest}}",
+      "depNameTemplate": "https://github.com/konflux-ci/konflux-operator-trusted-sources",
+      "autoReplaceStringTemplate": "- github.com/konflux-ci/konflux-operator-trusted-sources//data?ref={{newDigest}}",
       "datasourceTemplate": "git-refs",
       "currentValueTemplate": "main",
       "versioningTemplate": "git"


### PR DESCRIPTION
Switch the default EnterpriseContractPolicy from redhat-appstudio/tsf-conforma-data
to konflux-ci/konflux-operator-trusted-sources, which provides Conforma policy data
aligned with the ADR 0053 rule-based trust model [1].

Closes https://github.com/konflux-ci/konflux-ci/issues/7313

Changes:

- Upstream policy YAML: Replace tsf-conforma-data git data source with
  konflux-ci/konflux-operator-trusted-sources//data, pinned to the merge commit
  on main. Remove inline ruleData (now provided by the data source).

- Embedded manifests: Rebuild operator/pkg/manifests/enterprise-contract/manifests.yaml
  to reflect the updated data source.

- Renovate config: Replace the tsf-conforma-data custom manager with one tracking
  konflux-ci/konflux-operator-trusted-sources on main.

- Documentation: Update the custom policy example in
  conforma-policy-configuration.md to reference konflux-operator-trusted-sources
  and use the @redhat rule collection.

[1] https://github.com/konflux-ci/architecture/blob/main/ADR/0053-trusted-task-model.md

Assisted-by: Cursor + Opus 4.6