### PR TITLE
feat(#8570): split UI ingress host into fqdn and hostname

### DIFF
--- a/operator/api/v1alpha1/konfluxui_types.go
+++ b/operator/api/v1alpha1/konfluxui_types.go
@@ -46,13 +46,30 @@ type IngressSpec struct {
 	// IngressClassName specifies which IngressClass to use for the ingress.
 	// +optional
 	IngressClassName *string `json:"ingressClassName,omitempty"`
-	// Host is the hostname used as the endpoint for configuring oauth2-proxy, dex, and related components.
-	// When set, this hostname is always used regardless of whether ingress is enabled,
+	// FQDN is the full public DNS name used as the UI endpoint for configuring oauth2-proxy,
+	// dex, and related components.
+	// An optional :port suffix (e.g. "ui.example.com:8443") is supported only for
+	// endpoint-only / user-managed routing when ingress is not effectively enabled.
+	// Including a port while ingress is enabled (explicit true, or unset on OpenShift)
+	// fails reconcile with Ready=False (reason InvalidIngressFQDN), because Ingress host
+	// rules omit ports while auth redirect URLs and ConsoleLink would keep the port.
+	// When set, this value is always used regardless of whether ingress is enabled,
 	// allowing users who manage their own external routing (e.g., Gateway API, hardware LB)
 	// to configure the endpoint without the operator managing an Ingress resource.
-	// On OpenShift, if empty, the default ingress domain and naming convention will be used.
+	// Takes precedence over Hostname when both are set.
 	// +optional
-	Host string `json:"host,omitempty"`
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?(:[0-9]{1,5})?$`
+	FQDN string `json:"fqdn,omitempty"`
+	// Hostname is a short DNS label composed with the cluster ingress domain on OpenShift
+	// as "{hostname}.{cluster-ingress-domain}" (no namespace infix).
+	// Ignored when FQDN is set. Off OpenShift, Hostname is ignored and a warning is logged.
+	// When both FQDN and Hostname are empty on OpenShift with ingress enabled, the operator
+	// falls back to "konflux-ui-{namespace}.{domain}".
+	// +optional
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	Hostname string `json:"hostname,omitempty"`
 	// Annotations to add to the ingress resource.
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/operator/api/v1alpha1/konfluxui_types_test.go
+++ b/operator/api/v1alpha1/konfluxui_types_test.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"maps"
+	"regexp"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -151,4 +152,62 @@ func TestKonfluxUIConfigSpec_Accessors(t *testing.T) {
 	g.Expect(cfg.GetNodePortService()).To(gomega.BeNil())
 	g.Expect(cfg.GetProxy()).To(gomega.Equal(ProxyDeploymentSpec{Replicas: 1}))
 	g.Expect(cfg.GetDex()).To(gomega.Equal(DexDeploymentSpec{Replicas: 1}))
+}
+
+// Patterns must stay in sync with +kubebuilder:validation:Pattern on IngressSpec.
+var (
+	ingressFQDNPattern     = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?(:[0-9]{1,5})?$`)
+	ingressHostnamePattern = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+)
+
+func TestIngressSpecValidationPatterns(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fqdn accepts host and optional port", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		for _, value := range []string{
+			"konflux.example.com",
+			"ui.example.com:8443",
+			"localhost",
+			"a",
+		} {
+			g.Expect(ingressFQDNPattern.MatchString(value)).To(gomega.BeTrue(), "fqdn %q", value)
+		}
+	})
+
+	t.Run("fqdn rejects empty and invalid values", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		for _, value := range []string{
+			"",
+			"-bad.example.com",
+			"example.com:",
+			"example.com:port",
+		} {
+			g.Expect(ingressFQDNPattern.MatchString(value)).To(gomega.BeFalse(), "fqdn %q", value)
+		}
+	})
+
+	t.Run("hostname accepts a single DNS label", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		for _, value := range []string{
+			"konflux-ui",
+			"a",
+			"ui1",
+		} {
+			g.Expect(ingressHostnamePattern.MatchString(value)).To(gomega.BeTrue(), "hostname %q", value)
+		}
+	})
+
+	t.Run("hostname rejects dotted or uppercase names", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		for _, value := range []string{
+			"bad.dotted.name",
+			"Konflux-UI",
+			"-leading",
+			"trailing-",
+			"",
+		} {
+			g.Expect(ingressHostnamePattern.MatchString(value)).To(gomega.BeFalse(), "hostname %q", value)
+		}
+	})
 }

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
@@ -3408,13 +3408,31 @@ spec:
                               When nil (unset), defaults to true on OpenShift, false otherwise.
                             nullable: true
                             type: boolean
-                          host:
+                          fqdn:
                             description: |-
-                              Host is the hostname used as the endpoint for configuring oauth2-proxy, dex, and related components.
-                              When set, this hostname is always used regardless of whether ingress is enabled,
+                              FQDN is the full public DNS name used as the UI endpoint for configuring oauth2-proxy,
+                              dex, and related components.
+                              An optional :port suffix (e.g. "ui.example.com:8443") is supported only for
+                              endpoint-only / user-managed routing when ingress is not effectively enabled.
+                              Including a port while ingress is enabled (explicit true, or unset on OpenShift)
+                              fails reconcile with Ready=False (reason InvalidIngressFQDN), because Ingress host
+                              rules omit ports while auth redirect URLs and ConsoleLink would keep the port.
+                              When set, this value is always used regardless of whether ingress is enabled,
                               allowing users who manage their own external routing (e.g., Gateway API, hardware LB)
                               to configure the endpoint without the operator managing an Ingress resource.
-                              On OpenShift, if empty, the default ingress domain and naming convention will be used.
+                              Takes precedence over Hostname when both are set.
+                            minLength: 1
+                            pattern: ^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?(:[0-9]{1,5})?$
+                            type: string
+                          hostname:
+                            description: |-
+                              Hostname is a short DNS label composed with the cluster ingress domain on OpenShift
+                              as "{hostname}.{cluster-ingress-domain}" (no namespace infix).
+                              Ignored when FQDN is set. Off OpenShift, Hostname is ignored and a warning is logged.
+                              When both FQDN and Hostname are empty on OpenShift with ingress enabled, the operator
+                              falls back to "konflux-ui-{namespace}.{domain}".
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           ingressClassName:
                             description: IngressClassName specifies which IngressClass

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxuis.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxuis.yaml
@@ -471,13 +471,31 @@ spec:
                       When nil (unset), defaults to true on OpenShift, false otherwise.
                     nullable: true
                     type: boolean
-                  host:
+                  fqdn:
                     description: |-
-                      Host is the hostname used as the endpoint for configuring oauth2-proxy, dex, and related components.
-                      When set, this hostname is always used regardless of whether ingress is enabled,
+                      FQDN is the full public DNS name used as the UI endpoint for configuring oauth2-proxy,
+                      dex, and related components.
+                      An optional :port suffix (e.g. "ui.example.com:8443") is supported only for
+                      endpoint-only / user-managed routing when ingress is not effectively enabled.
+                      Including a port while ingress is enabled (explicit true, or unset on OpenShift)
+                      fails reconcile with Ready=False (reason InvalidIngressFQDN), because Ingress host
+                      rules omit ports while auth redirect URLs and ConsoleLink would keep the port.
+                      When set, this value is always used regardless of whether ingress is enabled,
                       allowing users who manage their own external routing (e.g., Gateway API, hardware LB)
                       to configure the endpoint without the operator managing an Ingress resource.
-                      On OpenShift, if empty, the default ingress domain and naming convention will be used.
+                      Takes precedence over Hostname when both are set.
+                    minLength: 1
+                    pattern: ^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?(:[0-9]{1,5})?$
+                    type: string
+                  hostname:
+                    description: |-
+                      Hostname is a short DNS label composed with the cluster ingress domain on OpenShift
+                      as "{hostname}.{cluster-ingress-domain}" (no namespace infix).
+                      Ignored when FQDN is set. Off OpenShift, Hostname is ignored and a warning is logged.
+                      When both FQDN and Hostname are empty on OpenShift with ingress enabled, the operator
+                      falls back to "konflux-ui-{namespace}.{domain}".
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   ingressClassName:
                     description: IngressClassName specifies which IngressClass to

--- a/operator/config/samples/konflux_v1alpha1_konfluxui.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konfluxui.yaml
@@ -12,7 +12,9 @@ spec:
   ingress:
     enabled: true
     ingressClassName: "nginx"
-    host: "konflux-ui.example.com"
+    fqdn: "konflux-ui.example.com"
+    # Or on OpenShift, set a short label instead of the full name:
+    # hostname: konflux-ui
     annotations:
       cert-manager.io/cluster-issuer: "letsencrypt-prod"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"

--- a/operator/docs/content/docs/guides/custom-url.md
+++ b/operator/docs/content/docs/guides/custom-url.md
@@ -20,7 +20,7 @@ creating or managing an Ingress resource.
 
 ## Configuration
 
-Set `ingress.enabled: false` and `ingress.host` to your desired hostname in the
+Set `ingress.enabled: false` and `ingress.fqdn` to your desired hostname in the
 Konflux CR:
 
 ```yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       ingress:
         enabled: false
-        host: konflux.example.com
+        fqdn: konflux.example.com
 ```
 
 With this configuration:
@@ -41,10 +41,18 @@ With this configuration:
 - **`ingress.enabled: false`** — the operator will **not** create an Ingress
   resource. You are responsible for routing traffic to the `proxy` service in the
   `konflux-ui` namespace.
-- **`ingress.host`** — the operator configures oauth2-proxy, dex, and all
+- **`ingress.fqdn`** — the operator configures oauth2-proxy, dex, and all
   related components to use this hostname for OIDC redirect URLs, issuer URLs,
   and allowed redirect domains. This ensures authentication flows work correctly
-  with your custom URL.
+  with your custom URL. An optional `:port` suffix (for example
+  `konflux.example.com:8443`) is supported in this endpoint-only mode. Do **not**
+  include `:port` when ingress is effectively enabled (explicit `true`, or unset on
+  OpenShift): reconcile fails with `Ready=False` / `InvalidIngressFQDN`, because a
+  managed Ingress host cannot include a port while auth URLs would keep it.
+
+On OpenShift, you can set `ingress.hostname` to a short DNS label instead (for
+example `konflux-ui`); the operator composes it with the cluster ingress domain
+as `<hostname>.<apps-domain>`. `fqdn` wins if both are set.
 
 ## Routing to the Backend
 

--- a/operator/docs/content/docs/guides/oidc-configuration.md
+++ b/operator/docs/content/docs/guides/oidc-configuration.md
@@ -49,8 +49,9 @@ https://<your-konflux-hostname>/idp/callback
 ```
 
 Dex is not exposed at a separate hostname — it runs behind the Konflux proxy at the `/idp/`
-path of your Konflux UI URL. The operator derives this URL automatically from `ingress.host`
-(or the OpenShift default ingress domain if not explicitly set).
+path of your Konflux UI URL. The operator derives this URL automatically from `ingress.fqdn`
+(or `ingress.hostname` composed with the OpenShift ingress domain, or the OpenShift
+default ingress naming if neither is set).
 
 Once created, note the **Client ID** and generate a **Client Secret** — you will need both in the next step.
 

--- a/operator/internal/condition/constants.go
+++ b/operator/internal/condition/constants.go
@@ -53,6 +53,10 @@ const (
 	// ReasonEndpointDeterminationFailed indicates that endpoint URL determination failed.
 	ReasonEndpointDeterminationFailed = "EndpointDeterminationFailed"
 
+	// ReasonInvalidIngressFQDN indicates ingress.fqdn includes a :port while ingress is
+	// effectively enabled (managed Ingress cannot carry a port in its host rule).
+	ReasonInvalidIngressFQDN = "InvalidIngressFQDN"
+
 	// ReasonConfigMapFailed indicates that ConfigMap reconciliation failed.
 	ReasonConfigMapFailed = "ConfigMapFailed"
 

--- a/operator/internal/controller/ui/konfluxui_controller.go
+++ b/operator/internal/controller/ui/konfluxui_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/url"
 
@@ -210,7 +211,11 @@ func (r *KonfluxUIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Determine the endpoint URL for ingress, dex, and oauth2-proxy configuration
 	endpoint, err := ingress.DetermineEndpointURL(ctx, r.Client, ui, uiNamespace, r.ClusterInfo)
 	if err != nil {
-		return errHandler.HandleWithReason(ctx, err, condition.ReasonEndpointDeterminationFailed, "determine endpoint URL")
+		reason := condition.ReasonEndpointDeterminationFailed
+		if errors.Is(err, ingress.ErrFQDNPortWithManagedIngress) {
+			reason = condition.ReasonInvalidIngressFQDN
+		}
+		return errHandler.HandleWithReason(ctx, err, reason, "determine endpoint URL")
 	}
 	log.Info("Determined endpoint for KonfluxUI", "url", endpoint.String())
 

--- a/operator/internal/controller/ui/konfluxui_controller_test.go
+++ b/operator/internal/controller/ui/konfluxui_controller_test.go
@@ -24,6 +24,7 @@ import (
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -420,7 +421,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 			refreshUI(ctx)
 			ui.Spec.Ingress = &konfluxv1alpha1.IngressSpec{
 				Enabled: ptr.To(true),
-				Host:    host,
+				FQDN:    host,
 			}
 			ExpectWithOffset(1, k8sClient.Update(ctx, ui)).To(Succeed())
 		}
@@ -521,7 +522,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 			By("updating to new hostname")
 			refreshUI(ctx)
-			ui.Spec.Ingress.Host = "updated.example.com"
+			ui.Spec.Ingress.FQDN = "updated.example.com"
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
 			Eventually(func(g Gomega) {
@@ -576,6 +577,162 @@ var _ = Describe("KonfluxUI Controller", func() {
 		})
 	})
 
+	Context("OpenShift ingress hostname resolution via Reconcile", Serial, func() {
+		const clusterDomain = "apps.cluster.example.com"
+
+		var openShiftClusterInfo *clusterinfo.Info
+
+		BeforeEach(func(ctx context.Context) {
+			By("building OpenShift cluster info")
+			var err error
+			openShiftClusterInfo, err = clusterinfo.DetectWithClient(&mockDiscoveryClient{
+				resources: map[string]*metav1.APIResourceList{
+					"config.openshift.io/v1": {
+						APIResources: []metav1.APIResource{{Kind: "ClusterVersion"}},
+					},
+				},
+				serverVersion: &version.Info{GitVersion: "v1.29.0"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("seeding OpenShift Ingress cluster domain")
+			ingressConfig := &configv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.IngressSpec{
+					Domain: clusterDomain,
+				},
+			}
+			Expect(k8sClient.Create(ctx, ingressConfig)).To(Succeed())
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, ingressConfig)
+
+			By("pre-cleaning Ingress and ConsoleLink")
+			_ = k8sClient.Delete(ctx, &networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{
+				Name: ingress.IngressName, Namespace: uiNamespace,
+			}})
+			_ = k8sClient.Delete(ctx, &consolev1.ConsoleLink{ObjectMeta: metav1.ObjectMeta{
+				Name: consolelink.ConsoleLinkName,
+			}})
+
+			startManager(openShiftClusterInfo)
+		})
+
+		createUI := func(ctx context.Context, ingressSpec *konfluxv1alpha1.IngressSpec) {
+			ui := &konfluxv1alpha1.KonfluxUI{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				Spec: konfluxv1alpha1.KonfluxUISpec{
+					KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
+						Ingress: ingressSpec,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ui)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, ui,
+				&consolev1.ConsoleLink{ObjectMeta: metav1.ObjectMeta{Name: consolelink.ConsoleLinkName}},
+				&networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}},
+			)
+		}
+
+		It("Should compose hostname with the cluster ingress domain", func(ctx context.Context) {
+			wantHost := "konflux-ui." + clusterDomain
+			createUI(ctx, &konfluxv1alpha1.IngressSpec{
+				Enabled:  ptr.To(true),
+				Hostname: "konflux-ui",
+			})
+
+			Eventually(func(g Gomega) {
+				updatedUI := &konfluxv1alpha1.KonfluxUI{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updatedUI)).To(Succeed())
+				g.Expect(updatedUI.Status.Ingress).NotTo(BeNil())
+				g.Expect(updatedUI.Status.Ingress.Hostname).To(Equal(wantHost))
+				g.Expect(updatedUI.Status.Ingress.URL).To(Equal("https://" + wantHost))
+
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, ing)).To(Succeed())
+				g.Expect(ing.Spec.Rules[0].Host).To(Equal(wantHost))
+
+				cl := &consolev1.ConsoleLink{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: consolelink.ConsoleLinkName,
+				}, cl)).To(Succeed())
+				g.Expect(cl.Spec.Href).To(Equal("https://" + wantHost))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("Should use the default OpenShift hostname when fqdn and hostname are unset", func(ctx context.Context) {
+			wantHost := ingress.IngressName + "-" + uiNamespace + "." + clusterDomain
+			createUI(ctx, &konfluxv1alpha1.IngressSpec{
+				Enabled: ptr.To(true),
+			})
+
+			Eventually(func(g Gomega) {
+				updatedUI := &konfluxv1alpha1.KonfluxUI{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updatedUI)).To(Succeed())
+				g.Expect(updatedUI.Status.Ingress).NotTo(BeNil())
+				g.Expect(updatedUI.Status.Ingress.Hostname).To(Equal(wantHost))
+				g.Expect(updatedUI.Status.Ingress.URL).To(Equal("https://" + wantHost))
+
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, ing)).To(Succeed())
+				g.Expect(ing.Spec.Rules[0].Host).To(Equal(wantHost))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("Should prefer fqdn over hostname when both are set", func(ctx context.Context) {
+			createUI(ctx, &konfluxv1alpha1.IngressSpec{
+				Enabled:  ptr.To(true),
+				FQDN:     "fqdn.example.com",
+				Hostname: "ignored-label",
+			})
+
+			Eventually(func(g Gomega) {
+				updatedUI := &konfluxv1alpha1.KonfluxUI{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updatedUI)).To(Succeed())
+				g.Expect(updatedUI.Status.Ingress).NotTo(BeNil())
+				g.Expect(updatedUI.Status.Ingress.Hostname).To(Equal("fqdn.example.com"))
+				g.Expect(updatedUI.Status.Ingress.URL).To(Equal("https://fqdn.example.com"))
+
+				ing := &networkingv1.Ingress{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: ingress.IngressName, Namespace: uiNamespace,
+				}, ing)).To(Succeed())
+				g.Expect(ing.Spec.Rules[0].Host).To(Equal("fqdn.example.com"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("Should compose hostname for the endpoint without creating Ingress when disabled", func(ctx context.Context) {
+			wantHost := "konflux-ui." + clusterDomain
+			createUI(ctx, &konfluxv1alpha1.IngressSpec{
+				Enabled:  ptr.To(false),
+				Hostname: "konflux-ui",
+			})
+
+			Eventually(func(g Gomega) {
+				updatedUI := &konfluxv1alpha1.KonfluxUI{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, updatedUI)).To(Succeed())
+				g.Expect(updatedUI.Status.Ingress).NotTo(BeNil())
+				g.Expect(updatedUI.Status.Ingress.Enabled).To(BeFalse())
+				g.Expect(updatedUI.Status.Ingress.Hostname).To(Equal(wantHost))
+				g.Expect(updatedUI.Status.Ingress.URL).To(Equal("https://" + wantHost))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("waiting for reconcile to settle")
+			waitForReconcile(ctx)
+
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: ingress.IngressName, Namespace: uiNamespace,
+			}, &networkingv1.Ingress{}))).To(BeTrue())
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+				Name: consolelink.ConsoleLinkName,
+			}, &consolev1.ConsoleLink{}))).To(BeTrue())
+		})
+	})
+
 	Context("OpenShift OAuth reconciliation via Reconcile", Serial, func() {
 		var openShiftClusterInfo *clusterinfo.Info
 		var defaultClusterInfo *clusterinfo.Info
@@ -613,7 +770,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 					KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
 						Ingress: &konfluxv1alpha1.IngressSpec{
 							Enabled: ptr.To(true),
-							Host:    "openshift-test.example.com",
+							FQDN:    "openshift-test.example.com",
 						},
 					},
 				},
@@ -930,7 +1087,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 					KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
 						Ingress: &konfluxv1alpha1.IngressSpec{
 							Enabled: ptr.To(true),
-							Host:    "consolelink-test.example.com",
+							FQDN:    "consolelink-test.example.com",
 						},
 					},
 				},
@@ -1040,7 +1197,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 			By("updating the hostname")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, ui)).To(Succeed())
-			ui.Spec.Ingress.Host = "updated-consolelink.example.com"
+			ui.Spec.Ingress.FQDN = "updated-consolelink.example.com"
 			Expect(k8sClient.Update(ctx, ui)).To(Succeed())
 
 			Eventually(func(g Gomega) {
@@ -1753,7 +1910,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 					KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
 						Ingress: &konfluxv1alpha1.IngressSpec{
 							Enabled: ptr.To(true),
-							Host:    "drift-test.example.com",
+							FQDN:    "drift-test.example.com",
 						},
 					},
 				},
@@ -1811,7 +1968,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 					KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
 						Ingress: &konfluxv1alpha1.IngressSpec{
 							Enabled: ptr.To(true),
-							Host:    "consolelink-drift.example.com",
+							FQDN:    "consolelink-drift.example.com",
 						},
 					},
 				},

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -20,6 +20,7 @@ package ingress
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 
@@ -29,9 +30,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
+)
+
+// ErrFQDNPortWithManagedIngress is returned when ingress.fqdn includes a :port
+// suffix while ingress is effectively enabled. Managed Ingress rules omit ports,
+// so auth redirects / ConsoleLink would disagree with the Ingress host.
+var ErrFQDNPortWithManagedIngress = errors.New(
+	"ingress.fqdn must not include a port when ingress is enabled; remove :port or set ingress.enabled=false",
 )
 
 const (
@@ -195,12 +204,19 @@ func GetOpenShiftIngressDomain(ctx context.Context, c client.Client) (string, er
 }
 
 // DetermineEndpointURL determines the endpoint URL for the UI based on ingress configuration.
-// If host is explicitly specified, use that host regardless of whether ingress is enabled.
-// This allows users who manage their own external routing (e.g., Gateway API, hardware LB)
-// to configure the endpoint without the operator managing an Ingress resource.
-// If ingress is enabled on OpenShift without a host, use the default OpenShift ingress domain.
-// Otherwise, use the default localhost configuration.
-// The namespace parameter is used for generating the OpenShift hostname convention.
+//
+// Resolution order:
+//  1. FQDN set → use as the UI endpoint host. Optional :port is allowed only when ingress
+//     is not effectively enabled; otherwise returns ErrFQDNPortWithManagedIngress. If
+//     Hostname is also set, FQDN wins and a warning is logged.
+//  2. Hostname set (FQDN empty) on OpenShift → compose <hostname>.<cluster-ingress-domain>
+//     (no -<namespace> infix). Domain lookup failure fails reconcile.
+//  3. Hostname set (FQDN empty) off OpenShift → ignore Hostname, log a warning, fall through.
+//  4. Neither set (or Hostname ignored) → OpenShift + ingress effectively enabled uses
+//     konflux-ui-<namespace>.<domain>; otherwise localhost:9443.
+//
+// FQDN and Hostname always define the UI endpoint URL independently of whether ingress is
+// enabled, so users managing their own external routing can still configure auth redirects.
 // Returns a *url.URL with Scheme set to "https" and Host set appropriately.
 func DetermineEndpointURL(
 	ctx context.Context,
@@ -209,23 +225,45 @@ func DetermineEndpointURL(
 	namespace string,
 	clusterInfo *clusterinfo.Info,
 ) (*url.URL, error) {
+	log := logf.FromContext(ctx)
 	ingressSpec := ui.Spec.GetIngress()
+	isOnOpenShift := clusterInfo != nil && clusterInfo.IsOpenShift()
+	// Effectively enabled: explicit true, or unset (nil) on OpenShift.
+	ingressEnabled := ptr.Deref(ingressSpec.Enabled, isOnOpenShift)
 
-	// If host is explicitly specified, always use it (no port for TLS on 443).
-	// This takes priority over the ingress-enabled check so that users who manage
-	// their own routing can set a hostname without the operator creating an Ingress.
-	if ingressSpec.Host != "" {
-		return &url.URL{
+	// FQDN takes precedence over Hostname and over the ingress-enabled check.
+	if ingressSpec.FQDN != "" {
+		if ingressSpec.Hostname != "" {
+			log.Info("Both ingress.fqdn and ingress.hostname are set; using fqdn and ignoring hostname",
+				"fqdn", ingressSpec.FQDN, "hostname", ingressSpec.Hostname)
+		}
+		endpoint := &url.URL{
 			Scheme: "https",
-			Host:   ingressSpec.Host,
-		}, nil
+			Host:   ingressSpec.FQDN,
+		}
+		if endpoint.Port() != "" && ingressEnabled {
+			return nil, ErrFQDNPortWithManagedIngress
+		}
+		return endpoint, nil
 	}
 
-	// Determine if ingress is effectively enabled:
-	// - Explicitly enabled (true), OR
-	// - Unset (nil) AND on OpenShift (defaults to true on OpenShift)
-	isOnOpenShift := clusterInfo != nil && clusterInfo.IsOpenShift()
-	ingressEnabled := ptr.Deref(ingressSpec.Enabled, isOnOpenShift)
+	// Short hostname label: compose with cluster ingress domain on OpenShift only.
+	if ingressSpec.Hostname != "" {
+		if isOnOpenShift {
+			domain, err := GetOpenShiftIngressDomain(ctx, c)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get OpenShift ingress domain: %w", err)
+			}
+			return &url.URL{
+				Scheme: "https",
+				Host:   fmt.Sprintf("%s.%s", ingressSpec.Hostname, domain),
+			}, nil
+		}
+		log.Info(
+			"ingress.hostname ignored off OpenShift; using defaults (set ingress.fqdn instead)",
+			"hostname", ingressSpec.Hostname,
+		)
+	}
 
 	// If ingress is not enabled, use defaults
 	if !ingressEnabled {
@@ -236,7 +274,7 @@ func DetermineEndpointURL(
 	}
 
 	// If on OpenShift, try to get the default ingress domain
-	if clusterInfo != nil && clusterInfo.IsOpenShift() {
+	if isOnOpenShift {
 		domain, err := GetOpenShiftIngressDomain(ctx, c)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get OpenShift ingress domain: %w", err)

--- a/operator/pkg/ingress/ingress_test.go
+++ b/operator/pkg/ingress/ingress_test.go
@@ -287,7 +287,7 @@ func TestBuildForUI(t *testing.T) {
 				KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
 					Ingress: &konfluxv1alpha1.IngressSpec{
 						Enabled: ptr.To(true),
-						Host:    "explicit.host.com",
+						FQDN:    "explicit.host.com",
 					},
 				},
 			},
@@ -399,7 +399,7 @@ func TestDetermineEndpointURL(t *testing.T) {
 		g.Expect(endpoint.Port()).To(gomega.Equal(DefaultProxyPort))
 	})
 
-	t.Run("returns explicit host when ingress is disabled but host is specified", func(t *testing.T) {
+	t.Run("returns explicit fqdn when ingress is disabled but fqdn is specified", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
 		ui := &konfluxv1alpha1.KonfluxUI{
@@ -407,13 +407,13 @@ func TestDetermineEndpointURL(t *testing.T) {
 				KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
 					Ingress: &konfluxv1alpha1.IngressSpec{
 						Enabled: ptr.To(false),
-						Host:    "my-custom-host.example.com",
+						FQDN:    "my-custom-host.example.com",
 					},
 				},
 			},
 		}
 
-		// Even with ingress disabled, explicit host should be honored
+		// Even with ingress disabled, explicit fqdn should be honored
 		// (e.g., user managing their own Gateway API or external routing)
 		endpoint, err := DetermineEndpointURL(
 			context.Background(), nil, ui, "konflux-ui", nil)
@@ -424,7 +424,7 @@ func TestDetermineEndpointURL(t *testing.T) {
 		g.Expect(endpoint.String()).To(gomega.Equal("https://my-custom-host.example.com"))
 	})
 
-	t.Run("returns explicit host when ingress is enabled with host specified", func(t *testing.T) {
+	t.Run("returns explicit fqdn when ingress is enabled with fqdn specified", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
 		ui := &konfluxv1alpha1.KonfluxUI{
@@ -432,7 +432,7 @@ func TestDetermineEndpointURL(t *testing.T) {
 				KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
 					Ingress: &konfluxv1alpha1.IngressSpec{
 						Enabled: ptr.To(true),
-						Host:    "my-custom-host.example.com",
+						FQDN:    "my-custom-host.example.com",
 					},
 				},
 			},
@@ -447,7 +447,30 @@ func TestDetermineEndpointURL(t *testing.T) {
 		g.Expect(endpoint.String()).To(gomega.Equal("https://my-custom-host.example.com"))
 	})
 
-	t.Run("returns explicit host on OpenShift instead of generating hostname", func(t *testing.T) {
+	t.Run("returns explicit fqdn with optional port", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		ui := &konfluxv1alpha1.KonfluxUI{
+			Spec: konfluxv1alpha1.KonfluxUISpec{
+				KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
+					Ingress: &konfluxv1alpha1.IngressSpec{
+						Enabled: ptr.To(false),
+						FQDN:    "my-custom-host.example.com:8443",
+					},
+				},
+			},
+		}
+
+		endpoint, err := DetermineEndpointURL(
+			context.Background(), nil, ui, "konflux-ui", nil)
+
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(endpoint.Hostname()).To(gomega.Equal("my-custom-host.example.com"))
+		g.Expect(endpoint.Port()).To(gomega.Equal("8443"))
+		g.Expect(endpoint.String()).To(gomega.Equal("https://my-custom-host.example.com:8443"))
+	})
+
+	t.Run("rejects fqdn with port when ingress is explicitly enabled", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
 		ui := &konfluxv1alpha1.KonfluxUI{
@@ -455,7 +478,66 @@ func TestDetermineEndpointURL(t *testing.T) {
 				KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
 					Ingress: &konfluxv1alpha1.IngressSpec{
 						Enabled: ptr.To(true),
-						Host:    "my-custom-host.example.com",
+						FQDN:    "my-custom-host.example.com:8443",
+					},
+				},
+			},
+		}
+
+		_, err := DetermineEndpointURL(
+			context.Background(), nil, ui, "konflux-ui", nil)
+
+		g.Expect(err).To(gomega.MatchError(ErrFQDNPortWithManagedIngress))
+	})
+
+	t.Run("rejects fqdn with port when ingress enabled defaults true on OpenShift", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		ui := &konfluxv1alpha1.KonfluxUI{
+			Spec: konfluxv1alpha1.KonfluxUISpec{
+				KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
+					Ingress: &konfluxv1alpha1.IngressSpec{
+						FQDN: "my-custom-host.example.com:8443",
+					},
+				},
+			},
+		}
+
+		_, err := DetermineEndpointURL(
+			context.Background(), nil, ui, "konflux-ui", createOpenShiftClusterInfo())
+
+		g.Expect(err).To(gomega.MatchError(ErrFQDNPortWithManagedIngress))
+	})
+
+	t.Run("allows fqdn with port when ingress enabled is unset off OpenShift", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		ui := &konfluxv1alpha1.KonfluxUI{
+			Spec: konfluxv1alpha1.KonfluxUISpec{
+				KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
+					Ingress: &konfluxv1alpha1.IngressSpec{
+						FQDN: "my-custom-host.example.com:8443",
+					},
+				},
+			},
+		}
+
+		endpoint, err := DetermineEndpointURL(
+			context.Background(), nil, ui, "konflux-ui", createNonOpenShiftClusterInfo())
+
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(endpoint.String()).To(gomega.Equal("https://my-custom-host.example.com:8443"))
+	})
+
+	t.Run("returns explicit fqdn on OpenShift instead of generating hostname", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		ui := &konfluxv1alpha1.KonfluxUI{
+			Spec: konfluxv1alpha1.KonfluxUISpec{
+				KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
+					Ingress: &konfluxv1alpha1.IngressSpec{
+						Enabled: ptr.To(true),
+						FQDN:    "my-custom-host.example.com",
 					},
 				},
 			},
@@ -463,7 +545,7 @@ func TestDetermineEndpointURL(t *testing.T) {
 
 		openShiftClusterInfo := createOpenShiftClusterInfo()
 
-		// Even on OpenShift, explicit host should take priority over auto-generated hostname
+		// Even on OpenShift, explicit fqdn should take priority over auto-generated hostname
 		endpoint, err := DetermineEndpointURL(
 			context.Background(), nil, ui, "konflux-ui", openShiftClusterInfo)
 
@@ -473,7 +555,153 @@ func TestDetermineEndpointURL(t *testing.T) {
 		g.Expect(endpoint.String()).To(gomega.Equal("https://my-custom-host.example.com"))
 	})
 
-	t.Run("generates OpenShift hostname when ingress enabled without host on OpenShift", func(t *testing.T) {
+	t.Run("prefers fqdn over hostname when both are set", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		ui := &konfluxv1alpha1.KonfluxUI{
+			Spec: konfluxv1alpha1.KonfluxUISpec{
+				KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
+					Ingress: &konfluxv1alpha1.IngressSpec{
+						Enabled:  ptr.To(true),
+						FQDN:     "fqdn.example.com",
+						Hostname: "ignored-label",
+					},
+				},
+			},
+		}
+
+		openShiftClusterInfo := createOpenShiftClusterInfo()
+
+		endpoint, err := DetermineEndpointURL(
+			context.Background(), nil, ui, "konflux-ui", openShiftClusterInfo)
+
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(endpoint.Hostname()).To(gomega.Equal("fqdn.example.com"))
+		g.Expect(endpoint.String()).To(gomega.Equal("https://fqdn.example.com"))
+	})
+
+	t.Run("composes hostname with OpenShift ingress domain", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		ui := &konfluxv1alpha1.KonfluxUI{
+			Spec: konfluxv1alpha1.KonfluxUISpec{
+				KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
+					Ingress: &konfluxv1alpha1.IngressSpec{
+						Enabled:  ptr.To(true),
+						Hostname: "konflux-ui",
+					},
+				},
+			},
+		}
+
+		ingressConfig := &unstructured.Unstructured{}
+		ingressConfig.SetGroupVersionKind(openshiftIngressGVK())
+		ingressConfig.SetName("cluster")
+		_ = unstructured.SetNestedField(ingressConfig.Object, "apps.cluster.example.com", "spec", "domain")
+
+		scheme := runtime.NewScheme()
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ingressConfig).
+			Build()
+
+		openShiftClusterInfo := createOpenShiftClusterInfo()
+
+		endpoint, err := DetermineEndpointURL(
+			context.Background(), fakeClient, ui, "konflux-ui", openShiftClusterInfo)
+
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		// Composed form has no -<namespace> infix
+		g.Expect(endpoint.Hostname()).To(gomega.Equal("konflux-ui.apps.cluster.example.com"))
+		g.Expect(endpoint.Port()).To(gomega.Equal(""))
+	})
+
+	t.Run("composes hostname on OpenShift even when ingress is disabled", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		ui := &konfluxv1alpha1.KonfluxUI{
+			Spec: konfluxv1alpha1.KonfluxUISpec{
+				KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
+					Ingress: &konfluxv1alpha1.IngressSpec{
+						Enabled:  ptr.To(false),
+						Hostname: "konflux-ui",
+					},
+				},
+			},
+		}
+
+		ingressConfig := &unstructured.Unstructured{}
+		ingressConfig.SetGroupVersionKind(openshiftIngressGVK())
+		ingressConfig.SetName("cluster")
+		_ = unstructured.SetNestedField(ingressConfig.Object, "apps.cluster.example.com", "spec", "domain")
+
+		scheme := runtime.NewScheme()
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ingressConfig).
+			Build()
+
+		openShiftClusterInfo := createOpenShiftClusterInfo()
+
+		endpoint, err := DetermineEndpointURL(
+			context.Background(), fakeClient, ui, "konflux-ui", openShiftClusterInfo)
+
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(endpoint.Hostname()).To(gomega.Equal("konflux-ui.apps.cluster.example.com"))
+	})
+
+	t.Run("ignores hostname off OpenShift and uses defaults", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		ui := &konfluxv1alpha1.KonfluxUI{
+			Spec: konfluxv1alpha1.KonfluxUISpec{
+				KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
+					Ingress: &konfluxv1alpha1.IngressSpec{
+						Enabled:  ptr.To(true),
+						Hostname: "konflux-ui",
+					},
+				},
+			},
+		}
+
+		nonOpenShiftClusterInfo := createNonOpenShiftClusterInfo()
+
+		endpoint, err := DetermineEndpointURL(
+			context.Background(), nil, ui, "konflux-ui", nonOpenShiftClusterInfo)
+
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(endpoint.Hostname()).To(gomega.Equal(DefaultProxyHostname))
+		g.Expect(endpoint.Port()).To(gomega.Equal(DefaultProxyPort))
+	})
+
+	t.Run("returns error when hostname set on OpenShift but domain fetch fails", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		ui := &konfluxv1alpha1.KonfluxUI{
+			Spec: konfluxv1alpha1.KonfluxUISpec{
+				KonfluxUIConfigSpec: konfluxv1alpha1.KonfluxUIConfigSpec{
+					Ingress: &konfluxv1alpha1.IngressSpec{
+						Hostname: "konflux-ui",
+					},
+				},
+			},
+		}
+
+		scheme := runtime.NewScheme()
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+
+		openShiftClusterInfo := createOpenShiftClusterInfo()
+
+		_, err := DetermineEndpointURL(
+			context.Background(), fakeClient, ui, "konflux-ui", openShiftClusterInfo)
+
+		g.Expect(err).To(gomega.HaveOccurred())
+		g.Expect(err.Error()).To(gomega.ContainSubstring("failed to get OpenShift ingress domain"))
+	})
+
+	t.Run("generates OpenShift hostname when ingress enabled without fqdn or hostname on OpenShift", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
 		ui := &konfluxv1alpha1.KonfluxUI{
@@ -507,7 +735,7 @@ func TestDetermineEndpointURL(t *testing.T) {
 		g.Expect(endpoint.Port()).To(gomega.Equal(""))
 	})
 
-	t.Run("returns defaults when not on OpenShift and no host specified", func(t *testing.T) {
+	t.Run("returns defaults when not on OpenShift and no fqdn specified", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
 		ui := &konfluxv1alpha1.KonfluxUI{


### PR DESCRIPTION
ingress.host was ambiguous and only accepted a full DNS name, so OpenShift users could not supply a short label and have the operator append the cluster apps domain. Rename it to fqdn for full overrides, add hostname for <label>.<cluster-domain> composition, and keep endpoint selection independent of whether the operator manages the Ingress object.

Assisted-by: Cursor

Closes: #8570