### PR TITLE
feat(KFLUXVNGD-1156): add imageProxy field to info.json on OpenShift

### DIFF
--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -155,16 +155,11 @@ rules:
   - config.openshift.io
   resources:
   - clusterversions
+  - ingresses
   verbs:
   - get
   - list
   - watch
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - ingresses
-  verbs:
-  - get
 - apiGroups:
   - console.openshift.io
   resources:

--- a/operator/internal/controller/info/konfluxinfo_controller.go
+++ b/operator/internal/controller/info/konfluxinfo_controller.go
@@ -47,6 +47,7 @@ import (
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/predicate"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/ingress"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/version"
@@ -147,6 +148,7 @@ type KonfluxInfoReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=ingresses,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -286,13 +288,19 @@ func (r *KonfluxInfoReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}).
 		WatchesRawSource(channelSource)
 
-	// Conditionally watch ClusterVersion only on OpenShift
+	// Conditionally watch OpenShift resources only on OpenShift
 	if r.ClusterInfo != nil && r.ClusterInfo.IsOpenShift() {
-		controllerBuilder = controllerBuilder.Watches(
-			&configv1.ClusterVersion{},
-			handler.EnqueueRequestsFromMapFunc(r.enqueueKonfluxInfoForVersionChange),
-			builder.WithPredicates(ctrlpredicate.ResourceVersionChangedPredicate{}),
-		)
+		controllerBuilder = controllerBuilder.
+			Watches(
+				&configv1.ClusterVersion{},
+				handler.EnqueueRequestsFromMapFunc(r.enqueueKonfluxInfoForVersionChange),
+				builder.WithPredicates(ctrlpredicate.ResourceVersionChangedPredicate{}),
+			).
+			Watches(
+				&configv1.Ingress{},
+				handler.EnqueueRequestsFromMapFunc(r.enqueueKonfluxInfoForVersionChange),
+				builder.WithPredicates(ctrlpredicate.ResourceVersionChangedPredicate{}),
+			)
 	}
 
 	return controllerBuilder.Complete(r)
@@ -301,8 +309,9 @@ func (r *KonfluxInfoReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // generateInfoJSON generates info.json content from PublicInfo.
 // Provides defaults if fields are missing. k8sVersion is the current cluster Kubernetes version (non-cached).
 // clusterId is the stable cluster identifier (OpenShift ClusterVersion UID or kube-system namespace UID).
-func (r *KonfluxInfoReconciler) generateInfoJSON(config *konfluxv1alpha1.PublicInfo, k8sVersion, openShiftVersion, clusterId string) ([]byte, error) {
-	info := r.applyInfoDefaults(config, k8sVersion, openShiftVersion, clusterId)
+// ingressDomain is the OpenShift ingress domain used to construct the imageProxy URL (empty on non-OpenShift).
+func (r *KonfluxInfoReconciler) generateInfoJSON(config *konfluxv1alpha1.PublicInfo, k8sVersion, openShiftVersion, clusterId, ingressDomain string) ([]byte, error) {
+	info := r.applyInfoDefaults(config, k8sVersion, openShiftVersion, clusterId, ingressDomain)
 	var buf bytes.Buffer
 	encoder := json.NewEncoder(&buf)
 	encoder.SetEscapeHTML(false)
@@ -315,7 +324,8 @@ func (r *KonfluxInfoReconciler) generateInfoJSON(config *konfluxv1alpha1.PublicI
 }
 
 // applyInfoDefaults applies default values to PublicInfo if not specified.
-func (r *KonfluxInfoReconciler) applyInfoDefaults(config *konfluxv1alpha1.PublicInfo, k8sVersion, openShiftVersion, clusterId string) *infoJSON {
+// ingressDomain is the OpenShift ingress domain used to construct the imageProxy URL (empty on non-OpenShift).
+func (r *KonfluxInfoReconciler) applyInfoDefaults(config *konfluxv1alpha1.PublicInfo, k8sVersion, openShiftVersion, clusterId, ingressDomain string) *infoJSON {
 	info := &infoJSON{
 		Environment:       "development",
 		Visibility:        "public",
@@ -324,6 +334,15 @@ func (r *KonfluxInfoReconciler) applyInfoDefaults(config *konfluxv1alpha1.Public
 		KubernetesVersion: k8sVersion,
 		OpenShiftVersion:  openShiftVersion,
 		RBAC:              getDefaultRBACRoles(),
+	}
+
+	if ingressDomain != "" {
+		// The image-rbac-proxy Route is created externally with a custom hostname
+		// (not the standard <name>-<namespace>.<domain> OpenShift Route convention).
+		info.ImageProxy = &imageProxyJSON{
+			URL:       fmt.Sprintf("https://image-rbac-proxy.%s", ingressDomain),
+			OAuthPath: "/oauth",
+		}
 	}
 
 	if config == nil {
@@ -370,6 +389,7 @@ func (r *KonfluxInfoReconciler) reconcileInfoConfigMap(ctx context.Context, tc *
 	k8sVersion := ""
 	openShiftVersion := ""
 	clusterId := ""
+	ingressDomain := ""
 	if r.ClusterInfo != nil {
 		if v, err := r.ClusterInfo.K8sVersion(); err == nil && v != nil {
 			k8sVersion = v.GitVersion
@@ -384,6 +404,10 @@ func (r *KonfluxInfoReconciler) reconcileInfoConfigMap(ctx context.Context, tc *
 			if err != nil {
 				return fmt.Errorf("failed to get OpenShift cluster ID: %w", err)
 			}
+			ingressDomain, err = ingress.GetOpenShiftIngressDomain(ctx, r.Client)
+			if err != nil {
+				log.Info("Failed to get OpenShift ingress domain, imageProxy will not be set", "error", err)
+			}
 		} else {
 			var err error
 			clusterId, err = clusterinfo.GetKubeSystemUID(ctx, r.Client)
@@ -396,12 +420,12 @@ func (r *KonfluxInfoReconciler) reconcileInfoConfigMap(ctx context.Context, tc *
 	var infoJSON []byte
 	var err error
 	if info.Spec.PublicInfo != nil {
-		infoJSON, err = r.generateInfoJSON(info.Spec.PublicInfo, k8sVersion, openShiftVersion, clusterId)
+		infoJSON, err = r.generateInfoJSON(info.Spec.PublicInfo, k8sVersion, openShiftVersion, clusterId, ingressDomain)
 		if err != nil {
 			return fmt.Errorf("failed to generate info.json: %w", err)
 		}
 	} else {
-		infoJSON, err = r.generateInfoJSON(nil, k8sVersion, openShiftVersion, clusterId)
+		infoJSON, err = r.generateInfoJSON(nil, k8sVersion, openShiftVersion, clusterId, ingressDomain)
 		if err != nil {
 			return fmt.Errorf("failed to generate default info.json: %w", err)
 		}
@@ -501,9 +525,15 @@ type infoJSON struct {
 	KonfluxVersion    string                              `json:"konfluxVersion,omitempty"`
 	KubernetesVersion string                              `json:"kubernetesVersion,omitempty"`
 	OpenShiftVersion  string                              `json:"openshiftVersion,omitempty"`
+	ImageProxy        *imageProxyJSON                     `json:"imageProxy,omitempty"`
 	Integrations      *konfluxv1alpha1.IntegrationsConfig `json:"integrations,omitempty"`
 	StatusPageUrl     string                              `json:"statusPageUrl,omitempty"`
 	RBAC              []rbacRoleJSON                      `json:"rbac,omitempty"`
+}
+
+type imageProxyJSON struct {
+	URL       string `json:"url"`
+	OAuthPath string `json:"oauthPath"`
 }
 
 type rbacRoleJSON struct {

--- a/operator/internal/controller/info/konfluxinfo_controller_test.go
+++ b/operator/internal/controller/info/konfluxinfo_controller_test.go
@@ -25,6 +25,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -547,6 +548,178 @@ var _ = Describe("KonfluxInfo Controller", func() {
 				g.Expect(info["kubernetesVersion"]).To(Equal("v1.29.0"))
 				g.Expect(info["openshiftVersion"]).To(Equal("4.15.0"))
 				g.Expect(info["clusterId"]).To(Equal("test-cluster-id-12345"))
+				g.Expect(info).NotTo(HaveKey("imageProxy"), "imageProxy should be absent when no Ingress config exists")
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+	})
+
+	Context("OpenShift imageProxy", func() {
+		It("should not include imageProxy in info.json without ClusterInfo", func(ctx context.Context) {
+			startManager(nil)
+
+			cr := &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			cmNN := types.NamespacedName{Name: infoConfigMapName, Namespace: infoNamespace}
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+				g.Expect(cm.Data).To(HaveKey("info.json"))
+
+				var info map[string]interface{}
+				g.Expect(json.Unmarshal([]byte(cm.Data["info.json"]), &info)).To(Succeed())
+				g.Expect(info).NotTo(HaveKey("imageProxy"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("should include imageProxy in info.json on OpenShift when ingress domain is available", func(ctx context.Context) {
+			By("building OpenShift cluster info")
+			mockDiscovery := &MockDiscoveryClient{
+				resources: map[string]*metav1.APIResourceList{
+					"config.openshift.io/v1": {
+						APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}},
+					},
+				},
+			}
+			mockDiscovery.SetVersion("v1.29.0")
+			openShiftClusterInfo, err := clusterinfo.DetectWithClient(mockDiscovery)
+			Expect(err).NotTo(HaveOccurred())
+
+			startManager(openShiftClusterInfo)
+
+			By("creating the OpenShift Ingress config")
+			ingressConfig := &configv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.IngressSpec{
+					Domain: "apps.test-cluster.example.com",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ingressConfig)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, ingressConfig)
+
+			By("creating the ClusterVersion resource")
+			clusterVersion := &configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{Name: "version"},
+				Spec: configv1.ClusterVersionSpec{
+					ClusterID: "test-cluster-id",
+				},
+			}
+			Expect(k8sClient.Create(ctx, clusterVersion)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, clusterVersion)
+
+			clusterVersion.Status = configv1.ClusterVersionStatus{
+				History: []configv1.UpdateHistory{
+					{State: configv1.CompletedUpdate, Version: "4.15.0", StartedTime: metav1.Now()},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, clusterVersion)).To(Succeed())
+
+			By("creating the KonfluxInfo CR")
+			cr := &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			By("verifying info.json contains imageProxy")
+			cmNN := types.NamespacedName{Name: infoConfigMapName, Namespace: infoNamespace}
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+				g.Expect(cm.Data).To(HaveKey("info.json"))
+
+				var info map[string]interface{}
+				g.Expect(json.Unmarshal([]byte(cm.Data["info.json"]), &info)).To(Succeed())
+
+				imageProxy, ok := info["imageProxy"].(map[string]interface{})
+				g.Expect(ok).To(BeTrue(), "imageProxy should be present in info.json")
+				g.Expect(imageProxy["url"]).To(Equal("https://image-rbac-proxy.apps.test-cluster.example.com"))
+				g.Expect(imageProxy["oauthPath"]).To(Equal("/oauth"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("should add imageProxy after Ingress config is created (watch triggers re-reconcile)", func(ctx context.Context) {
+			By("building OpenShift cluster info")
+			mockDiscovery := &MockDiscoveryClient{
+				resources: map[string]*metav1.APIResourceList{
+					"config.openshift.io/v1": {
+						APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}},
+					},
+				},
+			}
+			mockDiscovery.SetVersion("v1.29.0")
+			openShiftClusterInfo, err := clusterinfo.DetectWithClient(mockDiscovery)
+			Expect(err).NotTo(HaveOccurred())
+
+			startManager(openShiftClusterInfo)
+
+			By("creating the ClusterVersion resource (no Ingress config yet)")
+			clusterVersion := &configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{Name: "version"},
+				Spec: configv1.ClusterVersionSpec{
+					ClusterID: "test-cluster-id",
+				},
+			}
+			Expect(k8sClient.Create(ctx, clusterVersion)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, clusterVersion)
+
+			clusterVersion.Status = configv1.ClusterVersionStatus{
+				History: []configv1.UpdateHistory{
+					{State: configv1.CompletedUpdate, Version: "4.15.0", StartedTime: metav1.Now()},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, clusterVersion)).To(Succeed())
+
+			By("verifying Ingress 'cluster' does not exist (precondition)")
+			ingressCheck := &configv1.Ingress{}
+			Expect(apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: "cluster"}, ingressCheck))).
+				To(BeTrue(), "Ingress 'cluster' should not exist at this point")
+
+			By("creating the KonfluxInfo CR")
+			cr := &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, cr)
+
+			cmNN := types.NamespacedName{Name: infoConfigMapName, Namespace: infoNamespace}
+
+			By("verifying info.json has no imageProxy (Ingress config does not exist)")
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+				g.Expect(cm.Data).To(HaveKey("info.json"))
+
+				var info map[string]interface{}
+				g.Expect(json.Unmarshal([]byte(cm.Data["info.json"]), &info)).To(Succeed())
+				g.Expect(info).NotTo(HaveKey("imageProxy"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("creating the OpenShift Ingress config (triggers watch)")
+			ingressConfig := &configv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.IngressSpec{
+					Domain: "apps.late-cluster.example.com",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ingressConfig)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, ingressConfig)
+
+			By("verifying imageProxy appears after Ingress config is created")
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, cmNN, cm)).To(Succeed())
+
+				var info map[string]interface{}
+				g.Expect(json.Unmarshal([]byte(cm.Data["info.json"]), &info)).To(Succeed())
+
+				imageProxy, ok := info["imageProxy"].(map[string]interface{})
+				g.Expect(ok).To(BeTrue(), "imageProxy should appear after Ingress config is created")
+				g.Expect(imageProxy["url"]).To(Equal("https://image-rbac-proxy.apps.late-cluster.example.com"))
+				g.Expect(imageProxy["oauthPath"]).To(Equal("/oauth"))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})

--- a/operator/internal/controller/info/konfluxinfo_customization_test.go
+++ b/operator/internal/controller/info/konfluxinfo_customization_test.go
@@ -650,13 +650,13 @@ func TestApplyInfoDefaultsClusterId(t *testing.T) {
 
 	t.Run("should include clusterId when provided", func(t *testing.T) {
 		g := gomega.NewWithT(t)
-		info := r.applyInfoDefaults(nil, "v1.29.0", "", "test-cluster-id-123")
+		info := r.applyInfoDefaults(nil, "v1.29.0", "", "test-cluster-id-123", "")
 		g.Expect(info.ClusterId).To(gomega.Equal("test-cluster-id-123"))
 	})
 
 	t.Run("should omit clusterId when empty", func(t *testing.T) {
 		g := gomega.NewWithT(t)
-		info := r.applyInfoDefaults(nil, "v1.29.0", "", "")
+		info := r.applyInfoDefaults(nil, "v1.29.0", "", "", "")
 		g.Expect(info.ClusterId).To(gomega.BeEmpty())
 
 		jsonBytes, err := json.Marshal(info)
@@ -666,13 +666,50 @@ func TestApplyInfoDefaultsClusterId(t *testing.T) {
 
 	t.Run("should serialize clusterId in JSON output", func(t *testing.T) {
 		g := gomega.NewWithT(t)
-		jsonBytes, err := r.generateInfoJSON(nil, "v1.29.0", "", "my-cluster-uid")
+		jsonBytes, err := r.generateInfoJSON(nil, "v1.29.0", "", "my-cluster-uid", "")
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		var data map[string]interface{}
 		err = json.Unmarshal(jsonBytes, &data)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(data["clusterId"]).To(gomega.Equal("my-cluster-uid"))
+	})
+}
+
+func TestApplyInfoDefaultsImageProxy(t *testing.T) {
+	r := &KonfluxInfoReconciler{}
+
+	t.Run("should include imageProxy when ingressDomain is provided", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		info := r.applyInfoDefaults(nil, "v1.29.0", "4.15.0", "", "apps.stone-stage-p01.example.com")
+		g.Expect(info.ImageProxy).NotTo(gomega.BeNil())
+		g.Expect(info.ImageProxy.URL).To(gomega.Equal("https://image-rbac-proxy.apps.stone-stage-p01.example.com"))
+		g.Expect(info.ImageProxy.OAuthPath).To(gomega.Equal("/oauth"))
+	})
+
+	t.Run("should omit imageProxy when ingressDomain is empty", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		info := r.applyInfoDefaults(nil, "v1.29.0", "", "", "")
+		g.Expect(info.ImageProxy).To(gomega.BeNil())
+
+		jsonBytes, err := json.Marshal(info)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(string(jsonBytes)).NotTo(gomega.ContainSubstring("imageProxy"))
+	})
+
+	t.Run("should serialize imageProxy in JSON output", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		jsonBytes, err := r.generateInfoJSON(nil, "v1.29.0", "4.15.0", "", "apps.example.com")
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		var data map[string]interface{}
+		err = json.Unmarshal(jsonBytes, &data)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		imageProxy, ok := data["imageProxy"].(map[string]interface{})
+		g.Expect(ok).To(gomega.BeTrue())
+		g.Expect(imageProxy["url"]).To(gomega.Equal("https://image-rbac-proxy.apps.example.com"))
+		g.Expect(imageProxy["oauthPath"]).To(gomega.Equal("/oauth"))
 	})
 }
 
@@ -752,7 +789,7 @@ func TestGenerateInfoJSONDoesNotEscapeAngleBrackets(t *testing.T) {
 			},
 		}
 
-		jsonBytes, err := r.generateInfoJSON(config, "v1.29.0", "", "")
+		jsonBytes, err := r.generateInfoJSON(config, "v1.29.0", "", "", "")
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		jsonStr := string(jsonBytes)
@@ -768,7 +805,7 @@ func TestGenerateInfoJSONDoesNotEscapeAngleBrackets(t *testing.T) {
 			StatusPageUrl: "https://status.example.com/<org>",
 		}
 
-		jsonBytes, err := r.generateInfoJSON(config, "v1.29.0", "", "")
+		jsonBytes, err := r.generateInfoJSON(config, "v1.29.0", "", "", "")
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		jsonStr := string(jsonBytes)


### PR DESCRIPTION
Dynamically populate the imageProxy field in the info.json ConfigMap on OpenShift clusters. The URL is derived from the cluster's ingress domain (config.openshift.io/v1 Ingress) as
https://image-rbac-proxy.<ingressDomain>, with oauthPath hardcoded to /oauth. The image-rbac-proxy Route is created externally; the operator only advertises the URL.

On non-OpenShift clusters the field is omitted. If the ingress domain cannot be fetched, the field is omitted gracefully with a log warning.

No new CRD field is introduced — the value is entirely derived from cluster state.

Assisted-by: Cursor + Opus 4.6