### PR TITLE
fix: use valid singleton name in KonfluxDefaultTenant sample

### DIFF
--- a/operator/config/samples/konflux_v1alpha1_konfluxdefaulttenant.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konfluxdefaulttenant.yaml
@@ -6,6 +6,6 @@ metadata:
   labels:
     app.kubernetes.io/name: konflux-operator
     app.kubernetes.io/managed-by: kustomize
-  name: konfluxdefaulttenant-sample
+  name: konflux-default-tenant
 spec:
   # TODO(user): Add fields here


### PR DESCRIPTION
# Description

The KonfluxDefaultTenant sample had `metadata.name: konfluxdefaulttenant-sample` but the CRD only accepts `konflux-default-tenant`. This renames it so `kubectl apply` actually works.

One file changed: `operator/config/samples/konflux_v1alpha1_konfluxdefaulttenant.yaml`

Closes #8018
