### PR TITLE
feat(KFLUXVNGD-1138): add trusted-CA volume mount to integration-service deployment

### DIFF
--- a/operator/pkg/manifests/integration/manifests.yaml
+++ b/operator/pkg/manifests/integration/manifests.yaml
@@ -1885,6 +1885,10 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
         volumeMounts:
+        - mountPath: /etc/ssl/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -1893,6 +1897,13 @@ spec:
       serviceAccountName: integration-service-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
+      - configMap:
+          items:
+          - key: ca-bundle.crt
+            path: ca-bundle.crt
+          name: trusted-ca
+          optional: true
+        name: trusted-ca
       - name: cert
         secret:
           defaultMode: 420

--- a/operator/upstream-kustomizations/integration/kustomization.yaml
+++ b/operator/upstream-kustomizations/integration/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ./monitoring
 
 patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: integration-service-controller-manager
+    path: mount-custom-ca-bundle.yaml
   # Prevent deployment failures during slow dependency setup
   - target:
       group: apps

--- a/operator/upstream-kustomizations/integration/mount-custom-ca-bundle.yaml
+++ b/operator/upstream-kustomizations/integration/mount-custom-ca-bundle.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: integration-service-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        volumeMounts:
+          - name: trusted-ca
+            mountPath: /etc/ssl/certs/ca-custom-bundle.crt
+            subPath: ca-bundle.crt
+            readOnly: true
+      volumes:
+      - name: trusted-ca
+        configMap:
+          name: trusted-ca
+          optional: true
+          items:
+            - key: ca-bundle.crt
+              path: ca-bundle.crt


### PR DESCRIPTION
Add the trusted-ca ConfigMap volume mount to the integration-service controller-manager Deployment, matching the existing build-service pattern.

Previously, the integration-service Deployment had no mount point for custom CA certificates. In downstream deployments, the rh-certs kustomize component both creates the trusted-ca ConfigMap and patches the Deployment to mount it. With this change, the mount is already present in the base manifests, so only the ConfigMap creation remains as an external concern (via trust-manager Bundle in standalone deployments, or via the OpenShift inject-trusted-cabundle annotation in OpenShift environments).

The ConfigMap is optional: true, so deployments where no trusted-ca ConfigMap exists continue to work without issue.

It follows the build-service pattern

Assisted-by: Cursor + Opus 4.6