### PR TITLE
chore(#8132): remove infra deployments from docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ PRs trigger the following workflows:
 
 ## PR Guidelines
 
+- **Human-authored PR review:** Apply **pr-review** (`skills/pr-review/SKILL.md`) — at minimum run its upstream/downstream hygiene check so named consumers are not reintroduced.
 - **Go / `go.mod` PRs:** Apply **go-toolchain-upgrade** (`skills/go-toolchain-upgrade/SKILL.md`) and follow its triage table—do not summarize the workflow from memory.
 - **MintMaker/Renovate parent or companion PRs:** Apply **companion-pr-review** (`skills/companion-pr-review/SKILL.md`) — skip review on companion-eligible parents; review companions lightly.
 - **`.tekton` task/pipeline edits:** `pipeline.yaml` tasks `deploy-konflux-its` and `konflux-e2e-tests-its` hardcode `taskRef.revision: main`. To verify changes, temporarily point both at the PR’s git ref, run operator E2E, then restore `main` before merge (see `.tekton/pipelines/operator-e2e/README.md`).
@@ -152,6 +153,7 @@ Detailed guides live in `skills/` — each subdirectory contains a `SKILL.md` wi
 |-------|----------|
 | [ginkgo-testing](skills/ginkgo-testing/SKILL.md) | Writing or reviewing Ginkgo tests — cleanup patterns, soft assertions |
 | [go-toolchain-upgrade](skills/go-toolchain-upgrade/SKILL.md) | `go.mod`/`go.sum`, Go pins, or `go.mod requires go` CI failures |
+| [pr-review](skills/pr-review/SKILL.md) | Reviewing human-authored PRs — upstream/downstream hygiene and related checks |
 | [create-pr](skills/create-pr/SKILL.md) | Opening PRs, fork `/allow` behavior |
 | [debug-e2e-tests](skills/debug-e2e-tests/SKILL.md) | Triaging or investigating failed e2e / OpenShift CI runs |
 | [update-upstream-deps](skills/update-upstream-deps/SKILL.md) | Bumping upstream SHAs or editing `upstream-kustomizations/` (triggers manifest rebuild) |

--- a/dependencies/kyverno/kyverno-rbac.yaml
+++ b/dependencies/kyverno/kyverno-rbac.yaml
@@ -1,5 +1,4 @@
-# Copied from https://github.com/redhat-appstudio/infra-deployments/tree/da73b82a53bf491f178c06d87c1071d712f64105/components/policies/development/integration/bootstrap-namespace
-# and added rule for managing secrets.
+# Aggregated Kyverno ClusterRole for bootstrap-namespace resources (serviceaccounts, rolebindings).
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/operator/upstream-kustomizations/integration/core/konflux-integration-runner.yaml
+++ b/operator/upstream-kustomizations/integration/core/konflux-integration-runner.yaml
@@ -1,5 +1,5 @@
 ---
-# Based on https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/konflux-rbac/base/konflux-integration-runner.yaml
+# ClusterRole for the konflux-integration-runner service account.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/skills/go-toolchain-upgrade/SKILL.md
+++ b/skills/go-toolchain-upgrade/SKILL.md
@@ -31,7 +31,7 @@ Patch within same minor (1.26.0→1.26.1) = **Routine** unless other signals app
 
 ```markdown
 **Go toolchain (routine):** Dependency-only update; minimum Go unchanged. No
-openshift/release or infra-deployments image changes expected. In-repo CI suffices.
+openshift/release or external-consumer image changes expected. In-repo CI suffices.
 ```
 
 Do not request **Go toolchain impact**, parallel PRs, or local `make test`/`make lint`.
@@ -45,7 +45,7 @@ Do not ask the author to run them locally. Prow-only paths (`deploy-konflux-on-o
 **Author must identify** (link PRs; external repos may have no agent skills):
 
 - openshift/release — `build_root` / golang tags for konflux-ci jobs; rehearse OpenShift e2e
-- infra-deployments / legacy — `e2e-test-runner` if `test/go-tests` minimum Go rose
+- legacy / external consumers — `e2e-test-runner` if `test/go-tests` minimum Go rose
 - `.github/workflows` / `.tekton/` only if this PR changes Go or builder pins there
 
 Paths, PR body template, grep: [reference.md](reference.md). On significant PRs,

--- a/skills/go-toolchain-upgrade/reference.md
+++ b/skills/go-toolchain-upgrade/reference.md
@@ -36,11 +36,15 @@ cd openshift/release
 make ci-operator-prowgen WHAT='--config-dir ci-operator/config/konflux-ci/konflux-ci'
 ```
 
-## openshift/release — infra-deployments & legacy
+## openshift/release — legacy / external consumers
+
+External deployment repos and legacy App Studio jobs may still run conformance
+against this repo's `test/go-tests`. When the Go minimum rises, check their
+Prow configs and the shared runner image.
 
 | Area | Notes |
 |------|--------|
-| `ci-operator/config/redhat-appstudio/infra-deployments/redhat-appstudio-infra-deployments-main.yaml` | `appstudio-e2e-tests`; `e2e-test-runner` → `redhat-appstudio/ci` |
+| External deployment-repo Prow configs that run `appstudio-e2e-tests` | `e2e-test-runner` → `redhat-appstudio/ci` |
 | `ci-operator/step-registry/redhat-appstudio/conformance-tests/` | `from: e2e-test-runner` |
 | `ci-operator/step-registry/konflux-ci/install-konflux/` | `from: e2e-test-runner` |
 | `ci-operator/config/konflux-ci/e2e-tests/konflux-ci-e2e-tests-main.yaml` | builds/promotes `e2e-test-runner` |
@@ -49,10 +53,11 @@ make ci-operator-prowgen WHAT='--config-dir ci-operator/config/konflux-ci/konflu
 
 Rebuild when `test/go-tests` minimum Go rises—image is `redhat-appstudio/ci:e2e-test-runner`.
 
-## infra-deployments docs
+## External consumer docs
 
-- `components/konflux-operator/ci/openshift-overlay-e2e/README.md` — overlay step images
-- `docs/temp/operator-overlay-openshift-ci-e2e-notes.md` — `e2e-test-runner` vs `from: src`
+Some external deployment repos document operator-overlay CI images and when to
+use `e2e-test-runner` vs `from: src`. Consult those when Go bumps affect the
+runner image or overlay steps.
 
 Legacy `appstudio-e2e-tests`: `konflux-ci-install-konflux` + `redhat-appstudio-conformance-tests`.
 
@@ -66,7 +71,7 @@ Legacy `appstudio-e2e-tests`: `konflux-ci-install-konflux` + `redhat-appstudio-c
 ### openshift/release
 - [ ] build_root / golang tags:
 - [ ] Rehearse e2e:
-### infra-deployments / legacy
+### Legacy / external consumers
 - [ ] e2e-test-runner / overlay images:
 ### Merge order
 ```
@@ -78,7 +83,7 @@ Use **`rg`** ([ripgrep](https://github.com/BurntSushi/ripgrep)) or `grep -r` fro
 ```bash
 # openshift/release
 rg 'golang-1\.' ci-operator/config/konflux-ci/
-rg 'golang-1\.' ci-operator/config/redhat-appstudio/infra-deployments/
+rg 'golang-1\.' ci-operator/config/redhat-appstudio/
 rg 'e2e-test-runner|build_root' ci-operator/config/konflux-ci/konflux-ci/
 rg 'from: e2e-test-runner|from: src' ci-operator/step-registry/konflux-ci/
 rg 'from: e2e-test-runner' ci-operator/step-registry/redhat-appstudio/
@@ -94,4 +99,4 @@ rg 'GOTOOLCHAIN|golang|go version' deploy-konflux-on-ocp.sh test/e2e/run-e2e.sh 
 |-----|----------------|
 | `go.mod requires go >= 1.26` / `running go 1.25` | Stale Prow `build_root` or runner |
 | `GOTOOLCHAIN=auto` but env is `local` | RHEL builder; bump image |
-| infra-deployments conformance only fails | Stale `e2e-test-runner` |
+| External / legacy conformance only fails | Stale `e2e-test-runner` |

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: pr-review
+description: >-
+  Use when reviewing pull requests in konflux-ci/konflux-ci. Covers
+  upstream/downstream hygiene and other repo-wide review checks that are easy
+  to miss in a focused feature review.
+---
+
+# PR Review
+
+Apply these checks on human-authored PRs (skip companion-eligible MintMaker/Renovate
+parents — see [companion-pr-review](../companion-pr-review/SKILL.md)).
+
+## Upstream / downstream hygiene
+
+This repo is upstream. Diffs must not name specific downstream consumers.
+
+```bash
+# Flag only occurrences introduced by this PR (covers .github/, .tekton/, etc.).
+# Allow AGENTS.md and this skill (they document the ban by example).
+git diff origin/main...HEAD -- . ':!AGENTS.md' ':!skills/pr-review/**' \
+  | rg -n '^\+.*infra-deployments'
+```
+
+If that prints matches:
+
+- **Request changes** — replace with generic phrasing ("in some environments",
+  "by external policies", "legacy / external consumers") that still flags
+  possible downstream impact without naming a consumer.
+- Do **not** accept "based on" / "copied from" comments that link a named
+  downstream repo.
+
+Also flag other named consumer repos or internal deployment URLs introduced
+without a clear upstream need.
+
+## Also apply when relevant
+
+| Diff touches | Skill / rule |
+|--------------|--------------|
+| `go.mod` / Go pins | [go-toolchain-upgrade](../go-toolchain-upgrade/SKILL.md) |
+| MintMaker/Renovate companion flow | [companion-pr-review](../companion-pr-review/SKILL.md) |
+| Ginkgo tests | [ginkgo-testing](../ginkgo-testing/SKILL.md) |
+| `operator/upstream-kustomizations/` | Rebuild manifests; [update-upstream-deps](../update-upstream-deps/SKILL.md) |


### PR DESCRIPTION
Some mentions of downstream infra-deployments slipped into the repo over time. This change removes them (some code changes are done elsewhere).

Assisted-by: Cursor

Closes: #8132