### PR TITLE
feat(KFLUXVNGD-1140): add missing package registry proxy fields to the KonfluxInfo

### DIFF
--- a/operator/api/v1alpha1/konfluxinfo_types.go
+++ b/operator/api/v1alpha1/konfluxinfo_types.go
@@ -314,17 +314,41 @@ type ClusterConfigData struct {
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="!self.contains('@')",message="URL must not contain credentials (userinfo). Use a Secret for proxy authentication."
 	PackageRegistryProxyYarnURL string `json:"packageRegistryProxyYarnUrl,omitempty"`
+
+	// PackageRegistryProxyGomodURL is the URL of the Go module proxy.
+	// Written as "package-registry-proxy-gomod-url" in the cluster-config ConfigMap.
+	// Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
+	// +optional
+	// +kubebuilder:validation:XValidation:rule="!self.contains('@')",message="URL must not contain credentials (userinfo). Use a Secret for proxy authentication."
+	PackageRegistryProxyGomodURL string `json:"packageRegistryProxyGomodUrl,omitempty"`
+
+	// PackageRegistryProxyPipURL is the URL of the pip (Python) package registry proxy.
+	// Written as "package-registry-proxy-pip-url" in the cluster-config ConfigMap.
+	// Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
+	// +optional
+	// +kubebuilder:validation:XValidation:rule="!self.contains('@')",message="URL must not contain credentials (userinfo). Use a Secret for proxy authentication."
+	PackageRegistryProxyPipURL string `json:"packageRegistryProxyPipUrl,omitempty"`
+
+	// PackageRegistryProxyPnpmURL is the URL of the pnpm package registry proxy.
+	// Written as "package-registry-proxy-pnpm-url" in the cluster-config ConfigMap.
+	// Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
+	// +optional
+	// +kubebuilder:validation:XValidation:rule="!self.contains('@')",message="URL must not contain credentials (userinfo). Use a Secret for proxy authentication."
+	PackageRegistryProxyPnpmURL string `json:"packageRegistryProxyPnpmUrl,omitempty"`
 }
 
 // ConfigMap key constants for cluster-config proxy fields.
 // These are the kebab-case keys written to the ConfigMap, mapped from camelCase CRD fields.
 const (
-	ClusterConfigKeyAllowCacheProxy             = "allow-cache-proxy"
-	ClusterConfigKeyHTTPProxy                   = "http-proxy"
-	ClusterConfigKeyNoProxy                     = "no-proxy"
-	ClusterConfigKeyAllowPackageRegistryProxy   = "allow-package-registry-proxy"
-	ClusterConfigKeyPackageRegistryProxyNpmURL  = "package-registry-proxy-npm-url"
-	ClusterConfigKeyPackageRegistryProxyYarnURL = "package-registry-proxy-yarn-url"
+	ClusterConfigKeyAllowCacheProxy              = "allow-cache-proxy"
+	ClusterConfigKeyHTTPProxy                    = "http-proxy"
+	ClusterConfigKeyNoProxy                      = "no-proxy"
+	ClusterConfigKeyAllowPackageRegistryProxy    = "allow-package-registry-proxy"
+	ClusterConfigKeyPackageRegistryProxyNpmURL   = "package-registry-proxy-npm-url"
+	ClusterConfigKeyPackageRegistryProxyYarnURL  = "package-registry-proxy-yarn-url"
+	ClusterConfigKeyPackageRegistryProxyGomodURL = "package-registry-proxy-gomod-url"
+	ClusterConfigKeyPackageRegistryProxyPipURL   = "package-registry-proxy-pip-url"
+	ClusterConfigKeyPackageRegistryProxyPnpmURL  = "package-registry-proxy-pnpm-url"
 )
 
 // All is an iterator that yields all non-empty key-value pairs from ClusterConfigData.
@@ -427,6 +451,21 @@ func (d ClusterConfigData) All(yield func(key, value string) bool) {
 	}
 	if d.PackageRegistryProxyYarnURL != "" {
 		if !yield(ClusterConfigKeyPackageRegistryProxyYarnURL, d.PackageRegistryProxyYarnURL) {
+			return
+		}
+	}
+	if d.PackageRegistryProxyGomodURL != "" {
+		if !yield(ClusterConfigKeyPackageRegistryProxyGomodURL, d.PackageRegistryProxyGomodURL) {
+			return
+		}
+	}
+	if d.PackageRegistryProxyPipURL != "" {
+		if !yield(ClusterConfigKeyPackageRegistryProxyPipURL, d.PackageRegistryProxyPipURL) {
+			return
+		}
+	}
+	if d.PackageRegistryProxyPnpmURL != "" {
+		if !yield(ClusterConfigKeyPackageRegistryProxyPnpmURL, d.PackageRegistryProxyPnpmURL) {
 			return
 		}
 	}

--- a/operator/api/v1alpha1/konfluxinfo_types_test.go
+++ b/operator/api/v1alpha1/konfluxinfo_types_test.go
@@ -30,30 +30,33 @@ func TestClusterConfigData_All(t *testing.T) {
 
 		noProxy := ".cluster.local,169.254.169.254"
 		data := ClusterConfigData{
-			DefaultOIDCIssuer:           "https://oidc.example.com",
-			EnableKeylessSigning:        ptr.To(true),
-			FulcioInternalUrl:           "https://fulcio-internal.example.com",
-			FulcioExternalUrl:           "https://fulcio-external.example.com",
-			RekorInternalUrl:            "https://rekor-internal.example.com",
-			RekorExternalUrl:            "https://rekor-external.example.com",
-			TufInternalUrl:              "https://tuf-internal.example.com",
-			TufExternalUrl:              "https://tuf-external.example.com",
-			TrustifyServerInternalUrl:   "https://trustify-internal.example.com",
-			TrustifyServerExternalUrl:   "https://trustify-external.example.com",
-			BuildIdentityRegexp:         "^https://konflux\\.dev/build/.*$",
-			TrustifyOIDCIssuerUrl:       "https://keycloak-external/realm/foobar",
-			TektonChainsIdentity:        "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller",
-			AllowCacheProxy:             ptr.To(true),
-			HTTPProxy:                   "squid.caching.svc.cluster.local:3128",
-			NoProxy:                     &noProxy,
-			AllowPackageRegistryProxy:   ptr.To(true),
-			PackageRegistryProxyNpmURL:  "https://npm-proxy.example.com",
-			PackageRegistryProxyYarnURL: "https://yarn-proxy.example.com",
+			DefaultOIDCIssuer:            "https://oidc.example.com",
+			EnableKeylessSigning:         ptr.To(true),
+			FulcioInternalUrl:            "https://fulcio-internal.example.com",
+			FulcioExternalUrl:            "https://fulcio-external.example.com",
+			RekorInternalUrl:             "https://rekor-internal.example.com",
+			RekorExternalUrl:             "https://rekor-external.example.com",
+			TufInternalUrl:               "https://tuf-internal.example.com",
+			TufExternalUrl:               "https://tuf-external.example.com",
+			TrustifyServerInternalUrl:    "https://trustify-internal.example.com",
+			TrustifyServerExternalUrl:    "https://trustify-external.example.com",
+			BuildIdentityRegexp:          "^https://konflux\\.dev/build/.*$",
+			TrustifyOIDCIssuerUrl:        "https://keycloak-external/realm/foobar",
+			TektonChainsIdentity:         "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller",
+			AllowCacheProxy:              ptr.To(true),
+			HTTPProxy:                    "squid.caching.svc.cluster.local:3128",
+			NoProxy:                      &noProxy,
+			AllowPackageRegistryProxy:    ptr.To(true),
+			PackageRegistryProxyNpmURL:   "https://npm-proxy.example.com",
+			PackageRegistryProxyYarnURL:  "https://yarn-proxy.example.com",
+			PackageRegistryProxyGomodURL: "https://gomod-proxy.example.com",
+			PackageRegistryProxyPipURL:   "https://pip-proxy.example.com",
+			PackageRegistryProxyPnpmURL:  "https://pnpm-proxy.example.com",
 		}
 
 		collected := maps.Collect(data.All)
 
-		g.Expect(collected).To(gomega.HaveLen(19))
+		g.Expect(collected).To(gomega.HaveLen(22))
 		g.Expect(collected["defaultOIDCIssuer"]).To(gomega.Equal("https://oidc.example.com"))
 		g.Expect(collected["enableKeylessSigning"]).To(gomega.Equal("true"))
 		g.Expect(collected["fulcioInternalUrl"]).To(gomega.Equal("https://fulcio-internal.example.com"))
@@ -73,6 +76,9 @@ func TestClusterConfigData_All(t *testing.T) {
 		g.Expect(collected[ClusterConfigKeyAllowPackageRegistryProxy]).To(gomega.Equal("true"))
 		g.Expect(collected[ClusterConfigKeyPackageRegistryProxyNpmURL]).To(gomega.Equal("https://npm-proxy.example.com"))
 		g.Expect(collected[ClusterConfigKeyPackageRegistryProxyYarnURL]).To(gomega.Equal("https://yarn-proxy.example.com"))
+		g.Expect(collected[ClusterConfigKeyPackageRegistryProxyGomodURL]).To(gomega.Equal("https://gomod-proxy.example.com"))
+		g.Expect(collected[ClusterConfigKeyPackageRegistryProxyPipURL]).To(gomega.Equal("https://pip-proxy.example.com"))
+		g.Expect(collected[ClusterConfigKeyPackageRegistryProxyPnpmURL]).To(gomega.Equal("https://pnpm-proxy.example.com"))
 	})
 
 	t.Run("should not yield empty fields", func(t *testing.T) {
@@ -114,20 +120,30 @@ func TestClusterConfigData_All(t *testing.T) {
 	t.Run("should support early termination", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
+		noProxy := ""
 		data := ClusterConfigData{
-			DefaultOIDCIssuer:         "https://oidc.example.com",
-			EnableKeylessSigning:      ptr.To(true),
-			FulcioInternalUrl:         "https://fulcio-internal.example.com",
-			FulcioExternalUrl:         "https://fulcio-external.example.com",
-			RekorInternalUrl:          "https://rekor-internal.example.com",
-			RekorExternalUrl:          "https://rekor-external.example.com",
-			TufInternalUrl:            "https://tuf-internal.example.com",
-			TufExternalUrl:            "https://tuf-external.example.com",
-			TrustifyServerInternalUrl: "https://trustify-internal.example.com",
-			TrustifyServerExternalUrl: "https://trustify-external.example.com",
-			BuildIdentityRegexp:       "^https://konflux\\.dev/build/.*$",
-			TrustifyOIDCIssuerUrl:     "https://keycloak-external/realm/foobar",
-			TektonChainsIdentity:      "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller",
+			DefaultOIDCIssuer:            "https://oidc.example.com",
+			EnableKeylessSigning:         ptr.To(true),
+			FulcioInternalUrl:            "https://fulcio-internal.example.com",
+			FulcioExternalUrl:            "https://fulcio-external.example.com",
+			RekorInternalUrl:             "https://rekor-internal.example.com",
+			RekorExternalUrl:             "https://rekor-external.example.com",
+			TufInternalUrl:               "https://tuf-internal.example.com",
+			TufExternalUrl:               "https://tuf-external.example.com",
+			TrustifyServerInternalUrl:    "https://trustify-internal.example.com",
+			TrustifyServerExternalUrl:    "https://trustify-external.example.com",
+			BuildIdentityRegexp:          "^https://konflux\\.dev/build/.*$",
+			TrustifyOIDCIssuerUrl:        "https://keycloak-external/realm/foobar",
+			TektonChainsIdentity:         "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller",
+			AllowCacheProxy:              ptr.To(true),
+			HTTPProxy:                    "squid:3128",
+			NoProxy:                      &noProxy,
+			AllowPackageRegistryProxy:    ptr.To(true),
+			PackageRegistryProxyNpmURL:   "https://npm-proxy.example.com",
+			PackageRegistryProxyYarnURL:  "https://yarn-proxy.example.com",
+			PackageRegistryProxyGomodURL: "https://gomod-proxy.example.com",
+			PackageRegistryProxyPipURL:   "https://pip-proxy.example.com",
+			PackageRegistryProxyPnpmURL:  "https://pnpm-proxy.example.com",
 		}
 
 		var yielded []string
@@ -141,30 +157,81 @@ func TestClusterConfigData_All(t *testing.T) {
 		g.Expect(yielded[0]).To(gomega.Equal("defaultOIDCIssuer"))
 	})
 
+	t.Run("should support early termination at each field", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		noProxy := ""
+		data := ClusterConfigData{
+			DefaultOIDCIssuer:            "oidc",
+			EnableKeylessSigning:         ptr.To(true),
+			FulcioInternalUrl:            "fulcio-int",
+			FulcioExternalUrl:            "fulcio-ext",
+			RekorInternalUrl:             "rekor-int",
+			RekorExternalUrl:             "rekor-ext",
+			TufInternalUrl:               "tuf-int",
+			TufExternalUrl:               "tuf-ext",
+			TrustifyServerInternalUrl:    "trustify-int",
+			TrustifyServerExternalUrl:    "trustify-ext",
+			BuildIdentityRegexp:          "regexp",
+			TrustifyOIDCIssuerUrl:        "trustify-oidc",
+			TektonChainsIdentity:         "chains-identity",
+			AllowCacheProxy:              ptr.To(true),
+			HTTPProxy:                    "proxy:3128",
+			NoProxy:                      &noProxy,
+			AllowPackageRegistryProxy:    ptr.To(true),
+			PackageRegistryProxyNpmURL:   "npm",
+			PackageRegistryProxyYarnURL:  "yarn",
+			PackageRegistryProxyGomodURL: "gomod",
+			PackageRegistryProxyPipURL:   "pip",
+			PackageRegistryProxyPnpmURL:  "pnpm",
+		}
+
+		// Count total fields
+		totalFields := 0
+		data.All(func(_, _ string) bool {
+			totalFields++
+			return true
+		})
+		g.Expect(totalFields).To(gomega.Equal(22))
+
+		// Verify early termination works at every position
+		for stopAt := 1; stopAt <= totalFields; stopAt++ {
+			count := 0
+			data.All(func(_, _ string) bool {
+				count++
+				return count < stopAt
+			})
+			g.Expect(count).To(gomega.Equal(stopAt))
+		}
+	})
+
 	t.Run("should yield fields in correct order", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
 		noProxy := ""
 		data := ClusterConfigData{
-			DefaultOIDCIssuer:           "oidc",
-			EnableKeylessSigning:        ptr.To(false),
-			FulcioInternalUrl:           "fulcio-internal",
-			FulcioExternalUrl:           "fulcio-external",
-			RekorInternalUrl:            "rekor-internal",
-			RekorExternalUrl:            "rekor-external",
-			TufInternalUrl:              "tuf-internal",
-			TufExternalUrl:              "tuf-external",
-			TrustifyServerInternalUrl:   "trustify-internal",
-			TrustifyServerExternalUrl:   "trustify-external",
-			BuildIdentityRegexp:         "^https://konflux\\.dev/build/.*$",
-			TrustifyOIDCIssuerUrl:       "https://keycloak-external/realm/foobar",
-			TektonChainsIdentity:        "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller",
-			AllowCacheProxy:             ptr.To(true),
-			HTTPProxy:                   "proxy:3128",
-			NoProxy:                     &noProxy,
-			AllowPackageRegistryProxy:   ptr.To(false),
-			PackageRegistryProxyNpmURL:  "https://npm-proxy.example.com",
-			PackageRegistryProxyYarnURL: "https://yarn-proxy.example.com",
+			DefaultOIDCIssuer:            "oidc",
+			EnableKeylessSigning:         ptr.To(false),
+			FulcioInternalUrl:            "fulcio-internal",
+			FulcioExternalUrl:            "fulcio-external",
+			RekorInternalUrl:             "rekor-internal",
+			RekorExternalUrl:             "rekor-external",
+			TufInternalUrl:               "tuf-internal",
+			TufExternalUrl:               "tuf-external",
+			TrustifyServerInternalUrl:    "trustify-internal",
+			TrustifyServerExternalUrl:    "trustify-external",
+			BuildIdentityRegexp:          "^https://konflux\\.dev/build/.*$",
+			TrustifyOIDCIssuerUrl:        "https://keycloak-external/realm/foobar",
+			TektonChainsIdentity:         "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller",
+			AllowCacheProxy:              ptr.To(true),
+			HTTPProxy:                    "proxy:3128",
+			NoProxy:                      &noProxy,
+			AllowPackageRegistryProxy:    ptr.To(false),
+			PackageRegistryProxyNpmURL:   "https://npm-proxy.example.com",
+			PackageRegistryProxyYarnURL:  "https://yarn-proxy.example.com",
+			PackageRegistryProxyGomodURL: "https://gomod-proxy.example.com",
+			PackageRegistryProxyPipURL:   "https://pip-proxy.example.com",
+			PackageRegistryProxyPnpmURL:  "https://pnpm-proxy.example.com",
 		}
 
 		var keys []string
@@ -193,6 +260,9 @@ func TestClusterConfigData_All(t *testing.T) {
 			ClusterConfigKeyAllowPackageRegistryProxy,
 			ClusterConfigKeyPackageRegistryProxyNpmURL,
 			ClusterConfigKeyPackageRegistryProxyYarnURL,
+			ClusterConfigKeyPackageRegistryProxyGomodURL,
+			ClusterConfigKeyPackageRegistryProxyPipURL,
+			ClusterConfigKeyPackageRegistryProxyPnpmURL,
 		}
 
 		g.Expect(keys).To(gomega.Equal(expectedOrder))

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
@@ -1357,10 +1357,40 @@ spec:
                                   An empty string is a valid value meaning no hosts are excluded from proxying.
                                   When nil (omitted), the key is absent from the ConfigMap.
                                 type: string
+                              packageRegistryProxyGomodUrl:
+                                description: |-
+                                  PackageRegistryProxyGomodURL is the URL of the Go module proxy.
+                                  Written as "package-registry-proxy-gomod-url" in the cluster-config ConfigMap.
+                                  Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: URL must not contain credentials (userinfo).
+                                    Use a Secret for proxy authentication.
+                                  rule: '!self.contains(''@'')'
                               packageRegistryProxyNpmUrl:
                                 description: |-
                                   PackageRegistryProxyNpmURL is the URL of the npm package registry proxy.
                                   Written as "package-registry-proxy-npm-url" in the cluster-config ConfigMap.
+                                  Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: URL must not contain credentials (userinfo).
+                                    Use a Secret for proxy authentication.
+                                  rule: '!self.contains(''@'')'
+                              packageRegistryProxyPipUrl:
+                                description: |-
+                                  PackageRegistryProxyPipURL is the URL of the pip (Python) package registry proxy.
+                                  Written as "package-registry-proxy-pip-url" in the cluster-config ConfigMap.
+                                  Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: URL must not contain credentials (userinfo).
+                                    Use a Secret for proxy authentication.
+                                  rule: '!self.contains(''@'')'
+                              packageRegistryProxyPnpmUrl:
+                                description: |-
+                                  PackageRegistryProxyPnpmURL is the URL of the pnpm package registry proxy.
+                                  Written as "package-registry-proxy-pnpm-url" in the cluster-config ConfigMap.
                                   Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
                                 type: string
                                 x-kubernetes-validations:

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxinfoes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxinfoes.yaml
@@ -163,10 +163,40 @@ spec:
                           An empty string is a valid value meaning no hosts are excluded from proxying.
                           When nil (omitted), the key is absent from the ConfigMap.
                         type: string
+                      packageRegistryProxyGomodUrl:
+                        description: |-
+                          PackageRegistryProxyGomodURL is the URL of the Go module proxy.
+                          Written as "package-registry-proxy-gomod-url" in the cluster-config ConfigMap.
+                          Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: URL must not contain credentials (userinfo). Use
+                            a Secret for proxy authentication.
+                          rule: '!self.contains(''@'')'
                       packageRegistryProxyNpmUrl:
                         description: |-
                           PackageRegistryProxyNpmURL is the URL of the npm package registry proxy.
                           Written as "package-registry-proxy-npm-url" in the cluster-config ConfigMap.
+                          Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: URL must not contain credentials (userinfo). Use
+                            a Secret for proxy authentication.
+                          rule: '!self.contains(''@'')'
+                      packageRegistryProxyPipUrl:
+                        description: |-
+                          PackageRegistryProxyPipURL is the URL of the pip (Python) package registry proxy.
+                          Written as "package-registry-proxy-pip-url" in the cluster-config ConfigMap.
+                          Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: URL must not contain credentials (userinfo). Use
+                            a Secret for proxy authentication.
+                          rule: '!self.contains(''@'')'
+                      packageRegistryProxyPnpmUrl:
+                        description: |-
+                          PackageRegistryProxyPnpmURL is the URL of the pnpm package registry proxy.
+                          Written as "package-registry-proxy-pnpm-url" in the cluster-config ConfigMap.
                           Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
                         type: string
                         x-kubernetes-validations:

--- a/operator/config/samples/konflux-e2e.yaml
+++ b/operator/config/samples/konflux-e2e.yaml
@@ -143,7 +143,11 @@ spec:
       #     # noProxy: ""
       #     # allowPackageRegistryProxy: true
       #     # packageRegistryProxyNpmUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"
-      #     # packageRegistryProxyYarnUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/yarn-proxy"
+      #     # # Yarn and pnpm use the same npm-compatible registry endpoint in most deployments.
+      #     # packageRegistryProxyYarnUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"
+      #     # packageRegistryProxyGomodUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy"
+      #     # packageRegistryProxyPipUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple"
+      #     # packageRegistryProxyPnpmUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"
   # enterpriseContract:
   #   # skipPolicies disables deployment of EnterpriseContractPolicy resources.
   #   # When true, only CRDs, namespace, RBAC, and ConfigMap are deployed;

--- a/operator/config/samples/konflux_v1alpha1_konflux.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konflux.yaml
@@ -154,7 +154,11 @@ spec:
       #     # noProxy: ""
       #     # allowPackageRegistryProxy: true
       #     # packageRegistryProxyNpmUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"
-      #     # packageRegistryProxyYarnUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/yarn-proxy"
+      #     # # Yarn and pnpm use the same npm-compatible registry endpoint in most deployments.
+      #     # packageRegistryProxyYarnUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"
+      #     # packageRegistryProxyGomodUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy"
+      #     # packageRegistryProxyPipUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple"
+      #     # packageRegistryProxyPnpmUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"
   # enterpriseContract:
   #   # skipPolicies disables deployment of EnterpriseContractPolicy resources.
   #   # When true, only CRDs, namespace, RBAC, and ConfigMap are deployed;

--- a/operator/config/samples/konflux_v1alpha1_konfluxinfo.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konfluxinfo.yaml
@@ -138,4 +138,8 @@ spec:
       noProxy: ""
       allowPackageRegistryProxy: true
       packageRegistryProxyNpmUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"
-      packageRegistryProxyYarnUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/yarn-proxy"
+      # Yarn and pnpm use the same npm-compatible registry endpoint in most deployments.
+      packageRegistryProxyYarnUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"
+      packageRegistryProxyGomodUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy"
+      packageRegistryProxyPipUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple"
+      packageRegistryProxyPnpmUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"

--- a/operator/internal/controller/info/konfluxinfo_controller_test.go
+++ b/operator/internal/controller/info/konfluxinfo_controller_test.go
@@ -134,15 +134,66 @@ var _ = Describe("KonfluxInfo Controller", func() {
 			Expect(err.Error()).To(ContainSubstring("must not contain credentials"))
 		})
 
+		It("should reject packageRegistryProxyGomodUrl containing credentials", func(ctx context.Context) {
+			cr := &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				Spec: konfluxv1alpha1.KonfluxInfoSpec{
+					ClusterConfig: &konfluxv1alpha1.ClusterConfig{
+						Data: &konfluxv1alpha1.ClusterConfigData{
+							PackageRegistryProxyGomodURL: "https://token@go-proxy.example.com",
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, cr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must not contain credentials"))
+		})
+
+		It("should reject packageRegistryProxyPipUrl containing credentials", func(ctx context.Context) {
+			cr := &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				Spec: konfluxv1alpha1.KonfluxInfoSpec{
+					ClusterConfig: &konfluxv1alpha1.ClusterConfig{
+						Data: &konfluxv1alpha1.ClusterConfigData{
+							PackageRegistryProxyPipURL: "https://user:pass@pypi.example.com",
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, cr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must not contain credentials"))
+		})
+
+		It("should reject packageRegistryProxyPnpmUrl containing credentials", func(ctx context.Context) {
+			cr := &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				Spec: konfluxv1alpha1.KonfluxInfoSpec{
+					ClusterConfig: &konfluxv1alpha1.ClusterConfig{
+						Data: &konfluxv1alpha1.ClusterConfigData{
+							PackageRegistryProxyPnpmURL: "https://admin:secret@pnpm.example.com",
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, cr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must not contain credentials"))
+		})
+
 		It("should allow proxy URLs without credentials", func(ctx context.Context) {
 			cr := &konfluxv1alpha1.KonfluxInfo{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 				Spec: konfluxv1alpha1.KonfluxInfoSpec{
 					ClusterConfig: &konfluxv1alpha1.ClusterConfig{
 						Data: &konfluxv1alpha1.ClusterConfigData{
-							HTTPProxy:                   "squid.caching.svc.cluster.local:3128",
-							PackageRegistryProxyNpmURL:  "https://npm-proxy.internal.svc:8080",
-							PackageRegistryProxyYarnURL: "https://yarn-proxy.internal.svc:8080",
+							HTTPProxy:                    "squid.caching.svc.cluster.local:3128",
+							PackageRegistryProxyNpmURL:   "https://npm-proxy.internal.svc:8080",
+							PackageRegistryProxyYarnURL:  "https://yarn-proxy.internal.svc:8080",
+							PackageRegistryProxyGomodURL: "https://go-proxy.internal.svc:8080",
+							PackageRegistryProxyPipURL:   "https://pypi-proxy.internal.svc:8080",
+							PackageRegistryProxyPnpmURL:  "https://pnpm-proxy.internal.svc:8080",
 						},
 					},
 				},

--- a/operator/internal/controller/info/konfluxinfo_customization_test.go
+++ b/operator/internal/controller/info/konfluxinfo_customization_test.go
@@ -1259,12 +1259,15 @@ func TestKonfluxInfoClusterConfig(t *testing.T) {
 			Spec: konfluxv1alpha1.KonfluxInfoSpec{
 				ClusterConfig: &konfluxv1alpha1.ClusterConfig{
 					Data: &konfluxv1alpha1.ClusterConfigData{
-						AllowCacheProxy:             &allowCache,
-						HTTPProxy:                   "squid.caching.svc.cluster.local:3128",
-						NoProxy:                     &noProxy,
-						AllowPackageRegistryProxy:   &allowPkgRegistry,
-						PackageRegistryProxyNpmURL:  "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy",
-						PackageRegistryProxyYarnURL: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/yarn-proxy",
+						AllowCacheProxy:              &allowCache,
+						HTTPProxy:                    "squid.caching.svc.cluster.local:3128",
+						NoProxy:                      &noProxy,
+						AllowPackageRegistryProxy:    &allowPkgRegistry,
+						PackageRegistryProxyNpmURL:   "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy",
+						PackageRegistryProxyYarnURL:  "https://artifact-registry-proxy.caching.svc.cluster.local/repository/yarn-proxy",
+						PackageRegistryProxyGomodURL: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy",
+						PackageRegistryProxyPipURL:   "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple",
+						PackageRegistryProxyPnpmURL:  "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pnpm-proxy",
 					},
 				},
 			},
@@ -1298,6 +1301,9 @@ func TestKonfluxInfoClusterConfig(t *testing.T) {
 		g.Expect(clusterConfigMap.Data).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyAllowPackageRegistryProxy, "true"))
 		g.Expect(clusterConfigMap.Data).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyNpmURL, "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"))
 		g.Expect(clusterConfigMap.Data).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyYarnURL, "https://artifact-registry-proxy.caching.svc.cluster.local/repository/yarn-proxy"))
+		g.Expect(clusterConfigMap.Data).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyGomodURL, "https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy"))
+		g.Expect(clusterConfigMap.Data).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPipURL, "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple"))
+		g.Expect(clusterConfigMap.Data).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPnpmURL, "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pnpm-proxy"))
 	})
 
 	t.Run("should omit proxy keys from cluster-config ConfigMap when fields are nil/empty", func(t *testing.T) {
@@ -1345,6 +1351,9 @@ func TestKonfluxInfoClusterConfig(t *testing.T) {
 		g.Expect(clusterConfigMap.Data).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyAllowPackageRegistryProxy))
 		g.Expect(clusterConfigMap.Data).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyNpmURL))
 		g.Expect(clusterConfigMap.Data).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyYarnURL))
+		g.Expect(clusterConfigMap.Data).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyGomodURL))
+		g.Expect(clusterConfigMap.Data).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPipURL))
+		g.Expect(clusterConfigMap.Data).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPnpmURL))
 	})
 
 	t.Run("should write allow-cache-proxy as false when explicitly set to false", func(t *testing.T) {
@@ -1400,12 +1409,15 @@ func TestClusterConfigDataProxyFieldsIterator(t *testing.T) {
 		noProxy := ""
 
 		data := konfluxv1alpha1.ClusterConfigData{
-			AllowCacheProxy:             &allowCache,
-			HTTPProxy:                   "squid.caching.svc.cluster.local:3128",
-			NoProxy:                     &noProxy,
-			AllowPackageRegistryProxy:   &allowPkgRegistry,
-			PackageRegistryProxyNpmURL:  "https://npm-proxy.example.com",
-			PackageRegistryProxyYarnURL: "https://yarn-proxy.example.com",
+			AllowCacheProxy:              &allowCache,
+			HTTPProxy:                    "squid.caching.svc.cluster.local:3128",
+			NoProxy:                      &noProxy,
+			AllowPackageRegistryProxy:    &allowPkgRegistry,
+			PackageRegistryProxyNpmURL:   "https://npm-proxy.example.com",
+			PackageRegistryProxyYarnURL:  "https://yarn-proxy.example.com",
+			PackageRegistryProxyGomodURL: "https://gomod-proxy.example.com",
+			PackageRegistryProxyPipURL:   "https://pip-proxy.example.com",
+			PackageRegistryProxyPnpmURL:  "https://pnpm-proxy.example.com",
 		}
 
 		collected := make(map[string]string)
@@ -1419,6 +1431,9 @@ func TestClusterConfigDataProxyFieldsIterator(t *testing.T) {
 		g.Expect(collected).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyAllowPackageRegistryProxy, "true"))
 		g.Expect(collected).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyNpmURL, "https://npm-proxy.example.com"))
 		g.Expect(collected).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyYarnURL, "https://yarn-proxy.example.com"))
+		g.Expect(collected).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyGomodURL, "https://gomod-proxy.example.com"))
+		g.Expect(collected).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPipURL, "https://pip-proxy.example.com"))
+		g.Expect(collected).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPnpmURL, "https://pnpm-proxy.example.com"))
 	})
 
 	t.Run("should not yield proxy keys when fields are nil/empty", func(t *testing.T) {
@@ -1440,6 +1455,9 @@ func TestClusterConfigDataProxyFieldsIterator(t *testing.T) {
 		g.Expect(collected).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyAllowPackageRegistryProxy))
 		g.Expect(collected).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyNpmURL))
 		g.Expect(collected).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyYarnURL))
+		g.Expect(collected).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyGomodURL))
+		g.Expect(collected).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPipURL))
+		g.Expect(collected).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPnpmURL))
 	})
 
 	t.Run("should yield false for *bool set to false", func(t *testing.T) {


### PR DESCRIPTION
Add three missing package registry proxy URL fields to the KonfluxInfo ClusterConfig API to match what is deployed in staging/production environments via cluster-config.env:

- package-registry-proxy-gomod-url
- package-registry-proxy-pip-url
- package-registry-proxy-pnpm-url

These complement the existing npm and yarn proxy fields, enabling the operator to produce a complete cluster-config ConfigMap for all supported package ecosystems.


Assisted-by: Cursor + Opus 4.6