### PR TITLE
docs: document upstream CRD field-name casing convention for unstructured writes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Contributing Guidelines
 - [Editing Markdown Files](#editing-markdown-files)
 - [Using KubeLinter](#using-kubelinter)
 - [Operator Development](#operator-development)
+  * [Unstructured field names for upstream CRs](#unstructured-field-names-for-upstream-crs)
 - [CI/CD and Testing](#cicd-and-testing)
   * [Operator rendered manifests](#operator-rendered-manifests)
   * [Automated E2E Tests](#automated-e2e-tests)
@@ -110,6 +111,23 @@ this file will allow you to ignore or include specific KubeLinter checks.
 For building and running the operator from source, see the
 [operator README](operator/README.md). To deploy a locally built operator on a
 Kind cluster, use `OPERATOR_INSTALL_METHOD=build` with `deploy-local.sh`.
+
+## Unstructured field names for upstream CRs
+
+When a controller manipulates an upstream Custom Resource via `unstructured.Unstructured`
+(rather than a typed Go struct), the field names used in the unstructured map must match
+the **upstream CRD schema's** casing exactly, not the casing of the operator's own `json`
+struct tags. For example, `KonfluxReleaseServiceSpec.EmptyDirOverrides` uses the Go/JSON
+tag `emptyDirOverrides` (camelCase, by Go convention), but the upstream `ReleaseServiceConfig`
+CRD names the same field `EmptyDirOverrides` (PascalCase). Writing to the unstructured object
+must use the upstream's `EmptyDirOverrides`, even though it looks inconsistent with the
+operator's own struct tag. This is intentional, not a typo.
+
+Prefer defining a named string constant for each such unstructured field name (e.g.
+`const releaseServiceConfigOverridesField = "EmptyDirOverrides"`) instead of inline string
+literals, so the mapping is searchable, reviewable, and has a single place to update if the
+upstream schema changes. `verify-manifests-in-sync.sh` (see below) already partially guards
+against upstream CRD schema drift, but does not replace the need for these constants.
 
 # CI/CD and Testing
 


### PR DESCRIPTION
## What
Adds a short section to `CONTRIBUTING.md` under "Operator Development" documenting the convention for controllers that write to upstream CRDs via `unstructured.Unstructured`: field names must match the upstream CRD schema's casing (e.g. `EmptyDirOverrides`), not the operator's own Go/JSON struct tag casing (`emptyDirOverrides`).

This is based on the existing (correct) pattern in `applyReleaseServiceConfigCustomizations()` in `operator/internal/controller/releaseservice/konfluxreleaseservice_controller.go`, which was previously undocumented and could be mistaken for a typo during review.

Also recommends defining named string constants for these field names instead of inline literals, for searchability and easier updates if the upstream schema changes.

## Why
Without this documented, a reviewer unfamiliar with the upstream `ReleaseServiceConfig` CRD's casing could reasonably flag `EmptyDirOverrides` as a bug, since it doesn't match the operator's own `emptyDirOverrides` struct tag.

Closes #7930