### PR TITLE
feat(#8211): add GVK filtering to manifest store

### DIFF
--- a/operator/internal/common/operand_servicemonitor.go
+++ b/operator/internal/common/operand_servicemonitor.go
@@ -19,20 +19,22 @@ package common
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 )
 
-// OperandServiceMonitorFromObjects returns the embedded operand ServiceMonitor matching
-// namespace and name from a component manifest object list. Used by ApplyServiceMonitor
-// callbacks in deferred ServiceMonitor apply (SM is skipped in applyManifests, applied here).
-func OperandServiceMonitorFromObjects(objects []client.Object, namespace, name string) (client.Object, bool) {
+// OperandServiceMonitorFromStore returns the embedded operand ServiceMonitor matching
+// namespace and name for a component. Used by ApplyServiceMonitor callbacks in deferred
+// ServiceMonitor apply (SM is skipped in applyManifests, applied here).
+func OperandServiceMonitorFromStore(store *manifests.ObjectStore, component manifests.Component, namespace, name string) (client.Object, bool, error) {
+	objects, err := store.GetByGVK(component, operandServiceMonitorGVK)
+	if err != nil {
+		return nil, false, err
+	}
+
 	for _, obj := range objects {
-		if !kubernetes.IsComponentMetricsServiceMonitor(obj) {
-			continue
-		}
 		if obj.GetNamespace() == namespace && obj.GetName() == name {
-			return obj, true
+			return obj, true, nil
 		}
 	}
-	return nil, false
+	return nil, false, nil
 }

--- a/operator/internal/common/operand_servicemonitor_test.go
+++ b/operator/internal/common/operand_servicemonitor_test.go
@@ -19,49 +19,37 @@ package common
 import (
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 )
 
-func TestOperandServiceMonitorFromObjects(t *testing.T) {
+func TestOperandServiceMonitorFromStore(t *testing.T) {
 	t.Parallel()
+	g := NewWithT(t)
 
-	sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
-	sm.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "monitoring.coreos.com",
-		Version: "v1",
-		Kind:    "ServiceMonitor",
-	})
-	sm.SetNamespace(testBuildServiceNamespace)
-	sm.SetName(testBuildServiceNamespace)
+	store, err := manifests.NewObjectStore(runtime.NewScheme())
+	g.Expect(err).NotTo(HaveOccurred())
 
-	other := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
-	other.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "monitoring.coreos.com",
-		Version: "v1",
-		Kind:    "ServiceMonitor",
-	})
-	other.SetNamespace("image-controller")
-	other.SetName("image-controller")
+	got, ok, err := OperandServiceMonitorFromStore(
+		store, manifests.BuildService, testBuildServiceNamespace, testBuildServiceNamespace,
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ok).To(BeTrue())
+	g.Expect(got.GetName()).To(Equal(testBuildServiceNamespace))
+	g.Expect(got.GetNamespace()).To(Equal(testBuildServiceNamespace))
 
-	objects := []client.Object{
-		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "noop"}},
-		sm,
-		other,
-	}
+	_, ok, err = OperandServiceMonitorFromStore(
+		store, manifests.BuildService, testBuildServiceNamespace, "missing",
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ok).To(BeFalse())
 
-	got, ok := OperandServiceMonitorFromObjects(objects, testBuildServiceNamespace, testBuildServiceNamespace)
-	if !ok {
-		t.Fatal("expected to find build-service ServiceMonitor")
-	}
-	if got.GetName() != testBuildServiceNamespace || got.GetNamespace() != testBuildServiceNamespace {
-		t.Fatalf("unexpected SM: %s/%s", got.GetNamespace(), got.GetName())
-	}
-
-	if _, ok := OperandServiceMonitorFromObjects(objects, testBuildServiceNamespace, "missing"); ok {
-		t.Fatal("expected missing ServiceMonitor to not be found")
-	}
+	_, ok, err = OperandServiceMonitorFromStore(
+		store, manifests.Component("unknown"), testBuildServiceNamespace, testBuildServiceNamespace,
+	)
+	g.Expect(err).To(MatchError("unknown component: unknown"))
+	g.Expect(ok).To(BeFalse())
 }

--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
@@ -204,11 +204,12 @@ func (r *KonfluxBuildServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 				return tc.ApplyOwned(applyCtx, secret)
 			},
 			ApplyServiceMonitor: func(applyCtx context.Context) error {
-				objects, storeErr := r.ObjectStore.GetForComponent(manifests.BuildService)
+				sm, ok, storeErr := common.OperandServiceMonitorFromStore(
+					r.ObjectStore, manifests.BuildService, webhookConfigNamespace, "build-service",
+				)
 				if storeErr != nil {
 					return fmt.Errorf("get manifests for ServiceMonitor apply: %w", storeErr)
 				}
-				sm, ok := common.OperandServiceMonitorFromObjects(objects, webhookConfigNamespace, "build-service")
 				if !ok {
 					return fmt.Errorf("operand ServiceMonitor %s/%s not found in embedded manifests",
 						webhookConfigNamespace, "build-service")

--- a/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
+++ b/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
@@ -172,11 +172,12 @@ func (r *KonfluxImageControllerReconciler) Reconcile(ctx context.Context, req ct
 				return tc.ApplyOwned(applyCtx, secret)
 			},
 			ApplyServiceMonitor: func(applyCtx context.Context) error {
-				objects, storeErr := r.ObjectStore.GetForComponent(manifests.ImageController)
+				sm, ok, storeErr := common.OperandServiceMonitorFromStore(
+					r.ObjectStore, manifests.ImageController, imageControllerNamespace, "image-controller",
+				)
 				if storeErr != nil {
 					return fmt.Errorf("get manifests for ServiceMonitor apply: %w", storeErr)
 				}
-				sm, ok := common.OperandServiceMonitorFromObjects(objects, imageControllerNamespace, "image-controller")
 				if !ok {
 					return fmt.Errorf("operand ServiceMonitor %s/%s not found in embedded manifests",
 						imageControllerNamespace, "image-controller")

--- a/operator/pkg/manifests/manifests.go
+++ b/operator/pkg/manifests/manifests.go
@@ -10,13 +10,13 @@ import (
 	"io"
 	"path/filepath"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
 )
 
 //go:embed all:application-api all:build-service all:cli all:enterprise-contract all:image-controller all:integration all:namespace-lister all:rbac all:release all:ui all:info all:cert-manager all:registry all:default-tenant all:segment-bridge
@@ -185,19 +185,34 @@ func (s *ObjectStore) GetForComponent(component Component) ([]client.Object, err
 	return deepCopyObjects(objects), nil
 }
 
+// GetByGVK returns deep copies of objects for a component that match the given GVK.
+func (s *ObjectStore) GetByGVK(component Component, gvk schema.GroupVersionKind) ([]client.Object, error) {
+	objects, err := s.GetForComponent(component)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []client.Object
+	for _, obj := range objects {
+		if obj.GetObjectKind().GroupVersionKind() == gvk {
+			result = append(result, obj)
+		}
+	}
+	return result, nil
+}
+
 // GetCRDNamesForComponent returns the names of CustomResourceDefinitions
 // that are part of the component's manifests. Used to watch CRDs and enqueue
 // the component's CR when a managed CRD is deleted out of band.
 func (s *ObjectStore) GetCRDNamesForComponent(component Component) ([]string, error) {
-	objects, ok := s.objects[component]
-	if !ok {
-		return nil, fmt.Errorf("unknown component: %s", component)
+	objects, err := s.GetByGVK(component, apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
+	if err != nil {
+		return nil, err
 	}
+
 	var names []string
 	for _, obj := range objects {
-		if kubernetes.IsCustomResourceDefinition(obj) {
-			names = append(names, obj.GetName())
-		}
+		names = append(names, obj.GetName())
 	}
 	return names, nil
 }

--- a/operator/pkg/manifests/manifests.go
+++ b/operator/pkg/manifests/manifests.go
@@ -185,11 +185,12 @@ func (s *ObjectStore) GetForComponent(component Component) ([]client.Object, err
 	return deepCopyObjects(objects), nil
 }
 
-// GetByGVK returns deep copies of objects for a component that match the given GVK.
-func (s *ObjectStore) GetByGVK(component Component, gvk schema.GroupVersionKind) ([]client.Object, error) {
-	objects, err := s.GetForComponent(component)
-	if err != nil {
-		return nil, err
+// objectsByGVK returns references to stored objects whose GVK exactly matches gvk.
+// Callers must treat the returned objects as read-only.
+func (s *ObjectStore) objectsByGVK(component Component, gvk schema.GroupVersionKind) ([]client.Object, error) {
+	objects, ok := s.objects[component]
+	if !ok {
+		return nil, fmt.Errorf("unknown component: %s", component)
 	}
 
 	var result []client.Object
@@ -201,11 +202,24 @@ func (s *ObjectStore) GetByGVK(component Component, gvk schema.GroupVersionKind)
 	return result, nil
 }
 
+// GetByGVK returns deep copies of objects for a component whose GVK exactly matches gvk.
+// Objects stored by ObjectStore retain the GVK parsed from their embedded manifests.
+func (s *ObjectStore) GetByGVK(component Component, gvk schema.GroupVersionKind) ([]client.Object, error) {
+	objects, err := s.objectsByGVK(component, gvk)
+	if err != nil {
+		return nil, err
+	}
+	if objects == nil {
+		return nil, nil
+	}
+	return deepCopyObjects(objects), nil
+}
+
 // GetCRDNamesForComponent returns the names of CustomResourceDefinitions
 // that are part of the component's manifests. Used to watch CRDs and enqueue
 // the component's CR when a managed CRD is deleted out of band.
 func (s *ObjectStore) GetCRDNamesForComponent(component Component) ([]string, error) {
-	objects, err := s.GetByGVK(component, apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
+	objects, err := s.objectsByGVK(component, apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
 	if err != nil {
 		return nil, err
 	}

--- a/operator/pkg/manifests/manifests_test.go
+++ b/operator/pkg/manifests/manifests_test.go
@@ -4,10 +4,17 @@ import (
 	"strings"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestAllComponents(t *testing.T) {
@@ -143,4 +150,63 @@ func TestGetCRDNamesForComponent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetByGVK(t *testing.T) {
+	t.Parallel()
+
+	deploymentGVK := appsv1.SchemeGroupVersion.WithKind("Deployment")
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "controller-manager"}}
+	deployment.SetGroupVersionKind(deploymentGVK)
+	otherDeployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "webhook"}}
+	otherDeployment.SetGroupVersionKind(deploymentGVK)
+	service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "controller-manager"}}
+	service.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
+	oldDeployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "old-controller-manager"}}
+	oldDeployment.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1beta1", Kind: "Deployment"})
+
+	store := &ObjectStore{objects: map[Component][]client.Object{
+		BuildService: {deployment, service, oldDeployment, otherDeployment},
+	}}
+
+	t.Run("returns only exact GVK matches", func(t *testing.T) {
+		g := NewWithT(t)
+
+		objects, err := store.GetByGVK(BuildService, deploymentGVK)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(objects).To(HaveLen(2))
+		g.Expect(objects[0].GetName()).To(Equal("controller-manager"))
+		g.Expect(objects[1].GetName()).To(Equal("webhook"))
+	})
+
+	t.Run("returns an empty result when there are no matches", func(t *testing.T) {
+		g := NewWithT(t)
+
+		objects, err := store.GetByGVK(BuildService, corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(objects).To(BeEmpty())
+	})
+
+	t.Run("returns an error for an unknown component", func(t *testing.T) {
+		g := NewWithT(t)
+
+		objects, err := store.GetByGVK(Component("unknown"), deploymentGVK)
+
+		g.Expect(err).To(MatchError("unknown component: unknown"))
+		g.Expect(objects).To(BeNil())
+	})
+
+	t.Run("returns deep copies", func(t *testing.T) {
+		g := NewWithT(t)
+		objects, err := store.GetByGVK(BuildService, deploymentGVK)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		objects[0].SetName("mutated")
+		objectsAgain, err := store.GetByGVK(BuildService, deploymentGVK)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(objectsAgain[0].GetName()).To(Equal("controller-manager"))
+	})
 }


### PR DESCRIPTION
## Summary

- add `ObjectStore.GetByGVK` for exact `GroupVersionKind` filtering with deep-copy semantics
- reuse the new method when collecting component CRD names
- retrieve operand `ServiceMonitor` objects directly from the store in the build-service and image-controller reconciliation paths
- cover exact GVK matching, empty results, unknown components, deep-copy isolation, and the `ServiceMonitor` lookup

## Why

Callers that need one Kubernetes object kind currently load every object for a component and implement their own GVK filtering. Centralizing that behavior in `ObjectStore` removes the duplicated matching logic while preserving the store's guarantee that callers cannot mutate cached manifests.

Closes #8211

## Testing

- `make LOCALBIN=/tmp/konflux-ci-bin test`
- `go vet ./...`
- `golangci-lint v2.11.4 run`
