### PR TITLE
feat(segment-bridge):  RBAC for telemetry testing

### DIFF
--- a/operator/pkg/manifests/segment-bridge/manifests.yaml
+++ b/operator/pkg/manifests/segment-bridge/manifests.yaml
@@ -36,6 +36,54 @@ rules:
   - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: segment-bridge
+  name: segment-bridge-e2e-validation
+  namespace: segment-bridge
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  - events
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - external-secrets.io
+  resources:
+  - externalsecrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -100,6 +148,22 @@ subjects:
 - kind: ServiceAccount
   name: segment-bridge
   namespace: segment-bridge
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: segment-bridge
+  name: segment-bridge-e2e-validation
+  namespace: segment-bridge
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: segment-bridge-e2e-validation
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: oamsalem
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/operator/upstream-kustomizations/segment-bridge/e2e-validation-rbac.yaml
+++ b/operator/upstream-kustomizations/segment-bridge/e2e-validation-rbac.yaml
@@ -1,0 +1,65 @@
+---
+# Minimal read (+ optional job trigger) for e2e validation of segment-bridge.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: segment-bridge
+  name: segment-bridge-e2e-validation
+  namespace: segment-bridge
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  - events
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - external-secrets.io
+  resources:
+  - externalsecrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: segment-bridge
+  name: segment-bridge-e2e-validation
+  namespace: segment-bridge
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: segment-bridge-e2e-validation
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: oamsalem

--- a/operator/upstream-kustomizations/segment-bridge/kustomization.yaml
+++ b/operator/upstream-kustomizations/segment-bridge/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - https://github.com/konflux-ci/segment-bridge/config/base?ref=b8012bfa98a9d5a8e5baf6794d188161fbaa1e6f
+- e2e-validation-rbac.yaml
 images:
 - name: quay.io/konflux-ci/segment-bridge
   newName: quay.io/konflux-ci/segment-bridge


### PR DESCRIPTION
Deploy a namespace-scoped Role and RoleBinding in segment-bridge so telemetry validation can read segment-bridge resources and optionally trigger CronJob runs. These permissions are required to perform maintenance and e2e tests for the telemetry feature against staging segment

Assisted-by: Cursor