### PR TITLE
Remove build-time Segment write key from operator image

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -153,37 +153,6 @@ spec:
       workspaces:
         - name: basic-auth
           workspace: git-auth
-    # The Segment write key is a client-side analytics token (similar to a
-    # Google Analytics tracking ID). It only permits writing telemetry events
-    # and is baked into the public binary via ldflags, so exposing it through
-    # a Tekton result is acceptable.
-    - name: read-segment-key
-      runAfter:
-        - init
-      taskSpec:
-        results:
-          - name: segment-write-key
-            description: Segment write key read from the default-segment-key secret
-        volumes:
-          - name: segment-key
-            secret:
-              secretName: default-segment-key
-              optional: true
-        steps:
-          - name: read-secret
-            image: registry.access.redhat.com/ubi10/ubi-minimal@sha256:ceaad73890ea88685eeb1b40a502b7983f2cfac6f1aa10915d1176d51eb90124
-            volumeMounts:
-              - name: segment-key
-                mountPath: /var/run/secrets/segment
-                readOnly: true
-            script: |
-              #!/usr/bin/env bash
-              KEY_FILE="/var/run/secrets/segment/SEGMENT_WRITE_KEY"
-              if [ -f "$KEY_FILE" ]; then
-                tr -d '\n' < "$KEY_FILE" > "$(results.segment-write-key.path)"
-              else
-                printf '' > "$(results.segment-write-key.path)"
-              fi
     - name: prefetch-dependencies
       params:
         - name: input
@@ -236,7 +205,6 @@ spec:
         - name: BUILD_ARGS
           value:
             - $(params.build-args[*])
-            - "SEGMENT_WRITE_KEY=$(tasks.read-segment-key.results.segment-write-key)"
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)
         - name: PRIVILEGED_NESTED
@@ -265,7 +233,6 @@ spec:
           value: $(params.omit-history)
       runAfter:
         - prefetch-dependencies
-        - read-segment-key
       taskRef:
         params:
           - name: name

--- a/operator/Containerfile
+++ b/operator/Containerfile
@@ -4,7 +4,6 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG OPERATOR_VERSION
 ARG GIT_COMMIT
-ARG SEGMENT_WRITE_KEY
 
 ENV GOTOOLCHAIN=auto
 WORKDIR /workspace
@@ -24,8 +23,7 @@ COPY --chmod=755 pkg/ pkg/
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
     go build -a \
     -ldflags "-X github.com/konflux-ci/konflux-ci/operator/pkg/version.Version=${OPERATOR_VERSION:-unknown} \
-              -X github.com/konflux-ci/konflux-ci/operator/pkg/version.GitCommit=${GIT_COMMIT:-unknown} \
-              -X github.com/konflux-ci/konflux-ci/operator/pkg/segment.defaultWriteKey=${SEGMENT_WRITE_KEY:-}" \
+              -X github.com/konflux-ci/konflux-ci/operator/pkg/version.GitCommit=${GIT_COMMIT:-unknown}" \
     -o /opt/app-root/manager ./cmd/main.go
 
 # Use UBI minimal as base image

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -216,7 +216,6 @@ docker-build: ## Build docker image with the manager.
 		-t ${IMG} \
 		$(if $(VERSION),--build-arg OPERATOR_VERSION=$(VERSION)) \
 		$(if $(GIT_COMMIT),--build-arg GIT_COMMIT=$(GIT_COMMIT)) \
-		$(if $(SEGMENT_WRITE_KEY),--build-arg SEGMENT_WRITE_KEY=$(SEGMENT_WRITE_KEY)) \
 		.
 
 .PHONY: docker-push

--- a/operator/api/v1alpha1/konfluxsegmentbridge_types.go
+++ b/operator/api/v1alpha1/konfluxsegmentbridge_types.go
@@ -36,8 +36,8 @@ const (
 // KonfluxSegmentBridgeSpec defines the desired state of KonfluxSegmentBridge.
 type KonfluxSegmentBridgeSpec struct {
 	// SegmentKey is the write key used to authenticate with the Segment API.
-	// When not specified, a default key baked into the operator build is used,
-	// routing telemetry data to the Konflux dev team's Segment project.
+	// When not specified, no telemetry data is sent. Provide your own Segment
+	// write key to enable telemetry.
 	// +optional
 	SegmentKey string `json:"segmentKey,omitempty"`
 

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -68,7 +68,6 @@ import (
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
-	"github.com/konflux-ci/konflux-ci/operator/pkg/segment"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/version"
 	// +kubebuilder:scaffold:imports
 )
@@ -387,11 +386,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&ui.KonfluxUIReconciler{
-		Client:               mgr.GetClient(),
-		Scheme:               mgr.GetScheme(),
-		ObjectStore:          objectStore,
-		ClusterInfo:          clusterInfo,
-		GetDefaultSegmentKey: segment.GetDefaultWriteKey,
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ObjectStore: objectStore,
+		ClusterInfo: clusterInfo,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KonfluxUI")
 		os.Exit(1)
@@ -474,11 +472,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&segmentbridge.KonfluxSegmentBridgeReconciler{
-		Client:               mgr.GetClient(),
-		Scheme:               mgr.GetScheme(),
-		ObjectStore:          objectStore,
-		ClusterInfo:          clusterInfo,
-		GetDefaultSegmentKey: segment.GetDefaultWriteKey,
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		ObjectStore: objectStore,
+		ClusterInfo: clusterInfo,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KonfluxSegmentBridge")
 		os.Exit(1)

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
@@ -2923,8 +2923,8 @@ spec:
                       segmentKey:
                         description: |-
                           SegmentKey is the write key used to authenticate with the Segment API.
-                          When not specified, a default key baked into the operator build is used,
-                          routing telemetry data to the Konflux dev team's Segment project.
+                          When not specified, no telemetry data is sent. Provide your own Segment
+                          write key to enable telemetry.
                         type: string
                       tektonLimit:
                         description: |-

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxsegmentbridges.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxsegmentbridges.yaml
@@ -279,8 +279,8 @@ spec:
               segmentKey:
                 description: |-
                   SegmentKey is the write key used to authenticate with the Segment API.
-                  When not specified, a default key baked into the operator build is used,
-                  routing telemetry data to the Konflux dev team's Segment project.
+                  When not specified, no telemetry data is sent. Provide your own Segment
+                  write key to enable telemetry.
                 type: string
               tektonLimit:
                 description: |-

--- a/operator/config/samples/konflux_v1alpha1_konflux.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konflux.yaml
@@ -186,7 +186,7 @@ spec:
   #   # Defaults to false if not specified.
   #   enabled: true
   #   spec:
-  #     # segmentKey is the Segment write key; omit to use the default build-time key
+  #     # segmentKey is the Segment write key (required for telemetry to send data)
   #     # segmentKey: "your-write-key"
   #
   #     # segmentAPIURL is the base URL without "/batch". The operator appends "/batch".

--- a/operator/docs/content/docs/guides/telemetry.md
+++ b/operator/docs/content/docs/guides/telemetry.md
@@ -9,15 +9,14 @@ Konflux includes an optional telemetry component called **segment-bridge** that
 collects anonymized usage data and sends it to [Segment](https://segment.com/)
 for downstream analysis in tools such as [Amplitude](https://amplitude.com/).
 
-On **OpenShift**, telemetry is **enabled by default**. On **vanilla
-Kubernetes** clusters, telemetry is **disabled by default** and must be
-explicitly opted in.
+Telemetry is **disabled by default** and must be explicitly enabled in your
+`Konflux` CR.
 
 ## Enabling telemetry
 
-On OpenShift no action is needed — telemetry is active out of the box. On
-vanilla Kubernetes, set `spec.telemetry.enabled` to `true` in your `Konflux`
-CR:
+Set `spec.telemetry.enabled` to `true` and provide a Segment write key in
+`spec.telemetry.spec.segmentKey`. The operator does not ship a default key —
+without one, the CronJob may still run but no events are uploaded to Segment.
 
 ```yaml
 apiVersion: konflux.konflux-ci.dev/v1alpha1
@@ -27,6 +26,8 @@ metadata:
 spec:
   telemetry:
     enabled: true
+    spec:
+      segmentKey: "your-write-key"
 ```
 
 Apply the change:
@@ -47,21 +48,19 @@ resource and deploys the following into the `segment-bridge` namespace:
 Disabling telemetry (setting `enabled: false`) causes the operator to clean
 up all of these resources automatically.
 
-### Optional overrides
+### Segment endpoint
 
-You can override the Segment write key and API endpoint. If omitted the
-operator uses the key baked into the image at build time and the default
-Segment API (`https://api.segment.io/v1`).
+By default, events are sent to Segment's public API at
+`https://api.segment.io/v1` (the operator appends `/batch` for the upload
+endpoint). To route through a proxy or alternate host, set `segmentAPIURL` to
+the base URL only — do not include `/batch`:
 
 ```yaml
 spec:
   telemetry:
     enabled: true
     spec:
-      # Override the Segment write key (omit to use the build-time default)
       segmentKey: "your-write-key"
-
-      # Override the Segment API base URL — do NOT include "/batch"
       segmentAPIURL: "https://your-segment-proxy.example.com/v1"
 ```
 
@@ -187,9 +186,9 @@ information (PII):
 - **User and namespace names are hashed.** A one-way hash of the name is
   combined with a **cluster identifier** to produce an opaque, per-cluster
   unique ID. The original names are never sent to Segment.
-- **Cluster identifier** is derived from the OpenShift `ClusterVersion` object.
-  On vanilla Kubernetes clusters the `kube-system` namespace UID is used
-  instead.
+- **Cluster identifier** is published by the operator in the `konflux-public-info`
+  ConfigMap. When no cluster-wide ID is available, the `kube-system` namespace
+  UID is used as a fallback.
 - **No credentials or secrets** are included in telemetry events.
 - **No source code, image contents, or build logs** are transmitted.
 
@@ -198,15 +197,8 @@ outcomes) and component/namespace identifiers in hashed form.
 
 ## Accessing telemetry data
 
-Where telemetry data lands depends on the Segment write key used by your
-deployment:
-
-- **Build-time default key** — if no `segmentKey` is set in the CR, the
-  operator uses the key baked into the image at build time. Data is sent to
-  whichever Segment workspace that key belongs to.
-- **Custom key** — if you provide your own key via
-  `spec.telemetry.spec.segmentKey`, data is routed to your own Segment
-  workspace instead.
+Events are routed to the Segment workspace that owns the write key configured
+in `spec.telemetry.spec.segmentKey`.
 
 To view incoming events, log in to [app.segment.com](https://app.segment.com)
 with the account that owns the write key and open the source's **Debugger**
@@ -215,8 +207,7 @@ Segment workspace.
 
 ## Disabling telemetry
 
-To opt out of telemetry (including on OpenShift where it is on by default),
-set `enabled` to `false` in your Konflux CR:
+To opt out of telemetry, set `enabled` to `false` in your Konflux CR:
 
 ```yaml
 spec:

--- a/operator/internal/controller/segmentbridge/konfluxsegmentbridge_controller.go
+++ b/operator/internal/controller/segmentbridge/konfluxsegmentbridge_controller.go
@@ -91,10 +91,9 @@ type manifestSource interface {
 // KonfluxSegmentBridgeReconciler reconciles a KonfluxSegmentBridge object
 type KonfluxSegmentBridgeReconciler struct {
 	client.Client
-	Scheme               *runtime.Scheme
-	ObjectStore          manifestSource
-	ClusterInfo          *clusterinfo.Info
-	GetDefaultSegmentKey func() string
+	Scheme      *runtime.Scheme
+	ObjectStore manifestSource
+	ClusterInfo *clusterinfo.Info
 }
 
 // +kubebuilder:rbac:groups=konflux.konflux-ci.dev,resources=konfluxsegmentbridges,verbs=get;list;watch;create;update;patch;delete
@@ -204,14 +203,13 @@ func (r *KonfluxSegmentBridgeReconciler) tektonResultsAPIAddr() string {
 //
 // Key resolution precedence:
 //  1. CR inline spec.segmentKey (admin override)
-//  2. Build-time default from GetDefaultSegmentKey (baked into binary via ldflags)
-//  3. Empty -- Secret is still created so the CronJob can reach the Results API;
+//  2. Empty -- Secret is still created so the CronJob can reach the Results API;
 //     the segment-bridge scripts handle the missing key gracefully by skipping the
 //     upload step.
 func (r *KonfluxSegmentBridgeReconciler) reconcileSegmentBridgeSecret(ctx context.Context, tc *tracking.Client, spec *konfluxv1alpha1.KonfluxSegmentBridgeSpec) error {
 	log := logf.FromContext(ctx)
 
-	segmentKey, source := segment.ResolveWriteKey(spec.GetSegmentKey(), r.GetDefaultSegmentKey())
+	segmentKey, source := segment.ResolveWriteKey(spec.GetSegmentKey())
 	segment.LogWriteKeyResolution(log, segmentKey, source)
 
 	batchURL, err := url.JoinPath(spec.GetSegmentAPIURL(), "batch")

--- a/operator/internal/controller/segmentbridge/konfluxsegmentbridge_controller_test.go
+++ b/operator/internal/controller/segmentbridge/konfluxsegmentbridge_controller_test.go
@@ -44,9 +44,6 @@ import (
 
 const childResourceName = "segment-bridge"
 
-func noDefaultKey() string             { return "" }
-func staticKey(k string) func() string { return func() string { return k } }
-
 type mockDiscoveryClient struct {
 	resources     map[string]*metav1.APIResourceList
 	serverVersion *version.Info
@@ -79,16 +76,14 @@ var _ = Describe("KonfluxSegmentBridge Controller", func() {
 	// startManager creates a per-test manager with the given reconciler configuration
 	// and registers a DeferCleanup to cancel it after the test.
 	// A per-test manager is required because each test wires the reconciler with a different
-	// GetDefaultSegmentKey or ClusterInfo, and a shared suite-level manager cannot be
-	// re-configured between tests.
-	startManager := func(getDefaultSegmentKey func() string, clusterInfo *clusterinfo.Info) {
+	// ClusterInfo, and a shared suite-level manager cannot be re-configured between tests.
+	startManager := func(clusterInfo *clusterinfo.Info) {
 		mgr := testutil.NewTestManager(testEnv)
 		Expect((&KonfluxSegmentBridgeReconciler{
-			Client:               mgr.GetClient(),
-			Scheme:               mgr.GetScheme(),
-			ObjectStore:          objectStore,
-			GetDefaultSegmentKey: getDefaultSegmentKey,
-			ClusterInfo:          clusterInfo,
+			Client:      mgr.GetClient(),
+			Scheme:      mgr.GetScheme(),
+			ObjectStore: objectStore,
+			ClusterInfo: clusterInfo,
 		}).SetupWithManager(mgr)).To(Succeed())
 		mgrCtx, cancel := context.WithCancel(testEnv.Ctx)
 		waitForStop := testutil.StartManagerWithContext(mgrCtx, mgr)
@@ -151,7 +146,7 @@ var _ = Describe("KonfluxSegmentBridge Controller", func() {
 
 	Context("When reconciling a resource", func() {
 		Context("with no-op default segment key", func() {
-			BeforeEach(func() { startManager(noDefaultKey, nil) })
+			BeforeEach(func() { startManager(nil) })
 
 			It("should successfully reconcile the resource", func(ctx context.Context) {
 				createCR(ctx)
@@ -286,34 +281,6 @@ var _ = Describe("KonfluxSegmentBridge Controller", func() {
 			})
 		})
 
-		Context("with build-time default key", func() {
-			BeforeEach(func() { startManager(staticKey("build-time-key"), nil) })
-
-			It("should use build-time default key when CR key is empty", func(ctx context.Context) {
-				createCR(ctx)
-				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
-					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(Equal("build-time-key"))
-					g.Expect(string(data["SEGMENT_BATCH_API"])).To(Equal(
-						konfluxv1alpha1.DefaultSegmentAPIURL + "/batch"))
-					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
-				})
-			})
-
-			It("should prefer CR inline key over build-time default", func(ctx context.Context) {
-				createCR(ctx)
-
-				resource := &konfluxv1alpha1.KonfluxSegmentBridge{}
-				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, resource)).To(Succeed())
-				resource.Spec.SegmentKey = "cr-override-key"
-				Expect(k8sClient.Update(ctx, resource)).To(Succeed())
-
-				waitForSecret(ctx, func(g Gomega, data map[string][]byte) {
-					g.Expect(string(data["SEGMENT_WRITE_KEY"])).To(Equal("cr-override-key"))
-					g.Expect(string(data["TEKTON_RESULTS_API_ADDR"])).To(Equal(tektonResultsAPIAddrK8s))
-				})
-			})
-		})
-
 		Context("on OpenShift", func() {
 			BeforeEach(func() {
 				openShiftClusterInfo, err := clusterinfo.DetectWithClient(&mockDiscoveryClient{
@@ -327,7 +294,7 @@ var _ = Describe("KonfluxSegmentBridge Controller", func() {
 					serverVersion: &version.Info{GitVersion: "v1.29.0"},
 				})
 				Expect(err).NotTo(HaveOccurred())
-				startManager(noDefaultKey, openShiftClusterInfo)
+				startManager(openShiftClusterInfo)
 			})
 
 			It("should use OpenShift Tekton Results API address when running on OpenShift", func(ctx context.Context) {
@@ -369,7 +336,7 @@ var _ = Describe("KonfluxSegmentBridge Controller", func() {
 	})
 
 	Context("Self-healing", func() {
-		BeforeEach(func() { startManager(noDefaultKey, nil) })
+		BeforeEach(func() { startManager(nil) })
 
 		It("recreates ServiceAccount when deleted", func(ctx context.Context) {
 			cr := &konfluxv1alpha1.KonfluxSegmentBridge{
@@ -503,7 +470,7 @@ var _ = Describe("KonfluxSegmentBridge Controller", func() {
 	})
 
 	Context("Drift correction", func() {
-		BeforeEach(func() { startManager(noDefaultKey, nil) })
+		BeforeEach(func() { startManager(nil) })
 
 		It("restores Namespace labels when stripped", func(ctx context.Context) {
 			cr := &konfluxv1alpha1.KonfluxSegmentBridge{

--- a/operator/internal/controller/ui/konfluxui_controller.go
+++ b/operator/internal/controller/ui/konfluxui_controller.go
@@ -143,10 +143,9 @@ var UIClusterScopedAllowList = tracking.ClusterScopedAllowList{
 // KonfluxUIReconciler reconciles a KonfluxUI object
 type KonfluxUIReconciler struct {
 	client.Client
-	Scheme               *runtime.Scheme
-	ObjectStore          *manifests.ObjectStore
-	ClusterInfo          *clusterinfo.Info
-	GetDefaultSegmentKey func() string
+	Scheme      *runtime.Scheme
+	ObjectStore *manifests.ObjectStore
+	ClusterInfo *clusterinfo.Info
 }
 
 // +kubebuilder:rbac:groups=konflux.konflux-ci.dev,resources=konfluxuis,verbs=get;list;watch;create;update;patch;delete
@@ -770,8 +769,8 @@ func (r *KonfluxUIReconciler) reconcileSegmentSecret(ctx context.Context, tc *tr
 		return "", nil
 	}
 
-	// Resolve the write key (CR spec → build-time default → empty)
-	segmentKey, source := segment.ResolveWriteKey(segmentBridge.Spec.GetSegmentKey(), r.GetDefaultSegmentKey())
+	// Resolve the write key (CR spec → empty)
+	segmentKey, source := segment.ResolveWriteKey(segmentBridge.Spec.GetSegmentKey())
 	if !segment.LogWriteKeyResolution(log, segmentKey, source) {
 		return "", nil
 	}

--- a/operator/internal/controller/ui/konfluxui_controller_test.go
+++ b/operator/internal/controller/ui/konfluxui_controller_test.go
@@ -58,23 +58,18 @@ const (
 	caIssuerName              = "ui-ca-issuer"
 )
 
-func noDefaultSegmentKey() string             { return "" }
-func staticSegmentKey(k string) func() string { return func() string { return k } }
-
 var _ = Describe("KonfluxUI Controller", func() {
 	// startManager creates a per-test manager with the given reconciler configuration
 	// and registers a DeferCleanup to cancel it after the test.
 	// A per-test manager is required because each test wires the reconciler with a different
-	// GetDefaultSegmentKey or ClusterInfo, and a shared suite-level manager cannot be
-	// re-configured between tests.
-	startManager := func(getDefaultSegmentKey func() string, clusterInfo *clusterinfo.Info) {
+	// ClusterInfo, and a shared suite-level manager cannot be re-configured between tests.
+	startManager := func(clusterInfo *clusterinfo.Info) {
 		mgr := testutil.NewTestManager(testEnv)
 		Expect((&KonfluxUIReconciler{
-			Client:               mgr.GetClient(),
-			Scheme:               mgr.GetScheme(),
-			ObjectStore:          objectStore,
-			GetDefaultSegmentKey: getDefaultSegmentKey,
-			ClusterInfo:          clusterInfo,
+			Client:      mgr.GetClient(),
+			Scheme:      mgr.GetScheme(),
+			ObjectStore: objectStore,
+			ClusterInfo: clusterInfo,
 		}).SetupWithManager(mgr)).To(Succeed())
 		mgrCtx, cancel := context.WithCancel(testEnv.Ctx)
 		waitForStop := testutil.StartManagerWithContext(mgrCtx, mgr)
@@ -99,7 +94,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 	Context("When reconciling a resource", func() {
 		It("should successfully reconcile the resource", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			Expect(k8sClient.Create(ctx, &konfluxv1alpha1.KonfluxUI{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
@@ -128,7 +123,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		}
 
 		BeforeEach(func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			By("ensuring the UI namespace exists")
 			uiNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: uiNamespace}}
@@ -431,7 +426,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		}
 
 		BeforeEach(func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			By("pre-cleaning any existing Ingress")
 			_ = k8sClient.Delete(ctx, &networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{
@@ -634,7 +629,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		}
 
 		It("Should create OpenShift OAuth resources when running on OpenShift (default behavior)", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			startManager(openShiftClusterInfo)
 			createCR(ctx)
 
 			Eventually(func(g Gomega) {
@@ -650,7 +645,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("Should NOT annotate dex ServiceAccount when NOT running on OpenShift", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, defaultClusterInfo)
+			startManager(defaultClusterInfo)
 			createCR(ctx)
 
 			By("waiting for initial reconcile to complete")
@@ -666,7 +661,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("Should NOT create OpenShift OAuth resources when ClusterInfo is nil", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 			createCR(ctx)
 
 			By("waiting for initial reconcile to complete")
@@ -682,7 +677,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("Should NOT create OpenShift OAuth resources when explicitly disabled on OpenShift", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			startManager(openShiftClusterInfo)
 			ui := createCR(ctx)
 
 			By("disabling OpenShift login before first reconcile settles")
@@ -707,7 +702,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("Should create OpenShift OAuth resources when explicitly enabled on OpenShift", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			startManager(openShiftClusterInfo)
 			ui := createCR(ctx)
 
 			By("explicitly enabling OpenShift login")
@@ -732,7 +727,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("Should delete OpenShift OAuth resources when disabled after being enabled", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			startManager(openShiftClusterInfo)
 			ui := createCR(ctx)
 
 			By("waiting for OAuth resources to be created")
@@ -763,7 +758,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("Should set owner reference on OpenShift OAuth resources", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			startManager(openShiftClusterInfo)
 			createCR(ctx)
 
 			Eventually(func(g Gomega) {
@@ -778,7 +773,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("Should use correct redirect URI format without port", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			startManager(openShiftClusterInfo)
 			createCR(ctx)
 
 			Eventually(func(g Gomega) {
@@ -797,7 +792,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		var ui *konfluxv1alpha1.KonfluxUI
 
 		BeforeEach(func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui = &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -951,7 +946,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		}
 
 		It("Should create ConsoleLink when ingress is enabled and running on OpenShift", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			startManager(openShiftClusterInfo)
 			createCR(ctx)
 
 			Eventually(func(g Gomega) {
@@ -968,7 +963,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("Should NOT create ConsoleLink when NOT running on OpenShift", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, defaultClusterInfo)
+			startManager(defaultClusterInfo)
 			createCR(ctx)
 
 			By("waiting for initial reconcile to complete")
@@ -980,7 +975,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("Should NOT create ConsoleLink when ClusterInfo is nil", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 			createCR(ctx)
 
 			By("waiting for initial reconcile to complete")
@@ -992,7 +987,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("Should NOT create ConsoleLink when ingress is disabled on OpenShift", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			startManager(openShiftClusterInfo)
 			ui := createCR(ctx)
 
 			By("disabling ingress")
@@ -1008,7 +1003,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("Should delete ConsoleLink when ingress is disabled", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			startManager(openShiftClusterInfo)
 			ui := createCR(ctx)
 
 			By("waiting for ConsoleLink to be created")
@@ -1031,7 +1026,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("Should update ConsoleLink when hostname changes", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			startManager(openShiftClusterInfo)
 			ui := createCR(ctx)
 
 			By("waiting for initial ConsoleLink")
@@ -1058,7 +1053,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("recreates ConsoleLink when deleted while ingress is enabled", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			startManager(openShiftClusterInfo)
 			createCR(ctx)
 
 			By("waiting for initial ConsoleLink creation")
@@ -1090,7 +1085,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 	Context("Self-healing", func() {
 		It("recreates Deployment when deleted", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1120,7 +1115,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("recreates Service when deleted", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1147,7 +1142,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("recreates ServiceAccount when deleted", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1174,7 +1169,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("recreates ClusterRole when deleted", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1201,7 +1196,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("recreates ClusterRoleBinding when deleted", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1228,7 +1223,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("recreates Certificate when deleted", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1255,7 +1250,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("recreates Issuer when deleted", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1282,7 +1277,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("recreates ConfigMap when deleted", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1319,7 +1314,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 	Context("Drift correction", func() {
 		It("restores Deployment image when modified", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1359,7 +1354,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("restores ServiceAccount labels when stripped", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1393,7 +1388,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("restores Service labels when stripped", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1427,7 +1422,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("restores Service spec when modified", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1463,7 +1458,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("restores Namespace labels when stripped", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1497,7 +1492,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("restores ClusterRole rules when modified", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1535,7 +1530,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("restores ClusterRoleBinding subjects when modified", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1573,7 +1568,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("restores Certificate labels when stripped", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1607,7 +1602,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("restores Issuer labels when stripped", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1641,7 +1636,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("restores Certificate DNSNames when modified", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1675,7 +1670,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("restores Issuer CA secret name when modified", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1710,7 +1705,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("restores dex Deployment image when modified", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{ObjectMeta: metav1.ObjectMeta{Name: CRName}}
 			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
@@ -1750,7 +1745,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 
 		It("restores Ingress spec when modified", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
@@ -1808,7 +1803,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			startManager(noDefaultSegmentKey, openShiftClusterInfo)
+			startManager(openShiftClusterInfo)
 
 			ui := &konfluxv1alpha1.KonfluxUI{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
@@ -1906,7 +1901,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		}
 
 		It("Should not create segment secret when KonfluxSegmentBridge CR does not exist", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 			createUI(ctx)
 
 			By("waiting for initial reconcile to complete")
@@ -1917,7 +1912,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 		It("Should not create segment secret when no write key is configured", func(ctx context.Context) {
 			bridge := createBridgeCR(ctx)
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 			createUI(ctx)
 
 			By("waiting for initial reconcile with empty Bridge key")
@@ -1933,7 +1928,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 			bridge.Spec.SegmentKey = "test-write-key"
 			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 			createUI(ctx)
 
 			name := expectedSecretName("test-write-key", konfluxv1alpha1.DefaultSegmentAPIURL)
@@ -1954,7 +1949,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 			bridge.Spec.SegmentAPIURL = "https://console.redhat.com/connections/api/v1"
 			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 			createUI(ctx)
 
 			name := expectedSecretName("test-write-key", "https://console.redhat.com/connections/api/v1")
@@ -1968,47 +1963,13 @@ var _ = Describe("KonfluxUI Controller", func() {
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
-		It("Should use build-time default key when CR key is empty", func(ctx context.Context) {
-			createBridgeCR(ctx)
-			startManager(staticSegmentKey("build-time-key"), nil)
-			createUI(ctx)
-
-			name := expectedSecretName("build-time-key", konfluxv1alpha1.DefaultSegmentAPIURL)
-			Eventually(func(g Gomega) {
-				secret := &corev1.Secret{}
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
-					Name: name, Namespace: uiNamespace,
-				}, secret)).To(Succeed())
-				g.Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("build-time-key"))
-			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-		})
-
-		It("Should prefer CR key over build-time default", func(ctx context.Context) {
-			bridge := createBridgeCR(ctx)
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
-			bridge.Spec.SegmentKey = "cr-override-key"
-			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
-
-			startManager(staticSegmentKey("build-time-key"), nil)
-			createUI(ctx)
-
-			name := expectedSecretName("cr-override-key", konfluxv1alpha1.DefaultSegmentAPIURL)
-			Eventually(func(g Gomega) {
-				secret := &corev1.Secret{}
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
-					Name: name, Namespace: uiNamespace,
-				}, secret)).To(Succeed())
-				g.Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("cr-override-key"))
-			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
-		})
-
 		It("Should create a new secret and clean up old one when segment key changes", func(ctx context.Context) {
 			bridge := createBridgeCR(ctx)
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: segmentbridge.CRName}, bridge)).To(Succeed())
 			bridge.Spec.SegmentKey = "initial-key"
 			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 			createUI(ctx)
 
 			initialName := expectedSecretName("initial-key", konfluxv1alpha1.DefaultSegmentAPIURL)
@@ -2042,7 +2003,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 			bridge.Spec.SegmentKey = "temporary-key"
 			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 			createUI(ctx)
 
 			By("waiting for the secret to be created")
@@ -2066,7 +2027,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 			bridge.Spec.SegmentKey = "owner-ref-test-key"
 			Expect(k8sClient.Update(ctx, bridge)).To(Succeed())
 
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 			createUI(ctx)
 
 			Eventually(func(g Gomega) {
@@ -2081,7 +2042,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 	Context("RuntimeConfig reconciliation via Reconcile", Serial, func() {
 		BeforeEach(func() {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 		})
 
 		It("Should set RUNTIME_* env vars on generate-proxy-config init container", func(ctx context.Context) {
@@ -2193,7 +2154,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		}
 
 		It("applies ServiceMonitor and metrics-reader ClusterRole when ComponentMetrics is nil (default enabled)", func(ctx context.Context) {
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
@@ -2219,7 +2180,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 		It("skips ServiceMonitor and metrics-reader ClusterRole when ComponentMetrics.Enabled is false", func(ctx context.Context) {
 			cleanupMetricsResources(ctx)
 
-			startManager(noDefaultSegmentKey, nil)
+			startManager(nil)
 
 			ui := &konfluxv1alpha1.KonfluxUI{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},

--- a/operator/pkg/segment/segment.go
+++ b/operator/pkg/segment/segment.go
@@ -20,26 +20,12 @@ import (
 	"github.com/go-logr/logr"
 )
 
-// defaultWriteKey is the Segment write key baked into production builds.
-// Empty in development; set via -ldflags during container image builds.
-// Used as a fallback when the KonfluxSegmentBridge CR does not specify a key.
-var defaultWriteKey = ""
-
-// GetDefaultWriteKey returns the build-time Segment write key.
-func GetDefaultWriteKey() string {
-	return defaultWriteKey
-}
-
 // ResolveWriteKey determines the effective Segment write key.
-// It prefers crKey (from the CR spec); if empty, falls back to defaultKey
-// (typically the build-time value injected via ldflags).
-// Returns the key and its source ("cr", "build-time-default", or "" if unresolved).
-func ResolveWriteKey(crKey, defaultKey string) (key, source string) {
+// It uses crKey (from the CR spec) if non-empty.
+// Returns the key and its source ("cr", or "" if unresolved).
+func ResolveWriteKey(crKey string) (key, source string) {
 	if crKey != "" {
 		return crKey, "cr"
-	}
-	if defaultKey != "" {
-		return defaultKey, "build-time-default"
 	}
 	return "", ""
 }
@@ -48,7 +34,7 @@ func ResolveWriteKey(crKey, defaultKey string) (key, source string) {
 // Returns true if a key is available, false if no key was configured.
 func LogWriteKeyResolution(log logr.Logger, key, source string) bool {
 	if key == "" {
-		log.Info("No Segment write key configured (neither CR nor build-time default)")
+		log.Info("No Segment write key configured in CR")
 		return false
 	}
 	log.Info("Resolved Segment write key", "source", source)

--- a/operator/pkg/segment/segment_test.go
+++ b/operator/pkg/segment/segment_test.go
@@ -23,68 +23,31 @@ import (
 	"github.com/onsi/gomega"
 )
 
-func TestGetDefaultWriteKey(t *testing.T) {
-	g := gomega.NewWithT(t)
-	g.Expect(GetDefaultWriteKey()).To(gomega.BeEmpty(), "should return empty in source (no ldflags)")
-}
-
 func TestResolveWriteKey(t *testing.T) {
-	tests := []struct {
-		name       string
-		crKey      string
-		defaultKey string
-		wantKey    string
-		wantSource string
-	}{
-		{
-			name:       "CR key takes precedence",
-			crKey:      "cr-key",
-			wantKey:    "cr-key",
-			wantSource: "cr",
-		},
-		{
-			name:       "CR key takes precedence over default",
-			crKey:      "cr-key",
-			defaultKey: "build-key",
-			wantKey:    "cr-key",
-			wantSource: "cr",
-		},
-		{
-			name:       "falls back to default when CR key is empty",
-			crKey:      "",
-			defaultKey: "build-key",
-			wantKey:    "build-key",
-			wantSource: "build-time-default",
-		},
-		{
-			name:       "returns empty when neither is set",
-			crKey:      "",
-			defaultKey: "",
-			wantKey:    "",
-			wantSource: "",
-		},
-	}
+	t.Run("returns the CR key and source when the CR key is set", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		key, source := ResolveWriteKey("cr-key")
+		g.Expect(key).To(gomega.Equal("cr-key"))
+		g.Expect(source).To(gomega.Equal("cr"))
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
-
-			gotKey, gotSource := ResolveWriteKey(tt.crKey, tt.defaultKey)
-			g.Expect(gotKey).To(gomega.Equal(tt.wantKey))
-			g.Expect(gotSource).To(gomega.Equal(tt.wantSource))
-		})
-	}
+	t.Run("returns empty key and source when the CR key is not set", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		key, source := ResolveWriteKey("")
+		g.Expect(key).To(gomega.BeEmpty())
+		g.Expect(source).To(gomega.BeEmpty())
+	})
 }
 
 func TestLogWriteKeyResolution(t *testing.T) {
 	log := logr.Discard()
 
-	t.Run("returns false when key is empty", func(t *testing.T) {
+	t.Run("returns false when the key is empty", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 		g.Expect(LogWriteKeyResolution(log, "", "")).To(gomega.BeFalse())
 	})
 
-	t.Run("returns true when key is present", func(t *testing.T) {
+	t.Run("returns true when the key is present", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 		g.Expect(LogWriteKeyResolution(log, "some-key", "cr")).To(gomega.BeTrue())
 	})

--- a/operator/pkg/version/version.go
+++ b/operator/pkg/version/version.go
@@ -18,6 +18,18 @@ package version
 
 // These variables are set at build time via ldflags.
 // Default values are "unknown" and will be replaced during the build process.
+//
+// Version and GitCommit are immutable build identity: they describe which
+// source produced this binary and are safe to bake in, since they carry no
+// access and are identical for every consumer of a given image.
+//
+// This is deliberately different from the Segment write key, which is a
+// runtime credential rather than build identity. Baking a shared credential
+// into the binary would embed it in every published image and make it
+// effectively public; instead it is supplied at runtime via the Konflux CR
+// (see operator/pkg/segment). Don't add credentials to this file or wire
+// them through ldflags — pass them through the CR/runtime config path
+// instead.
 var (
 	// Version is the version of the operator (e.g., "v0.0.1")
 	Version = "unknown"

--- a/scripts/deploy-local.env.template
+++ b/scripts/deploy-local.env.template
@@ -157,9 +157,6 @@ SMEE_CHANNEL=""
 # Telemetry (OPTIONAL)
 # ==============================================================================
 
-# Segment write key for telemetry data collection (OPTIONAL)
-# Only needed with OPERATOR_INSTALL_METHOD=build (local operator development).
-# The 'release' method does not require a local secret.
-# Find the test write key in Segment workspace settings → Sources.
-# Leave empty to skip telemetry secret creation.
-# SEGMENT_WRITE_KEY=""
+# Telemetry is disabled by default and requires an explicit Segment write key.
+# To enable it, set spec.telemetry.spec.segmentKey in your Konflux CR after
+# deployment (get a free write key from your own Segment account).

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -204,7 +204,6 @@ SKIP_SECRETS="${SKIP_SECRETS:-false}"
 export KIND_CLUSTER KIND_MEMORY_GB PODMAN_MACHINE_NAME REGISTRY_HOST_PORT ENABLE_REGISTRY_PORT
 export INCREASE_PODMAN_PIDS_LIMIT ENABLE_IMAGE_CACHE
 export GITHUB_PRIVATE_KEY GITHUB_PRIVATE_KEY_PATH GITHUB_APP_ID WEBHOOK_SECRET QUAY_TOKEN QUAY_ORGANIZATION QUAY_API_URL
-export SEGMENT_WRITE_KEY
 
 # Child scripts only see exported variables (values from deploy-local.env are not
 # exported by sourcing); validate secrets after exports so checks see the same env.


### PR DESCRIPTION
Segment write key has been "baked" into the operator binary and build pipeline due to the previous dev implementation assumptions. This change reverts that mechanism so published images no longer embed a shared default key. Telemetry now requires an explicit segmentKey in the Konflux CR.

Assisted-by: Cursor