### PR TITLE
Apply TektonConfig on OpenShift Pipelines deployment path

### DIFF
--- a/dependencies/tekton-config-ocp/kustomization.yml
+++ b/dependencies/tekton-config-ocp/kustomization.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../tekton-config
+patches:
+  - target:
+      group: operator.tekton.dev
+      version: v1alpha1
+      kind: TektonConfig
+      name: config
+    patch: |
+      - op: remove
+        path: /spec/targetNamespace

--- a/deploy-deps.sh
+++ b/deploy-deps.sh
@@ -275,8 +275,10 @@ deploy_openshift_pipelines() {
           "Tekton webhook did not become available within the allocated time"
 
     echo "  ⚙️  Configuring Tekton..." >&2
-    retry "kubectl apply -k ${script_path}/dependencies/tekton-config" \
+    retry "kubectl apply -k ${script_path}/dependencies/tekton-config-ocp" \
           "The Tekton Config resource was not updated within the allocated time"
+    retry "kubectl wait --for=condition=Ready tektonconfig/config --timeout=120s" \
+          "TektonConfig did not reconcile after update within the allocated time"
 
     # Apply Tekton Chains RBAC for OpenShift Pipelines (uses openshift-pipelines namespace)
     echo "  🔐 Setting up Tekton Chains RBAC..." >&2

--- a/deploy-deps.sh
+++ b/deploy-deps.sh
@@ -274,6 +274,10 @@ deploy_openshift_pipelines() {
     retry "kubectl wait --for=condition=Available deployment/tekton-operator-proxy-webhook -n openshift-pipelines --timeout=120s" \
           "Tekton webhook did not become available within the allocated time"
 
+    echo "  ⚙️  Configuring Tekton..." >&2
+    retry "kubectl apply -k ${script_path}/dependencies/tekton-config" \
+          "The Tekton Config resource was not updated within the allocated time"
+
     # Apply Tekton Chains RBAC for OpenShift Pipelines (uses openshift-pipelines namespace)
     echo "  🔐 Setting up Tekton Chains RBAC..." >&2
     kubectl apply -k "${script_path}/dependencies/tekton-chains-rbac-ocp"


### PR DESCRIPTION
## Summary

- Applies `dependencies/tekton-config/` TektonConfig on the OpenShift Pipelines deployment path (`deploy_openshift_pipelines()`)
- Previously, only the upstream Kind path applied the custom TektonConfig; the OpenShift path only installed the operator and waited for readiness

## Motivation

The `deploy_openshift_pipelines()` function installs OpenShift Pipelines via OLM and waits for the operator-created `TektonConfig` to become ready, but never applies our customizations (pruner settings, Chains volume mounts, resolver retry config, etc.). This means deploying on OpenShift via `deploy-deps.sh` results in a default TektonConfig without our tuning.

## Test plan

- [ ] Deploy with `USE_OPENSHIFT_PIPELINES=true` and verify the TektonConfig includes customizations from `dependencies/tekton-config/tekton-config.yml`
- [ ] Verify the upstream Kind path (`USE_OPENSHIFT_PIPELINES=false`) still works as before


Made with [Cursor](https://cursor.com)