### PR TITLE
feat: Make konflux-ci release version configurable

### DIFF
--- a/scripts/deploy-local.env.template
+++ b/scripts/deploy-local.env.template
@@ -58,6 +58,13 @@ OPERATOR_IMAGE=""
 # See operator/config/samples/ for available configurations.
 # KONFLUX_CR=""
 
+# Release version used in conjunction with 'release' operator installation method
+# to construct Konflux CI release installation URL.
+# The version must be present in the GitHub releases.
+# For example, set 'v0.2.2-rc.9' in order to install konflux-ci from this version.
+# If version is omitted, the release installation URL points to the latest release.
+RELEASE_VERSION=""
+
 # ==============================================================================
 # Infrastructure Configuration (for Kind cluster setup)
 # ==============================================================================

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -80,6 +80,7 @@ ENABLE_IMAGE_CACHE="${ENABLE_IMAGE_CACHE:-0}"
 OPERATOR_INSTALL_METHOD="${OPERATOR_INSTALL_METHOD:-release}"
 OPERATOR_IMAGE="${OPERATOR_IMAGE:-quay.io/konflux-ci/konflux-operator:latest}"
 SKIP_SECRETS="${SKIP_SECRETS:-false}"
+RELEASE_VERSION="${RELEASE_VERSION:-latest}"
 
 # Export variables for child scripts
 export KIND_CLUSTER KIND_MEMORY_GB PODMAN_MACHINE_NAME REGISTRY_HOST_PORT ENABLE_REGISTRY_PORT
@@ -192,7 +193,11 @@ case "${INSTALL_METHOD}" in
 
     release)
         echo "Installing from latest GitHub release..."
-        RELEASE_URL="https://github.com/konflux-ci/konflux-ci/releases/latest/download/install.yaml"
+        if [ "$RELEASE_VERSION" == "latest" ]; then
+            RELEASE_URL="https://github.com/konflux-ci/konflux-ci/releases/latest/download/install.yaml"
+        else
+            RELEASE_URL="https://github.com/konflux-ci/konflux-ci/releases/download/${RELEASE_VERSION}/install.yaml"
+        fi
         echo "Downloading: ${RELEASE_URL}"
         kubectl apply -f "${RELEASE_URL}"
         ;;


### PR DESCRIPTION
If konflux-ci operator install method is 'release', the release URL always points to the latest. This does not work for installation from an alternative version rather than the latest, e.g. v0.2.2-rc.9 or even an older version. The mismatch version may cause compatibility issue.

Here is an example, checkout to version (tag) v0.2.2-rc.9 and deploy a local instance, then the latest version of konflux-ci operator is installed, then the following error is reported:

```
Konflux in version "v1alpha1" cannot be handled as a Konflux: strict decoding error: unknown field
"spec.buildService.spec.pacWebhookInsecureSSL"
```

The expectation is the matched version is installed.

This commit introduces an optional environment variable `RELEASE_VERSION`. Installing the latest is still the default behavior. A specific version can be assigned on-demand.