### PR TITLE
fix(e2e): tune etcd on Kind cluster

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -96,6 +96,7 @@ jobs:
             dependencies/**
             test/e2e/**
             test/go-tests/**
+            kind-config.yaml
             .github/workflows/operator-test-e2e.yaml
 
   # Lightweight jobs that create status checks when tests are skipped

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -19,6 +19,11 @@ nodes:
     apiServer:
       extraArgs:
         service-account-issuer: https://kubernetes.default.svc
+    etcd:
+      local:
+        extraArgs:
+          heartbeat-interval: "500"
+          election-timeout: "5000"
   extraPortMappings:
   - containerPort: 30010
     hostPort: 8888


### PR DESCRIPTION
The AMD64 e2e job intermittently fails with:
```
  CouldntGetTask: Couldn't retrieve Task "buildah-oci-ta-min":
  error requesting remote resource: etcdserver: request timed out
```
Root cause: on the 4-vCPU GitHub Actions runner, etcd becomes
overwhelmed during concurrent PipelineRun execution (load average >10),
causing leader re-elections and request timeouts.

Tune etcd in the Kind cluster config with relaxed heartbeat (500ms,
default 100ms) and election timeout (5000ms, default 1000ms) so etcd
tolerates transient CPU starvation without triggering leader
re-elections and request timeouts.

This issue surfaced after Prometheus Operator CRDs were enabled in CI
(https://github.com/konflux-ci/konflux-ci/commit/14cf474e331f53533acb04cfa5daafacd9edde67, Jun 29) which added sustained watcher load to etcd.

Ref: https://github.com/konflux-ci/konflux-ci/actions/runs/28854487535

Assisted-by: Cursor + Opus 4.6