### PR TITLE
chore(ui): switch oauth2-proxy image to Red Hat registry

### DIFF
--- a/operator/pkg/manifests/ui/manifests.yaml
+++ b/operator/pkg/manifests/ui/manifests.yaml
@@ -644,7 +644,7 @@ spec:
             secretKeyRef:
               key: cookie-secret
               name: oauth2-proxy-cookie-secret
-        image: quay.io/konflux-ci/oauth2-proxy@sha256:a1c514b5c2f692e756cea983f0df077934d0db748063a30e111c00a899412ee2
+        image: registry.access.redhat.com/hi/oauth2-proxy@sha256:196e86328f01ebd2d538dda15462b2070d06c03e8e5158b872e2bf712b7e7293
         name: oauth2-proxy
         ports:
         - containerPort: 6000

--- a/operator/upstream-kustomizations/ui/core/proxy/kustomization.yaml
+++ b/operator/upstream-kustomizations/ui/core/proxy/kustomization.yaml
@@ -16,9 +16,9 @@ images:
 - digest: sha256:5caf7bab8d7a0f3cc42ed8762128958debf0bf8d15382efc085764ae28bbda21
   name: quay.io/konflux-ci/konflux-ui
   newName: quay.io/konflux-ci/konflux-ui
-- digest: sha256:a1c514b5c2f692e756cea983f0df077934d0db748063a30e111c00a899412ee2
-  name: quay.io/konflux-ci/oauth2-proxy
-  newName: quay.io/konflux-ci/oauth2-proxy
+- digest: sha256:196e86328f01ebd2d538dda15462b2070d06c03e8e5158b872e2bf712b7e7293
+  name: registry.access.redhat.com/hi/oauth2-proxy
+  newName: registry.access.redhat.com/hi/oauth2-proxy
 - digest: sha256:2c83fa6da4ec297e6e324fcc4107b58639621131fa76b590d85cc1f91376962d
   name: quay.io/konflux-ci/reverse-proxy
   newName: quay.io/konflux-ci/reverse-proxy

--- a/operator/upstream-kustomizations/ui/core/proxy/proxy.yaml
+++ b/operator/upstream-kustomizations/ui/core/proxy/proxy.yaml
@@ -161,7 +161,7 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-      - image: quay.io/konflux-ci/oauth2-proxy@sha256:latest
+      - image: registry.access.redhat.com/hi/oauth2-proxy
         name: oauth2-proxy
         env:
         - name: OAUTH2_PROXY_CLIENT_SECRET


### PR DESCRIPTION
## Summary
- Switch the oauth2-proxy container image from `quay.io/konflux-ci/oauth2-proxy` to `registry.access.redhat.com/hi/oauth2-proxy`, pinned by digest
- Update the kustomize `images` section and rebuild rendered manifests
- Renovate will auto-update the digest (`registry.access.redhat.com/*` is already covered by the automerge rule)

## Test plan
- [ ] Verify kube-linter passes on rendered manifests
- [ ] Confirm operator e2e tests pass with the new image

Made with [Cursor](https://cursor.com)