### PR TITLE
feat(KFLUXVNGD-1139): inject CONSOLE_URL_TASKLOG into integration-service deployment

### DIFF
--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
@@ -254,9 +254,11 @@ func applyIntegrationServiceDeploymentCustomizations(deployment *appsv1.Deployme
 // When not set in the CRD, the upstream integration-service defaults apply.
 func buildControllerManagerOverlay(spec *konfluxv1alpha1.ControllerManagerDeploymentSpec, consoleURL string, integrationSpec konfluxv1alpha1.KonfluxIntegrationServiceConfigSpec) *customization.PodOverlay {
 	consoleURLTemplate := ""
+	consoleURLTasklogTemplate := ""
 	if consoleURL != "" {
-		consoleURLTemplate = fmt.Sprintf("%s/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}",
-			strings.TrimSuffix(consoleURL, "/"))
+		base := strings.TrimSuffix(consoleURL, "/")
+		consoleURLTemplate = base + "/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}"
+		consoleURLTasklogTemplate = consoleURLTemplate + "/logs/{{ .TaskName }}"
 	}
 
 	replicas := int32(1)
@@ -271,6 +273,7 @@ func buildControllerManagerOverlay(spec *konfluxv1alpha1.ControllerManagerDeploy
 		customization.WithContainerOpts(managerContainerName, deployCtx,
 			customization.FromContainerSpec(managerSpec),
 			customization.WithEnvOverride("CONSOLE_URL", consoleURLTemplate),
+			customization.WithEnvOverride("CONSOLE_URL_TASKLOG", consoleURLTasklogTemplate),
 			customization.WithOptionalEnvOverride(envPipelineTimeout, integrationSpec.PipelineTimeout),
 			customization.WithOptionalEnvOverride(envTasksTimeout, integrationSpec.TasksTimeout),
 			customization.WithOptionalEnvOverride(envFinallyTimeout, integrationSpec.FinallyTimeout),

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_customization_test.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_customization_test.go
@@ -32,8 +32,9 @@ import (
 )
 
 const (
-	testConsoleURL         = "https://konflux.example.com"
-	testConsoleURLTemplate = "https://konflux.example.com/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}"
+	testConsoleURL                = "https://konflux.example.com"
+	testConsoleURLTemplate        = testConsoleURL + "/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}"
+	testConsoleURLTasklogTemplate = testConsoleURLTemplate + "/logs/{{ .TaskName }}"
 )
 
 // getIntegrationSnapshotGCCronJob returns a deep copy of the snapshot GC CronJob from the IntegrationService manifests.
@@ -590,6 +591,113 @@ func TestBuildControllerManagerOverlay_ConsoleURL(t *testing.T) {
 		envVar = findEnvVar(managerContainer.Env, "CONSOLE_URL")
 		g.Expect(envVar).NotTo(gomega.BeNil())
 		g.Expect(envVar.Value).To(gomega.Equal(testConsoleURLTemplate))
+	})
+}
+
+func TestBuildControllerManagerOverlay_ConsoleURLTasklog(t *testing.T) {
+	t.Run("injects CONSOLE_URL_TASKLOG when provided", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := &konfluxv1alpha1.ControllerManagerDeploymentSpec{}
+
+		deployment := getIntegrationServiceDeployment(t)
+		overlay := buildControllerManagerOverlay(spec, testConsoleURL, konfluxv1alpha1.KonfluxIntegrationServiceConfigSpec{})
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+
+		envVar := findEnvVar(managerContainer.Env, "CONSOLE_URL_TASKLOG")
+		g.Expect(envVar).NotTo(gomega.BeNil())
+		g.Expect(envVar.Value).To(gomega.Equal(testConsoleURLTasklogTemplate))
+	})
+
+	t.Run("injects CONSOLE_URL_TASKLOG when provided with nil spec", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		deployment := getIntegrationServiceDeployment(t)
+		overlay := buildControllerManagerOverlay(nil, testConsoleURL, konfluxv1alpha1.KonfluxIntegrationServiceConfigSpec{})
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+
+		envVar := findEnvVar(managerContainer.Env, "CONSOLE_URL_TASKLOG")
+		g.Expect(envVar).NotTo(gomega.BeNil())
+		g.Expect(envVar.Value).To(gomega.Equal(testConsoleURLTasklogTemplate))
+	})
+
+	t.Run("injects CONSOLE_URL_TASKLOG with empty value when URL not available", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		spec := &konfluxv1alpha1.ControllerManagerDeploymentSpec{}
+
+		deployment := getIntegrationServiceDeployment(t)
+		overlay := buildControllerManagerOverlay(spec, "", konfluxv1alpha1.KonfluxIntegrationServiceConfigSpec{})
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+
+		envVar := findEnvVar(managerContainer.Env, "CONSOLE_URL_TASKLOG")
+		g.Expect(envVar).NotTo(gomega.BeNil())
+		g.Expect(envVar.Value).To(gomega.Equal(""))
+	})
+
+	t.Run("system-provided CONSOLE_URL_TASKLOG overrides user-provided value", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		userTasklogURL := "https://user-override.example.com/logs"
+		spec := &konfluxv1alpha1.ControllerManagerDeploymentSpec{
+			Manager: &konfluxv1alpha1.ContainerSpec{
+				Env: []corev1.EnvVar{
+					{Name: "CONSOLE_URL_TASKLOG", Value: userTasklogURL},
+				},
+			},
+		}
+
+		deployment := getIntegrationServiceDeployment(t)
+		overlay := buildControllerManagerOverlay(spec, testConsoleURL, konfluxv1alpha1.KonfluxIntegrationServiceConfigSpec{})
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+
+		envVar := findEnvVar(managerContainer.Env, "CONSOLE_URL_TASKLOG")
+		g.Expect(envVar).NotTo(gomega.BeNil())
+		g.Expect(envVar.Value).To(gomega.Equal(testConsoleURLTasklogTemplate))
+	})
+
+	t.Run("updates CONSOLE_URL_TASKLOG when console URL changes", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		oldConsoleURL := "https://old.example.com"
+		oldTasklogTemplate := oldConsoleURL + "/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}/logs/{{ .TaskName }}"
+
+		spec := &konfluxv1alpha1.ControllerManagerDeploymentSpec{}
+
+		deployment := getIntegrationServiceDeployment(t)
+		overlay := buildControllerManagerOverlay(spec, oldConsoleURL, konfluxv1alpha1.KonfluxIntegrationServiceConfigSpec{})
+		err := overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer := testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+
+		envVar := findEnvVar(managerContainer.Env, "CONSOLE_URL_TASKLOG")
+		g.Expect(envVar).NotTo(gomega.BeNil())
+		g.Expect(envVar.Value).To(gomega.Equal(oldTasklogTemplate))
+
+		overlay = buildControllerManagerOverlay(spec, testConsoleURL, konfluxv1alpha1.KonfluxIntegrationServiceConfigSpec{})
+		err = overlay.ApplyToDeployment(deployment)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerContainer = testutil.FindContainer(deployment.Spec.Template.Spec.Containers, managerContainerName)
+		g.Expect(managerContainer).NotTo(gomega.BeNil())
+
+		envVar = findEnvVar(managerContainer.Env, "CONSOLE_URL_TASKLOG")
+		g.Expect(envVar).NotTo(gomega.BeNil())
+		g.Expect(envVar.Value).To(gomega.Equal(testConsoleURLTasklogTemplate))
 	})
 }
 


### PR DESCRIPTION
The upstream integration-service reads CONSOLE_URL_TASKLOG from its environment to generate per-task log links in GitHub/GitLab check run reports. Without it, links render as
"https://CONSOLE_URL_TASKLOG_NOT_AVAILABLE".

Derive the value from the same KonfluxUI ingress URL already used for CONSOLE_URL, appending "/logs/{{ .TaskName }}" to the pipelinerun path.

Assisted-by: Cursor + Opus 4.6