### PR TITLE
ci: run e2e tests on k3s

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -48,6 +48,8 @@ jobs:
       operator: ${{ steps.changed-files.outputs.any_changed }}
       check_run_id: ${{ steps.create-check.outputs.check_run_id }}
       check_run_id_arm64: ${{ steps.create-check.outputs.check_run_id_arm64 }}
+      check_run_id_k3s_amd64: ${{ steps.create-check.outputs.check_run_id_k3s_amd64 }}
+      check_run_id_k3s_arm64: ${{ steps.create-check.outputs.check_run_id_k3s_arm64 }}
     steps:
       - name: Set checkout ref
         id: set-ref
@@ -66,22 +68,27 @@ jobs:
         with:
           script: |
             const head_sha = '${{ steps.set-ref.outputs.ref }}';
-            const { data: e2e } = await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'Run Operator E2E Tests (AMD64)',
-              head_sha,
-              status: 'in_progress'
-            });
-            const { data: arm64 } = await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'Run Operator E2E Tests (ARM64)',
-              head_sha,
-              status: 'in_progress'
-            });
-            core.setOutput('check_run_id', e2e.id);
-            core.setOutput('check_run_id_arm64', arm64.id);
+            const checks = [
+              'Run Operator E2E Tests (AMD64)',
+              'Run Operator E2E Tests (ARM64)',
+              'Run Operator E2E Tests (k3s AMD64)',
+              'Run Operator E2E Tests (k3s ARM64)',
+            ];
+            const ids = {};
+            for (const name of checks) {
+              const { data } = await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name,
+                head_sha,
+                status: 'in_progress'
+              });
+              ids[name] = data.id;
+            }
+            core.setOutput('check_run_id', ids['Run Operator E2E Tests (AMD64)']);
+            core.setOutput('check_run_id_arm64', ids['Run Operator E2E Tests (ARM64)']);
+            core.setOutput('check_run_id_k3s_amd64', ids['Run Operator E2E Tests (k3s AMD64)']);
+            core.setOutput('check_run_id_k3s_arm64', ids['Run Operator E2E Tests (k3s ARM64)']);
       - name: Checkout PR branch
         uses: actions/checkout@v7
         with:
@@ -97,6 +104,12 @@ jobs:
             test/e2e/**
             test/go-tests/**
             kind-config.yaml
+            scripts/deploy-local.sh
+            scripts/setup-kind-local-cluster.sh
+            scripts/setup-k3s-local-cluster.sh
+            scripts/publish-kind-compatible-host-ports.sh
+            scripts/diagnose-nested-unshare.sh
+            docs/local-k3s.md
             generate-err-logs.sh
             .github/workflows/operator-test-e2e.yaml
 
@@ -114,6 +127,7 @@ jobs:
       matrix:
         include:
           - arch: amd64
+            backend: kind
             runner: ubuntu-latest
             kind_binary: kind-linux-amd64
             kubectl_arch: amd64
@@ -127,6 +141,7 @@ jobs:
             webhook_secret: APP_WEBHOOK_SECRET_AMD64
             smee_channel: SMEE_CHANNEL_AMD64
           - arch: arm64
+            backend: kind
             runner: ubuntu-24.04-arm
             kind_binary: kind-linux-arm64
             kubectl_arch: arm64
@@ -135,6 +150,34 @@ jobs:
             test_scope: "integration+e2e"
             konflux_cr: "operator/config/samples/konflux-e2e.yaml"
             job_name: "Run Operator E2E Tests (ARM64)"
+            github_app_id: APP_ID_ARM64
+            github_private_key: APP_PRIVATE_KEY_ARM64
+            webhook_secret: APP_WEBHOOK_SECRET_ARM64
+            smee_channel: SMEE_CHANNEL_ARM64
+          - arch: amd64
+            backend: k3s
+            runner: ubuntu-latest
+            kind_binary: kind-linux-amd64
+            kubectl_arch: amd64
+            image_suffix: "-k3s"
+            cluster_suffix: "-k3s"
+            test_scope: "integration+e2e"
+            konflux_cr: "operator/config/samples/konflux-e2e.yaml"
+            job_name: "Run Operator E2E Tests (k3s AMD64)"
+            github_app_id: APP_ID_AMD64
+            github_private_key: APP_PRIVATE_KEY_AMD64
+            webhook_secret: APP_WEBHOOK_SECRET_AMD64
+            smee_channel: SMEE_CHANNEL_AMD64
+          - arch: arm64
+            backend: k3s
+            runner: ubuntu-24.04-arm
+            kind_binary: kind-linux-arm64
+            kubectl_arch: arm64
+            image_suffix: "-k3s-arm64"
+            cluster_suffix: "-k3s-arm"
+            test_scope: "integration+e2e"
+            konflux_cr: "operator/config/samples/konflux-e2e.yaml"
+            job_name: "Run Operator E2E Tests (k3s ARM64)"
             github_app_id: APP_ID_ARM64
             github_private_key: APP_PRIVATE_KEY_ARM64
             webhook_secret: APP_WEBHOOK_SECRET_ARM64
@@ -150,11 +193,12 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: [check-prerequisites, check-changes]
     if: needs.check-changes.outputs.operator == 'true'
-    # Cancel superseded test jobs per PR/arch to reduce shared smee contention (#6551).
+    # Cancel superseded test jobs per PR/arch/backend to reduce shared smee contention (#6551).
     # Job-level (not workflow-level) so report-operator-e2e-status can finalize /allow
     # Checks API runs when a superseded run's test job is cancelled.
     # Group key (first match wins): pull_request.number, client_payload.pr_number,
-    # ref (merge queue), run_id; matrix.arch keeps AMD64/ARM64 from cancelling each other.
+    # ref (merge queue), run_id; matrix.arch+backend keeps Kind/k3s and AMD64/ARM64
+    # from cancelling each other.
     concurrency:
       group: >-
         operator-e2e-${{
@@ -162,13 +206,14 @@ jobs:
           || github.event.client_payload.pr_number
           || github.ref
           || github.run_id
-        }}-${{ matrix.arch }}
+        }}-${{ matrix.arch }}-${{ matrix.backend }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
         include:
           - arch: amd64
+            backend: kind
             runner: ubuntu-latest
             kind_binary: kind-linux-amd64
             kubectl_arch: amd64
@@ -182,6 +227,7 @@ jobs:
             webhook_secret: APP_WEBHOOK_SECRET_AMD64
             smee_channel: SMEE_CHANNEL_AMD64
           - arch: arm64
+            backend: kind
             runner: ubuntu-24.04-arm
             kind_binary: kind-linux-arm64
             kubectl_arch: arm64
@@ -194,13 +240,44 @@ jobs:
             github_private_key: APP_PRIVATE_KEY_ARM64
             webhook_secret: APP_WEBHOOK_SECRET_ARM64
             smee_channel: SMEE_CHANNEL_ARM64
+          - arch: amd64
+            backend: k3s
+            runner: ubuntu-latest
+            kind_binary: kind-linux-amd64
+            kubectl_arch: amd64
+            image_suffix: "-k3s"
+            cluster_suffix: "-k3s"
+            test_scope: "integration+e2e"
+            konflux_cr: "operator/config/samples/konflux-e2e.yaml"
+            job_name: "Run Operator E2E Tests (k3s AMD64)"
+            github_app_id: APP_ID_AMD64
+            github_private_key: APP_PRIVATE_KEY_AMD64
+            webhook_secret: APP_WEBHOOK_SECRET_AMD64
+            smee_channel: SMEE_CHANNEL_AMD64
+          - arch: arm64
+            backend: k3s
+            runner: ubuntu-24.04-arm
+            kind_binary: kind-linux-arm64
+            kubectl_arch: arm64
+            image_suffix: "-k3s-arm64"
+            cluster_suffix: "-k3s-arm"
+            test_scope: "integration+e2e"
+            konflux_cr: "operator/config/samples/konflux-e2e.yaml"
+            job_name: "Run Operator E2E Tests (k3s ARM64)"
+            github_app_id: APP_ID_ARM64
+            github_private_key: APP_PRIVATE_KEY_ARM64
+            webhook_secret: APP_WEBHOOK_SECRET_ARM64
+            smee_channel: SMEE_CHANNEL_ARM64
     env:
       # renovate: datasource=github-releases depName=kubernetes-sigs/kind
       KIND_VERSION: "0.32.0"
       # renovate: datasource=github-releases depName=kubernetes/kubernetes
       KUBECTL_VERSION: "1.36.2"
+      # Optional pin for k3s (empty = channel stable from get.k3s.io)
+      K3S_VERSION: ""
       OPERATOR_IMAGE: example.com/konflux-operator:v0.0.1${{ matrix.image_suffix }}
       KIND_CLUSTER: konflux-operator-test-e2e${{ matrix.cluster_suffix }}
+      CLUSTER_BACKEND: ${{ matrix.backend }}
     defaults:
       run:
         working-directory: operator
@@ -227,10 +304,14 @@ jobs:
         with:
           ref: ${{ steps.set-ref.outputs.ref }}
 
-      - name: Disable AppArmor
-        # works around a change in ubuntu 24.04 that restricts Linux namespace access
-        # for unprivileged users
-        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+      - name: Relax AppArmor userns sysctls (Ubuntu)
+        # works around Ubuntu 24.04 restricting unprivileged user namespaces.
+        # Do not aa-teardown / disable host AppArmor: that breaks Docker/BuildKit
+        # (operator image build). Nested-build diagnostics live in a later k3s step.
+        working-directory: ${{ github.workspace }}
+        run: |
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_unconfined=0 || true
 
       - name: Setup Go
         uses: actions/setup-go@v7
@@ -239,6 +320,7 @@ jobs:
           cache-dependency-path: operator/go.sum
 
       - name: Install kind (${{ matrix.arch }})
+        if: matrix.backend == 'kind'
         run: |
           curl -Lo ./kind https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/${{ matrix.kind_binary }}
           chmod +x ./kind
@@ -251,13 +333,18 @@ jobs:
           sudo mv kubectl /usr/local/bin/kubectl
 
       - name: Verify kind installation
+        if: matrix.backend == 'kind'
         run: kind version
 
       - name: Deploy Konflux using deploy-local.sh
         working-directory: ${{ github.workspace }}
         env:
           # Cluster configuration
+          CLUSTER_BACKEND: ${{ matrix.backend }}
           KIND_CLUSTER: ${{ env.KIND_CLUSTER }}
+          K3S_VERSION: ${{ env.K3S_VERSION }}
+          # GHA Ubuntu has no firewalld; skip even if present
+          K3S_CONFIGURE_FIREWALL: "0"
           OPERATOR_INSTALL_METHOD: "build"
           OPERATOR_IMAGE: ${{ env.OPERATOR_IMAGE }}
 
@@ -285,11 +372,22 @@ jobs:
         working-directory: operator
         run: |
           kubectl version
-          kind version
+          if [[ "${{ matrix.backend }}" == "kind" ]]; then
+            kind version
+          else
+            k3s --version || true
+          fi
 
       - name: List namespaces
         run: |
           kubectl get namespace
+
+      - name: Diagnose nested unshare (k3s)
+        if: matrix.backend == 'k3s'
+        working-directory: ${{ github.workspace }}
+        run: |
+          chmod +x scripts/diagnose-nested-unshare.sh
+          ./scripts/diagnose-nested-unshare.sh
 
       - name: Run go-tests pkg unit tests
         working-directory: ${{ github.workspace }}
@@ -318,7 +416,7 @@ jobs:
         run: |
           ./test/e2e/run-e2e.sh \
             -ginkgo.github-output \
-            -ginkgo.junit-report=${{ github.workspace }}/junit-conformance-${{ matrix.arch }}.xml
+            -ginkgo.junit-report=${{ github.workspace }}/junit-conformance-${{ matrix.arch }}-${{ matrix.backend }}.xml
 
       - name: Generate error logs
         if: ${{ !cancelled() }}
@@ -333,13 +431,13 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           mkdir -p logs/junit
-          cp junit-conformance-${{ matrix.arch }}.xml logs/junit/ 2>/dev/null || true
+          cp junit-conformance-${{ matrix.arch }}-${{ matrix.backend }}.xml logs/junit/ 2>/dev/null || true
 
       - name: Archive logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
-          name: logs-${{ matrix.arch }}
+          name: logs-${{ matrix.arch }}-${{ matrix.backend }}
           path: logs
 
   # Report check result to PR when triggered by /allow (so the run appears on the PR and can gate it)
@@ -354,18 +452,25 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const checkRunId = parseInt(process.env.CHECK_RUN_ID);
-            const checkRunIdArm64 = parseInt(process.env.CHECK_RUN_ID_ARM64);
+            const ids = [
+              process.env.CHECK_RUN_ID,
+              process.env.CHECK_RUN_ID_ARM64,
+              process.env.CHECK_RUN_ID_K3S_AMD64,
+              process.env.CHECK_RUN_ID_K3S_ARM64,
+            ].map((v) => parseInt(v, 10)).filter((n) => Number.isFinite(n));
             const testResult = process.env.TEST_RESULT;
             const testSkipResult = process.env.TEST_SKIP_RESULT;
             let conclusion = 'failure';
             if (testResult === 'success' || testSkipResult === 'success') conclusion = 'success';
             else if (testResult === 'cancelled' || testSkipResult === 'cancelled') conclusion = 'cancelled';
             const update = { owner: context.repo.owner, repo: context.repo.repo, status: 'completed', conclusion };
-            await github.rest.checks.update({ ...update, check_run_id: checkRunId });
-            await github.rest.checks.update({ ...update, check_run_id: checkRunIdArm64 });
+            for (const check_run_id of ids) {
+              await github.rest.checks.update({ ...update, check_run_id });
+            }
         env:
           CHECK_RUN_ID: ${{ needs.check-changes.outputs.check_run_id }}
           CHECK_RUN_ID_ARM64: ${{ needs.check-changes.outputs.check_run_id_arm64 }}
+          CHECK_RUN_ID_K3S_AMD64: ${{ needs.check-changes.outputs.check_run_id_k3s_amd64 }}
+          CHECK_RUN_ID_K3S_ARM64: ${{ needs.check-changes.outputs.check_run_id_k3s_arm64 }}
           TEST_RESULT: ${{ needs.test.result }}
           TEST_SKIP_RESULT: ${{ needs.test-skip.result }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Always `cd operator` before running `make`, `go test`, or linting commands.
 ## Setup Commands
 
 ```bash
-# Local Kind deployment
+# Local Kind deployment (Linux: CLUSTER_BACKEND=k3s — see docs/local-k3s.md)
 cp scripts/deploy-local.env.template scripts/deploy-local.env
 # Fill in GITHUB_APP_ID, GITHUB_PRIVATE_KEY, WEBHOOK_SECRET
 ./scripts/deploy-local.sh

--- a/dependencies/kyverno/policy-components/k3s-buildah-apparmor/allow-build-container-nested-unshare.yaml
+++ b/dependencies/kyverno/policy-components/k3s-buildah-apparmor/allow-build-container-nested-unshare.yaml
@@ -1,0 +1,48 @@
+---
+# Narrow mutate for native k3s on Ubuntu: default cri-containerd AppArmor blocks
+# buildah `unshare -m` (filesystem propagation). Diagnostics showed:
+#   default fail; privileged ok; AppArmor+seccomp Unconfined (non-priv) ok.
+# Scope: only the image-build TaskRun pod (pipelineTask=build-container), CREATE,
+# admission-only (no background scans). Applied when CLUSTER_BACKEND=k3s.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: allow-build-container-nested-unshare
+  annotations:
+    policies.kyverno.io/title: Allow nested unshare for build-container TaskRuns
+    policies.kyverno.io/description: >-
+      On host-level k3s (Ubuntu), cri-containerd.apparmor.d blocks nested mount
+      namespaces needed by buildah in the build-container TaskRun. Sets AppArmor
+      and seccomp to Unconfined on that TaskRun's containers only. Applied only
+      when CLUSTER_BACKEND=k3s. Prefer Unconfined over privileged.
+spec:
+  background: false
+  rules:
+  - name: build-container-apparmor-seccomp-unconfined
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+          names:
+          - '*-pod'
+          operations:
+          - CREATE
+          selector:
+            matchLabels:
+              pipelines.appstudio.openshift.io/type: build
+              tekton.dev/pipelineTask: build-container
+    mutate:
+      # Per-container: Tekton often sets step securityContext that would override
+      # pod-level seccomp/AppArmor. Only this TaskRun's containers are touched.
+      foreach:
+      - list: request.object.spec.containers
+        patchStrategicMerge:
+          spec:
+            containers:
+            - name: "{{ element.name }}"
+              securityContext:
+                appArmorProfile:
+                  type: Unconfined
+                seccompProfile:
+                  type: Unconfined

--- a/dependencies/kyverno/policy-components/k3s-buildah-apparmor/kustomization.yaml
+++ b/dependencies/kyverno/policy-components/k3s-buildah-apparmor/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - allow-build-container-nested-unshare.yaml

--- a/deploy-deps.sh
+++ b/deploy-deps.sh
@@ -504,6 +504,16 @@ deploy_kyverno() {
     kyverno_apply_cmd=$(printf 'kubectl apply -k %q' "${kyverno_policy_dir}")
     retry "${kyverno_apply_cmd}" \
           "Failed to apply Kyverno policies (webhook may not be ready yet)"
+    # k3s on Ubuntu: cri-containerd AppArmor blocks buildah unshare in build-container.
+    # Kind does not need this; keep admission mutate off that path.
+    if [[ "${CLUSTER_BACKEND:-kind}" == "k3s" ]]; then
+        local k3s_apparmor_dir="${script_path}/dependencies/kyverno/policy-components/k3s-buildah-apparmor"
+        echo "  🛡️  Applying k3s buildah AppArmor policy from ${k3s_apparmor_dir}" >&2
+        local k3s_apparmor_cmd
+        k3s_apparmor_cmd=$(printf 'kubectl apply -k %q' "${k3s_apparmor_dir}")
+        retry "${k3s_apparmor_cmd}" \
+              "Failed to apply k3s buildah AppArmor Kyverno policy"
+    fi
 }
 
 deploy_konflux_info() {

--- a/operator/docs/content/docs/installation/_index.md
+++ b/operator/docs/content/docs/installation/_index.md
@@ -10,7 +10,8 @@ the right guide for your situation:
 
 | My situation | Guide |
 |---|---|
-| Quick local development | [Local Deployment (Kind)]({{< relref "install-local" >}}) |
+| Quick local development (Kind) | [Local Deployment (Kind)]({{< relref "install-local" >}}) |
+| Local / CI on Linux with k3s | See `docs/local-k3s.md` in the repository |
 | Existing OpenShift cluster | [Installing on OpenShift]({{< relref "install-openshift" >}}) |
 | Any Kubernetes cluster, building the operator from source | [Building and Installing from Source]({{< relref "install-from-source" >}}) |
 | Any Kubernetes cluster, release bundle | [Installing from Release]({{< relref "install-release" >}}) |

--- a/operator/docs/content/docs/installation/install-local.md
+++ b/operator/docs/content/docs/installation/install-local.md
@@ -63,6 +63,13 @@ export KIND_EXPERIMENTAL_PROVIDER=podman
 {{% /alert %}}
 
 
+{{% alert color="info" %}}
+On **Linux**, you can use native k3s instead of Kind:
+`CLUSTER_BACKEND=k3s ./scripts/deploy-local.sh`.
+See `docs/local-k3s.md` in the repository for firewalld/sudo requirements.
+macOS continues to use Kind.
+{{% /alert %}}
+
 ```bash
 ./scripts/deploy-local.sh
 ```

--- a/scripts/deploy-local.env.template
+++ b/scripts/deploy-local.env.template
@@ -59,10 +59,15 @@ OPERATOR_IMAGE=""
 # KONFLUX_CR=""
 
 # ==============================================================================
-# Infrastructure Configuration (for Kind cluster setup)
+# Infrastructure Configuration (cluster backend)
 # ==============================================================================
 
-# Memory allocated to Kind cluster (in GB)
+# Cluster backend: kind (default, macOS + Linux) or k3s (Linux / GHA only)
+# See docs/local-k3s.md for Fedora firewalld + sudo requirements.
+# k3s setup republishes Kind host ports (9443→30011, …); set K3S_PUBLISH_KIND_PORTS=0 to skip.
+# CLUSTER_BACKEND=kind
+
+# Memory allocated to Kind cluster (in GB) — ignored for k3s
 # Minimum: 8GB, Recommended: 16GB for full stack
 KIND_MEMORY_GB=8
 

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -3,23 +3,26 @@
 # Deploy Konflux for Local Development
 #
 # This script provides a one-command local development deployment of Konflux
-# on a Kind cluster. It's designed for LOCAL DEVELOPMENT CONVENIENCE ONLY.
+# on Kind (default) or native k3s (Linux). Designed for LOCAL / CI convenience.
 #
 # For production deployments on real clusters, see docs/operator-deployment.md
+# For k3s host/firewall/sudo notes, see docs/local-k3s.md
 #
 # What this script does:
-#  1. Creates a Kind cluster with proper configuration
+#  1. Creates a Kind or k3s cluster (CLUSTER_BACKEND)
 #  2. Deploys the Konflux operator
 #  3. Applies a Konflux CR configuration
 #  4. Creates secrets for GitHub integration
 #
 # Prerequisites:
-#  - kind, kubectl, podman (or docker)
+#  - kind (CLUSTER_BACKEND=kind), or Linux + sudo for k3s (CLUSTER_BACKEND=k3s)
+#  - kubectl, podman (or docker)
 #  - kustomize (only for 'local' install method)
 #  - Configuration file: scripts/deploy-local.env
 #
 # Usage:
 #   ./scripts/deploy-local.sh [konflux-cr-file]
+#   CLUSTER_BACKEND=k3s ./scripts/deploy-local.sh
 #
 # By default, uses operator/config/samples/konflux_v1alpha1_konflux.yaml
 #
@@ -45,7 +48,7 @@
 #   git checkout v1.0.0  # or the desired release tag
 #   OPERATOR_INSTALL_METHOD=local ./scripts/deploy-local.sh
 #
-# For 'none' method, the script sets up Kind + dependencies + secrets, then exits.
+# For 'none' method, the script sets up the cluster + dependencies + secrets, then exits.
 # You then run the operator yourself:
 #   cd operator && make install && make run
 
@@ -71,6 +74,7 @@ if [ -f "${ENV_FILE}" ]; then
 fi
 
 # Optional variables with defaults (using :- pattern)
+CLUSTER_BACKEND="${CLUSTER_BACKEND:-kind}" # kind | k3s
 KIND_CLUSTER="${KIND_CLUSTER:-konflux}"
 KIND_MEMORY_GB="${KIND_MEMORY_GB:-8}"
 REGISTRY_HOST_PORT="${REGISTRY_HOST_PORT:-5001}"
@@ -80,12 +84,51 @@ ENABLE_IMAGE_CACHE="${ENABLE_IMAGE_CACHE:-0}"
 OPERATOR_INSTALL_METHOD="${OPERATOR_INSTALL_METHOD:-release}"
 OPERATOR_IMAGE="${OPERATOR_IMAGE:-quay.io/konflux-ci/konflux-operator:latest}"
 SKIP_SECRETS="${SKIP_SECRETS:-false}"
+# Skip cluster create when kubeconfig already points at a usable cluster
+# (Tekton kind-aws, preinstalled k3s, etc.). DEPLOY_LOCAL_SKIP_KIND is kept as alias.
+DEPLOY_LOCAL_SKIP_CLUSTER="${DEPLOY_LOCAL_SKIP_CLUSTER:-${DEPLOY_LOCAL_SKIP_KIND:-0}}"
+
+case "${CLUSTER_BACKEND}" in
+kind | k3s) ;;
+*)
+	echo "ERROR: Invalid CLUSTER_BACKEND: ${CLUSTER_BACKEND} (expected kind or k3s)" >&2
+	exit 1
+	;;
+esac
 
 # Export variables for child scripts
+export CLUSTER_BACKEND
 export KIND_CLUSTER KIND_MEMORY_GB PODMAN_MACHINE_NAME REGISTRY_HOST_PORT ENABLE_REGISTRY_PORT
 export INCREASE_PODMAN_PIDS_LIMIT ENABLE_IMAGE_CACHE
 export GITHUB_PRIVATE_KEY GITHUB_PRIVATE_KEY_PATH GITHUB_APP_ID WEBHOOK_SECRET QUAY_TOKEN QUAY_ORGANIZATION QUAY_API_URL
 export SEGMENT_WRITE_KEY
+
+# Load a locally built image into the cluster node store (build install method).
+load_operator_image_into_cluster() {
+	local img="$1"
+	local container_tool="${CONTAINER_TOOL:-}"
+	if [[ -z "${container_tool}" ]]; then
+		if command -v docker >/dev/null 2>&1; then
+			container_tool=docker
+		elif command -v podman >/dev/null 2>&1; then
+			container_tool=podman
+		else
+			echo "ERROR: docker or podman required to load ${img}" >&2
+			exit 1
+		fi
+	fi
+
+	case "${CLUSTER_BACKEND}" in
+	kind)
+		echo "Loading operator image into Kind cluster (${KIND_CLUSTER})..."
+		kind load docker-image "${img}" --name "${KIND_CLUSTER}"
+		;;
+	k3s)
+		echo "Importing operator image into k3s containerd (requires sudo)..."
+		"${container_tool}" save "${img}" | sudo k3s ctr images import -
+		;;
+	esac
+}
 
 # Child scripts only see exported variables (values from deploy-local.env are not
 # exported by sourcing); validate secrets after exports so checks see the same env.
@@ -104,6 +147,7 @@ echo "========================================="
 echo ""
 echo "Configuration:"
 echo "  Environment: ${ENV_FILE}"
+echo "  Cluster:     ${CLUSTER_BACKEND}"
 echo "  Konflux CR:  ${KONFLUX_CR}"
 echo ""
 
@@ -121,16 +165,25 @@ if [ "${INSTALL_METHOD}" = "build" ]; then
     echo ""
 fi
 
-# Step 1: Setup Kind cluster (skip when using an existing kubeconfig, e.g. Tekton kind-aws-provision)
-if [ "${DEPLOY_LOCAL_SKIP_KIND:-0}" = "1" ]; then
+# Step 1: Setup cluster (skip when using an existing kubeconfig, e.g. Tekton kind-aws-provision)
+if [ "${DEPLOY_LOCAL_SKIP_CLUSTER}" = "1" ]; then
     echo "========================================="
-    echo "Step 1: Skipped (DEPLOY_LOCAL_SKIP_KIND=1 — using current KUBECONFIG)"
+    echo "Step 1: Skipped (DEPLOY_LOCAL_SKIP_CLUSTER=1 — using current KUBECONFIG)"
     echo "========================================="
 else
     echo "========================================="
-    echo "Step 1: Creating Kind cluster"
+    echo "Step 1: Creating ${CLUSTER_BACKEND} cluster"
     echo "========================================="
-    "${SCRIPT_DIR}/setup-kind-local-cluster.sh"
+    case "${CLUSTER_BACKEND}" in
+    kind)
+        "${SCRIPT_DIR}/setup-kind-local-cluster.sh"
+        ;;
+    k3s)
+        "${SCRIPT_DIR}/setup-k3s-local-cluster.sh"
+        # setup-k3s runs in a subshell; point this process at the kubeconfig it wrote.
+        export KUBECONFIG="${K3S_KUBECONFIG:-${HOME}/.kube/k3s.yaml}"
+        ;;
+    esac
 fi
 
 # Step 2: Deploy dependencies
@@ -178,15 +231,16 @@ case "${INSTALL_METHOD}" in
         ;;
 
     build)
-        echo "Loading operator image into Kind cluster..."
         cd "${REPO_ROOT}/operator"
-        kind load docker-image "${OPERATOR_IMG}" --name "${KIND_CLUSTER}"
+        load_operator_image_into_cluster "${OPERATOR_IMG}"
 
         echo "Installing CRDs..."
         make install
 
         echo "Deploying operator..."
         make deploy IMG="${OPERATOR_IMG}"
+        # Avoid leaving a dirty kustomization after set image
+        git checkout config/manager/kustomization.yaml 2>/dev/null || true
         cd "${REPO_ROOT}"
         ;;
 
@@ -289,7 +343,7 @@ echo "========================================="
 echo ""
 
 if [ "${INSTALL_METHOD}" = "none" ]; then
-    echo "Kind cluster and dependencies are ready."
+    echo "${CLUSTER_BACKEND} cluster and dependencies are ready."
     echo ""
     echo "Next steps - run the operator:"
     echo "  cd operator"
@@ -300,7 +354,7 @@ if [ "${INSTALL_METHOD}" = "none" ]; then
     echo "  kubectl apply -f ${KONFLUX_CR}"
     echo ""
 else
-    echo "Konflux is now running on your local Kind cluster"
+    echo "Konflux is now running on your local ${CLUSTER_BACKEND} cluster"
     echo ""
     echo "Access the UI:"
     echo "  https://localhost:9443"

--- a/scripts/diagnose-nested-unshare.sh
+++ b/scripts/diagnose-nested-unshare.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Probe whether nested mount namespaces work in pods (buildah/unshare).
+#
+# Prints AppArmor label, capabilities, mount propagation, and `unshare -m`
+# for three security postures:
+#   1. default (cri-containerd AppArmor / seccomp)
+#   2. privileged
+#   3. AppArmor + seccomp unconfined (non-privileged)
+#
+# Used on GHA k3s where Kind succeeds but bare-metal k3s TaskRuns fail with:
+#   unshare: cannot change root filesystem propagation: Permission denied
+#
+# Always exits 0 (informational). Env:
+#   DIAG_UNSHARE_NAMESPACE - namespace (default: unshare-diag)
+#   DIAG_UNSHARE_IMAGE     - image with bash + unshare (default: ubuntu:24.04)
+#
+set -euo pipefail
+
+NS="${DIAG_UNSHARE_NAMESPACE:-unshare-diag}"
+IMAGE="${DIAG_UNSHARE_IMAGE:-ubuntu:24.04}"
+
+DIAG_BODY=$(
+	cat <<'EOS'
+set +e
+echo "=== identity ==="
+id
+echo "=== AppArmor current ==="
+cat /proc/self/attr/current 2>/dev/null || echo "(no /proc/self/attr/current)"
+echo "=== CapEff ==="
+grep '^CapEff:' /proc/self/status || true
+echo "=== findmnt / ==="
+findmnt -o TARGET,PROPAGATION / 2>/dev/null || findmnt / || true
+echo "=== unshare -m true ==="
+unshare -m true
+echo "unshare_exit=$?"
+EOS
+)
+
+# Indent for YAML literal block under args.
+indent_diag() {
+	local line
+	while IFS= read -r line || [[ -n "${line}" ]]; do
+		printf '      %s\n' "${line}"
+	done <<<"${DIAG_BODY}"
+}
+
+wait_pod_done() {
+	local name=$1
+	local phase=""
+	local _
+	for _ in $(seq 1 90); do
+		phase="$(kubectl get pod -n "${NS}" "${name}" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+		case "${phase}" in
+		Succeeded | Failed)
+			echo "${phase}"
+			return 0
+			;;
+		esac
+		sleep 2
+	done
+	echo "${phase:-timeout}"
+}
+
+run_case() {
+	local name=$1
+	local manifest=$2
+	local ok_var=$3
+
+	kubectl delete pod -n "${NS}" "${name}" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+	kubectl apply -n "${NS}" -f - <<<"${manifest}"
+
+	local phase
+	phase="$(wait_pod_done "${name}")"
+	echo "----- pod/${name} phase=${phase} -----"
+	kubectl logs -n "${NS}" "${name}" || true
+	local unshare_exit
+	unshare_exit="$(kubectl logs -n "${NS}" "${name}" 2>/dev/null | sed -n 's/^unshare_exit=//p' | tail -1 || true)"
+	echo "RESULT ${name}: unshare_exit=${unshare_exit:-missing}"
+	kubectl delete pod -n "${NS}" "${name}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+	if [[ "${unshare_exit}" == "0" ]]; then
+		printf -v "${ok_var}" '%s' 1
+	else
+		printf -v "${ok_var}" '%s' 0
+	fi
+}
+
+echo "========================================="
+echo "Nested unshare / AppArmor diagnostic"
+echo "========================================="
+echo "Host sysctls (if present):"
+sysctl kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || true
+sysctl kernel.apparmor_restrict_unprivileged_unconfined 2>/dev/null || true
+if command -v aa-status >/dev/null 2>&1; then
+	echo "aa-status (summary):"
+	sudo aa-status 2>/dev/null | head -20 || aa-status 2>/dev/null | head -20 || true
+fi
+
+kubectl delete namespace "${NS}" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+kubectl create namespace "${NS}"
+
+echo "Pre-pulling ${IMAGE}..."
+kubectl -n "${NS}" delete pod puller --ignore-not-found --wait=true >/dev/null 2>&1 || true
+kubectl -n "${NS}" run puller --image="${IMAGE}" --restart=Never --command -- sleep 3600 >/dev/null
+kubectl -n "${NS}" wait --for=condition=Ready pod/puller --timeout=180s
+kubectl -n "${NS}" delete pod puller --ignore-not-found --wait=true >/dev/null 2>&1 || true
+
+default_ok=0
+priv_ok=0
+unconf_ok=0
+
+echo ""
+echo "### 1/3 default security context"
+run_case unshare-default "$(
+	cat <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: unshare-default
+spec:
+  restartPolicy: Never
+  containers:
+  - name: diag
+    image: ${IMAGE}
+    imagePullPolicy: IfNotPresent
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+$(indent_diag)
+EOF
+)" default_ok
+
+echo ""
+echo "### 2/3 privileged: true"
+run_case unshare-privileged "$(
+	cat <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: unshare-privileged
+spec:
+  restartPolicy: Never
+  containers:
+  - name: diag
+    image: ${IMAGE}
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      privileged: true
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+$(indent_diag)
+EOF
+)" priv_ok
+
+echo ""
+echo "### 3/3 AppArmor + seccomp Unconfined (non-privileged)"
+run_case unshare-unconfined "$(
+	cat <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: unshare-unconfined
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/diag: unconfined
+spec:
+  restartPolicy: Never
+  containers:
+  - name: diag
+    image: ${IMAGE}
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      allowPrivilegeEscalation: true
+      seccompProfile:
+        type: Unconfined
+      capabilities:
+        add: ["SYS_ADMIN", "SYS_CHROOT", "SETUID", "SETGID"]
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+$(indent_diag)
+EOF
+)" unconf_ok
+
+kubectl delete namespace "${NS}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+
+echo ""
+echo "========================================="
+echo "Summary (1=unshare -m ok):"
+echo "  default=${default_ok} privileged=${priv_ok} apparmor+seccomp_unconfined=${unconf_ok}"
+echo "========================================="
+exit 0

--- a/scripts/publish-kind-compatible-host-ports.sh
+++ b/scripts/publish-kind-compatible-host-ports.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Publish Kind-compatible host ports onto native NodePorts (k3s / bare metal).
+#
+# Kind's extraPortMappings (kind-config.yaml) make hostPort the public API while
+# Services use NodePorts in the 30000+ range. Native k3s exposes only the
+# NodePort numbers on the host, so clients that dial https://localhost:9443
+# (status.uiURL, Dex/oauth2-proxy) get connection refused unless we republish.
+#
+# This script mirrors kind-config.yaml hostPort → containerPort (NodePort):
+#   8888 → 30010
+#   9443 → 30011  (UI HTTPS)
+#   8180 → 30012  (PaC)
+#   5001 → 30001  (registry; override with REGISTRY_HOST_PORT)
+#   8443 → 30002  (Quay)
+#
+# Env:
+#   REGISTRY_HOST_PORT           - host port for registry (default: 5001)
+#   K3S_PUBLISH_KIND_PORTS       - set to 0 to skip (default: publish)
+#   KONFLUX_KIND_PORT_STATE_DIR  - pid/log dir (default: under XDG_RUNTIME_DIR or /tmp)
+#
+set -euo pipefail
+
+if [[ "${K3S_PUBLISH_KIND_PORTS:-1}" == "0" ]]; then
+	echo "Skipping Kind-compatible host port publish (K3S_PUBLISH_KIND_PORTS=0)"
+	exit 0
+fi
+
+REGISTRY_HOST_PORT="${REGISTRY_HOST_PORT:-5001}"
+STATE_DIR="${KONFLUX_KIND_PORT_STATE_DIR:-${XDG_RUNTIME_DIR:-/tmp}/konflux-kind-compatible-ports}"
+mkdir -p "${STATE_DIR}"
+
+# host_port:node_port — keep in sync with kind-config.yaml extraPortMappings
+PORT_MAPPINGS=(
+	"8888:30010"
+	"9443:30011"
+	"8180:30012"
+	"${REGISTRY_HOST_PORT}:30001"
+	"8443:30002"
+)
+
+ensure_socat() {
+	if command -v socat >/dev/null 2>&1; then
+		return 0
+	fi
+	echo "socat not found; installing (required to publish Kind-compatible host ports)..."
+	if command -v apt-get >/dev/null 2>&1; then
+		sudo apt-get update -qq
+		sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq socat
+	elif command -v dnf >/dev/null 2>&1; then
+		sudo dnf install -y socat
+	elif command -v yum >/dev/null 2>&1; then
+		sudo yum install -y socat
+	else
+		echo "ERROR: install socat (used to map Kind host ports → NodePorts), then re-run." >&2
+		exit 1
+	fi
+	command -v socat >/dev/null 2>&1
+}
+
+# True if our socat for this host port is still running.
+our_listener_alive() {
+	local host_port=$1
+	local pidfile="${STATE_DIR}/tcp4-${host_port}.pid"
+	local pid
+	[[ -f "${pidfile}" ]] || return 1
+	pid="$(cat "${pidfile}")"
+	kill -0 "${pid}" 2>/dev/null
+}
+
+# True if anything is listening on the host port (IPv4 or IPv6).
+host_port_busy() {
+	local host_port=$1
+	ss -ltnH "sport = :${host_port}" 2>/dev/null | grep -q .
+}
+
+stop_our_listeners() {
+	local host_port=$1
+	local fam pidfile pid
+	for fam in tcp4 tcp6; do
+		pidfile="${STATE_DIR}/${fam}-${host_port}.pid"
+		if [[ -f "${pidfile}" ]]; then
+			pid="$(cat "${pidfile}")"
+			kill "${pid}" 2>/dev/null || true
+			rm -f "${pidfile}"
+		fi
+	done
+}
+
+start_listener() {
+	local fam=$1 host_port=$2 node_port=$3
+	local pidfile="${STATE_DIR}/${fam}-${host_port}.pid"
+	local logfile="${STATE_DIR}/${fam}-${host_port}.log"
+	local listen_addr
+
+	case "${fam}" in
+	tcp4)
+		listen_addr="TCP4-LISTEN:${host_port},fork,reuseaddr,bind=0.0.0.0"
+		;;
+	tcp6)
+		# ipv6only=1 so this does not steal IPv4; forward to IPv4 NodePort.
+		listen_addr="TCP6-LISTEN:${host_port},fork,reuseaddr,bind=[::],ipv6only=1"
+		;;
+	*)
+		echo "ERROR: unknown address family ${fam}" >&2
+		return 1
+		;;
+	esac
+
+	# NodePorts listen on the host; prefer IPv4 loopback as the upstream.
+	nohup socat "${listen_addr}" "TCP:127.0.0.1:${node_port}" >"${logfile}" 2>&1 &
+	echo $! >"${pidfile}"
+	sleep 0.1
+	if ! kill -0 "$(cat "${pidfile}")" 2>/dev/null; then
+		echo "ERROR: socat ${fam} :${host_port} → :${node_port} failed to start; log:" >&2
+		cat "${logfile}" >&2 || true
+		rm -f "${pidfile}"
+		return 1
+	fi
+}
+
+publish_one() {
+	local host_port=$1 node_port=$2
+
+	if our_listener_alive "${host_port}"; then
+		echo "  :${host_port} → :${node_port} (already published)"
+		return 0
+	fi
+
+	if host_port_busy "${host_port}"; then
+		echo "ERROR: host port ${host_port} is already in use (and not by this script)." >&2
+		echo "  Free it, or stop Kind if both stacks share Kind host ports." >&2
+		echo "  To skip publishing: K3S_PUBLISH_KIND_PORTS=0" >&2
+		ss -ltnH "sport = :${host_port}" >&2 || true
+		return 1
+	fi
+
+	stop_our_listeners "${host_port}"
+	start_listener tcp4 "${host_port}" "${node_port}"
+	# IPv6 localhost ([::1]) is what Go often dials for "localhost"; Kind hostPorts accept it.
+	if [[ -e /proc/net/if_inet6 ]]; then
+		start_listener tcp6 "${host_port}" "${node_port}" || {
+			echo "WARNING: IPv6 publish for :${host_port} failed; IPv4-only (127.0.0.1:${host_port} still works)" >&2
+		}
+	fi
+	echo "  :${host_port} → :${node_port}"
+}
+
+ensure_socat
+
+echo "Publishing Kind-compatible host ports → NodePorts..."
+for mapping in "${PORT_MAPPINGS[@]}"; do
+	publish_one "${mapping%%:*}" "${mapping##*:}"
+done
+echo "✓ Kind-compatible host ports published (state: ${STATE_DIR})"

--- a/scripts/setup-k3s-local-cluster.sh
+++ b/scripts/setup-k3s-local-cluster.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Setup a native k3s cluster for Konflux (Linux only).
+#
+# See docs/local-k3s.md for host firewall / sudo requirements.
+#
+# Env:
+#   K3S_VERSION              - optional pin (e.g. v1.36.2+k3s1); default: channel stable
+#   K3S_KUBECONFIG           - user kubeconfig path (default: ~/.kube/k3s.yaml)
+#   K3S_CONFIGURE_FIREWALL   - if 1 (default) and firewall-cmd exists, apply runtime rules
+#   K3S_FIREWALL_ZONE        - egress zone for masquerade (default: FedoraWorkstation, else public)
+#   K3S_DISABLE_TRAFFIC_FW   - if 1, skip firewall configuration
+#   K3S_PUBLISH_KIND_PORTS   - if 0, skip Kind hostPort→NodePort publish (default: publish)
+#   REGISTRY_HOST_PORT       - host port for registry mapping (default: 5001; see kind-config.yaml)
+#
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+	echo "ERROR: native k3s is only supported on Linux. On macOS use Kind (CLUSTER_BACKEND=kind)." >&2
+	exit 1
+fi
+
+K3S_KUBECONFIG="${K3S_KUBECONFIG:-${HOME}/.kube/k3s.yaml}"
+K3S_CONFIGURE_FIREWALL="${K3S_CONFIGURE_FIREWALL:-1}"
+K3S_DISABLE_TRAFFIC_FW="${K3S_DISABLE_TRAFFIC_FW:-0}"
+
+configure_firewalld() {
+	if [[ "${K3S_DISABLE_TRAFFIC_FW}" == "1" || "${K3S_CONFIGURE_FIREWALL}" == "0" ]]; then
+		echo "Skipping firewalld configuration (K3S_CONFIGURE_FIREWALL=${K3S_CONFIGURE_FIREWALL}, K3S_DISABLE_TRAFFIC_FW=${K3S_DISABLE_TRAFFIC_FW})"
+		return 0
+	fi
+	if ! command -v firewall-cmd >/dev/null 2>&1; then
+		return 0
+	fi
+	if ! firewall-cmd --state >/dev/null 2>&1; then
+		echo "firewalld installed but not running; skipping firewall rules"
+		return 0
+	fi
+
+	local zone="${K3S_FIREWALL_ZONE:-}"
+	if [[ -z "${zone}" ]]; then
+		if firewall-cmd --get-zones 2>/dev/null | tr ' ' '\n' | grep -qx 'FedoraWorkstation'; then
+			zone=FedoraWorkstation
+		else
+			zone=public
+		fi
+	fi
+
+	echo "Configuring firewalld (runtime) for k3s pod egress (zone=${zone})..."
+	echo "  See docs/local-k3s.md — requires sudo"
+	sudo firewall-cmd --add-port=6443/tcp
+	sudo firewall-cmd --add-port=10250/tcp
+	sudo firewall-cmd --add-port=8472/udp
+	sudo firewall-cmd --add-port=51820/udp
+	sudo firewall-cmd --zone=trusted --add-source=10.42.0.0/16
+	sudo firewall-cmd --zone=trusted --add-source=10.43.0.0/16
+	sudo firewall-cmd --zone="${zone}" --add-masquerade
+	echo "✓ firewalld runtime rules applied"
+}
+
+install_or_reuse_k3s() {
+	if systemctl is-active --quiet k3s 2>/dev/null; then
+		echo "k3s service already active; reusing"
+		return 0
+	fi
+	if command -v k3s >/dev/null 2>&1 && sudo k3s kubectl get nodes >/dev/null 2>&1; then
+		echo "k3s binary present and API reachable; ensuring service is started"
+		sudo systemctl start k3s || true
+		return 0
+	fi
+
+	echo "Installing k3s (Traefik disabled)..."
+	local install_args=(--write-kubeconfig-mode 644 --disable traefik)
+	if [[ -n "${K3S_VERSION:-}" ]]; then
+		echo "  Pinning INSTALL_K3S_VERSION=${K3S_VERSION}"
+		curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${K3S_VERSION}" sh -s - "${install_args[@]}"
+	else
+		curl -sfL https://get.k3s.io | sh -s - "${install_args[@]}"
+	fi
+}
+
+write_kubeconfig() {
+	mkdir -p "$(dirname "${K3S_KUBECONFIG}")"
+	if [[ -r /etc/rancher/k3s/k3s.yaml ]]; then
+		cp /etc/rancher/k3s/k3s.yaml "${K3S_KUBECONFIG}"
+	else
+		sudo cp /etc/rancher/k3s/k3s.yaml "${K3S_KUBECONFIG}"
+		sudo chown "$(id -u):$(id -g)" "${K3S_KUBECONFIG}"
+	fi
+	chmod 600 "${K3S_KUBECONFIG}" 2>/dev/null || true
+	export KUBECONFIG="${K3S_KUBECONFIG}"
+	echo "KUBECONFIG=${KUBECONFIG}"
+
+	# Propagate to GitHub Actions subsequent steps when present.
+	if [[ -n "${GITHUB_ENV:-}" ]]; then
+		echo "KUBECONFIG=${KUBECONFIG}" >>"${GITHUB_ENV}"
+	fi
+}
+
+# Same shape as deploy-deps.sh / deploy-image-controller.sh: retry a command a few times.
+retry() {
+	local ret=0
+	for i in {1..3}; do
+		ret=0
+		# shellcheck disable=SC2086
+		$1 || ret="$?"
+		if [[ "$ret" -eq 0 ]]; then
+			return 0
+		fi
+		if [[ "$i" -lt 3 ]]; then
+			echo "🔄 Retrying command (attempt $((i + 1))/3)..." >&2
+			sleep 3
+		fi
+	done
+	echo "$1": "$2." >&2
+	return "$ret"
+}
+
+wait_for_node() {
+	export KUBECONFIG="${K3S_KUBECONFIG}"
+
+	# kubectl wait --all fails immediately with "no matching resources found" if the
+	# API is up but the node object is not registered yet (common right after k3s start).
+	# Match deploy-deps.sh: until the object exists, then retry the wait.
+	echo "Waiting for k3s node object to appear..."
+	local attempts=0
+	until kubectl get nodes --no-headers 2>/dev/null | grep -q .; do
+		attempts=$((attempts + 1))
+		if ((attempts > 60)); then
+			echo "Timed out waiting for k3s to register a node" >&2
+			kubectl get nodes -o wide >&2 || true
+			return 1
+		fi
+		sleep 2
+	done
+
+	echo "Waiting for k3s node Ready..."
+	retry "kubectl wait --for=condition=Ready nodes --all --timeout=120s" \
+		"k3s node did not become Ready within the allocated time"
+	kubectl get nodes -o wide
+	kubectl get storageclass
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "========================================="
+echo "Konflux k3s cluster setup"
+echo "========================================="
+
+configure_firewalld
+install_or_reuse_k3s
+write_kubeconfig
+wait_for_node
+
+# Kind hostPorts are the public API (uiURL https://localhost:9443, etc.).
+# Native k3s only binds NodePorts (30011, …); republish to match kind-config.yaml.
+"${SCRIPT_DIR}/publish-kind-compatible-host-ports.sh"
+
+echo "✓ k3s cluster ready"


### PR DESCRIPTION
We're stretching the resource limits with e2e tests based on kind. Trying to deploy on k3s instead, which is more lightweight and should be able to run on our CI.

Assisted-by: Cursor