### PR TITLE
Configure Tekton resolver retry/back-off and image pull timeout

### DIFF
--- a/dependencies/tekton-config/tekton-config.yml
+++ b/dependencies/tekton-config/tekton-config.yml
@@ -47,6 +47,20 @@ spec:
     default-service-account: default
     options:
       disabled: false
+      configMaps:
+        config-defaults:
+          data:
+            default-imagepullbackoff-timeout: "15m"
+        bundleresolver-config:
+          data:
+            fetch-timeout: "2m"
+            backoff-steps: "30"
+            backoff-cap: "30s"
+        git-resolver-config:
+          data:
+            fetch-timeout: "2m"
+            backoff-steps: "4"
+            backoff-cap: "30s"
       deployments:
         tekton-pipelines-remote-resolvers:
           spec:

--- a/dependencies/tekton-config/tekton-config.yml
+++ b/dependencies/tekton-config/tekton-config.yml
@@ -54,13 +54,13 @@ spec:
         bundleresolver-config:
           data:
             fetch-timeout: "2m"
-            backoff-steps: "30"
-            backoff-cap: "30s"
+            backoff-duration: "15s"
+            backoff-factor: "2.0"
+            backoff-steps: "10"
+            backoff-cap: "15m"
         git-resolver-config:
           data:
             fetch-timeout: "2m"
-            backoff-steps: "4"
-            backoff-cap: "30s"
       deployments:
         tekton-pipelines-remote-resolvers:
           spec:


### PR DESCRIPTION
## Summary

- Adds `configMaps` to `spec.pipeline.options` in the `TektonConfig` CR to improve resilience against transient registry/git failures
- Configures `default-imagepullbackoff-timeout: "15m"` so TaskRuns tolerate transient registry outages (KONFLUX-14906)
- Configures bundle resolver with true exponential back-off: 15s initial, factor 2.0, cap 15m — giving ~15.75 min retry window (KONFLUX-14907)
- Configures git resolver with `fetch-timeout: "2m"` (only supported param for retry tolerance)

## Motivation

Currently:
- TaskRuns fail immediately on the first `ImagePullBackOff` (default timeout is 0)
- Bundle resolver fails in 0 seconds with `CouldntGetTask` on transient registry errors (default: 2 retries only)
- Git resolver has a 1m fetch timeout (increased to 2m for slower networks)

## Bundle resolver back-off progression

```
15s → 30s → 60s → 2m → 4m → 8m → [cap hit, loop exits]
```

Total: ~15.75 minutes across 6 retries with true exponential growth (factor 2.0).

Note: the git resolver does not support `backoff-*` parameters — only `fetch-timeout` is effective.

## Test plan

- [ ] Deploy on Kind with `deploy-deps.sh` and verify:
  - `kubectl get configmap bundleresolver-config -n tekton-pipelines -o yaml` shows backoff params
  - `kubectl get configmap git-resolver-config -n tekton-pipelines -o yaml` shows `fetch-timeout: 2m`
  - `kubectl get configmap config-defaults -n tekton-pipelines -o yaml` shows `default-imagepullbackoff-timeout: 15m`
- [ ] Create a PipelineRun with a non-existent image and confirm it retries for ~15 min
- [ ] Create a PipelineRun with a non-existent bundle and confirm it retries with exponential back-off