### PR TITLE
feat(KFLUXVNGD-1169): Create trusted-ca ConfigMap on OpenShift in build-service and integration-service

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -367,6 +367,7 @@ func main() {
 		Client:              mgr.GetClient(),
 		Scheme:              mgr.GetScheme(),
 		ObjectStore:         objectStore,
+		ClusterInfo:         clusterInfo,
 		TokenCreator:        tokenCreator,
 		SecretReader:        mgr.GetAPIReader(),
 		TokenRotationEvents: integrationServiceRotation,

--- a/operator/internal/common/trusted_ca.go
+++ b/operator/internal/common/trusted_ca.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
+)
+
+const (
+	// TrustedCAConfigMapName is the name of the ConfigMap that OpenShift's
+	// cluster network operator populates with the cluster-wide trusted CA bundle.
+	TrustedCAConfigMapName = "trusted-ca"
+
+	// OpenShiftInjectTrustedCABundleLabel is the label that triggers OpenShift's
+	// CA bundle injection into a ConfigMap.
+	OpenShiftInjectTrustedCABundleLabel = "config.openshift.io/inject-trusted-cabundle"
+)
+
+// EnsureTrustedCAConfigMap creates or updates the trusted-ca ConfigMap with the
+// OpenShift CA injection label in the given namespace. On non-OpenShift clusters
+// (or when clusterInfo is nil) this is a no-op. OpenShift's cluster network operator
+// automatically populates the ca-bundle.crt key when this label is present.
+func EnsureTrustedCAConfigMap(ctx context.Context, namespace string, tc *tracking.Client, ci *clusterinfo.Info) error {
+	if ci == nil || !ci.IsOpenShift() {
+		return nil
+	}
+	configMap := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TrustedCAConfigMapName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				OpenShiftInjectTrustedCABundleLabel: "true",
+			},
+		},
+	}
+	if err := tc.ApplyOwned(ctx, configMap); err != nil {
+		return fmt.Errorf("failed to apply trusted-ca ConfigMap in %s: %w", namespace, err)
+	}
+	return nil
+}

--- a/operator/internal/common/trusted_ca_test.go
+++ b/operator/internal/common/trusted_ca_test.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/version"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
+)
+
+type mockDiscoveryClient struct {
+	resources map[string]*metav1.APIResourceList
+}
+
+func (m *mockDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	if r, ok := m.resources[groupVersion]; ok {
+		return r, nil
+	}
+	return &metav1.APIResourceList{}, nil
+}
+
+func (m *mockDiscoveryClient) ServerVersion() (*version.Info, error) {
+	return &version.Info{GitVersion: "v1.29.0"}, nil
+}
+
+func openShiftClusterInfo(t *testing.T) *clusterinfo.Info {
+	t.Helper()
+	info, err := clusterinfo.DetectWithClient(&mockDiscoveryClient{
+		resources: map[string]*metav1.APIResourceList{
+			"config.openshift.io/v1": {
+				APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create OpenShift clusterinfo: %v", err)
+	}
+	return info
+}
+
+func newTrackingClient(t *testing.T, objs ...client.Object) (client.Client, *tracking.Client) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add client-go scheme: %v", err)
+	}
+	owner := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-owner",
+			Namespace: "test-namespace",
+			UID:       "test-owner-uid",
+		},
+	}
+	allObjs := append([]client.Object{owner}, objs...)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(allObjs...).
+		Build()
+	tc := tracking.NewClientWithOwnership(fakeClient, tracking.OwnershipConfig{
+		Owner:             owner,
+		OwnerLabelKey:     "test.example.com/owner",
+		ComponentLabelKey: "test.example.com/component",
+		Component:         "test-component",
+		FieldManager:      "test-manager",
+	})
+	return fakeClient, tc
+}
+
+func TestEnsureTrustedCAConfigMap(t *testing.T) {
+	t.Run("creates ConfigMap with injection label", func(t *testing.T) {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"},
+		}
+		fakeClient, tc := newTrackingClient(t, ns)
+
+		err := EnsureTrustedCAConfigMap(context.Background(), "test-namespace", tc, openShiftClusterInfo(t))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		cm := &corev1.ConfigMap{}
+		if err := fakeClient.Get(context.Background(), types.NamespacedName{
+			Name:      TrustedCAConfigMapName,
+			Namespace: "test-namespace",
+		}, cm); err != nil {
+			t.Fatalf("failed to get ConfigMap: %v", err)
+		}
+
+		if cm.Name != TrustedCAConfigMapName {
+			t.Errorf("expected name %q, got %q", TrustedCAConfigMapName, cm.Name)
+		}
+		if cm.Namespace != "test-namespace" {
+			t.Errorf("expected namespace %q, got %q", "test-namespace", cm.Namespace)
+		}
+		val, ok := cm.Labels[OpenShiftInjectTrustedCABundleLabel]
+		if !ok {
+			t.Fatal("expected injection label to be present")
+		}
+		if val != "true" {
+			t.Errorf("expected injection label value %q, got %q", "true", val)
+		}
+
+		ownerVal, ok := cm.Labels["test.example.com/owner"]
+		if !ok {
+			t.Fatal("expected ownership label to be present")
+		}
+		if ownerVal != "test-owner" {
+			t.Errorf("expected owner label value %q, got %q", "test-owner", ownerVal)
+		}
+
+		componentVal, ok := cm.Labels["test.example.com/component"]
+		if !ok {
+			t.Fatal("expected component label to be present")
+		}
+		if componentVal != "test-component" {
+			t.Errorf("expected component label value %q, got %q", "test-component", componentVal)
+		}
+	})
+
+	t.Run("is idempotent", func(t *testing.T) {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"},
+		}
+		existingCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      TrustedCAConfigMapName,
+				Namespace: "test-namespace",
+				Labels: map[string]string{
+					OpenShiftInjectTrustedCABundleLabel: "true",
+				},
+			},
+		}
+		fakeClient, tc := newTrackingClient(t, ns, existingCM)
+
+		err := EnsureTrustedCAConfigMap(context.Background(), "test-namespace", tc, openShiftClusterInfo(t))
+		if err != nil {
+			t.Fatalf("unexpected error on second apply: %v", err)
+		}
+
+		cm := &corev1.ConfigMap{}
+		if err := fakeClient.Get(context.Background(), types.NamespacedName{
+			Name:      TrustedCAConfigMapName,
+			Namespace: "test-namespace",
+		}, cm); err != nil {
+			t.Fatalf("failed to get ConfigMap: %v", err)
+		}
+
+		val, ok := cm.Labels[OpenShiftInjectTrustedCABundleLabel]
+		if !ok {
+			t.Fatal("expected injection label to be present after re-apply")
+		}
+		if val != "true" {
+			t.Errorf("expected injection label value %q, got %q", "true", val)
+		}
+	})
+
+	t.Run("is a no-op when clusterInfo is nil", func(t *testing.T) {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"},
+		}
+		fakeClient, tc := newTrackingClient(t, ns)
+
+		err := EnsureTrustedCAConfigMap(context.Background(), "test-namespace", tc, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		cm := &corev1.ConfigMap{}
+		getErr := fakeClient.Get(context.Background(), types.NamespacedName{
+			Name:      TrustedCAConfigMapName,
+			Namespace: "test-namespace",
+		}, cm)
+		if getErr == nil {
+			t.Fatal("expected ConfigMap to not be created when clusterInfo is nil")
+		}
+	})
+
+	t.Run("is a no-op on non-OpenShift clusters", func(t *testing.T) {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"},
+		}
+		fakeClient, tc := newTrackingClient(t, ns)
+
+		nonOpenShiftInfo, err := clusterinfo.DetectWithClient(&mockDiscoveryClient{
+			resources: map[string]*metav1.APIResourceList{},
+		})
+		if err != nil {
+			t.Fatalf("failed to create non-OpenShift clusterinfo: %v", err)
+		}
+
+		err = EnsureTrustedCAConfigMap(context.Background(), "test-namespace", tc, nonOpenShiftInfo)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		cm := &corev1.ConfigMap{}
+		getErr := fakeClient.Get(context.Background(), types.NamespacedName{
+			Name:      TrustedCAConfigMapName,
+			Namespace: "test-namespace",
+		}, cm)
+		if getErr == nil {
+			t.Fatal("expected ConfigMap to not be created on non-OpenShift")
+		}
+	})
+
+	t.Run("does not claim data field so CNO-injected content survives re-apply", func(t *testing.T) {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"},
+		}
+		existingCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      TrustedCAConfigMapName,
+				Namespace: "test-namespace",
+				Labels: map[string]string{
+					OpenShiftInjectTrustedCABundleLabel: "true",
+				},
+			},
+			Data: map[string]string{
+				"ca-bundle.crt": "-----BEGIN CERTIFICATE-----\nMIIBkTCB...\n-----END CERTIFICATE-----\n",
+			},
+		}
+		fakeClient, tc := newTrackingClient(t, ns, existingCM)
+
+		err := EnsureTrustedCAConfigMap(context.Background(), "test-namespace", tc, openShiftClusterInfo(t))
+		if err != nil {
+			t.Fatalf("unexpected error on re-apply: %v", err)
+		}
+
+		cm := &corev1.ConfigMap{}
+		if err := fakeClient.Get(context.Background(), types.NamespacedName{
+			Name:      TrustedCAConfigMapName,
+			Namespace: "test-namespace",
+		}, cm); err != nil {
+			t.Fatalf("failed to get ConfigMap: %v", err)
+		}
+
+		caBundle, ok := cm.Data["ca-bundle.crt"]
+		if !ok {
+			t.Fatal("expected ca-bundle.crt data key to survive re-apply")
+		}
+		if caBundle == "" {
+			t.Error("expected ca-bundle.crt to retain its value")
+		}
+	})
+
+	t.Run("returns error when apply fails", func(t *testing.T) {
+		scheme := runtime.NewScheme()
+		if err := clientgoscheme.AddToScheme(scheme); err != nil {
+			t.Fatalf("failed to add client-go scheme: %v", err)
+		}
+		owner := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-owner",
+				Namespace: "test-namespace",
+				UID:       "test-owner-uid",
+			},
+		}
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(owner, ns).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+					return fmt.Errorf("simulated API server failure")
+				},
+			}).
+			Build()
+		tc := tracking.NewClientWithOwnership(fakeClient, tracking.OwnershipConfig{
+			Owner:             owner,
+			OwnerLabelKey:     "test.example.com/owner",
+			ComponentLabelKey: "test.example.com/component",
+			Component:         "test-component",
+			FieldManager:      "test-manager",
+		})
+
+		err := EnsureTrustedCAConfigMap(context.Background(), "test-namespace", tc, openShiftClusterInfo(t))
+		if err == nil {
+			t.Fatal("expected error when apply fails")
+		}
+		if !strings.Contains(err.Error(), "failed to apply trusted-ca ConfigMap in test-namespace") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+}

--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller.go
@@ -181,6 +181,12 @@ func (r *KonfluxBuildServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 		return errHandler.HandleWithReason(ctx, err, condition.ReasonNamespaceCreationFailed, "ensure namespace exists")
 	}
 
+	// On OpenShift, create the trusted-ca ConfigMap with the injection label so
+	// the cluster network operator populates it with the cluster CA bundle.
+	if err := common.EnsureTrustedCAConfigMap(ctx, webhookConfigNamespace, tc, r.ClusterInfo); err != nil {
+		return errHandler.HandleWithReason(ctx, err, condition.ReasonConfigMapFailed, "ensure trusted-ca ConfigMap")
+	}
+
 	// Reconcile webhook config ConfigMap.
 	// Must happen before applyManifests so the hashed ConfigMap name is available for the volume reference.
 	webhookConfigMapName, err := r.reconcileWebhookConfig(ctx, buildService)

--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
@@ -178,6 +178,95 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 		})
 	})
 
+	Context("OpenShift trusted-ca ConfigMap", func() {
+		var buildService *konfluxv1alpha1.KonfluxBuildService
+
+		trustedCAExists := func() bool {
+			cm := &corev1.ConfigMap{}
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "trusted-ca",
+				Namespace: buildServiceNamespace,
+			}, cm) == nil
+		}
+
+		trustedCAHasInjectionLabel := func(g Gomega) {
+			cm := &corev1.ConfigMap{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "trusted-ca",
+				Namespace: buildServiceNamespace,
+			}, cm)).To(Succeed())
+			g.Expect(cm.Labels).To(HaveKeyWithValue(
+				"config.openshift.io/inject-trusted-cabundle", "true"))
+		}
+
+		BeforeEach(func() {
+			buildService = newBuildServiceCR()
+			Expect(k8sClient.Create(ctx, buildService)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			testutil.DeleteAndWait(ctx, k8sClient, buildService)
+			testutil.DeleteAndWait(ctx, k8sClient, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "trusted-ca", Namespace: buildServiceNamespace},
+			})
+		})
+
+		It("Should create trusted-ca ConfigMap with injection label when running on OpenShift", func() {
+			openShiftClusterInfo, err := clusterinfo.DetectWithClient(&buildServiceMockDiscoveryClient{
+				resources: map[string]*metav1.APIResourceList{
+					"config.openshift.io/v1": {
+						APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}},
+					},
+				},
+				serverVersion: &version.Info{GitVersion: "v1.29.0"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			startManagerWithClusterInfo(openShiftClusterInfo)
+
+			By("verifying the trusted-ca ConfigMap was created with the injection label")
+			Eventually(trustedCAHasInjectionLabel).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("Should NOT create trusted-ca ConfigMap when NOT running on OpenShift", func() {
+			defaultClusterInfo, err := clusterinfo.DetectWithClient(&buildServiceMockDiscoveryClient{
+				resources:     map[string]*metav1.APIResourceList{},
+				serverVersion: &version.Info{GitVersion: "v1.29.0"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			startManagerWithClusterInfo(defaultClusterInfo)
+
+			By("waiting for the controller to apply manifests and create the build-service Deployment")
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      buildControllerManagerDeploymentName,
+					Namespace: buildServiceNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying no trusted-ca ConfigMap was created")
+			Expect(trustedCAExists()).To(BeFalse())
+		})
+
+		It("Should NOT create trusted-ca ConfigMap when ClusterInfo is nil", func() {
+			startManagerWithClusterInfo(nil)
+
+			By("waiting for the controller to apply manifests and create the build-service Deployment")
+			Eventually(func(g Gomega) {
+				dep := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      buildControllerManagerDeploymentName,
+					Namespace: buildServiceNamespace,
+				}, dep)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying no trusted-ca ConfigMap was created")
+			Expect(trustedCAExists()).To(BeFalse())
+		})
+	})
+
 	Context("PipelineConfig", func() {
 		var configMapNN types.NamespacedName
 

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
@@ -49,6 +49,7 @@ import (
 	crdhandler "github.com/konflux-ci/konflux-ci/operator/internal/controller/handler"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/ui"
 	"github.com/konflux-ci/konflux-ci/operator/internal/predicate"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/customization"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
@@ -110,6 +111,7 @@ type KonfluxIntegrationServiceReconciler struct {
 	client.Client
 	Scheme       *runtime.Scheme
 	ObjectStore  *manifests.ObjectStore
+	ClusterInfo  *clusterinfo.Info
 	TokenCreator kubernetes.TokenCreator
 	// SecretReader loads metrics TLS Secrets; prefer mgr.GetAPIReader() to avoid stale cache.
 	SecretReader        client.Reader
@@ -177,7 +179,20 @@ func (r *KonfluxIntegrationServiceReconciler) Reconcile(ctx context.Context, req
 		log.Info("Found console URL from KonfluxUI", "url", consoleURL)
 	}
 
-	// Apply all embedded manifests
+	// Ensure the integration-service namespace exists before creating resources in it.
+	if err := common.EnsureNamespaceExists(ctx, r.ObjectStore, manifests.Integration, integrationServiceNamespace, tc); err != nil {
+		return errHandler.HandleWithReason(ctx, err, condition.ReasonNamespaceCreationFailed, "ensure namespace exists")
+	}
+
+	// On OpenShift, create the trusted-ca ConfigMap with the injection label so
+	// the cluster network operator populates it with the cluster CA bundle.
+	// This runs before applyManifests so the ConfigMap is present when Deployments
+	// that mount it are applied.
+	if err := common.EnsureTrustedCAConfigMap(ctx, integrationServiceNamespace, tc, r.ClusterInfo); err != nil {
+		return errHandler.HandleWithReason(ctx, err, condition.ReasonConfigMapFailed, "ensure trusted-ca ConfigMap")
+	}
+
+	// Apply all embedded manifests (namespace is already ensured above).
 	if err := r.applyManifests(ctx, tc, integrationService, consoleURL); err != nil {
 		return errHandler.HandleApplyError(ctx, err)
 	}

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_test.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller_test.go
@@ -35,10 +35,12 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/version"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1497,3 +1499,127 @@ var _ = Describe("KonfluxIntegrationService Controller", func() {
 		})
 	})
 })
+
+var _ = Describe("KonfluxIntegrationService Controller - OpenShift trusted-ca", func() {
+	startManagerWithClusterInfo := func(clusterInfo *clusterinfo.Info) {
+		mgrCtx, mgrCancel := context.WithCancel(testEnv.Ctx)
+		mgr := testutil.NewTestManager(testEnv)
+		Expect((&KonfluxIntegrationServiceReconciler{
+			Client:      mgr.GetClient(),
+			Scheme:      mgr.GetScheme(),
+			ObjectStore: objectStore,
+			ClusterInfo: clusterInfo,
+		}).SetupWithManager(mgr)).To(Succeed())
+		waitForStop := testutil.StartManagerWithContext(mgrCtx, mgr)
+		DeferCleanup(func() {
+			mgrCancel()
+			waitForStop()
+		})
+	}
+
+	var integrationService *konfluxv1alpha1.KonfluxIntegrationService
+
+	trustedCAExists := func() bool {
+		cm := &corev1.ConfigMap{}
+		return k8sClient.Get(ctx, types.NamespacedName{
+			Name:      "trusted-ca",
+			Namespace: integrationServiceNamespace,
+		}, cm) == nil
+	}
+
+	trustedCAHasInjectionLabel := func(g Gomega) {
+		cm := &corev1.ConfigMap{}
+		g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name:      "trusted-ca",
+			Namespace: integrationServiceNamespace,
+		}, cm)).To(Succeed())
+		g.Expect(cm.Labels).To(HaveKeyWithValue(
+			"config.openshift.io/inject-trusted-cabundle", "true"))
+	}
+
+	BeforeEach(func() {
+		integrationService = &konfluxv1alpha1.KonfluxIntegrationService{
+			ObjectMeta: metav1.ObjectMeta{Name: CRName},
+		}
+		Expect(k8sClient.Create(ctx, integrationService)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		testutil.DeleteAndWait(ctx, k8sClient, integrationService)
+		testutil.DeleteAndWait(ctx, k8sClient, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "trusted-ca", Namespace: integrationServiceNamespace},
+		})
+	})
+
+	It("Should create trusted-ca ConfigMap with injection label when running on OpenShift", func() {
+		openShiftClusterInfo, err := clusterinfo.DetectWithClient(&integrationServiceMockDiscoveryClient{
+			resources: map[string]*metav1.APIResourceList{
+				"config.openshift.io/v1": {
+					APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}},
+				},
+			},
+			serverVersion: &version.Info{GitVersion: "v1.29.0"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		startManagerWithClusterInfo(openShiftClusterInfo)
+
+		By("verifying the trusted-ca ConfigMap was created with the injection label")
+		Eventually(trustedCAHasInjectionLabel).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+	})
+
+	It("Should NOT create trusted-ca ConfigMap when NOT running on OpenShift", func() {
+		defaultClusterInfo, err := clusterinfo.DetectWithClient(&integrationServiceMockDiscoveryClient{
+			resources:     map[string]*metav1.APIResourceList{},
+			serverVersion: &version.Info{GitVersion: "v1.29.0"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		startManagerWithClusterInfo(defaultClusterInfo)
+
+		By("waiting for the controller to apply manifests and create the Deployment")
+		Eventually(func(g Gomega) {
+			dep := &appsv1.Deployment{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      controllerManagerDeploymentName,
+				Namespace: integrationServiceNamespace,
+			}, dep)).To(Succeed())
+		}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+		By("verifying no trusted-ca ConfigMap was created")
+		Expect(trustedCAExists()).To(BeFalse())
+	})
+
+	It("Should NOT create trusted-ca ConfigMap when ClusterInfo is nil", func() {
+		startManagerWithClusterInfo(nil)
+
+		By("waiting for the controller to apply manifests and create the Deployment")
+		Eventually(func(g Gomega) {
+			dep := &appsv1.Deployment{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      controllerManagerDeploymentName,
+				Namespace: integrationServiceNamespace,
+			}, dep)).To(Succeed())
+		}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+		By("verifying no trusted-ca ConfigMap was created")
+		Expect(trustedCAExists()).To(BeFalse())
+	})
+})
+
+// integrationServiceMockDiscoveryClient implements clusterinfo.DiscoveryClient for testing.
+type integrationServiceMockDiscoveryClient struct {
+	resources     map[string]*metav1.APIResourceList
+	serverVersion *version.Info
+}
+
+func (m *integrationServiceMockDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	if r, ok := m.resources[groupVersion]; ok {
+		return r, nil
+	}
+	return nil, errors.NewNotFound(schema.GroupResource{Group: groupVersion}, "")
+}
+
+func (m *integrationServiceMockDiscoveryClient) ServerVersion() (*version.Info, error) {
+	return m.serverVersion, nil
+}


### PR DESCRIPTION
The trusted-ca ConfigMap is required by both build-service and integration-service deployments for custom CA trust. On non-OpenShift clusters, trust-manager creates it automatically via a Bundle resource. On OpenShift, trust-manager is skipped and the ConfigMap had to be created externally.

Add a shared helper (common.EnsureTrustedCAConfigMap) that creates the ConfigMap with the config.openshift.io/inject-trusted-cabundle label when the operator detects OpenShift. This brings the resource under operator lifecycle management, eliminating the need for external provisioning. OpenShift's cluster network operator populates the ConfigMap with the cluster CA bundle automatically.

The build-service controller already had ClusterInfo; the integration-service reconciler gains it here (wired in main.go). Non-OpenShift behavior is unchanged.

Follow-up: once this merges, update the operator reference downstream and remove the external trusted-ca ConfigMap creation from downstream deployments - the operator now manages it.

Assisted-by: Cursor + Opus 4.6