### PR TITLE
test(metrics): add OpenShift UWM e2e and fix operand scrape ordering

### DIFF
--- a/deploy-konflux-on-ocp.sh
+++ b/deploy-konflux-on-ocp.sh
@@ -110,6 +110,10 @@ SKIP_DEX=true \
 SKIP_SMEE="${SKIP_SMEE}" \
 "${REPO_ROOT}/deploy-deps.sh"
 
+echo ""
+echo "=== Enabling user-workload monitoring ==="
+bash "${REPO_ROOT}/scripts/operator-e2e/openshift/enable-uwm.sh"
+
 # Step 2: Install CRDs from the checked-out branch
 echo ""
 echo "=== Step 2/6: Installing Operator CRDs ==="

--- a/operator/docs/component-monitoring.md
+++ b/operator/docs/component-monitoring.md
@@ -133,6 +133,75 @@ Timing constants and trade-offs: `DefaultScrapeTokenTTL`,
 
 Example manifests: `operator/upstream-kustomizations/<component>/monitoring/`.
 
+### ServiceMonitor apply ordering (OpenShift UWM)
+
+On clusters where prometheus-operator evaluates ServiceMonitors at apply time, a
+ServiceMonitor that references `bearerTokenSecret: prometheus-scrape-token` before the
+Secret exists can be rejected (`InvalidConfiguration: secret not found`) and may not
+recover when the Secret appears later.
+
+Operand reconcilers on the operator scrape-token model address this in two layers:
+
+1. **Deferred apply** — when `componentMetrics` is enabled, the operand ServiceMonitor
+   is skipped in `applyManifests` and applied only from
+   `ReconcilePrometheusScrapeToken` after the scrape token Secret is readable. The SM is
+   re-applied on every reconcile (idempotent SSA) so tracking-client orphan cleanup
+   retains ownership.
+2. **Resync nudges** — after apply, `ResyncOperandServiceMonitor` patches SM annotations
+   so prometheus-operator re-evaluates the SM when:
+   - the token is minted (`token-minted`) or refreshed (`token-refreshed`)
+   - a settle requeue fires (~15s, `settle-retry`)
+   - the secret resource version drifts (`secret-sync`, blocked while settle is pending)
+
+Annotations (on the operand ServiceMonitor):
+
+| Annotation | Purpose |
+|------------|---------|
+| `konflux.konflux-ci.dev/metrics-scrape-resync` | RFC3339 timestamp of last nudge |
+| `konflux.konflux-ci.dev/metrics-scrape-resync-reason` | `token-minted`, `token-refreshed`, `settle-retry`, or `secret-sync` |
+| `konflux.konflux-ci.dev/metrics-scrape-resync-secret-rv` | Last seen `prometheus-scrape-token` resourceVersion |
+| `konflux.konflux-ci.dev/metrics-scrape-resync-settle` | `pending` while waiting for settle requeue |
+
+Implementation: `operator/internal/common/scrape_token.go`,
+`operator/pkg/kubernetes/servicemonitor_resync.go`, wired from build-service and
+image-controller reconcilers.
+
+`EnsurePrometheusScrapeToken` returns `EnsureScrapeTokenResult` (token bytes,
+`SecretExisted`, post-write `ResourceVersion`) from the write path. Operand
+reconciliation uses that result for resync decisions instead of re-reading the Secret
+or ServiceMonitor from the informer cache immediately after apply, when the cache may
+not have caught up yet.
+
+Operator logs (verbosity 1 unless noted):
+
+- `metrics scrape deferred ServiceMonitor apply` — first SM create at Info;
+  steady-state re-apply at V(1)
+- `metrics scrape resync` — Info, one line per annotation patch
+- `metrics scrape resync secret-sync deferred` — Info when settle blocks secret-sync
+
+### OpenShift UWM integration tests
+
+On OpenShift optional e2e (`konflux-e2e-v420-optional`, `konflux-e2e-v420-arm64-optional`),
+`scripts/operator-e2e/openshift/enable-uwm.sh` enables user-workload monitoring, then
+`run-metrics-openshift-tests.sh` runs `test/go-tests/metricsopenshift/`.
+
+The suite verifies:
+
+- UWM Prometheus is ready in `openshift-user-workload-monitoring`
+- Operand scrape contract (ServiceMonitor spec, resync annotations, token Secret) for
+  scrape-token targets (`konflux-operator`, `build-service`, `image-controller`)
+- `up==1` in UWM Prometheus for scrape-token targets (`metrics-uwm`) and legacy interim
+  HTTP operands with `UWMUpCheck` (`integration-service`, `konflux-ui-proxy`; label
+  `metrics-uwm-up-only`, no scrape-token contract)
+
+Before specs, tests emit `[UWM resync]` lines with `resync_reason`, secret/SM resource
+versions, `uwm_active_targets`, and `sm_after_secret` (SM `creationTimestamp` after
+scrape token). Use `sm_after_secret=true` and `uwm_active_targets=1` as pass fingerprints;
+`resync_reason` alone is not a reliable flake indicator.
+
+On failure, `[UWM debug]` dumps SM/secret metadata, prometheus-operator log tail, and
+peer target comparison. See `test/go-tests/pkg/metricsopenshift/`.
+
 ### Operator self-metrics
 
 The Konflux operator manager uses the same **operator scrape token** model in
@@ -265,3 +334,6 @@ Paths: `operator/upstream-kustomizations/<component>/`, matching controller unde
 | Operator self-metrics | `internal/operatormetrics/` (`scrape_token_rotator.go`, `scrape_wiring.go`) |
 | Embedded manifests | `operator/pkg/manifests/<component>/manifests.yaml` |
 | Cluster integration tests | `test/go-tests/metricsintegration/` + `test/go-tests/pkg/metricsauth.DefaultCatalog()` (via `scripts/operator-e2e/run-metrics-integration-tests.sh`, hooked in `test/e2e/run-e2e.sh`) |
+| OpenShift UWM tests | `test/go-tests/metricsopenshift/` + `test/go-tests/pkg/metricsopenshift/` (via `scripts/operator-e2e/openshift/run-metrics-openshift-tests.sh`, optional OCP e2e in `test/e2e/run-e2e.sh`) |
+| ServiceMonitor resync | `operator/pkg/kubernetes/servicemonitor_resync.go` |
+| Deferred SM apply | `operator/internal/common/scrape_token.go`, `operand_servicemonitor.go` |

--- a/operator/internal/common/metrics_scraper_test.go
+++ b/operator/internal/common/metrics_scraper_test.go
@@ -35,7 +35,7 @@ func TestApplyMetricsScraperBindingSubjects(t *testing.T) {
 			},
 		},
 	}
-	if err := ApplyMetricsScraperBindingSubjects("build-service", crb); err != nil {
+	if err := ApplyMetricsScraperBindingSubjects(testBuildServiceNamespace, crb); err != nil {
 		t.Fatalf("apply structured CRB: %v", err)
 	}
 	if len(crb.Subjects) != 1 {
@@ -44,7 +44,7 @@ func TestApplyMetricsScraperBindingSubjects(t *testing.T) {
 	if crb.Subjects[0].Name != kubernetes.MetricsScraperServiceAccountName {
 		t.Fatalf("unexpected subject name %q", crb.Subjects[0].Name)
 	}
-	if crb.Subjects[0].Namespace != "build-service" {
+	if crb.Subjects[0].Namespace != testBuildServiceNamespace {
 		t.Fatalf("unexpected subject namespace %q", crb.Subjects[0].Namespace)
 	}
 
@@ -55,7 +55,7 @@ func TestApplyMetricsScraperBindingSubjects(t *testing.T) {
 	u.SetAnnotations(map[string]string{
 		kubernetes.MetricsScraperBindingAnnotation: "true",
 	})
-	if err := ApplyMetricsScraperBindingSubjects("image-controller", u); err != nil {
+	if err := ApplyMetricsScraperBindingSubjects(testImageControllerNamespace, u); err != nil {
 		t.Fatalf("apply unstructured CRB: %v", err)
 	}
 	subjects, found, err := unstructured.NestedSlice(u.Object, "subjects")

--- a/operator/internal/common/operand_servicemonitor.go
+++ b/operator/internal/common/operand_servicemonitor.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
+)
+
+// OperandServiceMonitorFromObjects returns the embedded operand ServiceMonitor matching
+// namespace and name from a component manifest object list. Used by ApplyServiceMonitor
+// callbacks in deferred ServiceMonitor apply (SM is skipped in applyManifests, applied here).
+func OperandServiceMonitorFromObjects(objects []client.Object, namespace, name string) (client.Object, bool) {
+	for _, obj := range objects {
+		if !kubernetes.IsComponentMetricsServiceMonitor(obj) {
+			continue
+		}
+		if obj.GetNamespace() == namespace && obj.GetName() == name {
+			return obj, true
+		}
+	}
+	return nil, false
+}

--- a/operator/internal/common/operand_servicemonitor_test.go
+++ b/operator/internal/common/operand_servicemonitor_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestOperandServiceMonitorFromObjects(t *testing.T) {
+	t.Parallel()
+
+	sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	sm.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "monitoring.coreos.com",
+		Version: "v1",
+		Kind:    "ServiceMonitor",
+	})
+	sm.SetNamespace(testBuildServiceNamespace)
+	sm.SetName(testBuildServiceNamespace)
+
+	other := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	other.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "monitoring.coreos.com",
+		Version: "v1",
+		Kind:    "ServiceMonitor",
+	})
+	other.SetNamespace("image-controller")
+	other.SetName("image-controller")
+
+	objects := []client.Object{
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "noop"}},
+		sm,
+		other,
+	}
+
+	got, ok := OperandServiceMonitorFromObjects(objects, testBuildServiceNamespace, testBuildServiceNamespace)
+	if !ok {
+		t.Fatal("expected to find build-service ServiceMonitor")
+	}
+	if got.GetName() != testBuildServiceNamespace || got.GetNamespace() != testBuildServiceNamespace {
+		t.Fatalf("unexpected SM: %s/%s", got.GetNamespace(), got.GetName())
+	}
+
+	if _, ok := OperandServiceMonitorFromObjects(objects, testBuildServiceNamespace, "missing"); ok {
+		t.Fatal("expected missing ServiceMonitor to not be found")
+	}
+}

--- a/operator/internal/common/scrape_token.go
+++ b/operator/internal/common/scrape_token.go
@@ -20,36 +20,77 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
 )
 
+var operandServiceMonitorGVK = schema.GroupVersionKind{
+	Group:   "monitoring.coreos.com",
+	Version: "v1",
+	Kind:    "ServiceMonitor",
+}
+
 // ScrapeTokenReconcilerConfig configures operand-namespace Prometheus scrape token reconciliation.
 type ScrapeTokenReconcilerConfig struct {
-	Client           client.Reader
-	Clock            clock.Clock
-	TokenCreator     kubernetes.TokenCreator
-	Scraper          types.NamespacedName
-	OperandNamespace string
-	Apply            kubernetes.ScrapeTokenApplyFunc
+	Client             client.Client
+	Clock              clock.Clock
+	TokenCreator       kubernetes.TokenCreator
+	Scraper            types.NamespacedName
+	OperandNamespace   string
+	ServiceMonitorName string
+	Apply              kubernetes.ScrapeTokenApplyFunc
+	// ApplyServiceMonitor applies the operand ServiceMonitor after prometheus-scrape-token
+	// is readable (deferred ServiceMonitor apply). Must be idempotent and invoked on every
+	// reconcile so the tracking client retains the SM during orphan cleanup; callers
+	// typically use tc.ApplyOwned.
+	ApplyServiceMonitor func(ctx context.Context) error
+}
+
+// DeferredSMApplyResult captures operand ServiceMonitor state from deferred apply without
+// re-reading the informer cache immediately after the write.
+type DeferredSMApplyResult struct {
+	ExistedBeforeApply bool
+	Prior              *unstructured.Unstructured
 }
 
 // ReconcilePrometheusScrapeToken ensures the operand scrape token Secret exists and is fresh.
-// Periodic re-checks are driven by TokenRotationBroadcaster rather than RequeueAfter.
-func ReconcilePrometheusScrapeToken(ctx context.Context, cfg ScrapeTokenReconcilerConfig) error {
+// When ServiceMonitorName is set, it also applies the operand ServiceMonitor after the token
+// is readable (deferred ServiceMonitor apply) and nudges prometheus-operator to re-evaluate
+// the SM (resync nudges).
+//
+// Deferred ServiceMonitor apply: operand reconcilers skip the ServiceMonitor in applyManifests
+// when componentMetrics is enabled. This function applies it here via ApplyServiceMonitor
+// only after the scrape token Secret exists with non-empty token bytes. ApplyServiceMonitor
+// must run every reconcile (not only on create) so tracking-client orphan cleanup does not
+// delete the SM.
+//
+// Resync nudges: patches SM annotations via ResyncOperandServiceMonitor when the token is
+// minted (token-minted) or refreshed (token-refreshed), on settle requeue after
+// DefaultServiceMonitorResyncSettleDelay (settle-retry), or when secret resourceVersion
+// drifts (secret-sync). secret-sync is suppressed while metrics-scrape-resync-settle=pending.
+//
+// Returns RequeueAfter on mint/refresh so settle-retry runs once more before steady state.
+func ReconcilePrometheusScrapeToken(ctx context.Context, cfg ScrapeTokenReconcilerConfig) (reconcile.Result, error) {
 	if cfg.TokenCreator == nil {
-		return fmt.Errorf("token creator is required")
+		return reconcile.Result{}, fmt.Errorf("token creator is required")
 	}
 	if cfg.OperandNamespace == "" {
-		return fmt.Errorf("operand namespace is required")
+		return reconcile.Result{}, fmt.Errorf("operand namespace is required")
 	}
 	if cfg.Scraper.Namespace == "" || cfg.Scraper.Name == "" {
-		return fmt.Errorf("scraper service account is required")
+		return reconcile.Result{}, fmt.Errorf("scraper service account is required")
 	}
-	_, err := kubernetes.EnsurePrometheusScrapeToken(ctx, kubernetes.EnsureScrapeTokenInput{
+
+	tokenResult, err := kubernetes.EnsurePrometheusScrapeToken(ctx, kubernetes.EnsureScrapeTokenInput{
 		Client:           cfg.Client,
 		Clock:            cfg.Clock,
 		TokenCreator:     cfg.TokenCreator,
@@ -57,5 +98,148 @@ func ReconcilePrometheusScrapeToken(ctx context.Context, cfg ScrapeTokenReconcil
 		OperandNamespace: cfg.OperandNamespace,
 		Apply:            cfg.Apply,
 	})
-	return err
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if cfg.ServiceMonitorName == "" {
+		return reconcile.Result{}, nil
+	}
+
+	smKey := client.ObjectKey{Namespace: cfg.OperandNamespace, Name: cfg.ServiceMonitorName}
+	var smApply DeferredSMApplyResult
+	if cfg.ApplyServiceMonitor != nil {
+		var applyErr error
+		smApply, applyErr = applyDeferredOperandServiceMonitor(ctx, cfg, tokenResult, smKey)
+		if applyErr != nil {
+			return reconcile.Result{}, applyErr
+		}
+	} else {
+		smApply = probeOperandServiceMonitor(ctx, cfg.Client, smKey)
+		if !smApply.ExistedBeforeApply && tokenResult.TokenUpdated {
+			return reconcile.Result{RequeueAfter: kubernetes.DefaultServiceMonitorResyncSettleDelay}, nil
+		}
+	}
+
+	secretRV := tokenResult.ResourceVersion
+	var storedSecretRV string
+	var settlePending bool
+	if smApply.ExistedBeforeApply && smApply.Prior != nil {
+		storedSecretRV = kubernetes.ServiceMonitorResyncSecretRV(smApply.Prior)
+		settlePending = kubernetes.ServiceMonitorResyncSettlePending(smApply.Prior)
+	}
+	if secretRV != "" && secretRV != storedSecretRV && settlePending {
+		logf.FromContext(ctx).Info(
+			"metrics scrape resync secret-sync deferred",
+			"namespace", cfg.OperandNamespace,
+			"servicemonitor", cfg.ServiceMonitorName,
+			"secretResourceVersion", secretRV,
+			"storedSecretResourceVersion", storedSecretRV,
+			"settlePending", true,
+		)
+	}
+
+	resyncOpts := kubernetes.ServiceMonitorResyncOptions{Clock: cfg.Clock}
+	switch {
+	case tokenResult.TokenUpdated:
+		resyncOpts.Force = true
+		if tokenResult.SecretExisted {
+			resyncOpts.Reason = kubernetes.ServiceMonitorResyncReasonTokenRefreshed
+		} else {
+			resyncOpts.Reason = kubernetes.ServiceMonitorResyncReasonTokenMinted
+		}
+		resyncOpts.SecretResourceVersion = secretRV
+		resyncOpts.MarkSettlePending = true
+	case settlePending:
+		resyncOpts.Force = true
+		resyncOpts.Reason = kubernetes.ServiceMonitorResyncReasonSettleRetry
+		resyncOpts.SecretResourceVersion = secretRV
+		resyncOpts.ClearSettlePending = true
+	case secretRV != "" && secretRV != storedSecretRV && !settlePending:
+		resyncOpts.Force = true
+		resyncOpts.Reason = kubernetes.ServiceMonitorResyncReasonSecretSync
+		resyncOpts.SecretResourceVersion = secretRV
+	}
+
+	if resyncOpts.Force || resyncOpts.MarkSettlePending {
+		if resyncErr := kubernetes.ResyncOperandServiceMonitor(
+			ctx,
+			cfg.Client,
+			cfg.OperandNamespace,
+			cfg.ServiceMonitorName,
+			resyncOpts,
+		); resyncErr != nil {
+			return reconcile.Result{}, fmt.Errorf("resync servicemonitor %q: %w", cfg.ServiceMonitorName, resyncErr)
+		}
+	}
+
+	if tokenResult.TokenUpdated {
+		return reconcile.Result{RequeueAfter: kubernetes.DefaultServiceMonitorResyncSettleDelay}, nil
+	}
+	return reconcile.Result{}, nil
+}
+
+// applyDeferredOperandServiceMonitor invokes ApplyServiceMonitor after the scrape token is
+// readable. Deferred ServiceMonitor apply ensures prometheus-operator first sees the SM when
+// bearerTokenSecret exists. Re-applies on every reconcile for tracking-client orphan retention.
+func applyDeferredOperandServiceMonitor(
+	ctx context.Context,
+	cfg ScrapeTokenReconcilerConfig,
+	tokenResult kubernetes.EnsureScrapeTokenResult,
+	smKey client.ObjectKey,
+) (DeferredSMApplyResult, error) {
+	if cfg.ApplyServiceMonitor == nil {
+		return DeferredSMApplyResult{}, nil
+	}
+
+	log := logf.FromContext(ctx)
+	result := DeferredSMApplyResult{}
+	existedKnown := true
+	probe := &unstructured.Unstructured{}
+	probe.SetGroupVersionKind(operandServiceMonitorGVK)
+	switch probeErr := cfg.Client.Get(ctx, smKey, probe); {
+	case probeErr == nil:
+		result.ExistedBeforeApply = true
+		result.Prior = probe.DeepCopy()
+	case apierrors.IsNotFound(probeErr), meta.IsNoMatchError(probeErr):
+	default:
+		existedKnown = false
+		log.V(1).Info(
+			"metrics scrape ServiceMonitor probe failed; continuing apply",
+			"namespace", cfg.OperandNamespace,
+			"servicemonitor", cfg.ServiceMonitorName,
+			"error", probeErr,
+		)
+	}
+
+	logApply := log.Info
+	if existedKnown && result.ExistedBeforeApply {
+		logApply = log.V(1).Info
+	}
+	logApply(
+		"metrics scrape deferred ServiceMonitor apply",
+		"namespace", cfg.OperandNamespace,
+		"servicemonitor", cfg.ServiceMonitorName,
+		"existedBeforeApply", result.ExistedBeforeApply,
+		"secretResourceVersion", tokenResult.ResourceVersion,
+	)
+	if applyErr := cfg.ApplyServiceMonitor(ctx); applyErr != nil {
+		return DeferredSMApplyResult{}, fmt.Errorf("apply ServiceMonitor %q: %w", cfg.ServiceMonitorName, applyErr)
+	}
+	return result, nil
+}
+
+func probeOperandServiceMonitor(ctx context.Context, c client.Client, smKey client.ObjectKey) DeferredSMApplyResult {
+	probe := &unstructured.Unstructured{}
+	probe.SetGroupVersionKind(operandServiceMonitorGVK)
+	switch err := c.Get(ctx, smKey, probe); {
+	case err == nil:
+		return DeferredSMApplyResult{
+			ExistedBeforeApply: true,
+			Prior:              probe.DeepCopy(),
+		}
+	case apierrors.IsNotFound(err), meta.IsNoMatchError(err):
+		return DeferredSMApplyResult{}
+	default:
+		return DeferredSMApplyResult{}
+	}
 }

--- a/operator/internal/common/scrape_token_test.go
+++ b/operator/internal/common/scrape_token_test.go
@@ -19,19 +19,24 @@ package common
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	testclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
 )
+
+// These tests use controller-runtime's fake client, which registers types on a shared
+// runtime.Scheme. Running them with t.Parallel() races concurrent Scheme map access
+// (KnownTypes iteration vs Update) and can panic under load or with -race.
 
 type fakeTokenCreator struct {
 	token     string
@@ -53,15 +58,14 @@ func (f *fakeTokenCreator) CreateScraperToken(
 }
 
 func TestReconcilePrometheusScrapeToken_Validation(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 
-	err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{})
+	_, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{})
 	if err == nil {
 		t.Fatal("expected error when token creator is nil")
 	}
 
-	err = ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+	_, err = ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
 		TokenCreator: &fakeTokenCreator{},
 	})
 	if err == nil {
@@ -70,21 +74,20 @@ func TestReconcilePrometheusScrapeToken_Validation(t *testing.T) {
 }
 
 func TestReconcilePrometheusScrapeToken_CreatesToken(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
 	creator := &fakeTokenCreator{
 		token:     "operand-token",
 		expiresAt: now.Add(time.Hour),
 	}
-	scraper := kubernetes.OperandMetricsScraperSA("build-service")
+	scraper := kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace)
 
-	err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
-		Client:           &absentSecretReader{},
+	_, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:           fake.NewClientBuilder().Build(),
 		Clock:            testclock.NewFakeClock(now),
 		TokenCreator:     creator,
 		Scraper:          scraper,
-		OperandNamespace: "build-service",
+		OperandNamespace: testBuildServiceNamespace,
 		Apply: func(_ context.Context, _ *corev1.Secret) error {
 			return nil
 		},
@@ -98,17 +101,16 @@ func TestReconcilePrometheusScrapeToken_CreatesToken(t *testing.T) {
 }
 
 func TestReconcilePrometheusScrapeToken_PropagatesErrors(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
 	mintErr := errors.New("mint failed")
 
-	err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
-		Client:           &absentSecretReader{},
+	_, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:           fake.NewClientBuilder().Build(),
 		Clock:            testclock.NewFakeClock(now),
 		TokenCreator:     &fakeTokenCreator{err: mintErr},
 		Scraper:          types.NamespacedName{Namespace: "monitoring", Name: "prometheus"},
-		OperandNamespace: "build-service",
+		OperandNamespace: testBuildServiceNamespace,
 		Apply:            func(context.Context, *corev1.Secret) error { return nil },
 	})
 	if err == nil {
@@ -117,13 +119,12 @@ func TestReconcilePrometheusScrapeToken_PropagatesErrors(t *testing.T) {
 }
 
 func TestReconcilePrometheusScrapeToken_TracksFreshSecret(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
 	fresh := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kubernetes.ScrapeTokenSecretName,
-			Namespace: "build-service",
+			Namespace: testBuildServiceNamespace,
 			Annotations: map[string]string{
 				"konflux.konflux-ci.dev/scrape-token-expires-at": now.Add(45 * time.Minute).UTC().Format(time.RFC3339),
 			},
@@ -131,12 +132,12 @@ func TestReconcilePrometheusScrapeToken_TracksFreshSecret(t *testing.T) {
 		Data: map[string][]byte{kubernetes.ScrapeTokenSecretKey: []byte("existing")},
 	}
 
-	err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
-		Client:           &existingSecretReader{secret: fresh},
+	_, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:           fake.NewClientBuilder().WithObjects(fresh).Build(),
 		Clock:            testclock.NewFakeClock(now),
 		TokenCreator:     &fakeTokenCreator{},
-		Scraper:          kubernetes.OperandMetricsScraperSA("build-service"),
-		OperandNamespace: "build-service",
+		Scraper:          kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace: testBuildServiceNamespace,
 		Apply:            func(context.Context, *corev1.Secret) error { return nil },
 	})
 	if err != nil {
@@ -144,45 +145,561 @@ func TestReconcilePrometheusScrapeToken_TracksFreshSecret(t *testing.T) {
 	}
 }
 
-type existingSecretReader struct {
-	secret *corev1.Secret
+func TestReconcilePrometheusScrapeToken_MintsAndSettles(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+	sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	sm.SetGroupVersionKind(operandServiceMonitorGVK)
+	sm.SetNamespace(testBuildServiceNamespace)
+	sm.SetName(testBuildServiceNamespace)
+
+	c := fake.NewClientBuilder().WithObjects(sm).Build()
+	creator := &fakeTokenCreator{
+		token:     "operand-token",
+		expiresAt: now.Add(time.Hour),
+	}
+	cfg := ScrapeTokenReconcilerConfig{
+		Client:             c,
+		Clock:              testclock.NewFakeClock(now),
+		TokenCreator:       creator,
+		Scraper:            kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace:   testBuildServiceNamespace,
+		ServiceMonitorName: testBuildServiceNamespace,
+		Apply: func(applyCtx context.Context, secret *corev1.Secret) error {
+			key := types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}
+			existing := &corev1.Secret{}
+			if err := c.Get(applyCtx, key, existing); apierrors.IsNotFound(err) {
+				return c.Create(applyCtx, secret)
+			} else if err != nil {
+				return err
+			}
+			secret.SetResourceVersion(existing.ResourceVersion)
+			return c.Update(applyCtx, secret)
+		},
+	}
+
+	result, err := ReconcilePrometheusScrapeToken(ctx, cfg)
+	if err != nil {
+		t.Fatalf("mint reconcile: %v", err)
+	}
+	if result.RequeueAfter != kubernetes.DefaultServiceMonitorResyncSettleDelay {
+		t.Fatalf("requeue: got %v want %v", result.RequeueAfter, kubernetes.DefaultServiceMonitorResyncSettleDelay)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(operandServiceMonitorGVK)
+	if err := c.Get(ctx, types.NamespacedName{Namespace: testBuildServiceNamespace, Name: testBuildServiceNamespace}, updated); err != nil {
+		t.Fatalf("get SM: %v", err)
+	}
+	if updated.GetAnnotations()[kubernetes.ServiceMonitorResyncReasonAnnotation] != kubernetes.ServiceMonitorResyncReasonTokenMinted {
+		t.Fatalf("reason: got %q", updated.GetAnnotations()[kubernetes.ServiceMonitorResyncReasonAnnotation])
+	}
+
+	settleResult, err := ReconcilePrometheusScrapeToken(ctx, cfg)
+	if err != nil {
+		t.Fatalf("settle reconcile: %v", err)
+	}
+	if settleResult.RequeueAfter != 0 {
+		t.Fatalf("expected no requeue on settle pass")
+	}
+
+	if err := c.Get(ctx, types.NamespacedName{Namespace: testBuildServiceNamespace, Name: testBuildServiceNamespace}, updated); err != nil {
+		t.Fatalf("get SM after settle: %v", err)
+	}
+	if updated.GetAnnotations()[kubernetes.ServiceMonitorResyncReasonAnnotation] != kubernetes.ServiceMonitorResyncReasonSettleRetry {
+		t.Fatalf("settle reason: got %q", updated.GetAnnotations()[kubernetes.ServiceMonitorResyncReasonAnnotation])
+	}
+	if _, ok := updated.GetAnnotations()[kubernetes.ServiceMonitorResyncSettleAnnotation]; ok {
+		t.Fatalf("expected settle pending to be cleared")
+	}
 }
 
-func (r *existingSecretReader) Get(
-	_ context.Context,
+func TestReconcilePrometheusScrapeToken_SecretSyncWhenRVChanges(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+	sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	sm.SetGroupVersionKind(operandServiceMonitorGVK)
+	sm.SetNamespace(testBuildServiceNamespace)
+	sm.SetName(testBuildServiceNamespace)
+	sm.SetAnnotations(map[string]string{
+		kubernetes.ServiceMonitorResyncAnnotation:         "2026-07-12T07:00:00Z",
+		kubernetes.ServiceMonitorResyncSecretRVAnnotation: "100",
+		kubernetes.ServiceMonitorResyncReasonAnnotation:   kubernetes.ServiceMonitorResyncReasonTokenMinted,
+	})
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            kubernetes.ScrapeTokenSecretName,
+			Namespace:       testBuildServiceNamespace,
+			ResourceVersion: "200",
+			Annotations: map[string]string{
+				"konflux.konflux-ci.dev/scrape-token-expires-at": now.Add(45 * time.Minute).UTC().Format(time.RFC3339),
+			},
+		},
+		Data: map[string][]byte{kubernetes.ScrapeTokenSecretKey: []byte("token")},
+	}
+
+	c := fake.NewClientBuilder().WithObjects(sm, secret).Build()
+	_, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:             c,
+		Clock:              testclock.NewFakeClock(now),
+		TokenCreator:       &fakeTokenCreator{},
+		Scraper:            kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace:   testBuildServiceNamespace,
+		ServiceMonitorName: testBuildServiceNamespace,
+		Apply:              func(context.Context, *corev1.Secret) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("secret sync reconcile: %v", err)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(operandServiceMonitorGVK)
+	if err := c.Get(ctx, client.ObjectKey{Namespace: testBuildServiceNamespace, Name: testBuildServiceNamespace}, updated); err != nil {
+		t.Fatalf("get SM: %v", err)
+	}
+	if updated.GetAnnotations()[kubernetes.ServiceMonitorResyncReasonAnnotation] != kubernetes.ServiceMonitorResyncReasonSecretSync {
+		t.Fatalf("reason: got %q", updated.GetAnnotations()[kubernetes.ServiceMonitorResyncReasonAnnotation])
+	}
+}
+
+func TestReconcilePrometheusScrapeToken_SecretSyncBlockedDuringSettle(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+	sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	sm.SetGroupVersionKind(operandServiceMonitorGVK)
+	sm.SetNamespace(testBuildServiceNamespace)
+	sm.SetName(testBuildServiceNamespace)
+	sm.SetAnnotations(map[string]string{
+		kubernetes.ServiceMonitorResyncAnnotation:         "2026-07-12T07:00:00Z",
+		kubernetes.ServiceMonitorResyncSecretRVAnnotation: "100",
+		kubernetes.ServiceMonitorResyncReasonAnnotation:   kubernetes.ServiceMonitorResyncReasonTokenMinted,
+		kubernetes.ServiceMonitorResyncSettleAnnotation:   "pending",
+	})
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            kubernetes.ScrapeTokenSecretName,
+			Namespace:       testBuildServiceNamespace,
+			ResourceVersion: "200",
+			Annotations: map[string]string{
+				"konflux.konflux-ci.dev/scrape-token-expires-at": now.Add(45 * time.Minute).UTC().Format(time.RFC3339),
+			},
+		},
+		Data: map[string][]byte{kubernetes.ScrapeTokenSecretKey: []byte("token")},
+	}
+
+	c := fake.NewClientBuilder().WithObjects(sm, secret).Build()
+	_, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:             c,
+		Clock:              testclock.NewFakeClock(now),
+		TokenCreator:       &fakeTokenCreator{},
+		Scraper:            kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace:   testBuildServiceNamespace,
+		ServiceMonitorName: testBuildServiceNamespace,
+		Apply:              func(context.Context, *corev1.Secret) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("reconcile during settle: %v", err)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(operandServiceMonitorGVK)
+	if err := c.Get(ctx, client.ObjectKey{Namespace: testBuildServiceNamespace, Name: testBuildServiceNamespace}, updated); err != nil {
+		t.Fatalf("get SM: %v", err)
+	}
+	if updated.GetAnnotations()[kubernetes.ServiceMonitorResyncReasonAnnotation] != kubernetes.ServiceMonitorResyncReasonSettleRetry {
+		t.Fatalf("expected settle-retry instead of secret-sync during settle pending, got %q",
+			updated.GetAnnotations()[kubernetes.ServiceMonitorResyncReasonAnnotation])
+	}
+}
+
+func TestReconcilePrometheusScrapeToken_AppliesServiceMonitorWhenAbsent(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+	c := fake.NewClientBuilder().Build()
+	creator := &fakeTokenCreator{
+		token:     "operand-token",
+		expiresAt: now.Add(time.Hour),
+	}
+	applied := false
+	cfg := ScrapeTokenReconcilerConfig{
+		Client:             c,
+		Clock:              testclock.NewFakeClock(now),
+		TokenCreator:       creator,
+		Scraper:            kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace:   testBuildServiceNamespace,
+		ServiceMonitorName: testBuildServiceNamespace,
+		Apply: func(applyCtx context.Context, secret *corev1.Secret) error {
+			key := types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}
+			existing := &corev1.Secret{}
+			if err := c.Get(applyCtx, key, existing); apierrors.IsNotFound(err) {
+				return c.Create(applyCtx, secret)
+			} else if err != nil {
+				return err
+			}
+			secret.SetResourceVersion(existing.ResourceVersion)
+			return c.Update(applyCtx, secret)
+		},
+		ApplyServiceMonitor: func(applyCtx context.Context) error {
+			applied = true
+			sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+			sm.SetGroupVersionKind(operandServiceMonitorGVK)
+			sm.SetNamespace(testBuildServiceNamespace)
+			sm.SetName(testBuildServiceNamespace)
+			return c.Create(applyCtx, sm)
+		},
+	}
+
+	result, err := ReconcilePrometheusScrapeToken(ctx, cfg)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected ApplyServiceMonitor to run when SM is absent")
+	}
+	if result.RequeueAfter != kubernetes.DefaultServiceMonitorResyncSettleDelay {
+		t.Fatalf("requeue: got %v want %v", result.RequeueAfter, kubernetes.DefaultServiceMonitorResyncSettleDelay)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(operandServiceMonitorGVK)
+	if err := c.Get(ctx, types.NamespacedName{Namespace: testBuildServiceNamespace, Name: testBuildServiceNamespace}, updated); err != nil {
+		t.Fatalf("get SM: %v", err)
+	}
+	if updated.GetAnnotations()[kubernetes.ServiceMonitorResyncReasonAnnotation] != kubernetes.ServiceMonitorResyncReasonTokenMinted {
+		t.Fatalf("reason: got %q", updated.GetAnnotations()[kubernetes.ServiceMonitorResyncReasonAnnotation])
+	}
+}
+
+func TestReconcilePrometheusScrapeToken_ReappliesServiceMonitorWhenPresent(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+	sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	sm.SetGroupVersionKind(operandServiceMonitorGVK)
+	sm.SetNamespace(testBuildServiceNamespace)
+	sm.SetName(testBuildServiceNamespace)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubernetes.ScrapeTokenSecretName,
+			Namespace: testBuildServiceNamespace,
+			Annotations: map[string]string{
+				"konflux.konflux-ci.dev/scrape-token-expires-at": now.Add(45 * time.Minute).UTC().Format(time.RFC3339),
+			},
+		},
+		Data: map[string][]byte{kubernetes.ScrapeTokenSecretKey: []byte("token")},
+	}
+
+	c := fake.NewClientBuilder().WithObjects(sm, secret).Build()
+	applyCalls := 0
+	_, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:             c,
+		Clock:              testclock.NewFakeClock(now),
+		TokenCreator:       &fakeTokenCreator{},
+		Scraper:            kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace:   testBuildServiceNamespace,
+		ServiceMonitorName: testBuildServiceNamespace,
+		Apply:              func(context.Context, *corev1.Secret) error { return nil },
+		ApplyServiceMonitor: func(context.Context) error {
+			applyCalls++
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if applyCalls != 1 {
+		t.Fatalf("ApplyServiceMonitor calls: got %d want 1", applyCalls)
+	}
+}
+
+func TestReconcilePrometheusScrapeToken_ValidationScraper(t *testing.T) {
+	ctx := context.Background()
+
+	_, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		TokenCreator:     &fakeTokenCreator{},
+		OperandNamespace: testBuildServiceNamespace,
+	})
+	if err == nil {
+		t.Fatal("expected error when scraper is empty")
+	}
+}
+
+func TestReconcilePrometheusScrapeToken_NoServiceMonitorName(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+
+	result, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:           fake.NewClientBuilder().Build(),
+		Clock:            testclock.NewFakeClock(now),
+		TokenCreator:     &fakeTokenCreator{token: "tok", expiresAt: now.Add(time.Hour)},
+		Scraper:          kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace: testBuildServiceNamespace,
+		Apply:            func(context.Context, *corev1.Secret) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("reconcile without SM name: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Fatalf("expected no requeue when ServiceMonitorName is empty")
+	}
+}
+
+func TestReconcilePrometheusScrapeToken_TokenRefreshed(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+
+	staleSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            kubernetes.ScrapeTokenSecretName,
+			Namespace:       testBuildServiceNamespace,
+			ResourceVersion: "50",
+			Annotations: map[string]string{
+				"konflux.konflux-ci.dev/scrape-token-expires-at": now.Add(10 * time.Minute).UTC().Format(time.RFC3339),
+			},
+		},
+		Data: map[string][]byte{kubernetes.ScrapeTokenSecretKey: []byte("old-token")},
+	}
+	sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	sm.SetGroupVersionKind(operandServiceMonitorGVK)
+	sm.SetNamespace(testBuildServiceNamespace)
+	sm.SetName(testBuildServiceNamespace)
+
+	c := fake.NewClientBuilder().WithObjects(staleSecret, sm).Build()
+	creator := &fakeTokenCreator{
+		token:     "new-token",
+		expiresAt: now.Add(time.Hour),
+	}
+	result, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:             c,
+		Clock:              testclock.NewFakeClock(now),
+		TokenCreator:       creator,
+		Scraper:            kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace:   testBuildServiceNamespace,
+		ServiceMonitorName: testBuildServiceNamespace,
+		Apply: func(applyCtx context.Context, secret *corev1.Secret) error {
+			key := types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}
+			existing := &corev1.Secret{}
+			if err := c.Get(applyCtx, key, existing); err != nil {
+				return err
+			}
+			secret.SetResourceVersion(existing.ResourceVersion)
+			return c.Update(applyCtx, secret)
+		},
+	})
+	if err != nil {
+		t.Fatalf("refresh reconcile: %v", err)
+	}
+	if result.RequeueAfter != kubernetes.DefaultServiceMonitorResyncSettleDelay {
+		t.Fatalf("requeue: got %v", result.RequeueAfter)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(operandServiceMonitorGVK)
+	if err := c.Get(ctx, types.NamespacedName{Namespace: testBuildServiceNamespace, Name: testBuildServiceNamespace}, updated); err != nil {
+		t.Fatalf("get SM: %v", err)
+	}
+	if updated.GetAnnotations()[kubernetes.ServiceMonitorResyncReasonAnnotation] != kubernetes.ServiceMonitorResyncReasonTokenRefreshed {
+		t.Fatalf("reason: got %q want %q",
+			updated.GetAnnotations()[kubernetes.ServiceMonitorResyncReasonAnnotation],
+			kubernetes.ServiceMonitorResyncReasonTokenRefreshed,
+		)
+	}
+}
+
+func TestReconcilePrometheusScrapeToken_EmptyTokenAfterEnsure(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+
+	emptySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubernetes.ScrapeTokenSecretName,
+			Namespace: testBuildServiceNamespace,
+		},
+		Data: map[string][]byte{},
+	}
+
+	_, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:             fake.NewClientBuilder().WithObjects(emptySecret).Build(),
+		Clock:              testclock.NewFakeClock(now),
+		TokenCreator:       &fakeTokenCreator{},
+		Scraper:            kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace:   testBuildServiceNamespace,
+		ServiceMonitorName: testBuildServiceNamespace,
+		Apply:              func(context.Context, *corev1.Secret) error { return nil },
+	})
+	if err == nil {
+		t.Fatal("expected error when scrape token is empty after ensure")
+	}
+}
+
+func TestReconcilePrometheusScrapeToken_ApplyServiceMonitorFails(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+	applyErr := errors.New("apply failed")
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubernetes.ScrapeTokenSecretName,
+			Namespace: testBuildServiceNamespace,
+			Annotations: map[string]string{
+				"konflux.konflux-ci.dev/scrape-token-expires-at": now.Add(45 * time.Minute).UTC().Format(time.RFC3339),
+			},
+		},
+		Data: map[string][]byte{kubernetes.ScrapeTokenSecretKey: []byte("token")},
+	}
+
+	_, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:             fake.NewClientBuilder().WithObjects(secret).Build(),
+		Clock:              testclock.NewFakeClock(now),
+		TokenCreator:       &fakeTokenCreator{},
+		Scraper:            kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace:   testBuildServiceNamespace,
+		ServiceMonitorName: testBuildServiceNamespace,
+		Apply:              func(context.Context, *corev1.Secret) error { return nil },
+		ApplyServiceMonitor: func(context.Context) error {
+			return applyErr
+		},
+	})
+	if err == nil {
+		t.Fatal("expected apply ServiceMonitor error")
+	}
+}
+
+func TestReconcilePrometheusScrapeToken_SMNotFoundRequeuesWhenTokenUpdated(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+	c := fake.NewClientBuilder().Build()
+	creator := &fakeTokenCreator{
+		token:     "operand-token",
+		expiresAt: now.Add(time.Hour),
+	}
+
+	result, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:             c,
+		Clock:              testclock.NewFakeClock(now),
+		TokenCreator:       creator,
+		Scraper:            kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace:   testBuildServiceNamespace,
+		ServiceMonitorName: testBuildServiceNamespace,
+		Apply: func(applyCtx context.Context, secret *corev1.Secret) error {
+			return c.Create(applyCtx, secret)
+		},
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if result.RequeueAfter != kubernetes.DefaultServiceMonitorResyncSettleDelay {
+		t.Fatalf("requeue: got %v want settle delay", result.RequeueAfter)
+	}
+}
+
+func TestReconcilePrometheusScrapeToken_NilApplyServiceMonitor(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubernetes.ScrapeTokenSecretName,
+			Namespace: testBuildServiceNamespace,
+			Annotations: map[string]string{
+				"konflux.konflux-ci.dev/scrape-token-expires-at": now.Add(45 * time.Minute).UTC().Format(time.RFC3339),
+			},
+		},
+		Data: map[string][]byte{kubernetes.ScrapeTokenSecretKey: []byte("token")},
+	}
+	sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	sm.SetGroupVersionKind(operandServiceMonitorGVK)
+	sm.SetNamespace(testBuildServiceNamespace)
+	sm.SetName(testBuildServiceNamespace)
+
+	_, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:             fake.NewClientBuilder().WithObjects(secret, sm).Build(),
+		Clock:              testclock.NewFakeClock(now),
+		TokenCreator:       &fakeTokenCreator{},
+		Scraper:            kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace:   testBuildServiceNamespace,
+		ServiceMonitorName: testBuildServiceNamespace,
+		Apply:              func(context.Context, *corev1.Secret) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("reconcile without ApplyServiceMonitor: %v", err)
+	}
+}
+
+// laggingSecretGetClient simulates informer cache lag by returning NotFound for scrape
+// token Secret reads after the write path has persisted the object.
+type laggingSecretGetClient struct {
+	client.Client
+	blockSecretGets bool
+}
+
+func (l *laggingSecretGetClient) Get(
+	ctx context.Context,
 	key types.NamespacedName,
 	obj client.Object,
-	_ ...client.GetOption,
+	opts ...client.GetOption,
 ) error {
-	secret, ok := obj.(*corev1.Secret)
-	if !ok {
-		return fmt.Errorf("unexpected type %T", obj)
+	if l.blockSecretGets {
+		if _, ok := obj.(*corev1.Secret); ok && key.Name == kubernetes.ScrapeTokenSecretName {
+			return apierrors.NewNotFound(corev1.Resource("secrets"), key.Name)
+		}
 	}
-	if r.secret == nil || key.Name != r.secret.Name || key.Namespace != r.secret.Namespace {
-		return apierrors.NewNotFound(corev1.Resource("secrets"), key.Name)
-	}
-	*secret = *r.secret
-	return nil
+	return l.Client.Get(ctx, key, obj, opts...)
 }
 
-func (existingSecretReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
-	return fmt.Errorf("not implemented")
-}
-
-type absentSecretReader struct{}
-
-func (absentSecretReader) Get(
-	_ context.Context,
-	key types.NamespacedName,
-	obj client.Object,
-	_ ...client.GetOption,
-) error {
-	if _, ok := obj.(*corev1.Secret); !ok {
-		return fmt.Errorf("unexpected type %T", obj)
+func TestReconcilePrometheusScrapeToken_SucceedsWhenSecretCacheLagsAfterMint(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+	base := fake.NewClientBuilder().Build()
+	lagging := &laggingSecretGetClient{Client: base}
+	creator := &fakeTokenCreator{
+		token:     "operand-token",
+		expiresAt: now.Add(time.Hour),
 	}
-	return apierrors.NewNotFound(corev1.Resource("secrets"), key.Name)
-}
 
-func (absentSecretReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
-	return fmt.Errorf("not implemented")
+	result, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:             lagging,
+		Clock:              testclock.NewFakeClock(now),
+		TokenCreator:       creator,
+		Scraper:            kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace:   testBuildServiceNamespace,
+		ServiceMonitorName: testBuildServiceNamespace,
+		Apply: func(applyCtx context.Context, secret *corev1.Secret) error {
+			if err := base.Create(applyCtx, secret); err != nil {
+				return err
+			}
+			lagging.blockSecretGets = true
+			return nil
+		},
+		ApplyServiceMonitor: func(applyCtx context.Context) error {
+			sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+			sm.SetGroupVersionKind(operandServiceMonitorGVK)
+			sm.SetNamespace(testBuildServiceNamespace)
+			sm.SetName(testBuildServiceNamespace)
+			return base.Create(applyCtx, sm)
+		},
+	})
+	if err != nil {
+		t.Fatalf("reconcile with lagging secret cache: %v", err)
+	}
+	if !lagging.blockSecretGets {
+		t.Fatal("expected apply to enable lagging secret reads")
+	}
+	if result.RequeueAfter != kubernetes.DefaultServiceMonitorResyncSettleDelay {
+		t.Fatalf("requeue: got %v want %v", result.RequeueAfter, kubernetes.DefaultServiceMonitorResyncSettleDelay)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(operandServiceMonitorGVK)
+	if err := base.Get(ctx, types.NamespacedName{Namespace: testBuildServiceNamespace, Name: testBuildServiceNamespace}, updated); err != nil {
+		t.Fatalf("get SM: %v", err)
+	}
+	if updated.GetAnnotations()[kubernetes.ServiceMonitorResyncReasonAnnotation] != kubernetes.ServiceMonitorResyncReasonTokenMinted {
+		t.Fatalf("reason: got %q want %q",
+			updated.GetAnnotations()[kubernetes.ServiceMonitorResyncReasonAnnotation],
+			kubernetes.ServiceMonitorResyncReasonTokenMinted,
+		)
+	}
 }

--- a/operator/internal/common/test_constants_test.go
+++ b/operator/internal/common/test_constants_test.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+const (
+	testBuildServiceNamespace    = "build-service"
+	testImageControllerNamespace = "image-controller"
+)

--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
@@ -182,18 +182,38 @@ func (r *KonfluxBuildServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 		return errHandler.HandleApplyError(ctx, err)
 	}
 
+	scrapeResult := reconcile.Result{}
 	if buildService.Spec.ComponentMetrics.IsEnabled() && r.TokenCreator != nil {
+		// Deferred ServiceMonitor apply: mint scrape token, apply SM after token, resync nudges.
 		scraper := kubernetes.OperandMetricsScraperSA(webhookConfigNamespace)
-		if scrapeErr := common.ReconcilePrometheusScrapeToken(ctx, common.ScrapeTokenReconcilerConfig{
-			Client:           r.Client,
-			Clock:            r.Clock,
-			TokenCreator:     r.TokenCreator,
-			Scraper:          scraper,
-			OperandNamespace: webhookConfigNamespace,
+		var scrapeErr error
+		scrapeResult, scrapeErr = common.ReconcilePrometheusScrapeToken(ctx, common.ScrapeTokenReconcilerConfig{
+			Client:             r.Client,
+			Clock:              r.Clock,
+			TokenCreator:       r.TokenCreator,
+			Scraper:            scraper,
+			OperandNamespace:   webhookConfigNamespace,
+			ServiceMonitorName: "build-service",
 			Apply: func(applyCtx context.Context, secret *corev1.Secret) error {
 				return tc.ApplyOwned(applyCtx, secret)
 			},
-		}); scrapeErr != nil {
+			ApplyServiceMonitor: func(applyCtx context.Context) error {
+				objects, storeErr := r.ObjectStore.GetForComponent(manifests.BuildService)
+				if storeErr != nil {
+					return fmt.Errorf("get manifests for ServiceMonitor apply: %w", storeErr)
+				}
+				sm, ok := common.OperandServiceMonitorFromObjects(objects, webhookConfigNamespace, "build-service")
+				if !ok {
+					return fmt.Errorf("operand ServiceMonitor %s/%s not found in embedded manifests",
+						webhookConfigNamespace, "build-service")
+				}
+				if err := common.ApplyMetricsScraperBindingSubjects(webhookConfigNamespace, sm); err != nil {
+					return fmt.Errorf("apply metrics scraper binding subjects for ServiceMonitor: %w", err)
+				}
+				return tc.ApplyOwned(applyCtx, sm)
+			},
+		})
+		if scrapeErr != nil {
 			return errHandler.HandleWithReason(ctx, scrapeErr, condition.ReasonApplyFailed, "reconcile prometheus scrape token")
 		}
 	}
@@ -217,7 +237,7 @@ func (r *KonfluxBuildServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 
 	log.Info("Successfully reconciled KonfluxBuildService")
-	return ctrl.Result{}, nil
+	return scrapeResult, nil
 }
 
 // applyManifests loads and applies all embedded manifests to the cluster using the tracking client.
@@ -227,6 +247,7 @@ func (r *KonfluxBuildServiceReconciler) applyManifests(ctx context.Context, tc *
 	log := logf.FromContext(ctx)
 
 	metricsEnabled := owner.Spec.ComponentMetrics.IsEnabled()
+	deferServiceMonitor := metricsEnabled && r.TokenCreator != nil
 
 	objects, err := r.ObjectStore.GetForComponent(manifests.BuildService)
 	if err != nil {
@@ -234,6 +255,16 @@ func (r *KonfluxBuildServiceReconciler) applyManifests(ctx context.Context, tc *
 	}
 
 	for _, obj := range objects {
+		// Deferred ServiceMonitor apply: skip operand SM until ReconcilePrometheusScrapeToken
+		// applies it after prometheus-scrape-token is readable.
+		if deferServiceMonitor && kubernetes.IsComponentMetricsServiceMonitor(obj) {
+			log.V(1).Info("Deferring operand ServiceMonitor apply until scrape token is ready",
+				"kind", tracking.GetKind(obj),
+				"name", obj.GetName(),
+				"namespace", obj.GetNamespace(),
+			)
+			continue
+		}
 		if !metricsEnabled && kubernetes.IsComponentMetricsScrapeResource(obj) {
 			log.V(1).Info("Skipping component metrics scrape resource",
 				"kind", tracking.GetKind(obj),

--- a/operator/internal/controller/buildservice/konfluxbuildservice_scrape_token_test.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_scrape_token_test.go
@@ -142,6 +142,7 @@ var _ = Describe("Prometheus scrape token", func() {
 				g.Expect(secretRef["key"]).To(Equal(kubernetes.ScrapeTokenSecretKey))
 				_, hasFile := ep["bearerTokenFile"]
 				g.Expect(hasFile).To(BeFalse())
+				g.Expect(sm.GetAnnotations()).To(HaveKey(kubernetes.ServiceMonitorResyncAnnotation))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 

--- a/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
+++ b/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
@@ -156,18 +156,38 @@ func (r *KonfluxImageControllerReconciler) Reconcile(ctx context.Context, req ct
 		return errHandler.HandleApplyError(ctx, err)
 	}
 
+	scrapeResult := reconcile.Result{}
 	if imageController.Spec.ComponentMetrics.IsEnabled() && r.TokenCreator != nil {
+		// Deferred ServiceMonitor apply: mint scrape token, apply SM after token, resync nudges.
 		scraper := kubernetes.OperandMetricsScraperSA(imageControllerNamespace)
-		if scrapeErr := common.ReconcilePrometheusScrapeToken(ctx, common.ScrapeTokenReconcilerConfig{
-			Client:           r.Client,
-			Clock:            r.Clock,
-			TokenCreator:     r.TokenCreator,
-			Scraper:          scraper,
-			OperandNamespace: imageControllerNamespace,
+		var scrapeErr error
+		scrapeResult, scrapeErr = common.ReconcilePrometheusScrapeToken(ctx, common.ScrapeTokenReconcilerConfig{
+			Client:             r.Client,
+			Clock:              r.Clock,
+			TokenCreator:       r.TokenCreator,
+			Scraper:            scraper,
+			OperandNamespace:   imageControllerNamespace,
+			ServiceMonitorName: "image-controller",
 			Apply: func(applyCtx context.Context, secret *corev1.Secret) error {
 				return tc.ApplyOwned(applyCtx, secret)
 			},
-		}); scrapeErr != nil {
+			ApplyServiceMonitor: func(applyCtx context.Context) error {
+				objects, storeErr := r.ObjectStore.GetForComponent(manifests.ImageController)
+				if storeErr != nil {
+					return fmt.Errorf("get manifests for ServiceMonitor apply: %w", storeErr)
+				}
+				sm, ok := common.OperandServiceMonitorFromObjects(objects, imageControllerNamespace, "image-controller")
+				if !ok {
+					return fmt.Errorf("operand ServiceMonitor %s/%s not found in embedded manifests",
+						imageControllerNamespace, "image-controller")
+				}
+				if err := common.ApplyMetricsScraperBindingSubjects(imageControllerNamespace, sm); err != nil {
+					return fmt.Errorf("apply metrics scraper binding subjects for ServiceMonitor: %w", err)
+				}
+				return tc.ApplyOwned(applyCtx, sm)
+			},
+		})
+		if scrapeErr != nil {
 			return errHandler.HandleWithReason(ctx, scrapeErr, condition.ReasonApplyFailed, "reconcile prometheus scrape token")
 		}
 	}
@@ -190,7 +210,7 @@ func (r *KonfluxImageControllerReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	log.Info("Successfully reconciled KonfluxImageController")
-	return ctrl.Result{}, nil
+	return scrapeResult, nil
 }
 
 // applyManifests loads and applies all embedded manifests to the cluster using the tracking client.
@@ -199,6 +219,7 @@ func (r *KonfluxImageControllerReconciler) applyManifests(ctx context.Context, t
 	log := logf.FromContext(ctx)
 
 	metricsEnabled := owner.Spec.ComponentMetrics.IsEnabled()
+	deferServiceMonitor := metricsEnabled && r.TokenCreator != nil
 
 	objects, err := r.ObjectStore.GetForComponent(manifests.ImageController)
 	if err != nil {
@@ -206,6 +227,16 @@ func (r *KonfluxImageControllerReconciler) applyManifests(ctx context.Context, t
 	}
 
 	for _, obj := range objects {
+		// Deferred ServiceMonitor apply: skip operand SM until ReconcilePrometheusScrapeToken
+		// applies it after prometheus-scrape-token is readable.
+		if deferServiceMonitor && kubernetes.IsComponentMetricsServiceMonitor(obj) {
+			log.V(1).Info("Deferring operand ServiceMonitor apply until scrape token is ready",
+				"kind", tracking.GetKind(obj),
+				"name", obj.GetName(),
+				"namespace", obj.GetNamespace(),
+			)
+			continue
+		}
 		if !metricsEnabled && kubernetes.IsComponentMetricsScrapeResource(obj) {
 			log.V(1).Info("Skipping component metrics scrape resource",
 				"kind", tracking.GetKind(obj),

--- a/operator/internal/operatormetrics/scrape_token_rotator.go
+++ b/operator/internal/operatormetrics/scrape_token_rotator.go
@@ -112,7 +112,7 @@ func (r *ScrapeTokenRotator) reconcile(ctx context.Context, namespace string) (t
 		return 0, err
 	}
 
-	return kubernetes.EnsurePrometheusScrapeToken(ctx, kubernetes.EnsureScrapeTokenInput{
+	requeue, err := kubernetes.EnsurePrometheusScrapeToken(ctx, kubernetes.EnsureScrapeTokenInput{
 		Client:           r.Client,
 		Clock:            clk,
 		TokenCreator:     r.TokenCreator,
@@ -122,6 +122,7 @@ func (r *ScrapeTokenRotator) reconcile(ctx context.Context, namespace string) (t
 			return kubernetes.ApplyScrapeTokenSecret(applyCtx, r.Client, secret)
 		},
 	})
+	return requeue.RequeueAfter, err
 }
 
 func (r *ScrapeTokenRotator) rotationInterval() time.Duration {

--- a/operator/pkg/kubernetes/component_metrics.go
+++ b/operator/pkg/kubernetes/component_metrics.go
@@ -36,6 +36,18 @@ var ComponentMetricsOrphanCleanupGVKs = []schema.GroupVersionKind{
 	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"},
 }
 
+// IsComponentMetricsServiceMonitor reports whether obj is the operand ServiceMonitor
+// from upstream-kustomizations/*/monitoring/. Operand reconcilers skip this object in
+// applyManifests when componentMetrics is enabled (deferred ServiceMonitor apply); it is
+// applied later from ReconcilePrometheusScrapeToken after prometheus-scrape-token is readable.
+func IsComponentMetricsServiceMonitor(obj client.Object) bool {
+	if obj == nil {
+		return false
+	}
+	gvk := objectGroupVersionKind(obj)
+	return gvk.Group == "monitoring.coreos.com" && gvk.Kind == "ServiceMonitor"
+}
+
 // IsComponentMetricsScrapeResource reports whether obj is part of the component metrics
 // scrape contract under upstream-kustomizations/*/monitoring/ (ServiceMonitor,
 // metrics-reader ClusterRole, prometheus-* ClusterRoleBinding). Legacy dedicated

--- a/operator/pkg/kubernetes/component_metrics_test.go
+++ b/operator/pkg/kubernetes/component_metrics_test.go
@@ -28,6 +28,25 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func TestIsComponentMetricsServiceMonitor(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(IsComponentMetricsServiceMonitor(&unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "monitoring.coreos.com/v1",
+			"kind":       "ServiceMonitor",
+			"metadata": map[string]interface{}{
+				"name":      "build-service",
+				"namespace": "build-service",
+			},
+		},
+	})).To(BeTrue())
+	g.Expect(IsComponentMetricsServiceMonitor(&rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "build-service-metrics-reader"},
+	})).To(BeFalse())
+	g.Expect(IsComponentMetricsServiceMonitor(nil)).To(BeFalse())
+}
+
 func TestIsComponentMetricsScrapeResource(t *testing.T) {
 	g := NewWithT(t)
 

--- a/operator/pkg/kubernetes/scrape_token.go
+++ b/operator/pkg/kubernetes/scrape_token.go
@@ -134,6 +134,16 @@ func (c *ClientTokenCreator) CreateScraperToken(
 // ScrapeTokenApplyFunc persists the scrape token Secret (for example via tracking.Client.ApplyOwned).
 type ScrapeTokenApplyFunc func(ctx context.Context, secret *corev1.Secret) error
 
+// EnsureScrapeTokenResult carries scrape-token state from EnsurePrometheusScrapeToken
+// without re-reading the informer cache after the write.
+type EnsureScrapeTokenResult struct {
+	RequeueAfter    time.Duration
+	TokenUpdated    bool
+	SecretExisted   bool
+	Token           []byte
+	ResourceVersion string
+}
+
 // EnsureScrapeTokenInput configures EnsurePrometheusScrapeToken.
 type EnsureScrapeTokenInput struct {
 	Client           client.Reader
@@ -197,29 +207,33 @@ const OperatorScrapeTokenFieldManager = "konflux-operator-scrape-token"
 // ApplyScrapeTokenSecret persists a scrape token Secret without an owner reference.
 func ApplyScrapeTokenSecret(ctx context.Context, c client.Client, secret *corev1.Secret) error {
 	prepared := prepareSecretForApply(secret)
-	return c.Patch(
+	if err := c.Patch(
 		ctx,
 		prepared,
 		SSAPatch,
 		client.FieldOwner(OperatorScrapeTokenFieldManager),
 		client.ForceOwnership,
-	)
+	); err != nil {
+		return err
+	}
+	copySecretWriteMetadata(secret, prepared)
+	return nil
 }
 
 // EnsurePrometheusScrapeToken creates or refreshes the operand scrape token Secret.
-// It returns a suggested requeue interval for token rotation.
-func EnsurePrometheusScrapeToken(ctx context.Context, in EnsureScrapeTokenInput) (time.Duration, error) {
+// The result reflects the write path directly so callers do not re-read a stale cache.
+func EnsurePrometheusScrapeToken(ctx context.Context, in EnsureScrapeTokenInput) (EnsureScrapeTokenResult, error) {
 	if in.Apply == nil {
-		return 0, fmt.Errorf("scrape token apply func is required")
+		return EnsureScrapeTokenResult{}, fmt.Errorf("scrape token apply func is required")
 	}
 	if in.TokenCreator == nil {
-		return 0, fmt.Errorf("token creator is required")
+		return EnsureScrapeTokenResult{}, fmt.Errorf("token creator is required")
 	}
 	if in.OperandNamespace == "" {
-		return 0, fmt.Errorf("operand namespace is required")
+		return EnsureScrapeTokenResult{}, fmt.Errorf("operand namespace is required")
 	}
 	if in.Scraper.Namespace == "" || in.Scraper.Name == "" {
-		return 0, fmt.Errorf("scraper service account is required")
+		return EnsureScrapeTokenResult{}, fmt.Errorf("scraper service account is required")
 	}
 	clk := in.Clock
 	if clk == nil {
@@ -237,19 +251,22 @@ func EnsurePrometheusScrapeToken(ctx context.Context, in EnsureScrapeTokenInput)
 		Namespace: in.OperandNamespace,
 	}, existing)
 	if client.IgnoreNotFound(err) != nil {
-		return 0, fmt.Errorf("get scrape token secret: %w", err)
+		return EnsureScrapeTokenResult{}, fmt.Errorf("get scrape token secret: %w", err)
 	}
-	if err == nil && !ScrapeTokenNeedsRefresh(existing, now, ttl) {
+	secretExisted := err == nil
+	if secretExisted && !ScrapeTokenNeedsRefresh(existing, now, ttl) {
 		if applyErr := in.Apply(ctx, prepareSecretForApply(existing)); applyErr != nil {
-			return 0, fmt.Errorf("track scrape token secret: %w", applyErr)
+			return EnsureScrapeTokenResult{}, fmt.Errorf("track scrape token secret: %w", applyErr)
 		}
-		return ScrapeTokenRequeueAfter(existing, now, ttl), nil
+		return scrapeTokenResultFromSecret(existing, secretExisted, false, now, ttl)
 	}
 
 	scraper := in.Scraper
 	token, expiresAt, err := in.TokenCreator.CreateScraperToken(ctx, scraper, ttl)
 	if err != nil {
-		return 0, fmt.Errorf("create scraper token for %s/%s: %w", scraper.Namespace, scraper.Name, err)
+		return EnsureScrapeTokenResult{}, fmt.Errorf(
+			"create scraper token for %s/%s: %w", scraper.Namespace, scraper.Name, err,
+		)
 	}
 
 	secret := &corev1.Secret{
@@ -270,9 +287,46 @@ func EnsurePrometheusScrapeToken(ctx context.Context, in EnsureScrapeTokenInput)
 		},
 	}
 	if err := in.Apply(ctx, secret); err != nil {
-		return 0, fmt.Errorf("apply scrape token secret: %w", err)
+		return EnsureScrapeTokenResult{}, fmt.Errorf("apply scrape token secret: %w", err)
 	}
-	return ScrapeTokenRequeueAfter(secret, now, ttl), nil
+	return scrapeTokenResultFromSecret(secret, secretExisted, true, now, ttl)
+}
+
+func scrapeTokenResultFromSecret(
+	secret *corev1.Secret,
+	secretExisted, tokenUpdated bool,
+	now time.Time,
+	ttl time.Duration,
+) (EnsureScrapeTokenResult, error) {
+	token := secret.Data[ScrapeTokenSecretKey]
+	if len(token) == 0 {
+		return EnsureScrapeTokenResult{}, fmt.Errorf(
+			"scrape token secret %s/%s has empty %q after ensure",
+			secret.Namespace, ScrapeTokenSecretName, ScrapeTokenSecretKey,
+		)
+	}
+	return EnsureScrapeTokenResult{
+		RequeueAfter:    ScrapeTokenRequeueAfter(secret, now, ttl),
+		TokenUpdated:    tokenUpdated,
+		SecretExisted:   secretExisted,
+		Token:           append([]byte(nil), token...),
+		ResourceVersion: secret.ResourceVersion,
+	}, nil
+}
+
+func copySecretWriteMetadata(dst, src *corev1.Secret) {
+	if src == nil || dst == nil {
+		return
+	}
+	if src.ResourceVersion != "" {
+		dst.ResourceVersion = src.ResourceVersion
+	}
+	if src.UID != "" {
+		dst.UID = src.UID
+	}
+	if !src.CreationTimestamp.IsZero() {
+		dst.CreationTimestamp = src.CreationTimestamp
+	}
 }
 
 // IsPrometheusScrapeTokenSecret reports whether obj is the operator-managed scrape token Secret.

--- a/operator/pkg/kubernetes/scrape_token_test.go
+++ b/operator/pkg/kubernetes/scrape_token_test.go
@@ -131,9 +131,15 @@ func TestEnsurePrometheusScrapeTokenCreatesAndRefreshes(t *testing.T) {
 		TTL: time.Hour,
 	}
 
-	requeue, err := EnsurePrometheusScrapeToken(ctx, in)
+	result, err := EnsurePrometheusScrapeToken(ctx, in)
 	if err != nil {
 		t.Fatalf("ensure: %v", err)
+	}
+	if !result.TokenUpdated {
+		t.Fatal("expected tokenUpdated on first mint")
+	}
+	if result.SecretExisted {
+		t.Fatal("expected SecretExisted false on first mint")
 	}
 	if fake.calls != 1 {
 		t.Fatalf("expected one token mint, got %d", fake.calls)
@@ -141,30 +147,43 @@ func TestEnsurePrometheusScrapeTokenCreatesAndRefreshes(t *testing.T) {
 	if len(applied) != 1 || string(applied[0].Data[ScrapeTokenSecretKey]) != "first" {
 		t.Fatalf("unexpected applied secret: %#v", applied)
 	}
-	if requeue != 30*time.Minute {
-		t.Fatalf("unexpected requeue: %s", requeue)
+	if result.RequeueAfter != 30*time.Minute {
+		t.Fatalf("unexpected requeue: %s", result.RequeueAfter)
 	}
 
 	// Second call with fresh secret in reader should not mint again.
+	applied[0].ResourceVersion = "1"
 	in.Client = &fakeSecretReader{secret: applied[0]}
-	requeue, err = EnsurePrometheusScrapeToken(ctx, in)
+	result, err = EnsurePrometheusScrapeToken(ctx, in)
 	if err != nil {
 		t.Fatalf("ensure second: %v", err)
+	}
+	if result.TokenUpdated {
+		t.Fatal("expected tokenUpdated false for fresh secret")
+	}
+	if !result.SecretExisted {
+		t.Fatal("expected SecretExisted true for fresh secret")
+	}
+	if result.ResourceVersion != "1" {
+		t.Fatalf("resourceVersion: got %q want %q", result.ResourceVersion, "1")
 	}
 	if fake.calls != 1 {
 		t.Fatalf("expected no additional mint, got %d calls", fake.calls)
 	}
-	if requeue != 30*time.Minute {
-		t.Fatalf("unexpected second requeue: %s", requeue)
+	if result.RequeueAfter != 30*time.Minute {
+		t.Fatalf("unexpected second requeue: %s", result.RequeueAfter)
 	}
 
 	// Advance clock past refresh threshold and expect a new token.
 	clk.SetTime(clk.Now().Add(40 * time.Minute))
 	fake.token = "second"
 	fake.expiresAt = clk.Now().Add(time.Hour)
-	requeue, err = EnsurePrometheusScrapeToken(ctx, in)
+	result, err = EnsurePrometheusScrapeToken(ctx, in)
 	if err != nil {
 		t.Fatalf("ensure refresh: %v", err)
+	}
+	if !result.TokenUpdated {
+		t.Fatal("expected tokenUpdated on refresh")
 	}
 	if fake.calls != 2 {
 		t.Fatalf("expected refresh mint, got %d calls", fake.calls)
@@ -172,8 +191,8 @@ func TestEnsurePrometheusScrapeTokenCreatesAndRefreshes(t *testing.T) {
 	if string(applied[len(applied)-1].Data[ScrapeTokenSecretKey]) != "second" {
 		t.Fatalf("expected refreshed token")
 	}
-	if requeue != 30*time.Minute {
-		t.Fatalf("unexpected refresh requeue: %s", requeue)
+	if result.RequeueAfter != 30*time.Minute {
+		t.Fatalf("unexpected refresh requeue: %s", result.RequeueAfter)
 	}
 }
 
@@ -516,4 +535,33 @@ func (b *brokenSecretReader) Get(context.Context, types.NamespacedName, client.O
 
 func (b *brokenSecretReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
 	return b.err
+}
+
+func TestPrepareSecretForApplySetsTypeMeta(t *testing.T) {
+	t.Parallel()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: ScrapeTokenSecretName, Namespace: "build-service"},
+		Data:       map[string][]byte{ScrapeTokenSecretKey: []byte("tok")},
+	}
+	prepared := prepareSecretForApply(secret)
+	if prepared.APIVersion != "v1" || prepared.Kind != "Secret" {
+		t.Fatalf("type meta: got APIVersion=%q Kind=%q", prepared.APIVersion, prepared.Kind)
+	}
+	if prepared.ResourceVersion != "" {
+		t.Fatal("expected resourceVersion to be cleared")
+	}
+}
+
+func TestGetPrometheusScrapeToken_EmptyData(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: ScrapeTokenSecretName, Namespace: "build-service"},
+		Data:       map[string][]byte{},
+	}
+	c := ctrlfake.NewClientBuilder().WithObjects(secret).Build()
+	_, err := GetPrometheusScrapeToken(ctx, c, "build-service")
+	if err == nil {
+		t.Fatal("expected error for empty token data")
+	}
 }

--- a/operator/pkg/kubernetes/servicemonitor_resync.go
+++ b/operator/pkg/kubernetes/servicemonitor_resync.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// ServiceMonitorResyncAnnotation records the last time the operand reconciler
+	// nudged user-workload prometheus-operator to re-process a ServiceMonitor.
+	// See operator/docs/component-monitoring.md (resync nudges).
+	ServiceMonitorResyncAnnotation = "konflux.konflux-ci.dev/metrics-scrape-resync"
+	// ServiceMonitorResyncReasonAnnotation records why the last resync nudge ran.
+	ServiceMonitorResyncReasonAnnotation = "konflux.konflux-ci.dev/metrics-scrape-resync-reason"
+	// ServiceMonitorResyncSecretRVAnnotation records the scrape-token Secret
+	// resourceVersion last seen when the SM was nudged.
+	//nolint:gosec // G101: annotation key, not a credential
+	ServiceMonitorResyncSecretRVAnnotation = "konflux.konflux-ci.dev/metrics-scrape-resync-secret-rv"
+	// ServiceMonitorResyncSettleAnnotation marks a pending delayed settle nudge.
+	ServiceMonitorResyncSettleAnnotation = "konflux.konflux-ci.dev/metrics-scrape-resync-settle"
+
+	// ServiceMonitor resync reason values (also logged and echoed in e2e artifacts).
+	ServiceMonitorResyncReasonTokenMinted    = "token-minted"
+	ServiceMonitorResyncReasonTokenRefreshed = "token-refreshed"
+	ServiceMonitorResyncReasonSecretSync     = "secret-sync"
+	ServiceMonitorResyncReasonSettleRetry    = "settle-retry"
+
+	// DefaultServiceMonitorResyncSettleDelay waits before a settle-retry SM patch.
+	DefaultServiceMonitorResyncSettleDelay = 15 * time.Second
+
+	serviceMonitorResyncSettlePending = "pending"
+)
+
+var serviceMonitorGVK = schema.GroupVersionKind{
+	Group:   "monitoring.coreos.com",
+	Version: "v1",
+	Kind:    "ServiceMonitor",
+}
+
+// ServiceMonitorResyncOptions configures an operand ServiceMonitor resync patch.
+//
+// Resync patches are annotation-only nudges so prometheus-operator re-evaluates the SM
+// after the scrape token is readable. Callers in ReconcilePrometheusScrapeToken set
+// Reason and SecretResourceVersion; MarkSettlePending/ClearSettlePending coordinate the
+// settle-retry requeue so secret-sync does not race ahead of settle-retry.
+type ServiceMonitorResyncOptions struct {
+	// Force patches even when a prior resync annotation exists.
+	Force bool
+	// Reason is stored in ServiceMonitorResyncReasonAnnotation (token-minted, token-refreshed,
+	// settle-retry, secret-sync).
+	Reason string
+	// SecretResourceVersion is stored in ServiceMonitorResyncSecretRVAnnotation.
+	SecretResourceVersion string
+	// MarkSettlePending sets metrics-scrape-resync-settle=pending until settle-retry clears it.
+	MarkSettlePending bool
+	// ClearSettlePending removes the settle-pending annotation (settle-retry path).
+	ClearSettlePending bool
+	Clock              clock.Clock
+}
+
+// ResyncOperandServiceMonitor patches operand ServiceMonitor annotations so prometheus-operator
+// re-evaluates scrape configuration.
+//
+// On OpenShift UWM, prometheus-operator can reject a ServiceMonitor when bearerTokenSecret is
+// not visible at evaluation time and may not recover when the Secret appears later. A merge
+// patch on resync annotations triggers re-processing without changing scrape spec.
+//
+// No-op when the ServiceMonitor CRD is absent or the object is not found. When Force is
+// false and a resync annotation already exists, skips unless MarkSettlePending is set.
+func ResyncOperandServiceMonitor(
+	ctx context.Context,
+	c client.Client,
+	namespace, name string,
+	opts ServiceMonitorResyncOptions,
+) error {
+	if namespace == "" || name == "" {
+		return fmt.Errorf("serviceMonitor namespace and name are required")
+	}
+	clk := opts.Clock
+	if clk == nil {
+		clk = clock.RealClock{}
+	}
+
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(serviceMonitorGVK)
+	err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, existing)
+	if meta.IsNoMatchError(err) {
+		return nil
+	}
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get ServiceMonitor %s/%s: %w", namespace, name, err)
+	}
+
+	if !opts.Force && !opts.MarkSettlePending && hasServiceMonitorResyncAnnotation(existing) {
+		return nil
+	}
+
+	resyncAt := clk.Now().UTC().Format(time.RFC3339)
+	patch := existing.DeepCopy()
+	annotations := patch.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[ServiceMonitorResyncAnnotation] = resyncAt
+	if opts.Reason != "" {
+		annotations[ServiceMonitorResyncReasonAnnotation] = opts.Reason
+	}
+	if opts.SecretResourceVersion != "" {
+		annotations[ServiceMonitorResyncSecretRVAnnotation] = opts.SecretResourceVersion
+	}
+	if opts.MarkSettlePending {
+		annotations[ServiceMonitorResyncSettleAnnotation] = serviceMonitorResyncSettlePending
+	}
+	if opts.ClearSettlePending {
+		delete(annotations, ServiceMonitorResyncSettleAnnotation)
+	}
+	patch.SetAnnotations(annotations)
+
+	if err := c.Patch(ctx, patch, client.MergeFrom(existing)); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil
+		}
+		return fmt.Errorf("patch ServiceMonitor %s/%s: %w", namespace, name, err)
+	}
+
+	logf.FromContext(ctx).Info(
+		"metrics scrape resync",
+		"namespace", namespace,
+		"servicemonitor", name,
+		"reason", opts.Reason,
+		"secretResourceVersion", opts.SecretResourceVersion,
+		"resyncAt", resyncAt,
+	)
+	return nil
+}
+
+func hasServiceMonitorResyncAnnotation(sm *unstructured.Unstructured) bool {
+	if sm == nil {
+		return false
+	}
+	annotations := sm.GetAnnotations()
+	return annotations != nil && annotations[ServiceMonitorResyncAnnotation] != ""
+}
+
+// ServiceMonitorResyncSettlePending reports whether a delayed settle-retry nudge is pending.
+// While pending, ReconcilePrometheusScrapeToken blocks secret-sync resyncs.
+func ServiceMonitorResyncSettlePending(sm *unstructured.Unstructured) bool {
+	if sm == nil {
+		return false
+	}
+	annotations := sm.GetAnnotations()
+	return annotations != nil &&
+		annotations[ServiceMonitorResyncSettleAnnotation] == serviceMonitorResyncSettlePending
+}
+
+// ServiceMonitorResyncSecretRV returns the secret resourceVersion recorded on the SM.
+func ServiceMonitorResyncSecretRV(sm *unstructured.Unstructured) string {
+	if sm == nil {
+		return ""
+	}
+	annotations := sm.GetAnnotations()
+	if annotations == nil {
+		return ""
+	}
+	return annotations[ServiceMonitorResyncSecretRVAnnotation]
+}

--- a/operator/pkg/kubernetes/servicemonitor_resync_test.go
+++ b/operator/pkg/kubernetes/servicemonitor_resync_test.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	testclock "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestResyncOperandServiceMonitorSetsAnnotation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+
+	sm := &unstructured.Unstructured{Object: map[string]any{
+		"spec": map[string]any{
+			"endpoints": []any{map[string]any{"port": "https"}},
+		},
+	}}
+	sm.SetGroupVersionKind(serviceMonitorGVK)
+	sm.SetNamespace("build-service")
+	sm.SetName("build-service")
+
+	c := fake.NewClientBuilder().WithObjects(sm).Build()
+	clk := testclock.NewFakeClock(now)
+	err := ResyncOperandServiceMonitor(ctx, c, "build-service", "build-service", ServiceMonitorResyncOptions{
+		Force:                 true,
+		Reason:                ServiceMonitorResyncReasonTokenMinted,
+		SecretResourceVersion: "100",
+		MarkSettlePending:     true,
+		Clock:                 clk,
+	})
+	if err != nil {
+		t.Fatalf("resync: %v", err)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(serviceMonitorGVK)
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "build-service", Name: "build-service"}, updated); err != nil {
+		t.Fatalf("get updated SM: %v", err)
+	}
+	annotations := updated.GetAnnotations()
+	if got := annotations[ServiceMonitorResyncAnnotation]; got != now.UTC().Format(time.RFC3339) {
+		t.Fatalf("resync annotation: got %q want %q", got, now.UTC().Format(time.RFC3339))
+	}
+	if annotations[ServiceMonitorResyncReasonAnnotation] != ServiceMonitorResyncReasonTokenMinted {
+		t.Fatalf("resync reason: got %q", annotations[ServiceMonitorResyncReasonAnnotation])
+	}
+	if annotations[ServiceMonitorResyncSecretRVAnnotation] != "100" {
+		t.Fatalf("secret rv: got %q", annotations[ServiceMonitorResyncSecretRVAnnotation])
+	}
+	if annotations[ServiceMonitorResyncSettleAnnotation] != serviceMonitorResyncSettlePending {
+		t.Fatalf("settle pending: got %q", annotations[ServiceMonitorResyncSettleAnnotation])
+	}
+}
+
+func TestResyncOperandServiceMonitorSkipsWhenAnnotated(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+
+	sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	sm.SetGroupVersionKind(serviceMonitorGVK)
+	sm.SetNamespace("build-service")
+	sm.SetName("build-service")
+	sm.SetAnnotations(map[string]string{
+		ServiceMonitorResyncAnnotation: "2026-07-12T07:00:00Z",
+	})
+
+	c := fake.NewClientBuilder().WithObjects(sm).Build()
+	clk := testclock.NewFakeClock(now)
+	err := ResyncOperandServiceMonitor(ctx, c, "build-service", "build-service", ServiceMonitorResyncOptions{
+		Clock: clk,
+	})
+	if err != nil {
+		t.Fatalf("resync: %v", err)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(serviceMonitorGVK)
+	if err := c.Get(ctx, client.ObjectKey{Namespace: "build-service", Name: "build-service"}, updated); err != nil {
+		t.Fatalf("get updated SM: %v", err)
+	}
+	if updated.GetAnnotations()[ServiceMonitorResyncAnnotation] != "2026-07-12T07:00:00Z" {
+		t.Fatalf("expected resync annotation to remain unchanged")
+	}
+}
+
+func TestResyncOperandServiceMonitorForceWhenAnnotated(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+
+	sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	sm.SetGroupVersionKind(serviceMonitorGVK)
+	sm.SetNamespace("build-service")
+	sm.SetName("build-service")
+	sm.SetAnnotations(map[string]string{
+		ServiceMonitorResyncAnnotation:       "2026-07-12T07:00:00Z",
+		ServiceMonitorResyncSettleAnnotation: serviceMonitorResyncSettlePending,
+	})
+
+	c := fake.NewClientBuilder().WithObjects(sm).Build()
+	clk := testclock.NewFakeClock(now)
+	err := ResyncOperandServiceMonitor(ctx, c, "build-service", "build-service", ServiceMonitorResyncOptions{
+		Force:              true,
+		Reason:             ServiceMonitorResyncReasonSettleRetry,
+		ClearSettlePending: true,
+		Clock:              clk,
+	})
+	if err != nil {
+		t.Fatalf("resync: %v", err)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(serviceMonitorGVK)
+	if err := c.Get(ctx, client.ObjectKey{Namespace: "build-service", Name: "build-service"}, updated); err != nil {
+		t.Fatalf("get updated SM: %v", err)
+	}
+	annotations := updated.GetAnnotations()
+	if annotations[ServiceMonitorResyncReasonAnnotation] != ServiceMonitorResyncReasonSettleRetry {
+		t.Fatalf("reason: got %q", annotations[ServiceMonitorResyncReasonAnnotation])
+	}
+	if _, ok := annotations[ServiceMonitorResyncSettleAnnotation]; ok {
+		t.Fatalf("expected settle annotation to be cleared")
+	}
+}
+
+func TestResyncOperandServiceMonitor_Validation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := fake.NewClientBuilder().Build()
+
+	err := ResyncOperandServiceMonitor(ctx, c, "", "build-service", ServiceMonitorResyncOptions{Force: true})
+	if err == nil {
+		t.Fatal("expected error for empty namespace")
+	}
+	err = ResyncOperandServiceMonitor(ctx, c, "build-service", "", ServiceMonitorResyncOptions{Force: true})
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+}
+
+func TestResyncOperandServiceMonitor_NotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := fake.NewClientBuilder().Build()
+	err := ResyncOperandServiceMonitor(ctx, c, "build-service", "build-service", ServiceMonitorResyncOptions{
+		Force: true,
+	})
+	if err != nil {
+		t.Fatalf("expected no error when ServiceMonitor is absent: %v", err)
+	}
+}
+
+func TestResyncOperandServiceMonitor_DefaultClock(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	sm.SetGroupVersionKind(serviceMonitorGVK)
+	sm.SetNamespace("build-service")
+	sm.SetName("build-service")
+
+	c := fake.NewClientBuilder().WithObjects(sm).Build()
+	err := ResyncOperandServiceMonitor(ctx, c, "build-service", "build-service", ServiceMonitorResyncOptions{
+		Force:  true,
+		Reason: ServiceMonitorResyncReasonSecretSync,
+	})
+	if err != nil {
+		t.Fatalf("resync with default clock: %v", err)
+	}
+}
+
+func TestResyncOperandServiceMonitor_MarkSettleWhenAnnotated(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+
+	sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	sm.SetGroupVersionKind(serviceMonitorGVK)
+	sm.SetNamespace("build-service")
+	sm.SetName("build-service")
+	sm.SetAnnotations(map[string]string{
+		ServiceMonitorResyncAnnotation: "2026-07-12T07:00:00Z",
+	})
+
+	c := fake.NewClientBuilder().WithObjects(sm).Build()
+	err := ResyncOperandServiceMonitor(ctx, c, "build-service", "build-service", ServiceMonitorResyncOptions{
+		MarkSettlePending: true,
+		Clock:             testclock.NewFakeClock(now),
+	})
+	if err != nil {
+		t.Fatalf("resync: %v", err)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(serviceMonitorGVK)
+	if err := c.Get(ctx, client.ObjectKey{Namespace: "build-service", Name: "build-service"}, updated); err != nil {
+		t.Fatalf("get updated SM: %v", err)
+	}
+	if updated.GetAnnotations()[ServiceMonitorResyncSettleAnnotation] != serviceMonitorResyncSettlePending {
+		t.Fatalf("expected settle pending to be set")
+	}
+}
+
+func TestServiceMonitorResyncHelpers(t *testing.T) {
+	t.Parallel()
+
+	if ServiceMonitorResyncSettlePending(nil) {
+		t.Fatal("nil SM should not be settle pending")
+	}
+	if ServiceMonitorResyncSecretRV(nil) != "" {
+		t.Fatal("nil SM should have empty secret RV")
+	}
+
+	sm := &unstructured.Unstructured{}
+	if ServiceMonitorResyncSettlePending(sm) {
+		t.Fatal("empty annotations should not be settle pending")
+	}
+	if ServiceMonitorResyncSecretRV(sm) != "" {
+		t.Fatal("empty annotations should have empty secret RV")
+	}
+
+	sm.SetAnnotations(map[string]string{
+		ServiceMonitorResyncSettleAnnotation:   serviceMonitorResyncSettlePending,
+		ServiceMonitorResyncSecretRVAnnotation: "42",
+	})
+	if !ServiceMonitorResyncSettlePending(sm) {
+		t.Fatal("expected settle pending")
+	}
+	if ServiceMonitorResyncSecretRV(sm) != "42" {
+		t.Fatalf("secret RV: got %q", ServiceMonitorResyncSecretRV(sm))
+	}
+}

--- a/scripts/operator-e2e/README.md
+++ b/scripts/operator-e2e/README.md
@@ -29,6 +29,32 @@ Override with `METRICS_GINKGO_LABEL_FILTER` (see `run-metrics-integration-tests.
 
 Catalog: `test/go-tests/pkg/metricsauth.DefaultCatalog()` (`group: operator` or `component` per target; `scrapeTokenSecret` for HTTPS operands).
 
+## OpenShift UWM metrics tests
+
+`openshift/run-metrics-openshift-tests.sh` runs `test/go-tests/metricsopenshift` against **user-workload Prometheus** (not port-forward direct scrape). Proves ServiceMonitors are picked up by UWM (`up{namespace,service}==1`) plus HTTPS scrape contract (ServiceMonitor, `prometheus-scrape-token`, metrics-reader CRB). UWM readiness (enable flag, Prometheus pods, optional canary) runs in the suite `BeforeSuite` (`pkg/metricsopenshift/wait.go`).
+
+| Entry point | UWM enable | Canary wait | Tests |
+|-------------|------------|-------------|-------|
+| `deploy-konflux-on-ocp.sh` (Prow install) | `openshift/enable-uwm.sh` after `deploy-deps.sh` | — | — |
+| `test/e2e/run-e2e.sh` (Prow e2e, infra overlay) | (install / preview) | `dummy-service` when that namespace exists | `run-metrics-openshift-tests.sh` |
+| Tekton / Kind | — | — | **not invoked** |
+
+Label filter: `METRICS_OPENSHIFT_GINKGO_LABEL_FILTER` (default `openshift`). Sub-labels: `metrics-contract`, `metrics-uwm`.
+
+Override canary: `UWM_CANARY_QUERY` or `UWM_SKIP_CANARY=true` (see `pkg/metricsopenshift/wait.go`).
+
+On UWM target failure, the suite logs to the CI build log (no live cluster login required):
+
+| Env | Default | Effect |
+|-----|---------|--------|
+| `UWM_DEBUG_LOG_INTERVAL` | `60` | Seconds between progress logs while waiting for `up==1`; `0` logs first poll and label/value changes only |
+| `UWM_DEBUG_DIRECT_SCRAPE` | off | When `true`, failure snapshot also port-forwards the operand metrics Service and logs HTTP status |
+| `UWM_DEBUG_OPERATOR_LOG_LINES` | `500` | Tail lines from user-workload `prometheus-operator` pod; filtered to failed namespace and ServiceMonitor messages |
+
+Every run (pass or fail) emits `[UWM resync]` lines after UWM readiness: for `build-service` and `image-controller`, logs ServiceMonitor `resync_at` (`konflux.konflux-ci.dev/metrics-scrape-resync`), scrape-token presence, and UWM `active_targets` / strict `up` at that moment. The metrics-contract specs also require `resync_at` to be set on those operands.
+
+Failure snapshot includes strict/broad `up` queries, a **peer comparison** row per UWM target (active + dropped target counts + `up` for operator/build-service/image-controller), active/dropped target details for the failed namespace, namespace monitoring labels, ServiceMonitor vs metrics Service selector match, ServiceMonitor/secret metadata (creation time, resourceVersion, labels) for all peers, endpoints/pods for the failed target, filtered **prometheus-operator** log tail from `openshift-user-workload-monitoring`, and optional direct scrape.
+
 ## Extra `go test` arguments (integration / conformance)
 
 The Tekton Task sets optional env vars from pipeline params (empty by default). Scripts **omit quotes** around those expansions on purpose: the shell must **split on spaces** so each flag becomes its own argument to `go test`. (Shellcheck rule SC2086 is disabled next to those lines because unquoted expansion is usually risky; here it is required for the same reason as forwarding `"$@"`.)
@@ -64,6 +90,9 @@ Use **one token per flag** where possible (e.g. `-ginkgo.skip=Flaky`). Values wi
 | `tekton-deploy-operator-and-wait.sh` | **Tekton (go-toolset):** `make install`/build, `bin/manager`, apply CR, wait Ready. |
 | `tekton-run-e2e-tests.sh` | **Tekton:** `deploy-test-resources.sh` (`SKIP_SAMPLE_COMPONENTS=true`), optional `kubectl port-forward` + `KONFLUX_PROXY_URL` for remote Kind, integration + conformance `go test`. Proxy tests wait for Konflux Ready and read `status.uiURL` in Go (`BeforeSuite` in `test/go-tests/proxy_setup.go`). Optional env: `KONFLUX_PROXY_URL`, `E2E_INTEGRATION_GO_TEST_EXTRA_ARGS`, `E2E_CONFORMANCE_GO_TEST_EXTRA_ARGS`. |
 | `run-proxy-integration-tests.sh` | Select proxy auth mode and run `go test` in `test/go-tests`. OpenShift OAuth runs in test `BeforeSuite`. Called from `test/e2e/run-e2e.sh`. |
+| `run-metrics-integration-tests.sh` | Runs `test/go-tests/metricsintegration` (port-forward + bearer token scrape). |
+| `openshift/enable-uwm.sh` | **OpenShift CI only:** idempotent `enableUserWorkload: true` via `cluster-monitoring-config`. |
+| `openshift/run-metrics-openshift-tests.sh` | **OpenShift CI only:** `go test ./metricsopenshift` (UWM readiness in BeforeSuite, ServiceMonitor contract + UWM `up`). |
 
 ## Proxy integration tests
 

--- a/scripts/operator-e2e/openshift/enable-uwm.sh
+++ b/scripts/operator-e2e/openshift/enable-uwm.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Enable OpenShift user-workload monitoring (UWM) when not already configured.
+#
+# Idempotent: safe on clusters where external GitOps or preview already applied
+# cluster-monitoring-config with user-workload monitoring enabled.
+#
+# When patching an existing cluster-monitoring-config, the merge patch replaces the entire
+# config.yaml data key (does not merge YAML fields). Safe on ephemeral CI clusters; clusters
+# with other monitoring settings in config.yaml need read-modify-write instead.
+set -euo pipefail
+
+OC="${OC:-oc}"
+NS="openshift-monitoring"
+CM="cluster-monitoring-config"
+
+if ! command -v "${OC}" &>/dev/null; then
+  echo "ERROR: ${OC} not found" >&2
+  exit 1
+fi
+
+if ! "${OC}" get namespace "${NS}" &>/dev/null; then
+  echo "ERROR: namespace ${NS} not found (not an OpenShift cluster?)" >&2
+  exit 1
+fi
+
+if "${OC}" get configmap "${CM}" -n "${NS}" &>/dev/null; then
+  if "${OC}" get configmap "${CM}" -n "${NS}" -o yaml | grep -q 'enableUserWorkload: true'; then
+    echo "[INFO] ${CM} already has enableUserWorkload: true"
+    exit 0
+  fi
+  echo "[INFO] Patching ${CM} to set enableUserWorkload: true"
+  "${OC}" patch configmap "${CM}" -n "${NS}" --type merge -p \
+    '{"data":{"config.yaml":"enableUserWorkload: true\n"}}'
+  exit 0
+fi
+
+echo "[INFO] Creating ${CM} with enableUserWorkload: true"
+"${OC}" apply -f - <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+EOF

--- a/scripts/operator-e2e/openshift/run-metrics-openshift-tests.sh
+++ b/scripts/operator-e2e/openshift/run-metrics-openshift-tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Run OpenShift metrics integration tests (UWM readiness, ServiceMonitor contract + Prometheus targets).
+#
+# Usage: run-metrics-openshift-tests.sh [REPO_ROOT]
+#
+# UWM readiness waits run in the metricsopenshift BeforeSuite (see pkg/metricsopenshift/wait.go).
+# Env: UWM_PROM_WAIT_TIMEOUT, UWM_CANARY_WAIT_TIMEOUT, UWM_POLL_INTERVAL, UWM_CANARY_QUERY, UWM_SKIP_CANARY.
+# Debug (CI log): UWM_DEBUG_LOG_INTERVAL (seconds, default 60), UWM_DEBUG_DIRECT_SCRAPE=true for direct scrape in failure snapshot, UWM_DEBUG_OPERATOR_LOG_LINES (default 500).
+# Resync evidence: every run logs [UWM resync] lines with operand ServiceMonitor resync_at=... before specs (see pkg/metricsopenshift/resync_evidence.go).
+#
+# Intended for OpenShift CI only (via test/e2e/run-e2e.sh or infra overlay e2e). Not invoked from
+# Kind/Tekton operator E2E.
+set -euo pipefail
+
+REPO_ROOT="$(cd "${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}" && pwd)"
+LABEL_FILTER="${METRICS_OPENSHIFT_GINKGO_LABEL_FILTER:-openshift}"
+
+cd "${REPO_ROOT}/test/go-tests"
+echo "Running OpenShift metrics tests (label filter: ${LABEL_FILTER})..."
+go test -mod=mod ./metricsopenshift -v -timeout 120m -ginkgo.label-filter="${LABEL_FILTER}"

--- a/test/e2e/run-e2e.sh
+++ b/test/e2e/run-e2e.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Deploy demo-user fixtures (opt-in), run proxy integration tests, then E2E conformance tests.
+# Deploy demo-user fixtures (opt-in), run proxy integration tests, metrics tests, then E2E conformance.
 # Set E2E_DEPLOY_TEST_RESOURCES=true to run deploy-test-resources.sh (required for Kind Dex proxy-dex tests).
 # Extra arguments are forwarded to the conformance "go test" only, e.g.:
 #   ./test/e2e/run-e2e.sh -ginkgo.focus="build" -ginkgo.junit-report=report.xml
@@ -35,6 +35,16 @@ case "${E2E_DEPLOY_TEST_RESOURCES:-}" in
 esac
 
 bash "${REPO_ROOT}/scripts/operator-e2e/run-proxy-integration-tests.sh" "${REPO_ROOT}"
+
+# OpenShift UWM metrics (skipped on Kind — no openshift-user-workload-monitoring namespace).
+if kubectl get namespace openshift-user-workload-monitoring &>/dev/null; then
+    if [[ -z "${UWM_SKIP_CANARY:-}" ]] && ! kubectl get namespace dummy-service &>/dev/null; then
+        export UWM_SKIP_CANARY=true
+    fi
+    bash "${REPO_ROOT}/scripts/operator-e2e/openshift/run-metrics-openshift-tests.sh" "${REPO_ROOT}"
+else
+    echo "Skipping OpenShift UWM metrics tests (openshift-user-workload-monitoring namespace not found)" >&2
+fi
 
 bash "${REPO_ROOT}/scripts/operator-e2e/run-metrics-integration-tests.sh" "${REPO_ROOT}"
 

--- a/test/go-tests/metricsopenshift/contract_test.go
+++ b/test/go-tests/metricsopenshift/contract_test.go
@@ -1,0 +1,36 @@
+package metricsopenshift
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/metricsauth"
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/metricsopenshift"
+)
+
+func init() {
+	loadMetricsCatalog()
+}
+
+var _ = Describe("Metrics scrape contract", Label("openshift", "metrics-contract"), func() {
+	Expect(metricsCatalog).NotTo(BeNil())
+	Expect(uwmTargets).NotTo(BeEmpty())
+
+	for _, target := range uwmTargets {
+		It("wires HTTPS scrape resources for "+target.ID,
+			Label(target.LabelGroup()),
+			func(ctx SpecContext) {
+				GinkgoHelper()
+				Eventually(func(g Gomega) {
+					ready, err := metricsauth.WaitForServiceEndpointsReady(ctx, kubeClient, target.Namespace, target.Service, target.Port)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(ready).To(BeTrue(), "metrics service endpoints should be ready")
+				}).WithTimeout(contractReadyTimeout).WithPolling(contractReadyInterval).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					g.Expect(metricsopenshift.ValidateScrapeContract(ctx, kubeClient, target)).To(Succeed())
+				}).WithTimeout(contractReadyTimeout).WithPolling(contractReadyInterval).Should(Succeed())
+			},
+		)
+	}
+})

--- a/test/go-tests/metricsopenshift/k8s_client.go
+++ b/test/go-tests/metricsopenshift/k8s_client.go
@@ -1,0 +1,32 @@
+package metricsopenshift
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+var (
+	kubeScheme = runtime.NewScheme()
+	kubeREST   *rest.Config
+	kubeClient crclient.Client
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(kubeScheme))
+	utilruntime.Must(rbacv1.AddToScheme(kubeScheme))
+}
+
+func initKubernetesClient() error {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return err
+	}
+	kubeREST = cfg
+	kubeClient, err = crclient.New(cfg, crclient.Options{Scheme: kubeScheme})
+	return err
+}

--- a/test/go-tests/metricsopenshift/setup_test.go
+++ b/test/go-tests/metricsopenshift/setup_test.go
@@ -1,0 +1,52 @@
+package metricsopenshift
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/metricsauth"
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/metricsopenshift"
+)
+
+const (
+	contractReadyTimeout  = 5 * time.Minute
+	contractReadyInterval = 5 * time.Second
+	uwmTargetTimeout      = 10 * time.Minute
+	uwmTargetInterval     = 15 * time.Second
+)
+
+var (
+	metricsCatalog  *metricsauth.Catalog
+	uwmTargets      []metricsauth.Target
+	uwmUpOnlyTargets []metricsauth.Target
+)
+
+var _ = BeforeSuite(func(ctx SpecContext) {
+	Expect(initKubernetesClient()).To(Succeed())
+	Expect(kubeClient).NotTo(BeNil())
+	Expect(kubeREST).NotTo(BeNil())
+
+	loadMetricsCatalog()
+
+	waitCfg := metricsopenshift.WaitConfigFromEnv()
+	Expect(metricsopenshift.WaitReady(ctx, kubeREST, waitCfg)).To(Succeed())
+
+	metricsopenshift.LogScrapeResyncEvidence(ctx, kubeREST, kubeClient, uwmTargets)
+})
+
+func loadMetricsCatalog() {
+	if metricsCatalog != nil {
+		return
+	}
+
+	catalog, err := metricsauth.DefaultCatalog()
+	if err != nil {
+		panic(fmt.Sprintf("metrics catalog: %v", err))
+	}
+	metricsCatalog = catalog
+	uwmTargets = metricsopenshift.UWMCatalogTargets(catalog)
+	uwmUpOnlyTargets = metricsopenshift.UWMUpOnlyTargets(catalog)
+}

--- a/test/go-tests/metricsopenshift/suite_test.go
+++ b/test/go-tests/metricsopenshift/suite_test.go
@@ -1,0 +1,17 @@
+// Package metricsopenshift is the Ginkgo e2e suite for OpenShift UWM metrics.
+//
+// BeforeSuite enables UWM readiness polling, then logs [UWM resync] evidence before specs.
+// Contract specs validate scrape wiring; uwm_targets specs poll up==1 in UWM Prometheus.
+package metricsopenshift
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetricsOpenShift(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics OpenShift Suite")
+}

--- a/test/go-tests/metricsopenshift/uwm_targets_test.go
+++ b/test/go-tests/metricsopenshift/uwm_targets_test.go
@@ -1,0 +1,47 @@
+package metricsopenshift
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/metricsopenshift"
+)
+
+func init() {
+	loadMetricsCatalog()
+}
+
+var _ = Describe("UWM Prometheus targets", Label("openshift", "metrics-uwm"), func() {
+	Expect(metricsCatalog).NotTo(BeNil())
+	Expect(uwmTargets).NotTo(BeEmpty())
+
+	for _, target := range uwmTargets {
+		It("scrapes "+target.ID+" via user-workload Prometheus",
+			Label(target.LabelGroup()),
+			func(ctx SpecContext) {
+				GinkgoHelper()
+				promql := metricsopenshift.UpPromQL(target)
+				dumpOnFailure := true
+				defer func() {
+					if dumpOnFailure {
+						metricsopenshift.DumpTargetDebugOnFailure(ctx, GinkgoWriter, kubeREST, kubeClient, target, promql, uwmTargets)
+					}
+				}()
+
+				pollState := &metricsopenshift.UWMPollLogState{}
+				Eventually(func(g Gomega) {
+					result, err := metricsopenshift.QueryPrometheus(ctx, kubeREST, promql)
+					g.Expect(err).NotTo(HaveOccurred())
+					if metricsopenshift.HasUpSample(result) {
+						dumpOnFailure = false
+						return
+					}
+					metricsopenshift.LogUWMPollProgress(GinkgoWriter, kubeREST, target, promql, result, pollState)
+					g.Expect(metricsopenshift.HasUpSample(result)).To(BeTrue(),
+						"expected UWM up sample for %s (%s); got %s",
+						target.ID, promql, metricsopenshift.FormatUpResult(result))
+				}).WithTimeout(uwmTargetTimeout).WithPolling(uwmTargetInterval).Should(Succeed())
+			},
+		)
+	}
+})

--- a/test/go-tests/metricsopenshift/uwm_up_only_test.go
+++ b/test/go-tests/metricsopenshift/uwm_up_only_test.go
@@ -1,0 +1,47 @@
+package metricsopenshift
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/metricsopenshift"
+)
+
+func init() {
+	loadMetricsCatalog()
+}
+
+var _ = Describe("UWM Prometheus legacy up targets", Label("openshift", "metrics-uwm-up-only"), func() {
+	Expect(metricsCatalog).NotTo(BeNil())
+	Expect(uwmUpOnlyTargets).NotTo(BeEmpty())
+
+	for _, target := range uwmUpOnlyTargets {
+		It("scrapes "+target.ID+" via user-workload Prometheus",
+			Label(target.LabelGroup()),
+			func(ctx SpecContext) {
+				GinkgoHelper()
+				promql := metricsopenshift.UpPromQL(target)
+				dumpOnFailure := true
+				defer func() {
+					if dumpOnFailure {
+						metricsopenshift.DumpTargetDebugOnFailure(ctx, GinkgoWriter, kubeREST, kubeClient, target, promql, uwmUpOnlyTargets)
+					}
+				}()
+
+				pollState := &metricsopenshift.UWMPollLogState{}
+				Eventually(func(g Gomega) {
+					result, err := metricsopenshift.QueryPrometheus(ctx, kubeREST, promql)
+					g.Expect(err).NotTo(HaveOccurred())
+					if metricsopenshift.HasUpSample(result) {
+						dumpOnFailure = false
+						return
+					}
+					metricsopenshift.LogUWMPollProgress(GinkgoWriter, kubeREST, target, promql, result, pollState)
+					g.Expect(metricsopenshift.HasUpSample(result)).To(BeTrue(),
+						"expected UWM up sample for %s (%s); got %s",
+						target.ID, promql, metricsopenshift.FormatUpResult(result))
+				}).WithTimeout(uwmTargetTimeout).WithPolling(uwmTargetInterval).Should(Succeed())
+			},
+		)
+	}
+})

--- a/test/go-tests/pkg/metricsauth/catalog.go
+++ b/test/go-tests/pkg/metricsauth/catalog.go
@@ -30,6 +30,9 @@ type Target struct {
 	MetricsReaderClusterRole string
 	ScrapeTokenSecret        string
 	BodyMustMatchAny         []string
+	// UWMUpCheck includes the target in OpenShift UWM up==1 specs outside the
+	// scrape-token contract suite (legacy interim HTTP operands).
+	UWMUpCheck bool
 }
 
 func (c *Catalog) validate() error {

--- a/test/go-tests/pkg/metricsauth/catalog_test.go
+++ b/test/go-tests/pkg/metricsauth/catalog_test.go
@@ -23,6 +23,9 @@ func TestDefaultCatalog_TargetGroups(t *testing.T) {
 	assert.Equal(t, TargetGroupComponent, byID["integration-service"].LabelGroup())
 	assert.Equal(t, TargetGroupComponent, byID["image-controller"].LabelGroup())
 	assert.Equal(t, TargetGroupComponent, byID["konflux-ui-proxy"].LabelGroup())
+	assert.True(t, byID["integration-service"].UWMUpCheck)
+	assert.True(t, byID["konflux-ui-proxy"].UWMUpCheck)
+	assert.Empty(t, byID["konflux-ui-proxy"].ScrapeTokenSecret)
 }
 
 func TestNewCatalog_InvalidGroup(t *testing.T) {

--- a/test/go-tests/pkg/metricsauth/default_catalog.go
+++ b/test/go-tests/pkg/metricsauth/default_catalog.go
@@ -62,6 +62,7 @@ func DefaultCatalog() (*Catalog, error) {
 					Port:                     8080,
 					Path:                     "/metrics",
 					MetricsReaderClusterRole: "integration-service-metrics-reader",
+					UWMUpCheck:               true,
 					BodyMustMatchAny:         prometheusBodyMatchers,
 				},
 				{
@@ -88,6 +89,7 @@ func DefaultCatalog() (*Catalog, error) {
 					Port:                     2112,
 					Path:                     "/metrics",
 					MetricsReaderClusterRole: "konflux-ui-proxy-metrics-reader",
+					UWMUpCheck:               true,
 					BodyMustMatchAny:         []string{"caddy_"},
 				},
 			},

--- a/test/go-tests/pkg/metricsauth/portforward.go
+++ b/test/go-tests/pkg/metricsauth/portforward.go
@@ -19,17 +19,7 @@ type portForwardHandle struct {
 	readyCh chan struct{}
 }
 
-func startServicePortForward(ctx context.Context, cfg *rest.Config, svc ServiceRef) (*portForwardHandle, int, error) {
-	clientset, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	podName, err := readyPodFromService(ctx, clientset, svc.Namespace, svc.Name, svc.Port)
-	if err != nil {
-		return nil, 0, err
-	}
-
+func startPodPortForward(ctx context.Context, cfg *rest.Config, namespace, podName string, remotePort int32) (*portForwardHandle, int, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, 0, err
@@ -42,7 +32,7 @@ func startServicePortForward(ctx context.Context, cfg *rest.Config, svc ServiceR
 		return nil, 0, err
 	}
 
-	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", svc.Namespace, podName)
+	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", namespace, podName)
 	serverURL, err := url.Parse(cfg.Host)
 	if err != nil {
 		return nil, 0, err
@@ -53,7 +43,7 @@ func startServicePortForward(ctx context.Context, cfg *rest.Config, svc ServiceR
 	stopCh := make(chan struct{})
 	readyCh := make(chan struct{})
 
-	forwarder, err := portforward.New(dialer, []string{fmt.Sprintf("%d:%d", localPort, svc.Port)}, stopCh, readyCh, nil, nil)
+	forwarder, err := portforward.New(dialer, []string{fmt.Sprintf("%d:%d", localPort, remotePort)}, stopCh, readyCh, nil, nil)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -68,8 +58,41 @@ func startServicePortForward(ctx context.Context, cfg *rest.Config, svc ServiceR
 	case <-readyCh:
 	case <-waitCtx.Done():
 		close(stopCh)
-		return nil, 0, fmt.Errorf("port-forward to %s/%s pod %s not ready: %w", svc.Namespace, svc.Name, podName, waitCtx.Err())
+		return nil, 0, fmt.Errorf("port-forward to %s pod %s not ready: %w", namespace, podName, waitCtx.Err())
 	}
 
 	return &portForwardHandle{stopCh: stopCh, readyCh: readyCh}, localPort, nil
+}
+
+// startServicePortForward resolves a ready pod behind svc and port-forwards to it.
+// Errors from startPodPortForward are wrapped with the service namespace/name for diagnostics.
+func startServicePortForward(ctx context.Context, cfg *rest.Config, svc ServiceRef) (*portForwardHandle, int, error) {
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	podName, err := readyPodFromService(ctx, clientset, svc.Namespace, svc.Name, svc.Port)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	pf, port, err := startPodPortForward(ctx, cfg, svc.Namespace, podName, svc.Port)
+	if err != nil {
+		return nil, 0, fmt.Errorf("service %s/%s: %w", svc.Namespace, svc.Name, err)
+	}
+	return pf, port, nil
+}
+
+// StartPodPortForward listens on 127.0.0.1:0 and forwards to a pod port.
+func StartPodPortForward(ctx context.Context, cfg *rest.Config, namespace, podName string, remotePort int32) (*PortForwarder, error) {
+	pf, localPort, err := startPodPortForward(ctx, cfg, namespace, podName, remotePort)
+	if err != nil {
+		return nil, err
+	}
+	return &PortForwarder{
+		stopCh:    pf.stopCh,
+		readyCh:   pf.readyCh,
+		localPort: localPort,
+	}, nil
 }

--- a/test/go-tests/pkg/metricsauth/portforward_test.go
+++ b/test/go-tests/pkg/metricsauth/portforward_test.go
@@ -1,0 +1,63 @@
+package metricsauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func TestStartServicePortForwardWrapsPodPortForwardError(t *testing.T) {
+	const (
+		namespace = "build-service"
+		svcName   = "build-service-controller-manager-metrics-service"
+		podName   = "metrics-pod-0"
+		port      = int32(8443)
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/endpointslices"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"items": [{
+					"metadata": {
+						"name": "metrics-endpoints",
+						"namespace": "` + namespace + `",
+						"labels": {"kubernetes.io/service-name": "` + svcName + `"}
+					},
+					"ports": [{"name": "https", "port": 8443, "protocol": "TCP"}],
+					"endpoints": [{
+						"conditions": {"ready": true},
+						"targetRef": {"kind": "Pod", "name": "` + podName + `"}
+					}]
+				}]
+			}`))
+		default:
+			http.Error(w, "port-forward unavailable", http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &rest.Config{
+		Host:    server.URL,
+		Timeout: time.Second,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, _, err := startServicePortForward(ctx, cfg, ServiceRef{
+		Namespace: namespace,
+		Name:      svcName,
+		Port:      port,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service "+namespace+"/"+svcName)
+}

--- a/test/go-tests/pkg/metricsopenshift/contract.go
+++ b/test/go-tests/pkg/metricsopenshift/contract.go
@@ -1,0 +1,62 @@
+package metricsopenshift
+
+import (
+	"context"
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/metricsauth"
+)
+
+// ValidateScrapeContract checks ServiceMonitor, scrape token, metrics-reader CRB wiring, and
+// that operand reconcilers set the metrics-scrape-resync annotation.
+func ValidateScrapeContract(ctx context.Context, c client.Reader, target metricsauth.Target) error {
+	sm, err := GetServiceMonitor(ctx, c, target.Namespace, ServiceMonitorName(target))
+	if err != nil {
+		return fmt.Errorf("serviceMonitor: %w", err)
+	}
+	if err := ValidateOperandScrapeResync(sm, target); err != nil {
+		return err
+	}
+
+	scheme, bearerSecret, err := ServiceMonitorEndpointScheme(sm)
+	if err != nil {
+		return err
+	}
+	if scheme != "https" {
+		return fmt.Errorf("servicemonitor %s/%s endpoint scheme %q, want https", target.Namespace, sm.GetName(), scheme)
+	}
+	if bearerSecret != kubernetes.ScrapeTokenSecretName {
+		return fmt.Errorf("servicemonitor %s/%s bearerTokenSecret %q, want %q",
+			target.Namespace, sm.GetName(), bearerSecret, kubernetes.ScrapeTokenSecretName)
+	}
+
+	if _, err := metricsauth.SecretToken(ctx, c, target.Namespace, target.ScrapeTokenSecret, kubernetes.ScrapeTokenSecretKey); err != nil {
+		return fmt.Errorf("scrape token secret: %w", err)
+	}
+
+	crb := &rbacv1.ClusterRoleBinding{}
+	if err := c.Get(ctx, types.NamespacedName{Name: PrometheusBindingName(target)}, crb); err != nil {
+		return fmt.Errorf("clusterRoleBinding: %w", err)
+	}
+	if crb.Annotations[kubernetes.MetricsScraperBindingAnnotation] != "true" {
+		return fmt.Errorf("clusterRoleBinding %q missing %s annotation", crb.Name, kubernetes.MetricsScraperBindingAnnotation)
+	}
+	if crb.RoleRef.Name != target.MetricsReaderClusterRole {
+		return fmt.Errorf("clusterRoleBinding %q roleRef %q, want %q", crb.Name, crb.RoleRef.Name, target.MetricsReaderClusterRole)
+	}
+
+	wantSA := kubernetes.OperandMetricsScraperSA(target.Namespace)
+	for _, subject := range crb.Subjects {
+		if subject.Kind == rbacv1.ServiceAccountKind &&
+			subject.Name == wantSA.Name &&
+			subject.Namespace == wantSA.Namespace {
+			return nil
+		}
+	}
+	return fmt.Errorf("clusterRoleBinding %q subjects missing metrics-scraper SA in %s", crb.Name, target.Namespace)
+}

--- a/test/go-tests/pkg/metricsopenshift/debug.go
+++ b/test/go-tests/pkg/metricsopenshift/debug.go
@@ -1,0 +1,589 @@
+package metricsopenshift
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	konfluxkubernetes "github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/metricsauth"
+)
+
+const (
+	envDebugLogInterval      = "UWM_DEBUG_LOG_INTERVAL"
+	envDebugDirectScrape     = "UWM_DEBUG_DIRECT_SCRAPE"
+	envDebugOperatorLogLines = "UWM_DEBUG_OPERATOR_LOG_LINES"
+	defaultDebugLogPeriod    = 60 * time.Second
+	defaultOperatorLogLines  = 500
+)
+
+// UWMPollLogState tracks throttling for progress logs during Eventually polling.
+type UWMPollLogState struct {
+	PollCount       int
+	lastLog         time.Time
+	lastFingerprint string
+}
+
+// DebugLogIntervalFromEnv returns how often to emit progress logs while waiting for up==1.
+// 0 means log only on the first poll and when the result fingerprint changes.
+func DebugLogIntervalFromEnv() time.Duration {
+	raw := strings.TrimSpace(os.Getenv(envDebugLogInterval))
+	if raw == "" {
+		return defaultDebugLogPeriod
+	}
+	seconds, err := strconv.Atoi(raw)
+	if err != nil || seconds < 0 {
+		return defaultDebugLogPeriod
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func debugDirectScrapeEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(envDebugDirectScrape)), "true")
+}
+
+// LogUWMPollProgress writes compact UWM query state to w when polling has not yet succeeded.
+func LogUWMPollProgress(
+	w io.Writer,
+	cfg *rest.Config,
+	target metricsauth.Target,
+	strictPromQL string,
+	result *QueryResult,
+	state *UWMPollLogState,
+) {
+	if w == nil || state == nil {
+		return
+	}
+	state.PollCount++
+	fingerprint := FormatUpResult(result)
+	if !shouldEmitPollLog(state, fingerprint) {
+		state.lastFingerprint = fingerprint
+		return
+	}
+
+	fmt.Fprintf(w, "[UWM debug] %s poll %d strict (%s): %s\n",
+		target.ID, state.PollCount, strictPromQL, fingerprint)
+
+	ctx, cancel := context.WithTimeout(context.Background(), prometheusQueryTimeout)
+	defer cancel()
+	broadPromQL := BroadUpPromQL(target)
+	if broad, err := QueryPrometheus(ctx, cfg, broadPromQL); err != nil {
+		fmt.Fprintf(w, "[UWM debug] %s poll %d broad (%s): query error: %v\n",
+			target.ID, state.PollCount, broadPromQL, err)
+	} else {
+		fmt.Fprintf(w, "[UWM debug] %s poll %d broad (%s): %s\n",
+			target.ID, state.PollCount, broadPromQL, FormatUpResult(broad))
+	}
+
+	state.lastLog = time.Now()
+	state.lastFingerprint = fingerprint
+}
+
+func shouldEmitPollLog(state *UWMPollLogState, fingerprint string) bool {
+	if state.PollCount == 1 {
+		return true
+	}
+	if fingerprint != state.lastFingerprint {
+		return true
+	}
+	interval := DebugLogIntervalFromEnv()
+	if interval == 0 {
+		return false
+	}
+	if state.lastLog.IsZero() {
+		return true
+	}
+	return time.Since(state.lastLog) >= interval
+}
+
+// DumpTargetDebugOnFailure emits a one-shot cluster and Prometheus snapshot for CI logs.
+// peerTargets should include all UWM catalog targets for side-by-side comparison.
+func DumpTargetDebugOnFailure(
+	ctx context.Context,
+	w io.Writer,
+	cfg *rest.Config,
+	kube client.Client,
+	target metricsauth.Target,
+	strictPromQL string,
+	peerTargets []metricsauth.Target,
+) {
+	if w == nil {
+		return
+	}
+
+	fmt.Fprintf(w, "[UWM debug] %s failure snapshot begin\n", target.ID)
+
+	queryCtx, cancel := context.WithTimeout(ctx, prometheusQueryTimeout)
+	defer cancel()
+	if strict, err := QueryPrometheus(queryCtx, cfg, strictPromQL); err != nil {
+		fmt.Fprintf(w, "[UWM debug] %s final strict query error: %v\n", target.ID, err)
+	} else {
+		fmt.Fprintf(w, "[UWM debug] %s final strict (%s): %s\n", target.ID, strictPromQL, FormatUpResult(strict))
+	}
+
+	broadPromQL := BroadUpPromQL(target)
+	if broad, err := QueryPrometheus(queryCtx, cfg, broadPromQL); err != nil {
+		fmt.Fprintf(w, "[UWM debug] %s final broad query error: %v\n", target.ID, err)
+	} else {
+		fmt.Fprintf(w, "[UWM debug] %s final broad (%s): %s\n", target.ID, broadPromQL, FormatUpResult(broad))
+	}
+
+	targetsCtx, targetsCancel := context.WithTimeout(ctx, prometheusQueryTimeout)
+	defer targetsCancel()
+	promTargets, promTargetsErr := FetchPrometheusTargets(targetsCtx, cfg)
+	if promTargetsErr != nil {
+		fmt.Fprintf(w, "[UWM debug] prometheus targets error: %v\n", promTargetsErr)
+	} else {
+		dumpUWMPeerComparison(ctx, w, cfg, promTargets, peerTargets)
+		fmt.Fprintf(w, "[UWM debug] %s prometheus active targets detail:\n%s\n",
+			target.ID, FormatTargetsForNamespace(promTargets, target.Namespace))
+		fmt.Fprintf(w, "[UWM debug] %s prometheus dropped targets detail:\n%s\n",
+			target.ID, FormatDroppedTargetsForNamespace(promTargets, target.Namespace))
+	}
+
+	dumpServiceMonitorComparison(ctx, w, kube, target, peerTargets)
+	dumpClusterSnapshot(ctx, w, cfg, kube, target)
+	dumpPrometheusOperatorLogs(ctx, w, cfg, target.Namespace)
+
+	if debugDirectScrapeEnabled() {
+		dumpDirectScrape(ctx, w, cfg, kube, target)
+	}
+
+	fmt.Fprintf(w, "[UWM debug] %s failure snapshot end\n", target.ID)
+}
+
+func dumpUWMPeerComparison(
+	ctx context.Context,
+	w io.Writer,
+	cfg *rest.Config,
+	promTargets *TargetsResult,
+	peerTargets []metricsauth.Target,
+) {
+	if len(peerTargets) == 0 {
+		return
+	}
+
+	fmt.Fprintf(w, "[UWM debug] UWM peer comparison (targets + up query at failure time):\n")
+	queryCtx, cancel := context.WithTimeout(ctx, prometheusQueryTimeout)
+	defer cancel()
+
+	for _, peer := range peerTargets {
+		activeCount := CountTargetsForNamespace(promTargets, peer.Namespace)
+		droppedCount := CountDroppedTargetsForNamespace(promTargets, peer.Namespace)
+		upSummary := "query error"
+		if result, err := QueryPrometheus(queryCtx, cfg, UpPromQL(peer)); err != nil {
+			upSummary = fmt.Sprintf("query error: %v", err)
+		} else {
+			upSummary = FormatUpResult(result)
+		}
+		marker := " "
+		fmt.Fprintf(w, "[UWM debug] %s %-18s namespace=%-20s active_targets=%d dropped_targets=%d up_strict=%s\n",
+			marker, peer.ID, peer.Namespace, activeCount, droppedCount, upSummary)
+	}
+}
+
+func dumpServiceMonitorComparison(
+	ctx context.Context,
+	w io.Writer,
+	kube client.Client,
+	failedTarget metricsauth.Target,
+	peerTargets []metricsauth.Target,
+) {
+	peers := peerTargets
+	if len(peers) == 0 {
+		peers = []metricsauth.Target{failedTarget}
+	}
+
+	fmt.Fprintf(w, "[UWM debug] ServiceMonitor + scrape secret comparison:\n")
+	for _, peer := range peers {
+		dumpOperandScrapeResources(ctx, w, kube, peer)
+	}
+}
+
+func dumpOperandScrapeResources(ctx context.Context, w io.Writer, kube client.Client, target metricsauth.Target) {
+	dumpNamespaceMonitoringLabels(ctx, w, kube, target)
+	dumpServiceMonitorSelectorMatch(ctx, w, kube, target)
+
+	smName := ServiceMonitorName(target)
+	sm, smErr := GetServiceMonitor(ctx, kube, target.Namespace, smName)
+	if smErr != nil {
+		fmt.Fprintf(w, "[UWM debug]   %s SM %s/%s: %v\n", target.ID, target.Namespace, smName, smErr)
+	} else {
+		fmt.Fprintf(w, "[UWM debug]   %s SM %s: %s\n", target.ID, smName, formatServiceMonitorSummary(sm))
+	}
+
+	allSMs, listErr := ListServiceMonitorsInNamespace(ctx, kube, target.Namespace)
+	if listErr != nil {
+		fmt.Fprintf(w, "[UWM debug]   %s ServiceMonitors in %s: list error: %v\n", target.ID, target.Namespace, listErr)
+	} else if len(allSMs) > 1 {
+		names := make([]string, 0, len(allSMs))
+		for _, sm := range allSMs {
+			names = append(names, sm.GetName())
+		}
+		fmt.Fprintf(w, "[UWM debug]   %s note: %d ServiceMonitors in namespace (expected 1): %v\n",
+			target.ID, len(allSMs), names)
+	}
+
+	secret := &corev1.Secret{}
+	secretKey := client.ObjectKey{Namespace: target.Namespace, Name: konfluxkubernetes.ScrapeTokenSecretName}
+	if err := kube.Get(ctx, secretKey, secret); err != nil {
+		fmt.Fprintf(w, "[UWM debug]   %s secret %s: %v\n", target.ID, secretKey.Name, err)
+	} else {
+		fmt.Fprintf(w, "[UWM debug]   %s secret %s: %s\n",
+			target.ID, secretKey.Name, formatScrapeSecretSummary(secret))
+	}
+}
+
+func dumpNamespaceMonitoringLabels(ctx context.Context, w io.Writer, kube client.Client, target metricsauth.Target) {
+	ns := &corev1.Namespace{}
+	if err := kube.Get(ctx, client.ObjectKey{Name: target.Namespace}, ns); err != nil {
+		fmt.Fprintf(w, "[UWM debug]   %s namespace %s: %v\n", target.ID, target.Namespace, err)
+		return
+	}
+	fmt.Fprintf(w, "[UWM debug]   %s namespace %s: metadata=%s labels=%v\n",
+		target.ID, target.Namespace, formatNamespaceMetadata(ns), monitoringRelevantLabels(ns.Labels))
+}
+
+func dumpServiceMonitorSelectorMatch(ctx context.Context, w io.Writer, kube client.Client, target metricsauth.Target) {
+	smName := ServiceMonitorName(target)
+	sm, err := GetServiceMonitor(ctx, kube, target.Namespace, smName)
+	if err != nil {
+		fmt.Fprintf(w, "[UWM debug]   %s service selector check: ServiceMonitor %s/%s: %v\n",
+			target.ID, target.Namespace, smName, err)
+		return
+	}
+
+	selector, err := ServiceMonitorMatchLabels(sm)
+	if err != nil {
+		fmt.Fprintf(w, "[UWM debug]   %s service selector check: %v\n", target.ID, err)
+		return
+	}
+
+	svc := &corev1.Service{}
+	if err := kube.Get(ctx, client.ObjectKey{Namespace: target.Namespace, Name: target.Service}, svc); err != nil {
+		fmt.Fprintf(w, "[UWM debug]   %s service selector check: service %s/%s: %v selector=%v\n",
+			target.ID, target.Namespace, target.Service, err, selector)
+		return
+	}
+
+	matches, mismatches := SelectorMatchReport(svc.Labels, selector)
+	if matches {
+		fmt.Fprintf(w, "[UWM debug]   %s service selector check: service %s labels match SM selector %v\n",
+			target.ID, target.Service, selector)
+		return
+	}
+	fmt.Fprintf(w, "[UWM debug]   %s service selector check: service %s labels=%v SM selector=%v mismatches=%v\n",
+		target.ID, target.Service, svc.Labels, selector, mismatches)
+}
+
+func formatNamespaceMetadata(ns *corev1.Namespace) string {
+	if ns == nil {
+		return "nil"
+	}
+	return fmt.Sprintf(
+		"rv=%s created=%s uid=%s",
+		ns.ResourceVersion,
+		formatTimestamp(ns.CreationTimestamp),
+		ns.UID,
+	)
+}
+
+func monitoringRelevantLabels(labels map[string]string) map[string]string {
+	if len(labels) == 0 {
+		return nil
+	}
+	relevant := make(map[string]string)
+	for key, value := range labels {
+		if strings.HasPrefix(key, "openshift.io/") || strings.HasPrefix(key, "pod-security") {
+			relevant[key] = value
+		}
+	}
+	if len(relevant) == 0 {
+		return map[string]string{"<none>": "no openshift.io or pod-security labels"}
+	}
+	return relevant
+}
+
+func formatServiceMonitorSummary(sm *unstructured.Unstructured) string {
+	if sm == nil {
+		return "nil"
+	}
+	scheme, bearerSecret, err := ServiceMonitorEndpointScheme(sm)
+	if err != nil {
+		return fmt.Sprintf("metadata=%s endpoint_error=%v", formatObjectMetadata(sm), err)
+	}
+	return fmt.Sprintf(
+		"metadata=%s scheme=%s bearerTokenSecret=%s labels=%v resync=%q resync_reason=%q",
+		formatObjectMetadata(sm), scheme, bearerSecret, sm.GetLabels(),
+		ServiceMonitorResyncAt(sm), ServiceMonitorResyncReason(sm),
+	)
+}
+
+func formatScrapeSecretSummary(secret *corev1.Secret) string {
+	if secret == nil {
+		return "nil"
+	}
+	hasToken := len(secret.Data[konfluxkubernetes.ScrapeTokenSecretKey]) > 0
+	return fmt.Sprintf(
+		"metadata=%s has_token=%t keys=%v",
+		formatSecretMetadata(secret), hasToken, secretKeyNames(secret),
+	)
+}
+
+func formatObjectMetadata(obj *unstructured.Unstructured) string {
+	if obj == nil {
+		return "nil"
+	}
+	return fmt.Sprintf(
+		"rv=%s created=%s uid=%s",
+		obj.GetResourceVersion(),
+		formatTimestamp(obj.GetCreationTimestamp()),
+		obj.GetUID(),
+	)
+}
+
+func formatSecretMetadata(secret *corev1.Secret) string {
+	if secret == nil {
+		return "nil"
+	}
+	return fmt.Sprintf(
+		"rv=%s created=%s uid=%s",
+		secret.ResourceVersion,
+		formatTimestamp(secret.CreationTimestamp),
+		secret.UID,
+	)
+}
+
+func formatTimestamp(ts metav1.Time) string {
+	if ts.IsZero() {
+		return "<unknown>"
+	}
+	age := time.Since(ts.Time).Round(time.Second)
+	return fmt.Sprintf("%s age=%s", ts.UTC().Format(time.RFC3339), age)
+}
+
+func dumpClusterSnapshot(
+	ctx context.Context,
+	w io.Writer,
+	cfg *rest.Config,
+	kube client.Client,
+	target metricsauth.Target,
+) {
+	if ready, err := metricsauth.WaitForServiceEndpointsReady(ctx, kube, target.Namespace, target.Service, target.Port); err != nil {
+		fmt.Fprintf(w, "[UWM debug] %s endpoints %s/%s:%d: error: %v\n",
+			target.ID, target.Namespace, target.Service, target.Port, err)
+	} else {
+		fmt.Fprintf(w, "[UWM debug] %s endpoints %s/%s:%d ready=%t\n",
+			target.ID, target.Namespace, target.Service, target.Port, ready)
+	}
+
+	clientset, err := k8sclient.NewForConfig(cfg)
+	if err != nil {
+		fmt.Fprintf(w, "[UWM debug] %s kubernetes client: %v\n", target.ID, err)
+		return
+	}
+
+	list, err := clientset.CoreV1().Pods(target.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "control-plane=controller-manager",
+	})
+	if err != nil {
+		fmt.Fprintf(w, "[UWM debug] %s controller-manager pods: %v\n", target.ID, err)
+		return
+	}
+	if len(list.Items) == 0 {
+		fmt.Fprintf(w, "[UWM debug] %s controller-manager pods: none found\n", target.ID)
+		return
+	}
+	for _, pod := range list.Items {
+		fmt.Fprintf(w, "[UWM debug] %s pod %s/%s phase=%s ready=%t restarts=%d\n",
+			target.ID, pod.Namespace, pod.Name, pod.Status.Phase, podReady(&pod), podRestartCount(&pod))
+	}
+
+	deployments, err := clientset.AppsV1().Deployments(target.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "control-plane=controller-manager",
+	})
+	if err != nil {
+		fmt.Fprintf(w, "[UWM debug] %s controller-manager deployments: %v\n", target.ID, err)
+		return
+	}
+	for _, dep := range deployments.Items {
+		fmt.Fprintf(w, "[UWM debug] %s deployment %s/%s ready=%d/%d updated=%d available=%d\n",
+			target.ID, dep.Namespace, dep.Name,
+			dep.Status.ReadyReplicas, desiredReplicas(&dep),
+			dep.Status.UpdatedReplicas, dep.Status.AvailableReplicas)
+	}
+}
+
+func operatorLogLineLimit() int64 {
+	raw := strings.TrimSpace(os.Getenv(envDebugOperatorLogLines))
+	if raw == "" {
+		return defaultOperatorLogLines
+	}
+	lines, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || lines <= 0 {
+		return defaultOperatorLogLines
+	}
+	return lines
+}
+
+func dumpPrometheusOperatorLogs(ctx context.Context, w io.Writer, cfg *rest.Config, namespaceFilter string) {
+	clientset, err := k8sclient.NewForConfig(cfg)
+	if err != nil {
+		fmt.Fprintf(w, "[UWM debug] prometheus-operator logs: client error: %v\n", err)
+		return
+	}
+
+	podName, err := prometheusOperatorPodName(ctx, clientset)
+	if err != nil {
+		fmt.Fprintf(w, "[UWM debug] prometheus-operator logs: %v\n", err)
+		return
+	}
+
+	logCtx, cancel := context.WithTimeout(ctx, prometheusQueryTimeout)
+	defer cancel()
+	tailLines := operatorLogLineLimit()
+	req := clientset.CoreV1().Pods(UWMNamespace).GetLogs(podName, &corev1.PodLogOptions{
+		Container: "prometheus-operator",
+		TailLines: &tailLines,
+	})
+	stream, err := req.Stream(logCtx)
+	if err != nil {
+		fmt.Fprintf(w, "[UWM debug] prometheus-operator logs pod/%s: %v\n", podName, err)
+		return
+	}
+	defer stream.Close()
+
+	body, err := io.ReadAll(stream)
+	if err != nil {
+		fmt.Fprintf(w, "[UWM debug] prometheus-operator logs pod/%s: read error: %v\n", podName, err)
+		return
+	}
+
+	fmt.Fprintf(w, "[UWM debug] prometheus-operator logs pod/%s (filtered for %q and ServiceMonitor skips):\n",
+		podName, namespaceFilter)
+	printFilteredOperatorLogLines(w, string(body), namespaceFilter)
+}
+
+func prometheusOperatorPodName(ctx context.Context, clientset k8sclient.Interface) (string, error) {
+	list, err := clientset.CoreV1().Pods(UWMNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=prometheus-operator",
+	})
+	if err != nil {
+		return "", err
+	}
+	for _, pod := range list.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			return pod.Name, nil
+		}
+	}
+	for _, pod := range list.Items {
+		if strings.Contains(pod.Name, "prometheus-operator") {
+			return pod.Name, nil
+		}
+	}
+	if len(list.Items) == 0 {
+		return "", fmt.Errorf("no prometheus-operator pods in %s", UWMNamespace)
+	}
+	return list.Items[0].Name, nil
+}
+
+func printFilteredOperatorLogLines(w io.Writer, raw string, namespaceFilter string) {
+	lines := strings.Split(raw, "\n")
+	filterTerms := []string{
+		namespaceFilter,
+		"skipping servicemonitor",
+		"Syncing ServiceMonitor",
+		"servicemonitor",
+		"ServiceMonitor",
+	}
+	matched := 0
+	for _, line := range lines {
+		lower := strings.ToLower(line)
+		for _, term := range filterTerms {
+			if term != "" && strings.Contains(lower, strings.ToLower(term)) {
+				fmt.Fprintf(w, "[UWM debug]   %s\n", strings.TrimSpace(line))
+				matched++
+				break
+			}
+		}
+	}
+	if matched == 0 {
+		fmt.Fprintf(w, "[UWM debug]   (no log lines matched namespace %q or ServiceMonitor events in tail)\n", namespaceFilter)
+	}
+}
+
+func dumpDirectScrape(ctx context.Context, w io.Writer, cfg *rest.Config, kube client.Client, target metricsauth.Target) {
+	token, err := metricsauth.SecretToken(ctx, kube, target.Namespace, target.ScrapeTokenSecret, konfluxkubernetes.ScrapeTokenSecretKey)
+	if err != nil {
+		fmt.Fprintf(w, "[UWM debug] %s direct scrape: token read error: %v\n", target.ID, err)
+		return
+	}
+
+	pf, err := metricsauth.StartPortForward(ctx, cfg, metricsauth.ServiceRef{
+		Namespace: target.Namespace,
+		Name:      target.Service,
+		Port:      target.Port,
+	})
+	if err != nil {
+		fmt.Fprintf(w, "[UWM debug] %s direct scrape: port-forward error: %v\n", target.ID, err)
+		return
+	}
+	defer pf.Close()
+
+	localURL := metricsauth.LocalMetricsURL(pf.LocalPort(), target.Path, target.Scheme)
+	result, err := metricsauth.ScrapeLocal(ctx, localURL, token, target.Scheme, target.TLSInsecureSkipVerifyForScrape())
+	if err != nil {
+		fmt.Fprintf(w, "[UWM debug] %s direct scrape: request error: %v\n", target.ID, err)
+		return
+	}
+	snippet := string(result.Body)
+	if len(snippet) > 200 {
+		snippet = snippet[:200] + "..."
+	}
+	fmt.Fprintf(w, "[UWM debug] %s direct scrape %s: status=%d body_prefix=%q\n",
+		target.ID, localURL, result.StatusCode, snippet)
+}
+
+func secretKeyNames(secret *corev1.Secret) []string {
+	if secret == nil || len(secret.Data) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(secret.Data))
+	for key := range secret.Data {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func podRestartCount(pod *corev1.Pod) int32 {
+	if pod == nil {
+		return 0
+	}
+	var restarts int32
+	for _, status := range pod.Status.ContainerStatuses {
+		restarts += status.RestartCount
+	}
+	return restarts
+}
+
+func desiredReplicas(dep *appsv1.Deployment) int32 {
+	if dep == nil {
+		return 0
+	}
+	if dep.Spec.Replicas != nil {
+		return *dep.Spec.Replicas
+	}
+	return 1
+}

--- a/test/go-tests/pkg/metricsopenshift/names.go
+++ b/test/go-tests/pkg/metricsopenshift/names.go
@@ -1,0 +1,75 @@
+package metricsopenshift
+
+import (
+	"fmt"
+
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/metricsauth"
+)
+
+const (
+	// UWMNamespace is OpenShift user-workload monitoring.
+	UWMNamespace = "openshift-user-workload-monitoring"
+	// CanaryNamespace is the dummy-service UWM canary namespace used in some environments.
+	CanaryNamespace = "dummy-service"
+)
+
+// PrometheusBindingName returns the ClusterRoleBinding wired to the UWM scraper for a target.
+func PrometheusBindingName(target metricsauth.Target) string {
+	if target.ID == "konflux-operator" {
+		return "konflux-operator-prometheus-konflux-operator-metrics-reader"
+	}
+	return "prometheus-" + target.ID + "-metrics-reader"
+}
+
+// ServiceMonitorName returns the ServiceMonitor resource name for a target.
+func ServiceMonitorName(target metricsauth.Target) string {
+	if target.ID == "konflux-operator" {
+		return "controller-manager-metrics-monitor"
+	}
+	return target.ID
+}
+
+// UpPromQL returns a PromQL expression that is true when the target is scraped by UWM.
+func UpPromQL(target metricsauth.Target) string {
+	return fmt.Sprintf(
+		`up{namespace=%q, service=%q} == 1`,
+		target.Namespace,
+		target.Service,
+	)
+}
+
+// BroadUpPromQL returns a relaxed up query for debugging label mismatches in UWM.
+func BroadUpPromQL(target metricsauth.Target) string {
+	return fmt.Sprintf(`up{namespace=%q}`, target.Namespace)
+}
+
+// UWMCatalogTargets returns scrape-token catalog targets for UWM contract and up==1 specs
+// (operator + operands with operator-managed prometheus-scrape-token).
+func UWMCatalogTargets(catalog *metricsauth.Catalog) []metricsauth.Target {
+	if catalog == nil {
+		return nil
+	}
+	var out []metricsauth.Target
+	for _, t := range catalog.Targets {
+		if t.ScrapeTokenSecret == "" {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// UWMUpOnlyTargets returns catalog targets that need UWM up==1 coverage without the
+// scrape-token contract (legacy interim operands with UWMUpCheck set).
+func UWMUpOnlyTargets(catalog *metricsauth.Catalog) []metricsauth.Target {
+	if catalog == nil {
+		return nil
+	}
+	var out []metricsauth.Target
+	for _, t := range catalog.Targets {
+		if t.UWMUpCheck {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/test/go-tests/pkg/metricsopenshift/names_test.go
+++ b/test/go-tests/pkg/metricsopenshift/names_test.go
@@ -1,0 +1,44 @@
+package metricsopenshift
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/metricsauth"
+)
+
+func TestPrometheusBindingName(t *testing.T) {
+	operator := metricsauth.Target{ID: "konflux-operator"}
+	assert.Equal(t, "konflux-operator-prometheus-konflux-operator-metrics-reader", PrometheusBindingName(operator))
+	assert.Equal(t, "prometheus-build-service-metrics-reader", PrometheusBindingName(metricsauth.Target{ID: "build-service"}))
+}
+
+func TestServiceMonitorName(t *testing.T) {
+	assert.Equal(t, "controller-manager-metrics-monitor", ServiceMonitorName(metricsauth.Target{ID: "konflux-operator"}))
+	assert.Equal(t, "build-service", ServiceMonitorName(metricsauth.Target{ID: "build-service"}))
+}
+
+func TestUpPromQL(t *testing.T) {
+	target := metricsauth.Target{
+		Namespace: "build-service",
+		Service:   "build-service-controller-manager-metrics-service",
+	}
+	assert.Equal(t,
+		`up{namespace="build-service", service="build-service-controller-manager-metrics-service"} == 1`,
+		UpPromQL(target),
+	)
+}
+
+func TestUWMUpOnlyTargets(t *testing.T) {
+	catalog, err := metricsauth.DefaultCatalog()
+	assert.NoError(t, err)
+
+	targets := UWMUpOnlyTargets(catalog)
+	assert.Len(t, targets, 2)
+	ids := []string{targets[0].ID, targets[1].ID}
+	assert.ElementsMatch(t, []string{"integration-service", "konflux-ui-proxy"}, ids)
+	for _, target := range targets {
+		assert.Empty(t, target.ScrapeTokenSecret)
+	}
+}

--- a/test/go-tests/pkg/metricsopenshift/prometheus.go
+++ b/test/go-tests/pkg/metricsopenshift/prometheus.go
@@ -1,0 +1,396 @@
+package metricsopenshift
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/metricsauth"
+)
+
+const prometheusQueryTimeout = 30 * time.Second
+
+var serviceMonitorGVR = schema.GroupVersionResource{
+	Group: "monitoring.coreos.com", Version: "v1", Resource: "servicemonitors",
+}
+
+// QueryResult is a subset of the Prometheus HTTP API query response.
+type QueryResult struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string `json:"resultType"`
+		Result     []struct {
+			Metric map[string]string `json:"metric"`
+			Value  []any             `json:"value"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+// QueryPrometheus runs an instant query against UWM Prometheus via port-forward to the prometheus pod.
+func QueryPrometheus(ctx context.Context, cfg *rest.Config, promql string) (*QueryResult, error) {
+	body, err := prometheusHTTPGet(ctx, cfg, "/api/v1/query", url.Values{"query": {promql}})
+	if err != nil {
+		return nil, err
+	}
+	var result QueryResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+	if result.Status != "success" {
+		return nil, fmt.Errorf("prometheus query status %q", result.Status)
+	}
+	return &result, nil
+}
+
+// TargetsResult is a subset of the Prometheus targets API response.
+type TargetsResult struct {
+	Status string `json:"status"`
+	Data   struct {
+		ActiveTargets  []PrometheusTarget `json:"activeTargets"`
+		DroppedTargets []PrometheusTarget `json:"droppedTargets"`
+	} `json:"data"`
+}
+
+// PrometheusTarget holds scrape target state from /api/v1/targets.
+type PrometheusTarget struct {
+	DiscoveredLabels map[string]string `json:"discoveredLabels"`
+	Labels           map[string]string `json:"labels"`
+	ScrapeURL        string            `json:"scrapeUrl"`
+	LastError        string            `json:"lastError"`
+	Health           string            `json:"health"`
+	LastScrape       string            `json:"lastScrape"`
+}
+
+// FetchPrometheusTargets returns active scrape targets from UWM Prometheus.
+func FetchPrometheusTargets(ctx context.Context, cfg *rest.Config) (*TargetsResult, error) {
+	body, err := prometheusHTTPGet(ctx, cfg, "/api/v1/targets", url.Values{"state": {"any"}})
+	if err != nil {
+		return nil, err
+	}
+	var result TargetsResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+	if result.Status != "success" {
+		return nil, fmt.Errorf("prometheus targets status %q", result.Status)
+	}
+	return &result, nil
+}
+
+// FormatUpResult summarizes an instant query result for CI logs.
+func FormatUpResult(result *QueryResult) string {
+	if result == nil {
+		return "no result"
+	}
+	if len(result.Data.Result) == 0 {
+		return "no series"
+	}
+
+	lines := make([]string, 0, len(result.Data.Result))
+	for _, sample := range result.Data.Result {
+		value := "<missing>"
+		if len(sample.Value) >= 2 {
+			value = fmt.Sprint(sample.Value[1])
+		}
+		lines = append(lines, fmt.Sprintf("labels=%v value=%s", sample.Metric, value))
+	}
+	sort.Strings(lines)
+	return fmt.Sprintf("%d sample(s): %s", len(lines), strings.Join(lines, "; "))
+}
+
+// CountTargetsForNamespace returns how many active Prometheus targets belong to a namespace.
+func CountTargetsForNamespace(result *TargetsResult, namespace string) int {
+	return countTargetsForNamespace(result, namespace, func(r *TargetsResult) []PrometheusTarget {
+		return r.Data.ActiveTargets
+	})
+}
+
+// CountDroppedTargetsForNamespace returns how many dropped Prometheus targets belong to a namespace.
+func CountDroppedTargetsForNamespace(result *TargetsResult, namespace string) int {
+	return countTargetsForNamespace(result, namespace, func(r *TargetsResult) []PrometheusTarget {
+		return r.Data.DroppedTargets
+	})
+}
+
+func countTargetsForNamespace(
+	result *TargetsResult,
+	namespace string,
+	targets func(*TargetsResult) []PrometheusTarget,
+) int {
+	if result == nil {
+		return 0
+	}
+	count := 0
+	for _, target := range targets(result) {
+		if targetNamespace(target) == namespace {
+			count++
+		}
+	}
+	return count
+}
+
+// ListServiceMonitorsInNamespace returns ServiceMonitors in a namespace.
+func ListServiceMonitorsInNamespace(ctx context.Context, c client.Reader, namespace string) ([]unstructured.Unstructured, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   serviceMonitorGVR.Group,
+		Version: serviceMonitorGVR.Version,
+		Kind:    "ServiceMonitorList",
+	})
+	if err := c.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+	out := make([]unstructured.Unstructured, 0, len(list.Items))
+	for _, item := range list.Items {
+		out = append(out, item)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].GetName() < out[j].GetName()
+	})
+	return out, nil
+}
+
+// FormatTargetsForNamespace summarizes active Prometheus targets that match a namespace.
+func FormatTargetsForNamespace(result *TargetsResult, namespace string) string {
+	return formatTargetsForNamespace(result, namespace, func(r *TargetsResult) []PrometheusTarget {
+		return r.Data.ActiveTargets
+	}, "active")
+}
+
+// FormatDroppedTargetsForNamespace summarizes dropped Prometheus targets that match a namespace.
+func FormatDroppedTargetsForNamespace(result *TargetsResult, namespace string) string {
+	return formatTargetsForNamespace(result, namespace, func(r *TargetsResult) []PrometheusTarget {
+		return r.Data.DroppedTargets
+	}, "dropped")
+}
+
+func formatTargetsForNamespace(
+	result *TargetsResult,
+	namespace string,
+	targets func(*TargetsResult) []PrometheusTarget,
+	kind string,
+) string {
+	if result == nil {
+		return fmt.Sprintf("no %s targets result", kind)
+	}
+	var matches []PrometheusTarget
+	for _, target := range targets(result) {
+		if targetNamespace(target) == namespace {
+			matches = append(matches, target)
+		}
+	}
+	if len(matches) == 0 {
+		return fmt.Sprintf("no %s targets in namespace %q", kind, namespace)
+	}
+
+	lines := make([]string, 0, len(matches))
+	for _, target := range matches {
+		lines = append(lines, formatPrometheusTargetLine(target))
+	}
+	sort.Strings(lines)
+	return strings.Join(lines, "\n")
+}
+
+func formatPrometheusTargetLine(target PrometheusTarget) string {
+	service := targetLabel(target, "service")
+	if service == "" {
+		service = targetLabel(target, "service_name")
+	}
+	lastError := target.LastError
+	if lastError == "" {
+		lastError = "<none>"
+	}
+	return fmt.Sprintf(
+		"health=%s service=%s scrapeUrl=%s lastScrape=%s lastError=%s labels=%v discovered=%v",
+		target.Health, service, target.ScrapeURL, target.LastScrape, lastError, target.Labels, target.DiscoveredLabels,
+	)
+}
+
+// ServiceMonitorMatchLabels returns spec.selector.matchLabels from a ServiceMonitor.
+func ServiceMonitorMatchLabels(sm *unstructured.Unstructured) (map[string]string, error) {
+	if sm == nil {
+		return nil, fmt.Errorf("serviceMonitor is nil")
+	}
+	labels, found, err := unstructured.NestedStringMap(sm.Object, "spec", "selector", "matchLabels")
+	if err != nil {
+		return nil, err
+	}
+	if !found || len(labels) == 0 {
+		return nil, fmt.Errorf("servicemonitor %s/%s has no spec.selector.matchLabels", sm.GetNamespace(), sm.GetName())
+	}
+	return labels, nil
+}
+
+// SelectorMatchReport compares service labels against a ServiceMonitor selector.
+func SelectorMatchReport(serviceLabels, selector map[string]string) (matches bool, mismatches []string) {
+	if len(selector) == 0 {
+		return false, []string{"empty ServiceMonitor selector"}
+	}
+	mismatches = make([]string, 0)
+	for key, want := range selector {
+		got, ok := serviceLabels[key]
+		if !ok {
+			mismatches = append(mismatches, fmt.Sprintf("service missing label %q (selector wants %q)", key, want))
+			continue
+		}
+		if got != want {
+			mismatches = append(mismatches, fmt.Sprintf("label %q=%q selector wants %q", key, got, want))
+		}
+	}
+	sort.Strings(mismatches)
+	return len(mismatches) == 0, mismatches
+}
+
+func targetNamespace(target PrometheusTarget) string {
+	if ns := targetLabel(target, "namespace"); ns != "" {
+		return ns
+	}
+	return targetLabel(target, "kubernetes_namespace")
+}
+
+func targetLabel(target PrometheusTarget, key string) string {
+	if target.Labels != nil {
+		if value := target.Labels[key]; value != "" {
+			return value
+		}
+	}
+	if target.DiscoveredLabels != nil {
+		return target.DiscoveredLabels[key]
+	}
+	return ""
+}
+
+func prometheusHTTPGet(ctx context.Context, cfg *rest.Config, path string, query url.Values) ([]byte, error) {
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	podName, err := prometheusPodName(ctx, clientset)
+	if err != nil {
+		return nil, err
+	}
+
+	pf, err := metricsauth.StartPodPortForward(ctx, cfg, UWMNamespace, podName, 9090)
+	if err != nil {
+		return nil, err
+	}
+	defer pf.Close()
+
+	requestURL := fmt.Sprintf("http://127.0.0.1:%d%s", pf.LocalPort(), path)
+	if encoded := query.Encode(); encoded != "" {
+		requestURL += "?" + encoded
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := &http.Client{Timeout: prometheusQueryTimeout}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		snippet := string(body)
+		if len(snippet) > 200 {
+			snippet = snippet[:200] + "..."
+		}
+		return nil, fmt.Errorf("prometheus HTTP GET %s: %d: %s", path, resp.StatusCode, snippet)
+	}
+	return body, nil
+}
+
+// HasUpSample reports whether the query result contains at least one sample with value 1.
+func HasUpSample(result *QueryResult) bool {
+	if result == nil {
+		return false
+	}
+	for _, sample := range result.Data.Result {
+		if len(sample.Value) < 2 {
+			continue
+		}
+		if fmt.Sprint(sample.Value[1]) == "1" {
+			return true
+		}
+	}
+	return false
+}
+
+func prometheusPodName(ctx context.Context, clientset kubernetes.Interface) (string, error) {
+	list, err := clientset.CoreV1().Pods(UWMNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=prometheus",
+	})
+	if err != nil {
+		return "", err
+	}
+	for _, pod := range list.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			return pod.Name, nil
+		}
+	}
+	if len(list.Items) == 0 {
+		return "", fmt.Errorf("no prometheus pods in %s", UWMNamespace)
+	}
+	return "", fmt.Errorf(
+		"no running prometheus pods in %s (%d pods in non-Running state)",
+		UWMNamespace,
+		len(list.Items),
+	)
+}
+
+// GetServiceMonitor fetches a ServiceMonitor as unstructured.
+func GetServiceMonitor(ctx context.Context, c client.Reader, namespace, name string) (*unstructured.Unstructured, error) {
+	sm := &unstructured.Unstructured{}
+	sm.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   serviceMonitorGVR.Group,
+		Version: serviceMonitorGVR.Version,
+		Kind:    "ServiceMonitor",
+	})
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, sm); err != nil {
+		return nil, err
+	}
+	return sm, nil
+}
+
+// ServiceMonitorEndpointScheme returns scheme and bearerTokenSecret name from the first endpoint.
+func ServiceMonitorEndpointScheme(sm *unstructured.Unstructured) (scheme, bearerSecret string, err error) {
+	if sm == nil {
+		return "", "", fmt.Errorf("serviceMonitor is nil")
+	}
+	endpoints, found, err := unstructured.NestedSlice(sm.Object, "spec", "endpoints")
+	if err != nil {
+		return "", "", err
+	}
+	if !found || len(endpoints) == 0 {
+		return "", "", fmt.Errorf("servicemonitor %s/%s has no endpoints", sm.GetNamespace(), sm.GetName())
+	}
+	ep, ok := endpoints[0].(map[string]any)
+	if !ok {
+		return "", "", fmt.Errorf("unexpected endpoint shape in %s/%s", sm.GetNamespace(), sm.GetName())
+	}
+	scheme, _, _ = unstructured.NestedString(ep, "scheme")
+	bearerSecret, _, _ = unstructured.NestedString(ep, "bearerTokenSecret", "name")
+	return scheme, bearerSecret, nil
+}

--- a/test/go-tests/pkg/metricsopenshift/prometheus_test.go
+++ b/test/go-tests/pkg/metricsopenshift/prometheus_test.go
@@ -1,0 +1,208 @@
+package metricsopenshift
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestHasUpSample(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, HasUpSample(nil))
+
+	assert.False(t, HasUpSample(&QueryResult{}))
+	assert.False(t, HasUpSample(&QueryResult{
+		Status: "success",
+		Data: struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric map[string]string `json:"metric"`
+				Value  []any             `json:"value"`
+			} `json:"result"`
+		}{
+			Result: []struct {
+				Metric map[string]string `json:"metric"`
+				Value  []any             `json:"value"`
+			}{
+				{Metric: map[string]string{"namespace": "build-service"}, Value: []any{1, "0"}},
+			},
+		},
+	}))
+
+	assert.True(t, HasUpSample(&QueryResult{
+		Status: "success",
+		Data: struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric map[string]string `json:"metric"`
+				Value  []any             `json:"value"`
+			} `json:"result"`
+		}{
+			Result: []struct {
+				Metric map[string]string `json:"metric"`
+				Value  []any             `json:"value"`
+			}{
+				{
+					Metric: map[string]string{
+						"namespace": "build-service",
+						"service":   "build-service-controller-manager-metrics-service",
+					},
+					Value: []any{1, "1"},
+				},
+			},
+		},
+	}))
+}
+
+func TestFormatUpResult(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "no result", FormatUpResult(nil))
+	assert.Equal(t, "no series", FormatUpResult(&QueryResult{Status: "success"}))
+	assert.Contains(t, FormatUpResult(&QueryResult{
+		Status: "success",
+		Data: struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric map[string]string `json:"metric"`
+				Value  []any             `json:"value"`
+			} `json:"result"`
+		}{
+			Result: []struct {
+				Metric map[string]string `json:"metric"`
+				Value  []any             `json:"value"`
+			}{
+				{Metric: map[string]string{"service": "svc"}, Value: []any{1, "0"}},
+			},
+		},
+	}), "value=0")
+}
+
+func TestCountTargetsForNamespace(t *testing.T) {
+	t.Parallel()
+
+	result := &TargetsResult{
+		Status: "success",
+		Data: struct {
+			ActiveTargets  []PrometheusTarget `json:"activeTargets"`
+			DroppedTargets []PrometheusTarget `json:"droppedTargets"`
+		}{
+			ActiveTargets: []PrometheusTarget{
+				{Labels: map[string]string{"namespace": "build-service"}},
+				{Labels: map[string]string{"namespace": "image-controller"}},
+				{DiscoveredLabels: map[string]string{"kubernetes_namespace": "build-service"}},
+			},
+			DroppedTargets: []PrometheusTarget{
+				{Labels: map[string]string{"namespace": "build-service"}, LastError: "401 Unauthorized"},
+			},
+		},
+	}
+	assert.Equal(t, 2, CountTargetsForNamespace(result, "build-service"))
+	assert.Equal(t, 1, CountTargetsForNamespace(result, "image-controller"))
+	assert.Equal(t, 0, CountTargetsForNamespace(result, "konflux-operator"))
+	assert.Equal(t, 1, CountDroppedTargetsForNamespace(result, "build-service"))
+	assert.Equal(t, 0, CountDroppedTargetsForNamespace(result, "image-controller"))
+}
+
+func TestFormatTargetsForNamespace(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "no active targets result", FormatTargetsForNamespace(nil, "build-service"))
+	assert.Contains(t, FormatTargetsForNamespace(&TargetsResult{
+		Status: "success",
+		Data: struct {
+			ActiveTargets  []PrometheusTarget `json:"activeTargets"`
+			DroppedTargets []PrometheusTarget `json:"droppedTargets"`
+		}{
+			ActiveTargets: []PrometheusTarget{
+				{
+					Labels:     map[string]string{"namespace": "build-service", "service": "metrics"},
+					Health:     "down",
+					LastError:  "401 Unauthorized",
+					ScrapeURL:  "https://example/metrics",
+					LastScrape: "2026-07-09T00:00:00Z",
+				},
+			},
+		},
+	}, "build-service"), "401 Unauthorized")
+}
+
+func TestFormatDroppedTargetsForNamespace(t *testing.T) {
+	t.Parallel()
+
+	assert.Contains(t, FormatDroppedTargetsForNamespace(&TargetsResult{
+		Status: "success",
+		Data: struct {
+			ActiveTargets  []PrometheusTarget `json:"activeTargets"`
+			DroppedTargets []PrometheusTarget `json:"droppedTargets"`
+		}{
+			DroppedTargets: []PrometheusTarget{
+				{
+					Labels:    map[string]string{"namespace": "build-service", "service": "metrics"},
+					LastError: "server returned HTTP status 403 Forbidden",
+				},
+			},
+		},
+	}, "build-service"), "403 Forbidden")
+	assert.Equal(t, `no dropped targets in namespace "build-service"`, FormatDroppedTargetsForNamespace(&TargetsResult{
+		Status: "success",
+	}, "build-service"))
+}
+
+func TestSelectorMatchReport(t *testing.T) {
+	t.Parallel()
+
+	matches, mismatches := SelectorMatchReport(map[string]string{
+		"control-plane": "controller-manager",
+		"app":           "build-service",
+	}, map[string]string{
+		"control-plane": "controller-manager",
+	})
+	assert.True(t, matches)
+	assert.Empty(t, mismatches)
+
+	matches, mismatches = SelectorMatchReport(map[string]string{
+		"control-plane": "controller-manager",
+	}, map[string]string{
+		"control-plane": "controller-manager",
+		"app":           "build-service",
+	})
+	assert.False(t, matches)
+	assert.Contains(t, mismatches[0], `service missing label "app"`)
+}
+
+func TestServiceMonitorMatchLabels(t *testing.T) {
+	t.Parallel()
+
+	sm := &unstructured.Unstructured{Object: map[string]any{
+		"spec": map[string]any{
+			"selector": map[string]any{
+				"matchLabels": map[string]any{
+					"control-plane": "controller-manager",
+				},
+			},
+		},
+	}}
+	sm.SetNamespace("build-service")
+	sm.SetName("build-service")
+
+	labels, err := ServiceMonitorMatchLabels(sm)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"control-plane": "controller-manager"}, labels)
+}
+
+func TestShouldEmitPollLog(t *testing.T) {
+	t.Parallel()
+
+	state := &UWMPollLogState{}
+	assert.True(t, shouldEmitPollLog(state, "a"))
+
+	state.PollCount = 2
+	state.lastFingerprint = "a"
+	state.lastLog = time.Now()
+	assert.False(t, shouldEmitPollLog(state, "a"))
+	assert.True(t, shouldEmitPollLog(state, "b"))
+}

--- a/test/go-tests/pkg/metricsopenshift/resync_evidence.go
+++ b/test/go-tests/pkg/metricsopenshift/resync_evidence.go
@@ -1,0 +1,166 @@
+package metricsopenshift
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	konfluxkubernetes "github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/metricsauth"
+)
+
+// OperandScrapeResyncExpected reports whether the operand reconciler should set
+// konflux.konflux-ci.dev/metrics-scrape-resync on the ServiceMonitor.
+func OperandScrapeResyncExpected(target metricsauth.Target) bool {
+	return target.ScrapeTokenSecret != "" && target.LabelGroup() == metricsauth.TargetGroupComponent
+}
+
+// ServiceMonitorResyncAt returns the operand scrape-resync annotation timestamp, if set.
+func ServiceMonitorResyncAt(sm *unstructured.Unstructured) string {
+	if sm == nil {
+		return ""
+	}
+	annotations := sm.GetAnnotations()
+	if annotations == nil {
+		return ""
+	}
+	return annotations[konfluxkubernetes.ServiceMonitorResyncAnnotation]
+}
+
+// ServiceMonitorResyncReason returns the operand scrape-resync reason annotation, if set.
+func ServiceMonitorResyncReason(sm *unstructured.Unstructured) string {
+	if sm == nil {
+		return ""
+	}
+	annotations := sm.GetAnnotations()
+	if annotations == nil {
+		return ""
+	}
+	return annotations[konfluxkubernetes.ServiceMonitorResyncReasonAnnotation]
+}
+
+// ValidateOperandScrapeResync checks that operand reconcilers ran a resync nudge by
+// patching the ServiceMonitor metrics-scrape-resync annotation after minting the scrape token.
+func ValidateOperandScrapeResync(sm *unstructured.Unstructured, target metricsauth.Target) error {
+	if !OperandScrapeResyncExpected(target) {
+		return nil
+	}
+	if ServiceMonitorResyncAt(sm) == "" {
+		return fmt.Errorf("servicemonitor %s/%s missing %q annotation (operand scrape resync)",
+			target.Namespace, sm.GetName(), konfluxkubernetes.ServiceMonitorResyncAnnotation)
+	}
+	return nil
+}
+
+// LogScrapeResyncEvidence logs scrape-resync state on every run (pass or fail) for CI artifacts.
+// Uses stdout like wait.go so Prow build logs capture output even when specs pass.
+//
+// Each line includes resync_at, resync_reason, secret/SM resource versions, uwm_active_targets,
+// and sm_after_secret (true when the ServiceMonitor was created after prometheus-scrape-token).
+// sm_after_secret=true is the deferred SM apply ordering fingerprint; resync_reason alone is not a
+// reliable flake indicator.
+func LogScrapeResyncEvidence(
+	ctx context.Context,
+	cfg *rest.Config,
+	kube client.Reader,
+	targets []metricsauth.Target,
+) {
+	fmt.Println("[UWM resync] operand ServiceMonitor scrape-resync evidence (before metrics specs):")
+
+	var promTargets *TargetsResult
+	if cfg != nil {
+		if result, err := FetchPrometheusTargets(ctx, cfg); err == nil {
+			promTargets = result
+		}
+	}
+
+	for _, target := range targets {
+		if !OperandScrapeResyncExpected(target) {
+			continue
+		}
+		fmt.Printf("[UWM resync]   %s\n", formatScrapeResyncEvidenceLine(ctx, cfg, kube, promTargets, target))
+	}
+}
+
+func formatScrapeResyncEvidenceLine(
+	ctx context.Context,
+	cfg *rest.Config,
+	kube client.Reader,
+	promTargets *TargetsResult,
+	target metricsauth.Target,
+) string {
+	smName := ServiceMonitorName(target)
+	resyncAt := "MISSING"
+	resyncReason := "MISSING"
+	smRV := "unknown"
+	smCreated := "unknown"
+	var sm *unstructured.Unstructured
+	if got, err := GetServiceMonitor(ctx, kube, target.Namespace, smName); err != nil {
+		resyncAt = fmt.Sprintf("error:%v", err)
+		resyncReason = resyncAt
+		smRV = resyncAt
+		smCreated = resyncAt
+	} else {
+		sm = got
+		smRV = sm.GetResourceVersion()
+		smCreated = formatTimestamp(sm.GetCreationTimestamp())
+		if at := ServiceMonitorResyncAt(sm); at != "" {
+			resyncAt = at
+		}
+		if reason := ServiceMonitorResyncReason(sm); reason != "" {
+			resyncReason = reason
+		}
+	}
+
+	tokenState := "absent"
+	secretRV := "unknown"
+	secretCreated := "unknown"
+	smAfterSecret := "unknown"
+	secret := &corev1.Secret{}
+	if err := kube.Get(ctx, types.NamespacedName{Namespace: target.Namespace, Name: target.ScrapeTokenSecret}, secret); err != nil {
+		tokenState = fmt.Sprintf("error:%v", err)
+		secretRV = tokenState
+		secretCreated = tokenState
+	} else if _, err := metricsauth.SecretToken(ctx, kube, target.Namespace, target.ScrapeTokenSecret, konfluxkubernetes.ScrapeTokenSecretKey); err == nil {
+		tokenState = "present"
+		secretRV = secret.ResourceVersion
+		secretCreated = formatTimestamp(secret.CreationTimestamp)
+		if sm != nil {
+			smCreatedAt := sm.GetCreationTimestamp().Time
+			secretCreatedAt := secret.CreationTimestamp.Time
+			if !smCreatedAt.IsZero() && !secretCreatedAt.IsZero() {
+				smAfterSecret = strconv.FormatBool(!smCreatedAt.Before(secretCreatedAt))
+			}
+		}
+	} else {
+		tokenState = fmt.Sprintf("error:%v", err)
+		secretRV = secret.ResourceVersion
+		secretCreated = formatTimestamp(secret.CreationTimestamp)
+	}
+
+	activeTargets := "unknown"
+	if promTargets != nil {
+		activeTargets = strconv.Itoa(CountTargetsForNamespace(promTargets, target.Namespace))
+	}
+
+	upState := "unknown"
+	if cfg != nil {
+		if result, err := QueryPrometheus(ctx, cfg, UpPromQL(target)); err != nil {
+			upState = fmt.Sprintf("error:%v", err)
+		} else {
+			upState = FormatUpResult(result)
+		}
+	}
+
+	return fmt.Sprintf(
+		"id=%s sm=%s sm_rv=%s sm_created=%s secret_created=%s sm_after_secret=%s resync_at=%s resync_reason=%s secret_rv=%s scrape_token=%s uwm_active_targets=%s uwm_up=%s",
+		target.ID, smName, smRV, smCreated, secretCreated, smAfterSecret,
+		resyncAt, resyncReason, secretRV, tokenState, activeTargets, upState,
+	)
+}

--- a/test/go-tests/pkg/metricsopenshift/resync_evidence_test.go
+++ b/test/go-tests/pkg/metricsopenshift/resync_evidence_test.go
@@ -1,0 +1,87 @@
+package metricsopenshift
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	konfluxkubernetes "github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/metricsauth"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestOperandScrapeResyncExpected(t *testing.T) {
+	assert.True(t, OperandScrapeResyncExpected(metricsauth.Target{
+		ID:                "build-service",
+		Group:             metricsauth.TargetGroupComponent,
+		ScrapeTokenSecret: konfluxkubernetes.ScrapeTokenSecretName,
+	}))
+	assert.False(t, OperandScrapeResyncExpected(metricsauth.Target{
+		ID:    "integration-service",
+		Group: metricsauth.TargetGroupComponent,
+	}))
+	assert.False(t, OperandScrapeResyncExpected(metricsauth.Target{
+		ID:                "konflux-operator",
+		Group:             metricsauth.TargetGroupOperator,
+		ScrapeTokenSecret: konfluxkubernetes.ScrapeTokenSecretName,
+	}))
+}
+
+func TestValidateOperandScrapeResync(t *testing.T) {
+	target := metricsauth.Target{
+		ID:        "build-service",
+		Namespace: "build-service",
+		Group:     metricsauth.TargetGroupComponent,
+		ScrapeTokenSecret: konfluxkubernetes.ScrapeTokenSecretName,
+	}
+
+	sm := &unstructured.Unstructured{}
+	sm.SetName("build-service")
+	sm.SetNamespace("build-service")
+	require.Error(t, ValidateOperandScrapeResync(sm, target))
+
+	sm.SetAnnotations(map[string]string{
+		konfluxkubernetes.ServiceMonitorResyncAnnotation: "2026-07-12T10:00:00Z",
+	})
+	require.NoError(t, ValidateOperandScrapeResync(sm, target))
+}
+
+func TestServiceMonitorResyncAt(t *testing.T) {
+	sm := &unstructured.Unstructured{}
+	assert.Empty(t, ServiceMonitorResyncAt(sm))
+
+	sm.SetAnnotations(map[string]string{
+		konfluxkubernetes.ServiceMonitorResyncAnnotation: "2026-07-12T10:00:00Z",
+	})
+	assert.Equal(t, "2026-07-12T10:00:00Z", ServiceMonitorResyncAt(sm))
+}
+
+func TestServiceMonitorResyncReason(t *testing.T) {
+	sm := &unstructured.Unstructured{}
+	assert.Empty(t, ServiceMonitorResyncReason(sm))
+
+	sm.SetAnnotations(map[string]string{
+		konfluxkubernetes.ServiceMonitorResyncReasonAnnotation: konfluxkubernetes.ServiceMonitorResyncReasonSettleRetry,
+	})
+	assert.Equal(t, konfluxkubernetes.ServiceMonitorResyncReasonSettleRetry, ServiceMonitorResyncReason(sm))
+}
+
+func TestFormatScrapeResyncEvidenceLine(t *testing.T) {
+	target := metricsauth.Target{
+		ID:                "build-service",
+		Namespace:         "build-service",
+		Group:             metricsauth.TargetGroupComponent,
+		Service:           "build-service-controller-manager-metrics-service",
+		ScrapeTokenSecret: konfluxkubernetes.ScrapeTokenSecretName,
+	}
+
+	line := formatScrapeResyncEvidenceLine(context.Background(), nil, fake.NewClientBuilder().Build(), nil, target)
+	assert.Contains(t, line, "id=build-service")
+	assert.Contains(t, line, "sm=build-service")
+	assert.Contains(t, line, "resync_at=error:")
+	assert.Contains(t, line, "scrape_token=error:")
+	assert.Contains(t, line, "uwm_active_targets=unknown")
+}

--- a/test/go-tests/pkg/metricsopenshift/wait.go
+++ b/test/go-tests/pkg/metricsopenshift/wait.go
@@ -1,0 +1,241 @@
+// Package metricsopenshift provides helpers for OpenShift user-workload monitoring (UWM)
+// metrics integration tests used by test/go-tests/metricsopenshift.
+//
+// Operator scrape wiring is documented in operator/docs/component-monitoring.md (deferred
+// ServiceMonitor apply, resync nudges). This package implements the test-side waits,
+// contract checks, Prometheus queries, and CI log evidence.
+package metricsopenshift
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	openshiftMonitoringNamespace = "openshift-monitoring"
+	clusterMonitoringConfigName  = "cluster-monitoring-config"
+	defaultCanaryQuery           = `up{namespace="dummy-service"} == 1`
+
+	envPromWaitTimeout    = "UWM_PROM_WAIT_TIMEOUT"
+	envCanaryWaitTimeout  = "UWM_CANARY_WAIT_TIMEOUT"
+	envPollInterval       = "UWM_POLL_INTERVAL"
+	envCanaryQuery        = "UWM_CANARY_QUERY"
+	envSkipCanary         = "UWM_SKIP_CANARY"
+)
+
+// WaitConfig controls UWM readiness polling (env-backed defaults match wait-uwm-ready.sh).
+type WaitConfig struct {
+	PromWaitTimeout   time.Duration
+	CanaryWaitTimeout time.Duration
+	PollInterval      time.Duration
+	CanaryQuery       string
+	SkipCanary        bool
+}
+
+// WaitConfigFromEnv returns wait settings from the process environment.
+func WaitConfigFromEnv() WaitConfig {
+	canaryQuery := os.Getenv(envCanaryQuery)
+	if canaryQuery == "" {
+		canaryQuery = defaultCanaryQuery
+	}
+
+	return WaitConfig{
+		PromWaitTimeout:   secondsFromEnv(envPromWaitTimeout, 600),
+		CanaryWaitTimeout: secondsFromEnv(envCanaryWaitTimeout, 600),
+		PollInterval:      secondsFromEnv(envPollInterval, 15),
+		CanaryQuery:       canaryQuery,
+		SkipCanary:        skipCanaryFromEnv(),
+	}
+}
+
+func skipCanaryFromEnv() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(envSkipCanary)), "true")
+}
+
+func secondsFromEnv(key string, defaultSeconds int) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return time.Duration(defaultSeconds) * time.Second
+	}
+	seconds, err := strconv.Atoi(raw)
+	if err != nil || seconds <= 0 {
+		return time.Duration(defaultSeconds) * time.Second
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// WaitReady blocks until user-workload monitoring is enabled, the UWM Prometheus deployment
+// is ready, and optionally a canary up query succeeds. Called from the metricsopenshift
+// BeforeSuite before contract and target specs run.
+func WaitReady(ctx context.Context, restConfig *rest.Config, wait WaitConfig) error {
+	if restConfig == nil {
+		return fmt.Errorf("rest config is required")
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("kubernetes client: %w", err)
+	}
+
+	logInfo("Checking %s for enableUserWorkload...", clusterMonitoringConfigName)
+	if err := pollUntil(ctx, wait.PollInterval, time.Now().Add(wait.PromWaitTimeout),
+		fmt.Sprintf("%s enableUserWorkload: true", clusterMonitoringConfigName),
+		func(ctx context.Context) (bool, error) {
+			enabled, err := userWorkloadEnabled(ctx, clientset)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+			return enabled, nil
+		},
+	); err != nil {
+		return err
+	}
+	logSuccess("enableUserWorkload: true")
+
+	logInfo("Waiting for prometheus-user-workload pods in %s...", UWMNamespace)
+	if err := pollUntil(ctx, wait.PollInterval, time.Now().Add(wait.PromWaitTimeout),
+		fmt.Sprintf("prometheus pods ready in %s", UWMNamespace),
+		func(ctx context.Context) (bool, error) {
+			return prometheusPodsReady(ctx, clientset)
+		},
+	); err != nil {
+		return err
+	}
+	logSuccess("prometheus-user-workload pod(s) ready")
+
+	if wait.SkipCanary {
+		logInfo("Skipping UWM canary wait (UWM_SKIP_CANARY=%s)", os.Getenv(envSkipCanary))
+		return nil
+	}
+
+	logInfo("Waiting for UWM canary target (%s) to be up...", wait.CanaryQuery)
+	if err := pollUntil(ctx, wait.PollInterval, time.Now().Add(wait.CanaryWaitTimeout),
+		fmt.Sprintf("UWM canary query %q", wait.CanaryQuery),
+		func(ctx context.Context) (bool, error) {
+			result, err := QueryPrometheus(ctx, restConfig, wait.CanaryQuery)
+			if err != nil {
+				return false, nil
+			}
+			return HasUpSample(result), nil
+		},
+	); err != nil {
+		if result, qerr := QueryPrometheus(ctx, restConfig, wait.CanaryQuery); qerr == nil {
+			return fmt.Errorf("%w; last query status=%q samples=%d", err, result.Status, len(result.Data.Result))
+		}
+		return err
+	}
+	logSuccess("UWM canary target is up")
+	return nil
+}
+
+func userWorkloadEnabled(ctx context.Context, clientset kubernetes.Interface) (bool, error) {
+	cm, err := clientset.CoreV1().ConfigMaps(openshiftMonitoringNamespace).Get(
+		ctx, clusterMonitoringConfigName, metav1.GetOptions{},
+	)
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(cm.Data["config.yaml"], "enableUserWorkload: true"), nil
+}
+
+func prometheusPodsReady(ctx context.Context, clientset kubernetes.Interface) (bool, error) {
+	ready, err := podsReadyWithSelector(ctx, clientset,
+		"app.kubernetes.io/name=prometheus,app.kubernetes.io/component=prometheus")
+	if err != nil {
+		return false, err
+	}
+	if ready {
+		return true, nil
+	}
+	return podsReadyWithSelector(ctx, clientset, "app.kubernetes.io/name=prometheus")
+}
+
+func podsReadyWithSelector(ctx context.Context, clientset kubernetes.Interface, selector string) (bool, error) {
+	list, err := clientset.CoreV1().Pods(UWMNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector,
+	})
+	if err != nil {
+		return false, err
+	}
+	if len(list.Items) == 0 {
+		return false, nil
+	}
+	for _, pod := range list.Items {
+		if podReady(&pod) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func podReady(pod *corev1.Pod) bool {
+	if pod == nil || pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func pollUntil(
+	ctx context.Context,
+	interval time.Duration,
+	deadline time.Time,
+	description string,
+	check func(context.Context) (bool, error),
+) error {
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+
+	started := time.Now()
+	for {
+		ok, err := check(ctx)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for %s", description)
+		}
+		logWait("%s not ready yet (%s)", description, time.Since(started).Round(time.Second))
+
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func logInfo(format string, args ...any) {
+	fmt.Printf("[INFO] "+format+"\n", args...)
+}
+
+func logSuccess(msg string) {
+	fmt.Printf("[SUCCESS] %s\n", msg)
+}
+
+func logWait(format string, args ...any) {
+	fmt.Printf("[WAIT] "+format+"\n", args...)
+}

--- a/test/go-tests/pkg/metricsopenshift/wait_test.go
+++ b/test/go-tests/pkg/metricsopenshift/wait_test.go
@@ -1,0 +1,58 @@
+package metricsopenshift
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestWaitConfigFromEnvDefaults(t *testing.T) {
+	t.Setenv(envPromWaitTimeout, "")
+	t.Setenv(envCanaryWaitTimeout, "")
+	t.Setenv(envPollInterval, "")
+	t.Setenv(envCanaryQuery, "")
+	t.Setenv(envSkipCanary, "")
+
+	cfg := WaitConfigFromEnv()
+	assert.Equal(t, 600*time.Second, cfg.PromWaitTimeout)
+	assert.Equal(t, 600*time.Second, cfg.CanaryWaitTimeout)
+	assert.Equal(t, 15*time.Second, cfg.PollInterval)
+	assert.Equal(t, defaultCanaryQuery, cfg.CanaryQuery)
+	assert.False(t, cfg.SkipCanary)
+}
+
+func TestWaitConfigFromEnvSkipCanary(t *testing.T) {
+	t.Setenv(envSkipCanary, "true")
+	cfg := WaitConfigFromEnv()
+	assert.True(t, cfg.SkipCanary)
+}
+
+func TestWaitConfigFromEnvUnsetCanaryUsesDefault(t *testing.T) {
+	t.Setenv(envCanaryQuery, "")
+	t.Setenv(envSkipCanary, "")
+	cfg := WaitConfigFromEnv()
+	assert.Equal(t, defaultCanaryQuery, cfg.CanaryQuery)
+	assert.False(t, cfg.SkipCanary)
+}
+
+func TestPodReady(t *testing.T) {
+	assert.False(t, podReady(nil))
+	assert.False(t, podReady(&corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodPending}}))
+	assert.True(t, podReady(&corev1.Pod{
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}))
+}
+
+func TestUserWorkloadConfigYAMLMarker(t *testing.T) {
+	assert.True(t, strings.Contains("enableUserWorkload: true\n", "enableUserWorkload: true"))
+	assert.False(t, strings.Contains("enableUserWorkload: false\n", "enableUserWorkload: true"))
+}


### PR DESCRIPTION
Add optional OpenShift e2e coverage that verifies Konflux operand
metrics are scraped by user-workload monitoring (UWM Prometheus):
UWM readiness, scrape contract (ServiceMonitor, prometheus-scrape-token,
metrics-scraper CRB), and up==1 per catalog target.

Fix intermittent UWM flakes where prometheus-operator rejects operand
ServiceMonitors when bearerTokenSecret is missing at evaluation time:
- Phase 1: annotation resync nudges (token-minted/refreshed,
  settle-retry, secret-sync) so PO re-evaluates the SM after the scrape
  token exists
- Phase 2: defer operand ServiceMonitor apply until
  prometheus-scrape-token is readable; re-apply every reconcile for
  tracking-client orphan safety

Wire the suite into OCP optional e2e (enable-uwm.sh, run-e2e.sh), emit
[UWM resync] CI evidence (sm_after_secret, active_targets), and document
operator behavior in component-monitoring.md.

Assisted-by: Cursor