### PR TITLE
feat(KFLUXVNGD-1179): add konflux_up Prometheus gauge for platform readiness

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
 	github.com/openshift/api v0.0.0-20260624175654-50c3975e874f
+	github.com/prometheus/client_golang v1.23.2
 	golang.org/x/crypto v0.54.0
 	golang.org/x/sync v0.22.0
 	k8s.io/api v0.36.3
@@ -58,11 +59,11 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.69.0 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect

--- a/operator/internal/controller/konflux/konflux_controller.go
+++ b/operator/internal/controller/konflux/konflux_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -47,6 +48,7 @@ import (
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/releaseservice"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/segmentbridge"
 	uictrl "github.com/konflux-ci/konflux-ci/operator/internal/controller/ui"
+	"github.com/konflux-ci/konflux-ci/operator/internal/operatormetrics"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
 )
@@ -166,8 +168,14 @@ func (r *KonfluxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Fetch the Konflux instance
 	konflux := &konfluxv1alpha1.Konflux{}
 	if err := r.Get(ctx, req.NamespacedName, konflux); err != nil {
+		if apierrors.IsNotFound(err) {
+			operatormetrics.SetKonfluxUp(false)
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+
+	// Update health metric on every exit path based on the final Ready condition.
+	defer func() { operatormetrics.SetKonfluxUp(konflux.IsReady()) }()
 
 	log.Info("Reconciling Konflux", "name", konflux.Name)
 

--- a/operator/internal/controller/konflux/konflux_controller_test.go
+++ b/operator/internal/controller/konflux/konflux_controller_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	prometheustestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -48,6 +49,7 @@ import (
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/segmentbridge"
 	"github.com/konflux-ci/konflux-ci/operator/internal/controller/testutil"
 	uictrl "github.com/konflux-ci/konflux-ci/operator/internal/controller/ui"
+	"github.com/konflux-ci/konflux-ci/operator/internal/operatormetrics"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/clusterinfo"
 )
 
@@ -841,6 +843,60 @@ var _ = Describe("Konflux Controller", func() {
 				ec := &konfluxv1alpha1.KonfluxEnterpriseContract{}
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: enterprisecontract.CRName}, ec)).To(Succeed())
 				g.Expect(ec.Spec.SkipPolicies).To(BeFalse())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+	})
+
+	Context("konflux_up metric", func() {
+		const resourceName = "konflux"
+
+		It("should set konflux_up to 0 when the Konflux CR is deleted", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
+			// Create the CR and wait for reconcile to settle.
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: resourceName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
+
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updated)).To(Succeed())
+				g.Expect(apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)).NotTo(BeNil())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			// Re-seed gauge to 1 AFTER reconcile settled (defer already set it to 0
+			// because Ready=False without sub-controllers). This ensures that only the
+			// NotFound path can flip the gauge back to 0.
+			operatormetrics.SetKonfluxUp(true)
+			Expect(prometheustestutil.ToFloat64(operatormetrics.KonfluxUpGauge())).To(Equal(float64(1)))
+
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+
+			Eventually(func() float64 {
+				return prometheustestutil.ToFloat64(operatormetrics.KonfluxUpGauge())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Equal(float64(0)))
+		})
+
+		It("should update konflux_up after a successful reconcile", func(ctx context.Context) {
+			startManager(createTestClusterInfo())
+
+			cr := &konfluxv1alpha1.Konflux{ObjectMeta: metav1.ObjectMeta{Name: resourceName}}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, cr, allSubCRs()...)
+
+			// After reconcile completes, the gauge should be set (0 because sub-controllers
+			// are not running so Ready will not be True, but the metric is actively updated).
+			Eventually(func(g Gomega) {
+				updated := &konfluxv1alpha1.Konflux{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: resourceName}, updated)).To(Succeed())
+				g.Expect(apimeta.FindStatusCondition(updated.GetConditions(), constant.ConditionTypeReady)).NotTo(BeNil())
+				// Gauge must reflect the current Ready state.
+				val := prometheustestutil.ToFloat64(operatormetrics.KonfluxUpGauge())
+				if updated.IsReady() {
+					g.Expect(val).To(Equal(float64(1)))
+				} else {
+					g.Expect(val).To(Equal(float64(0)))
+				}
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 	})

--- a/operator/internal/operatormetrics/health.go
+++ b/operator/internal/operatormetrics/health.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operatormetrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var konfluxUp = prometheus.NewGauge(prometheus.GaugeOpts{
+	Name: "konflux_up",
+	Help: "Whether the Konflux platform is ready (1) or not (0). Aggregated from all component sub-CR readiness conditions.",
+})
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(konfluxUp)
+}
+
+// SetKonfluxUp updates the konflux_up gauge based on the Konflux CR readiness.
+func SetKonfluxUp(ready bool) {
+	if ready {
+		konfluxUp.Set(1)
+	} else {
+		konfluxUp.Set(0)
+	}
+}
+
+// KonfluxUpGauge returns the konflux_up gauge collector for use in tests.
+func KonfluxUpGauge() prometheus.Gauge {
+	return konfluxUp
+}

--- a/operator/internal/operatormetrics/health_test.go
+++ b/operator/internal/operatormetrics/health_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2025 Konflux CI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operatormetrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestSetKonfluxUp(t *testing.T) {
+	SetKonfluxUp(true)
+	if v := testutil.ToFloat64(konfluxUp); v != 1 {
+		t.Errorf("SetKonfluxUp(true): expected gauge value 1, got %f", v)
+	}
+
+	SetKonfluxUp(false)
+	if v := testutil.ToFloat64(konfluxUp); v != 0 {
+		t.Errorf("SetKonfluxUp(false): expected gauge value 0, got %f", v)
+	}
+}


### PR DESCRIPTION
Expose a `konflux_up` metric (gauge, 1 or 0) on the operator's `/metrics` endpoint. 
The value reflects the Konflux CR's aggregated Ready condition, which is True only when all component sub-CRs report Ready and the `cert-manager` dependency gate passes.

This is the foundation for Prometheus-based health monitoring of the Konflux deployment, enabling alerting rules to be layered on top.

Assisted-by: Cursor + Opus 4.6