### PR TITLE
scripts: add Minikube as an alternative local deployment driver

### DIFF
--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -3,18 +3,19 @@
 # Deploy Konflux for Local Development
 #
 # This script provides a one-command local development deployment of Konflux
-# on a Kind cluster. It's designed for LOCAL DEVELOPMENT CONVENIENCE ONLY.
+# on a Kind or Minikube cluster. It's designed for LOCAL DEVELOPMENT
+# CONVENIENCE ONLY.
 #
 # For production deployments on real clusters, see docs/operator-deployment.md
 #
 # What this script does:
-#  1. Creates a Kind cluster with proper configuration
+#  1. Creates a Kind/Minikube cluster with proper configuration
 #  2. Deploys the Konflux operator
 #  3. Applies a Konflux CR configuration
 #  4. Creates secrets for GitHub integration
 #
 # Prerequisites:
-#  - kind, kubectl, podman (or docker)
+#  - kind or minikube, kubectl, podman/docker
 #  - kustomize (only for 'local' install method)
 #  - Configuration file: scripts/deploy-local.env
 #
@@ -27,6 +28,9 @@
 #   cp scripts/deploy-local.env.template scripts/deploy-local.env
 #   # Edit deploy-local.env with your secrets
 #   ./scripts/deploy-local.sh
+#
+# For Minikube instead of Kind:
+#   DEPLOY_DRIVER=minikube ./scripts/deploy-local.sh
 #
 # To customize the Konflux configuration:
 #   cp operator/config/samples/konflux_v1alpha1_konflux.yaml my-konflux.yaml
@@ -55,6 +59,26 @@ set -euo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 REPO_ROOT=$(dirname "$SCRIPT_DIR")
 
+# Cluster driver: "kind" (default) or "minikube"
+DEPLOY_DRIVER="${DEPLOY_DRIVER:-kind}"
+
+case "${DEPLOY_DRIVER}" in
+    kind)
+        DRIVER_LABEL="Kind"
+        CLUSTER_SETUP_SCRIPT="${SCRIPT_DIR}/setup-kind-local-cluster.sh"
+        ;;
+    minikube)
+        DRIVER_LABEL="Minikube"
+        CLUSTER_SETUP_SCRIPT="${SCRIPT_DIR}/setup-minikube-local-cluster.sh"
+        trap 'echo ""; echo "ERROR: Deployment failed. The Minikube cluster may still be running."; echo "       Fix the issue and rerun this script to retry."; echo "       To delete the cluster: minikube -p ${MINIKUBE_PROFILE:-konflux} delete"' ERR
+        ;;
+    *)
+        echo "ERROR: Invalid DEPLOY_DRIVER: ${DEPLOY_DRIVER}"
+        echo "Valid options: kind, minikube"
+        exit 1
+        ;;
+esac
+
 # Optional: Load environment configuration from file if it exists.
 # Precedence (high to low): injected env vars > env file > script defaults.
 # Snapshot the caller's environment first so that any vars passed on the
@@ -70,20 +94,34 @@ if [ -f "${ENV_FILE}" ]; then
     unset _pre_env
 fi
 
-# Optional variables with defaults (using :- pattern)
-KIND_CLUSTER="${KIND_CLUSTER:-konflux}"
-KIND_MEMORY_GB="${KIND_MEMORY_GB:-8}"
+# Driver-specific variables
+case "${DEPLOY_DRIVER}" in
+    kind)
+        KIND_CLUSTER="${KIND_CLUSTER:-konflux}"
+        KIND_MEMORY_GB="${KIND_MEMORY_GB:-8}"
+        INCREASE_PODMAN_PIDS_LIMIT="${INCREASE_PODMAN_PIDS_LIMIT:-1}"
+        ENABLE_IMAGE_CACHE="${ENABLE_IMAGE_CACHE:-0}"
+        export KIND_CLUSTER KIND_MEMORY_GB PODMAN_MACHINE_NAME
+        export INCREASE_PODMAN_PIDS_LIMIT ENABLE_IMAGE_CACHE
+        ;;
+    minikube)
+        MINIKUBE_PROFILE="${MINIKUBE_PROFILE:-konflux}"
+        MINIKUBE_MEMORY_MB="${MINIKUBE_MEMORY_MB:-max}"
+        MINIKUBE_CPUS="${MINIKUBE_CPUS:-max}"
+        MINIKUBE_DISK_SIZE="${MINIKUBE_DISK_SIZE:-100g}"
+        export MINIKUBE_PROFILE MINIKUBE_MEMORY_MB MINIKUBE_CPUS MINIKUBE_DISK_SIZE
+        ;;
+esac
+
+# Shared variables with defaults
 REGISTRY_HOST_PORT="${REGISTRY_HOST_PORT:-5001}"
 ENABLE_REGISTRY_PORT="${ENABLE_REGISTRY_PORT:-1}"
-INCREASE_PODMAN_PIDS_LIMIT="${INCREASE_PODMAN_PIDS_LIMIT:-1}"
-ENABLE_IMAGE_CACHE="${ENABLE_IMAGE_CACHE:-0}"
 OPERATOR_INSTALL_METHOD="${OPERATOR_INSTALL_METHOD:-release}"
 OPERATOR_IMAGE="${OPERATOR_IMAGE:-quay.io/konflux-ci/konflux-operator:latest}"
 SKIP_SECRETS="${SKIP_SECRETS:-false}"
 
 # Export variables for child scripts
-export KIND_CLUSTER KIND_MEMORY_GB PODMAN_MACHINE_NAME REGISTRY_HOST_PORT ENABLE_REGISTRY_PORT
-export INCREASE_PODMAN_PIDS_LIMIT ENABLE_IMAGE_CACHE
+export REGISTRY_HOST_PORT ENABLE_REGISTRY_PORT
 export GITHUB_PRIVATE_KEY GITHUB_PRIVATE_KEY_PATH GITHUB_APP_ID WEBHOOK_SECRET QUAY_TOKEN QUAY_ORGANIZATION QUAY_API_URL
 export SEGMENT_WRITE_KEY
 
@@ -100,11 +138,17 @@ KONFLUX_CR=$("${SCRIPT_DIR}/resolve-konflux-cr.sh")
 
 echo "========================================="
 echo "Konflux Local Development Deployment"
+if [ "${DEPLOY_DRIVER}" = "minikube" ]; then
+    echo "  (Minikube + Docker)"
+fi
 echo "========================================="
 echo ""
 echo "Configuration:"
 echo "  Environment: ${ENV_FILE}"
 echo "  Konflux CR:  ${KONFLUX_CR}"
+if [ "${DEPLOY_DRIVER}" = "minikube" ]; then
+    echo "  Profile:     ${MINIKUBE_PROFILE}"
+fi
 echo ""
 
 INSTALL_METHOD="${OPERATOR_INSTALL_METHOD:-local}"
@@ -121,16 +165,17 @@ if [ "${INSTALL_METHOD}" = "build" ]; then
     echo ""
 fi
 
-# Step 1: Setup Kind cluster (skip when using an existing kubeconfig, e.g. Tekton kind-aws-provision)
-if [ "${DEPLOY_LOCAL_SKIP_KIND:-0}" = "1" ]; then
+# Step 1: Setup cluster (skip when using an existing kubeconfig, e.g. Tekton kind-aws-provision)
+DEPLOY_LOCAL_SKIP_CLUSTER="${DEPLOY_LOCAL_SKIP_CLUSTER:-${DEPLOY_LOCAL_SKIP_KIND:-0}}"
+if [ "${DEPLOY_LOCAL_SKIP_CLUSTER}" = "1" ]; then
     echo "========================================="
-    echo "Step 1: Skipped (DEPLOY_LOCAL_SKIP_KIND=1 — using current KUBECONFIG)"
+    echo "Step 1: Skipped (using current KUBECONFIG)"
     echo "========================================="
 else
     echo "========================================="
-    echo "Step 1: Creating Kind cluster"
+    echo "Step 1: Creating ${DRIVER_LABEL} cluster"
     echo "========================================="
-    "${SCRIPT_DIR}/setup-kind-local-cluster.sh"
+    "${CLUSTER_SETUP_SCRIPT}"
 fi
 
 # Step 2: Deploy dependencies
@@ -178,9 +223,12 @@ case "${INSTALL_METHOD}" in
         ;;
 
     build)
-        echo "Loading operator image into Kind cluster..."
+        echo "Loading operator image into ${DRIVER_LABEL} cluster..."
         cd "${REPO_ROOT}/operator"
-        kind load docker-image "${OPERATOR_IMG}" --name "${KIND_CLUSTER}"
+        case "${DEPLOY_DRIVER}" in
+            kind)     kind load docker-image "${OPERATOR_IMG}" --name "${KIND_CLUSTER}" ;;
+            minikube) minikube -p "${MINIKUBE_PROFILE}" image load "${OPERATOR_IMG}" ;;
+        esac
 
         echo "Installing CRDs..."
         make install
@@ -289,7 +337,7 @@ echo "========================================="
 echo ""
 
 if [ "${INSTALL_METHOD}" = "none" ]; then
-    echo "Kind cluster and dependencies are ready."
+    echo "${DRIVER_LABEL} cluster and dependencies are ready."
     echo ""
     echo "Next steps - run the operator:"
     echo "  cd operator"
@@ -300,7 +348,7 @@ if [ "${INSTALL_METHOD}" = "none" ]; then
     echo "  kubectl apply -f ${KONFLUX_CR}"
     echo ""
 else
-    echo "Konflux is now running on your local Kind cluster"
+    echo "Konflux is now running on your local ${DRIVER_LABEL} cluster"
     echo ""
     echo "Access the UI:"
     echo "  https://localhost:9443"
@@ -315,5 +363,13 @@ fi
 if [[ "${ENABLE_REGISTRY_PORT:-1}" -eq 1 ]]; then
     echo "Internal registry:"
     echo "  localhost:${REGISTRY_HOST_PORT:-5001}"
+    echo ""
+fi
+
+if [ "${DEPLOY_DRIVER}" = "minikube" ]; then
+    echo "Useful minikube commands:"
+    echo "  minikube -p ${MINIKUBE_PROFILE} status      # Check cluster status"
+    echo "  minikube -p ${MINIKUBE_PROFILE} dashboard    # Open Kubernetes dashboard"
+    echo "  minikube -p ${MINIKUBE_PROFILE} delete       # Delete the cluster"
     echo ""
 fi

--- a/scripts/setup-minikube-local-cluster.sh
+++ b/scripts/setup-minikube-local-cluster.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Setup Minikube Local Cluster for Konflux
+#
+# This script sets up a local Minikube cluster with the Docker driver and proper
+# configuration for Konflux development. It handles resource validation and
+# configures networking (port mappings via NodePorts).
+#
+# This script is for LOCAL DEVELOPMENT CONVENIENCE ONLY. The Konflux operator
+# and its components work on ANY Kubernetes cluster. This script just automates
+# the common setup tasks for local Minikube clusters.
+#
+# Prerequisites:
+# - minikube, docker
+#
+# Configuration:
+# Set these environment variables:
+# - MINIKUBE_MEMORY_MB: Memory allocated to Minikube (default: 8192)
+# - MINIKUBE_CPUS: CPUs allocated to Minikube (default: 4)
+# - MINIKUBE_DISK_SIZE: Disk size for Minikube (default: 100g)
+# - MINIKUBE_PROFILE: Minikube profile name (default: konflux)
+# - REGISTRY_HOST_PORT: Host port for registry (default: 5001)
+# - ENABLE_REGISTRY_PORT: Enable registry port binding (default: 1)
+
+# Determine the absolute path of this script's directory
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+# Set defaults for optional variables
+MINIKUBE_MEMORY_MB="${MINIKUBE_MEMORY_MB:-max}"
+MINIKUBE_CPUS="${MINIKUBE_CPUS:-max}"
+MINIKUBE_DISK_SIZE="${MINIKUBE_DISK_SIZE:-100g}"
+MINIKUBE_PROFILE="${MINIKUBE_PROFILE:-konflux}"
+ENABLE_REGISTRY_PORT="${ENABLE_REGISTRY_PORT:-1}"
+REGISTRY_HOST_PORT="${REGISTRY_HOST_PORT:-5001}"
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+
+if ! command -v minikube &> /dev/null; then
+    echo "ERROR: minikube is not installed."
+    echo "Install it from: https://minikube.sigs.k8s.io/docs/start/"
+    exit 1
+fi
+
+if ! command -v docker &> /dev/null; then
+    echo "ERROR: docker is not installed."
+    echo "Install Docker Desktop or Docker Engine for your platform."
+    exit 1
+fi
+
+# Verify Docker daemon is running
+if ! docker info &> /dev/null; then
+    echo "ERROR: Docker daemon is not running."
+    echo "Start Docker and try again."
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Increase inotify limits on Linux (only if current values are lower than required)
+# ---------------------------------------------------------------------------
+
+if [[ "$(uname)" == "Linux" ]]; then
+    WATCHES_REQUIRED=524288
+    INSTANCES_REQUIRED=512
+    WATCHES_CURRENT=$(cat /proc/sys/fs/inotify/max_user_watches 2>/dev/null || echo 0)
+    INSTANCES_CURRENT=$(cat /proc/sys/fs/inotify/max_user_instances 2>/dev/null || echo 0)
+    if [[ "$WATCHES_CURRENT" -lt "$WATCHES_REQUIRED" ]] || [[ "$INSTANCES_CURRENT" -lt "$INSTANCES_REQUIRED" ]]; then
+        echo "Increasing inotify limits for Minikube cluster..."
+        echo "  Current:  max_user_watches=${WATCHES_CURRENT}, max_user_instances=${INSTANCES_CURRENT}"
+        echo "  Required: max_user_watches=${WATCHES_REQUIRED}, max_user_instances=${INSTANCES_REQUIRED}"
+        echo ""
+        echo "You may be prompted for your password. If you prefer, cancel and run"
+        echo "these commands yourself, then rerun this script:"
+        echo "  sudo sysctl fs.inotify.max_user_watches=${WATCHES_REQUIRED}"
+        echo "  sudo sysctl fs.inotify.max_user_instances=${INSTANCES_REQUIRED}"
+        echo ""
+        sudo sysctl fs.inotify.max_user_watches="${WATCHES_REQUIRED}"
+        sudo sysctl fs.inotify.max_user_instances="${INSTANCES_REQUIRED}"
+    else
+        echo "inotify limits already sufficient (watches=${WATCHES_CURRENT}, instances=${INSTANCES_CURRENT})."
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check for existing cluster
+# ---------------------------------------------------------------------------
+
+if minikube status -p "${MINIKUBE_PROFILE}" &>/dev/null; then
+    if kubectl --context "${MINIKUBE_PROFILE}" cluster-info &>/dev/null; then
+        echo "Minikube cluster '${MINIKUBE_PROFILE}' already exists and is usable."
+        echo "Skipping cluster creation. Delete it first if you want to recreate:"
+        echo "  minikube delete -p ${MINIKUBE_PROFILE}"
+        exit 0
+    else
+        echo "Minikube cluster '${MINIKUBE_PROFILE}' exists but is not responding."
+        echo "Deleting and recreating..."
+        minikube delete -p "${MINIKUBE_PROFILE}"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check for port conflicts if registry port binding is enabled
+# ---------------------------------------------------------------------------
+
+if [[ "${ENABLE_REGISTRY_PORT}" -eq 1 ]]; then
+    echo "Registry port binding is enabled. Checking if port ${REGISTRY_HOST_PORT} is available..."
+
+    if command -v lsof &> /dev/null; then
+        if lsof -i ":${REGISTRY_HOST_PORT}" >/dev/null 2>&1; then
+            echo "ERROR: Port ${REGISTRY_HOST_PORT} is already in use."
+            echo ""
+            echo "Port ${REGISTRY_HOST_PORT} is currently bound by another process:"
+            lsof -i ":${REGISTRY_HOST_PORT}"
+            echo ""
+            echo "To resolve this issue, you have several options:"
+            echo "  1. Stop the service using port ${REGISTRY_HOST_PORT}"
+            echo "  2. Choose a different port by setting REGISTRY_HOST_PORT"
+            echo "  3. Disable registry port binding by setting ENABLE_REGISTRY_PORT=0"
+            echo ""
+            echo "Note: On macOS, port 5000 is often used by AirPlay Receiver."
+            echo "      You can disable it in System Settings > General > AirDrop & Handoff > AirPlay Receiver"
+            exit 1
+        fi
+    elif command -v ss &> /dev/null; then
+        if ss -ltn "sport = :${REGISTRY_HOST_PORT}" | grep -q ":${REGISTRY_HOST_PORT}"; then
+            echo "ERROR: Port ${REGISTRY_HOST_PORT} is already in use."
+            echo "To resolve: stop the service, change REGISTRY_HOST_PORT, or set ENABLE_REGISTRY_PORT=0"
+            exit 1
+        fi
+    else
+        echo "WARNING: Unable to check port availability (lsof and ss not found)."
+        echo "         Proceeding anyway, but cluster creation may fail if port ${REGISTRY_HOST_PORT} is in use."
+    fi
+
+    echo "Port ${REGISTRY_HOST_PORT} is available."
+fi
+
+# ---------------------------------------------------------------------------
+# Build port mapping flags
+# ---------------------------------------------------------------------------
+# Minikube with Docker driver supports --ports for host:container port mappings.
+# These mirror the Kind extraPortMappings from kind-config.yaml.
+
+PORTS_FLAGS=(
+    "--ports=8888:30010"    # Generic
+    "--ports=9443:30011"    # UI
+    "--ports=8180:30012"    # PaC
+    "--ports=8443:30002"    # Quay
+)
+
+if [[ "${ENABLE_REGISTRY_PORT}" -eq 1 ]]; then
+    PORTS_FLAGS+=("--ports=${REGISTRY_HOST_PORT}:30001")  # Registry
+fi
+
+# ---------------------------------------------------------------------------
+# Create the Minikube cluster
+# ---------------------------------------------------------------------------
+
+echo "Creating Minikube cluster '${MINIKUBE_PROFILE}' with Docker driver..."
+echo "  Memory: ${MINIKUBE_MEMORY_MB}MB"
+echo "  CPUs:   ${MINIKUBE_CPUS}"
+echo "  Disk:   ${MINIKUBE_DISK_SIZE}"
+
+minikube start \
+    -p "${MINIKUBE_PROFILE}" \
+    --driver=docker \
+    --memory="${MINIKUBE_MEMORY_MB}" \
+    --cpus="${MINIKUBE_CPUS}" \
+    --disk-size="${MINIKUBE_DISK_SIZE}" \
+    --container-runtime=containerd \
+    --extra-config=apiserver.service-account-issuer=https://kubernetes.default.svc \
+    --extra-config=kubelet.serialize-image-pulls=false \
+    "${PORTS_FLAGS[@]}"
+
+# Label the node for ingress-ready (matches Kind config)
+kubectl label node "${MINIKUBE_PROFILE}" ingress-ready=true --overwrite
+
+sleep 2
+
+echo ""
+echo "Minikube cluster '${MINIKUBE_PROFILE}' created successfully"
+echo ""
+echo "Next steps:"
+echo "  1. Deploy dependencies: ./deploy-deps.sh"
+echo "  2. Deploy operator: cd operator && make deploy"
+echo "  3. Apply Konflux CR: kubectl apply -f my-konflux.yaml"
+echo ""
+echo "Or use the all-in-one script: DEPLOY_DRIVER=minikube ./scripts/deploy-local.sh"


### PR DESCRIPTION
## Summary

- Adds `DEPLOY_DRIVER=minikube` support to `scripts/deploy-local.sh`, making it the single entry point for both Kind and Minikube local deployments
- Moves `scripts/minikube/setup-minikube-local-cluster.sh` up to `scripts/` to sit symmetrically alongside `scripts/setup-kind-local-cluster.sh`
- Removes `scripts/minikube/deploy-local.sh` thin wrapper — callers use `DEPLOY_DRIVER=minikube ./scripts/deploy-local.sh` directly
- Updates all internal path and comment references accordingly

## Test plan

- [ ] `./scripts/deploy-local.sh` (default Kind path) continues to work unchanged
- [ ] `DEPLOY_DRIVER=minikube ./scripts/deploy-local.sh` spins up a Minikube cluster and deploys Konflux
- [ ] `DEPLOY_DRIVER=invalid` exits with a clear error message
- [ ] Existing `DEPLOY_LOCAL_SKIP_KIND=1` env var still works (aliased to `DEPLOY_LOCAL_SKIP_CLUSTER`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)