### PR TITLE
chore: Enable Caddy HTTP metrics

### DIFF
--- a/operator/pkg/manifests/ui/manifests.yaml
+++ b/operator/pkg/manifests/ui/manifests.yaml
@@ -160,8 +160,10 @@ metadata:
 ---
 apiVersion: v1
 data:
-  Caddyfile: "{\n\tauto_https off\n\tadmin off\n\torder inject_cached_vars before
-    reverse_proxy\n\tfile_watcher {\n\t\tcache kube_token /var/run/secrets/konflux-ci.dev/serviceaccount/token\n\t\tcache
+  Caddyfile: "{\n\tauto_https off\n\tadmin off\n\t# Enable HTTP middleware metrics
+    (scraped via :2112 /metrics).\n\t# Do not add per_host — Host labels are unbounded
+    on this catch-all :9443 site.\n\tmetrics\n\torder inject_cached_vars before reverse_proxy\n\tfile_watcher
+    {\n\t\tcache kube_token /var/run/secrets/konflux-ci.dev/serviceaccount/token\n\t\tcache
     backend_token /var/run/secrets/konflux-ci.dev/backend/token\n\t\tcache watson_auth
     /mnt/watson-config/API_KEY {\n\t\t\tdefault \"\"\n\t\t}\n\t\twatch /var/run/secrets/kubernetes.io/serviceaccount\n\t\twatch
     /mnt/cluster-ca\n\t\twatch /mnt/service-ca\n\t\twatch /mnt/serving-cert\n\t}\n}\n\n#
@@ -211,7 +213,7 @@ data:
     {path} /index.html\n\t\tfile_server\n\t}\n}\n"
 kind: ConfigMap
 metadata:
-  name: proxy-caddyfile-567h9kth9f
+  name: proxy-caddyfile-45hm8d8b52
   namespace: konflux-ui
 ---
 apiVersion: v1
@@ -746,7 +748,7 @@ spec:
           items:
           - key: Caddyfile
             path: Caddyfile
-          name: proxy-caddyfile-567h9kth9f
+          name: proxy-caddyfile-45hm8d8b52
         name: proxy-caddyfile
       - configMap:
           defaultMode: 420

--- a/operator/upstream-kustomizations/ui/core/proxy/Caddyfile
+++ b/operator/upstream-kustomizations/ui/core/proxy/Caddyfile
@@ -1,6 +1,9 @@
 {
 	auto_https off
 	admin off
+	# Enable HTTP middleware metrics (scraped via :2112 /metrics).
+	# Do not add per_host — Host labels are unbounded on this catch-all :9443 site.
+	metrics
 	order inject_cached_vars before reverse_proxy
 	file_watcher {
 		cache kube_token /var/run/secrets/konflux-ci.dev/serviceaccount/token

--- a/test/go-tests/pkg/metricsauth/catalog_test.go
+++ b/test/go-tests/pkg/metricsauth/catalog_test.go
@@ -32,6 +32,7 @@ func TestDefaultCatalog_TargetGroups(t *testing.T) {
 	assert.Equal(t, "https", byID["release-service"].Scheme)
 	assert.True(t, byID["konflux-ui-proxy"].UWMUpCheck)
 	assert.Empty(t, byID["konflux-ui-proxy"].ScrapeTokenSecret)
+	assert.Equal(t, []string{"caddy_http_request_duration_seconds"}, byID["konflux-ui-proxy"].BodyMustMatchAny)
 
 	assert.False(t, byID["konflux-operator"].TLSInsecureSkipVerifyForScrape())
 	assert.Equal(t, MetricsCASecretName, byID["konflux-operator"].MetricsCASecret)

--- a/test/go-tests/pkg/metricsauth/default_catalog.go
+++ b/test/go-tests/pkg/metricsauth/default_catalog.go
@@ -110,7 +110,9 @@ func DefaultCatalog() (*Catalog, error) {
 					Path:                     "/metrics",
 					MetricsReaderClusterRole: "konflux-ui-proxy-metrics-reader",
 					UWMUpCheck:               true,
-					BodyMustMatchAny:         []string{"caddy_"},
+					// Require the HTTP duration family used by UI error-rate recording rules
+					// (caddy_http_request_duration_seconds_count with code=...).
+					BodyMustMatchAny: []string{"caddy_http_request_duration_seconds"},
 				},
 			},
 		}


### PR DESCRIPTION
Enable additional Caddy metrics (without per_host) to support UI proxy error-rate recording and alerting.

Assisted-by: Cursor