### PR TITLE
fix(#8521): add ServiceMonitor watches for operands

### DIFF
--- a/operator/docs/component-monitoring.md
+++ b/operator/docs/component-monitoring.md
@@ -128,6 +128,10 @@ Operand controllers use complementary mechanisms:
 - **Secret watch (metrics TLS)** — `Watches` on `metrics-server-cert` by name
   (cert-manager creates this Secret without CR ownerRefs) so metrics TLS changes are detected without
   waiting for the rotation ticker.
+- **ServiceMonitor watch** — CRD-gated `Owns` on the operand ServiceMonitor (via
+  `common.OperandServiceMonitorWatchObjectIfInstalled`) so out-of-band delete/mutate
+  triggers immediate reconcile. When the ServiceMonitor CRD is absent, controllers
+  fall back to the rotation broadcaster.
 - **Rotation broadcaster** — a leader-elected ticker (default every 15 minutes) nudges
   subscribed controllers to reconcile so tokens refresh before expiry and rotation still
   runs if a reconcile was skipped.
@@ -418,27 +422,36 @@ steps (creating `monitoring/` kustomization, rebuilding embedded manifests via
    `get;list;watch;create;patch` — omitting `create` will prevent the
    controller from creating ServiceMonitors
 
+**Controller watches:**
+
+8. In `SetupWithManager`, register a CRD-gated ServiceMonitor `Owns` watch
+   with `common.OperandServiceMonitorWatchObjectIfInstalled(mgr.GetRESTMapper())`
+   so out-of-band ServiceMonitor delete/mutate triggers immediate reconcile.
+   Follow the pattern in build-service, image-controller, release-service,
+   integration-service, and UI. When the CRD is absent, skip the watch and
+   rely on the rotation broadcaster.
+
 **Orphan cleanup:**
 
-8. Extend orphan cleanup GVKs with
+9. Extend orphan cleanup GVKs with
    `kubernetes.ComponentMetricsOrphanCleanupGVKs` and add
    ClusterRole/ClusterRoleBinding names to the cluster-scoped resource
    allowlist in the component reconciler
 
 **Tests:**
 
-9. Add unit tests for both gating paths: `ComponentMetrics: nil` (enabled by
-   default) and `ComponentMetrics: &ComponentMetricsConfig{Enabled:
-   ptr.To(false)}` (disabled, scrape resources skipped/deleted). Follow the
-   test style established in the target package; if the package uses
-   Ginkgo/Gomega, apply [ginkgo-testing](../../skills/ginkgo-testing/SKILL.md)
-   conventions.
-10. Register the new scrape target in the metrics integration test catalog
+10. Add unit tests for both gating paths: `ComponentMetrics: nil` (enabled by
+    default) and `ComponentMetrics: &ComponentMetricsConfig{Enabled:
+    ptr.To(false)}` (disabled, scrape resources skipped/deleted). Follow the
+    test style established in the target package; if the package uses
+    Ginkgo/Gomega, apply [ginkgo-testing](../../skills/ginkgo-testing/SKILL.md)
+    conventions.
+11. Register the new scrape target in the metrics integration test catalog
     (`test/go-tests/pkg/metricsauth/default_catalog.go`)
 
 **Documentation:**
 
-11. Update this document to list the new component under the appropriate
+12. Update this document to list the new component under the appropriate
     scrape model in the [Scope](#scope) tables
 
 ## Related paths

--- a/operator/internal/common/operand_servicemonitor.go
+++ b/operator/internal/common/operand_servicemonitor.go
@@ -17,7 +17,10 @@ limitations under the License.
 package common
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
 )
@@ -35,4 +38,30 @@ func OperandServiceMonitorFromObjects(objects []client.Object, namespace, name s
 		}
 	}
 	return nil, false
+}
+
+// OperandServiceMonitorWatchObjectIfInstalled returns an unstructured ServiceMonitor
+// watch object when the CRD is discoverable in mapper. Controllers can call Owns()
+// with the returned object to reconcile promptly on out-of-band ServiceMonitor
+// delete/mutate without requiring a hard startup dependency on the optional
+// ServiceMonitor CRD. Pass mgr.GetRESTMapper() from SetupWithManager.
+func OperandServiceMonitorWatchObjectIfInstalled(mapper meta.RESTMapper) (*unstructured.Unstructured, bool) {
+	if mapper == nil {
+		return nil, false
+	}
+	// RESTMapper discovery is backed by the API server discovery endpoints.
+	// Use RESTMapping here to gate watch registration on runtime CRD availability
+	// without wiring a dedicated discovery client into each controller.
+	if _, err := mapper.RESTMapping(operandServiceMonitorGVK.GroupKind(), operandServiceMonitorGVK.Version); err != nil {
+		// NoMatch means the optional ServiceMonitor CRD is absent — expected.
+		// Other errors (discovery/RBAC) still skip the watch, but log so setup
+		// failures are visible rather than silent permanent omission.
+		if !meta.IsNoMatchError(err) {
+			logf.Log.Error(err, "failed to resolve ServiceMonitor REST mapping; skipping watch registration")
+		}
+		return nil, false
+	}
+	sm := &unstructured.Unstructured{}
+	sm.SetGroupVersionKind(operandServiceMonitorGVK)
+	return sm, true
 }

--- a/operator/internal/common/operand_servicemonitor_test.go
+++ b/operator/internal/common/operand_servicemonitor_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package common
 
 import (
+	"errors"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -64,4 +66,71 @@ func TestOperandServiceMonitorFromObjects(t *testing.T) {
 	if _, ok := OperandServiceMonitorFromObjects(objects, testBuildServiceNamespace, "missing"); ok {
 		t.Fatal("expected missing ServiceMonitor to not be found")
 	}
+}
+
+func TestOperandServiceMonitorWatchObjectIfInstalled(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil mapper", func(t *testing.T) {
+		t.Parallel()
+		if sm, ok := OperandServiceMonitorWatchObjectIfInstalled(nil); ok || sm != nil {
+			t.Fatalf("expected nil mapper to skip watch object, got ok=%v sm=%v", ok, sm)
+		}
+	})
+
+	t.Run("CRD absent", func(t *testing.T) {
+		t.Parallel()
+		mapper := meta.NewDefaultRESTMapper(nil)
+		if sm, ok := OperandServiceMonitorWatchObjectIfInstalled(mapper); ok || sm != nil {
+			t.Fatalf("expected absent CRD to skip watch object, got ok=%v sm=%v", ok, sm)
+		}
+	})
+
+	t.Run("CRD present", func(t *testing.T) {
+		t.Parallel()
+		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{operandServiceMonitorGVK.GroupVersion()})
+		mapper.Add(operandServiceMonitorGVK, meta.RESTScopeNamespace)
+		sm, ok := OperandServiceMonitorWatchObjectIfInstalled(mapper)
+		if !ok || sm == nil {
+			t.Fatal("expected watch object when ServiceMonitor CRD is mapped")
+		}
+		if sm.GroupVersionKind() != operandServiceMonitorGVK {
+			t.Fatalf("unexpected GVK: %#v", sm.GroupVersionKind())
+		}
+	})
+
+	t.Run("non-NoMatch mapping error", func(t *testing.T) {
+		t.Parallel()
+		sm, ok := OperandServiceMonitorWatchObjectIfInstalled(errRESTMapper{err: errors.New("discovery unavailable")})
+		if ok || sm != nil {
+			t.Fatalf("expected non-NoMatch mapping error to skip watch object, got ok=%v sm=%v", ok, sm)
+		}
+	})
+}
+
+// errRESTMapper returns a fixed RESTMapping error for ServiceMonitor lookups.
+type errRESTMapper struct {
+	err error
+}
+
+func (m errRESTMapper) KindFor(_ schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, m.err
+}
+func (m errRESTMapper) KindsFor(_ schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, m.err
+}
+func (m errRESTMapper) ResourceFor(_ schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, m.err
+}
+func (m errRESTMapper) ResourcesFor(_ schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, m.err
+}
+func (m errRESTMapper) RESTMapping(_ schema.GroupKind, _ ...string) (*meta.RESTMapping, error) {
+	return nil, m.err
+}
+func (m errRESTMapper) RESTMappings(_ schema.GroupKind, _ ...string) ([]*meta.RESTMapping, error) {
+	return nil, m.err
+}
+func (m errRESTMapper) ResourceSingularizer(_ string) (string, error) {
+	return "", m.err
 }

--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
@@ -477,6 +477,9 @@ func (r *KonfluxBuildServiceReconciler) SetupWithManager(mgr ctrl.Manager) error
 			&corev1.Secret{},
 			builder.WithPredicates(predicate.PrometheusScrapeTokenSecretPredicate),
 		)
+		if sm, ok := common.OperandServiceMonitorWatchObjectIfInstalled(mgr.GetRESTMapper()); ok {
+			controllerBuilder = controllerBuilder.Owns(sm)
+		}
 		// metrics-server-cert is created by cert-manager (not CR ownerRefs).
 		controllerBuilder = controllerBuilder.Watches(
 			&corev1.Secret{},

--- a/operator/internal/controller/buildservice/konfluxbuildservice_scrape_token_test.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_scrape_token_test.go
@@ -186,6 +186,56 @@ var _ = Describe("Prometheus scrape token", func() {
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
+		It("recreates the ServiceMonitor when deleted out of band", func(ctx context.Context) {
+			clk := testclock.NewFakeClock(time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC))
+			fake := &fakeTokenCreator{
+				token:     "envtest-scrape-token",
+				expiresAt: clk.Now().Add(time.Hour),
+			}
+			startManagerWithTokenCreator(fake, clk)
+
+			buildService := testBuildServiceWithComponentMetrics(testutil.DefaultComponentMetricsConfig())
+			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, buildService)
+
+			smNN := types.NamespacedName{
+				Name:      "build-service",
+				Namespace: buildServiceNamespace,
+			}
+			smGVK := schema.GroupVersionKind{
+				Group:   "monitoring.coreos.com",
+				Version: "v1",
+				Kind:    "ServiceMonitor",
+			}
+			Eventually(func(g Gomega) {
+				sm := &unstructured.Unstructured{}
+				sm.SetGroupVersionKind(smGVK)
+				g.Expect(k8sClient.Get(ctx, smNN, sm)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			sm := &unstructured.Unstructured{}
+			sm.SetGroupVersionKind(smGVK)
+			sm.SetNamespace(smNN.Namespace)
+			sm.SetName(smNN.Name)
+			Expect(k8sClient.Delete(ctx, sm)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				recreated := &unstructured.Unstructured{}
+				recreated.SetGroupVersionKind(smGVK)
+				g.Expect(k8sClient.Get(ctx, smNN, recreated)).To(Succeed())
+				endpoints, found, err := unstructured.NestedSlice(recreated.Object, "spec", "endpoints")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(endpoints).NotTo(BeEmpty())
+				ep, ok := endpoints[0].(map[string]interface{})
+				g.Expect(ok).To(BeTrue())
+				secretRef, found, err := unstructured.NestedMap(ep, "bearerTokenSecret")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(secretRef["name"]).To(Equal(kubernetes.ScrapeTokenSecretName))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
 		It("refreshes the scrape token after the rotation threshold", func(ctx context.Context) {
 			clk := testclock.NewFakeClock(time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC))
 			fake := &fakeTokenCreator{

--- a/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
+++ b/operator/internal/controller/imagecontroller/konfluximagecontroller_controller.go
@@ -394,6 +394,9 @@ func (r *KonfluxImageControllerReconciler) SetupWithManager(mgr ctrl.Manager) er
 			&corev1.Secret{},
 			builder.WithPredicates(predicate.PrometheusScrapeTokenSecretPredicate),
 		)
+		if sm, ok := common.OperandServiceMonitorWatchObjectIfInstalled(mgr.GetRESTMapper()); ok {
+			controllerBuilder = controllerBuilder.Owns(sm)
+		}
 		// metrics-server-cert is created by cert-manager (not CR ownerRefs).
 		controllerBuilder = controllerBuilder.Watches(
 			&corev1.Secret{},

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
@@ -428,6 +428,9 @@ func (r *KonfluxIntegrationServiceReconciler) SetupWithManager(mgr ctrl.Manager)
 			&corev1.Secret{},
 			builder.WithPredicates(predicate.PrometheusScrapeTokenSecretPredicate),
 		)
+		if sm, ok := common.OperandServiceMonitorWatchObjectIfInstalled(mgr.GetRESTMapper()); ok {
+			controllerBuilder = controllerBuilder.Owns(sm)
+		}
 		// metrics-server-cert is created by cert-manager (not CR ownerRefs).
 		controllerBuilder = controllerBuilder.Watches(
 			&corev1.Secret{},

--- a/operator/internal/controller/releaseservice/konfluxreleaseservice_controller.go
+++ b/operator/internal/controller/releaseservice/konfluxreleaseservice_controller.go
@@ -382,6 +382,9 @@ func (r *KonfluxReleaseServiceReconciler) SetupWithManager(mgr ctrl.Manager) err
 			&corev1.Secret{},
 			builder.WithPredicates(predicate.PrometheusScrapeTokenSecretPredicate),
 		)
+		if sm, ok := common.OperandServiceMonitorWatchObjectIfInstalled(mgr.GetRESTMapper()); ok {
+			controllerBuilder = controllerBuilder.Owns(sm)
+		}
 		// metrics-server-cert is created by cert-manager (not CR ownerRefs).
 		controllerBuilder = controllerBuilder.Watches(
 			&corev1.Secret{},

--- a/operator/internal/controller/ui/konfluxui_controller.go
+++ b/operator/internal/controller/ui/konfluxui_controller.go
@@ -41,6 +41,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
+	"github.com/konflux-ci/konflux-ci/operator/internal/common"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/segmentbridge"
@@ -827,6 +828,9 @@ func (r *KonfluxUIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// to avoid informer startup failures when the CRD is absent.
 	if r.ClusterInfo != nil && r.ClusterInfo.IsOpenShift() {
 		b = b.Owns(&consolev1.ConsoleLink{})
+	}
+	if sm, ok := common.OperandServiceMonitorWatchObjectIfInstalled(mgr.GetRESTMapper()); ok {
+		b = b.Owns(sm)
 	}
 
 	return b.Complete(r)

--- a/operator/internal/operatormetrics/scrape_token_rotator_test.go
+++ b/operator/internal/operatormetrics/scrape_token_rotator_test.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -121,6 +122,66 @@ func TestScrapeTokenRotator_ReconcileWithoutKonfluxCR(t *testing.T) {
 	}
 	if creator.calls != 1 {
 		t.Fatalf("expected token mint without Konflux CR, got %d calls", creator.calls)
+	}
+}
+
+func TestScrapeTokenRotator_ReconcileRecreatesDeletedServiceMonitor(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	creator := &fakeTokenCreator{token: "operator-scrape-token", expiresAt: now.Add(time.Hour)}
+	c := testClientWithMetricsTLS(t)
+	clk := testclock.NewFakeClock(now)
+	rotator := &ScrapeTokenRotator{
+		Client:       c,
+		Clock:        clk,
+		TokenCreator: creator,
+		Namespace:    OperatorNamespace,
+	}
+
+	if _, err := rotator.reconcile(ctx, OperatorNamespace); err != nil {
+		t.Fatalf("initial reconcile: %v", err)
+	}
+
+	smKey := types.NamespacedName{
+		Name:      operatorServiceMonitorName,
+		Namespace: OperatorNamespace,
+	}
+	sm := &unstructured.Unstructured{}
+	sm.SetGroupVersionKind(serviceMonitorGVK)
+	if err := c.Get(ctx, smKey, sm); err != nil {
+		t.Fatalf("get ServiceMonitor after create: %v", err)
+	}
+	if err := c.Delete(ctx, sm); err != nil {
+		t.Fatalf("delete ServiceMonitor: %v", err)
+	}
+	if err := c.Get(ctx, smKey, sm); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected ServiceMonitor deleted, got err=%v", err)
+	}
+
+	// Advance past the post-mint settle window so reconcile re-applies the SM
+	// on the next rotator tick (periodic recovery path for operator SM drift).
+	clk.Step(kubernetes.DefaultServiceMonitorResyncSettleDelay + time.Second)
+	if _, err := rotator.reconcile(ctx, OperatorNamespace); err != nil {
+		t.Fatalf("reconcile after ServiceMonitor delete: %v", err)
+	}
+
+	recreated := &unstructured.Unstructured{}
+	recreated.SetGroupVersionKind(serviceMonitorGVK)
+	if err := c.Get(ctx, smKey, recreated); err != nil {
+		t.Fatalf("expected ServiceMonitor recreated by rotator reconcile: %v", err)
+	}
+	endpoints, found, err := unstructured.NestedSlice(recreated.Object, "spec", "endpoints")
+	if err != nil || !found || len(endpoints) != 1 {
+		t.Fatalf("unexpected endpoints after recreate: found=%v err=%v len=%d", found, err, len(endpoints))
+	}
+	endpoint, ok := endpoints[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected endpoint map after recreate")
+	}
+	tokenSecret, ok := endpoint["bearerTokenSecret"].(map[string]interface{})
+	if !ok || tokenSecret["name"] != kubernetes.ScrapeTokenSecretName {
+		t.Fatalf("unexpected bearer token secret after recreate: %#v", endpoint["bearerTokenSecret"])
 	}
 }
 


### PR DESCRIPTION
This change is adding ServiceMonitor watches for all operands. Watching the operator ServiceMonitor is not as straightforward, so instead, we rely on periodic reconciliation for fixing operator ServiceMonitor CR drifts.

Assisted-by: Cursor

Closes: #8521