### PR TITLE
feat(KFLUXVNGD-1179): add ecosystem labels to konflux_up gauge

### DIFF
--- a/operator/docs/component-monitoring.md
+++ b/operator/docs/component-monitoring.md
@@ -458,10 +458,38 @@ steps (creating `monitoring/` kustomization, rebuilding embedded manifests via
 
 | Topic | Location |
 |-------|----------|
-| Operator self-metrics | `internal/operatormetrics/` (`scrape_token_rotator.go`, `scrape_wiring.go`) |
+| Operator self-metrics | `internal/operatormetrics/` (`scrape_token_rotator.go`, `scrape_wiring.go`, `health.go`) |
 | Embedded manifests | `operator/pkg/manifests/<component>/manifests.yaml` |
 | Cluster integration tests | `test/go-tests/metricsintegration/` + `test/go-tests/pkg/metricsauth.DefaultCatalog()` (via `scripts/operator-e2e/run-metrics-integration-tests.sh`, hooked in `test/e2e/run-e2e.sh`) |
 | OpenShift UWM tests | `test/go-tests/metricsopenshift/` + `test/go-tests/pkg/metricsopenshift/` (via `scripts/operator-e2e/openshift/run-metrics-openshift-tests.sh`, optional OCP e2e in `test/e2e/run-e2e.sh`) |
 | Deferred SM apply + scrape token | `operator/internal/common/scrape_token.go`, `operand_servicemonitor.go` |
 | Metrics TLS readiness | `operator/pkg/kubernetes/metrics_tls.go` |
 | SM annotation resync | `operator/pkg/kubernetes/servicemonitor_resync.go` (UWM nudge on token/CA change) |
+
+## `konflux_up` ecosystem labels
+
+The `konflux_up` metric is a standardized binary gauge (0 = down, 1 = up) used
+across all Konflux services to report availability. It enables unified alerting
+and dashboards across the fleet.
+
+**Required labels** for any `konflux_up` metric:
+
+| Label | Description | Example |
+|-------|-------------|---------|
+| `service` | Component name (must be unique across all `konflux_up` emitters) | `konflux-operator`|
+| `check` | What aspect of availability is being verified | `konflux-ready`|
+
+**Implementation in the operator:**
+
+The operator emits `konflux_up` with `ConstLabels` in `internal/operatormetrics/health.go`.
+Because `ConstLabels` produce a metric-side `service` label that collides with the
+Prometheus target label of the same name, the operator's ServiceMonitor sets
+`honorLabels: true` (in `scrape_wiring.go`) to preserve the metric's labels.
+
+**Adding new `konflux_up` signals:**
+
+When adding a new availability metric to the operator or any component:
+
+1. Use the metric name `konflux_up` with unique `service` + `check` label values
+2. If using `ConstLabels` that collide with target labels, set `honorLabels: true`
+   on the ServiceMonitor endpoint

--- a/operator/internal/operatormetrics/health.go
+++ b/operator/internal/operatormetrics/health.go
@@ -23,7 +23,11 @@ import (
 
 var konfluxUp = prometheus.NewGauge(prometheus.GaugeOpts{
 	Name: "konflux_up",
-	Help: "Whether the Konflux platform is ready (1) or not (0). Aggregated from all component sub-CR readiness conditions.",
+	Help: "Whether Konflux is ready (1) or not (0). Aggregated from all component sub-CR readiness conditions.",
+	ConstLabels: prometheus.Labels{
+		"service": "konflux-operator",
+		"check":   "konflux-ready",
+	},
 })
 
 func init() {

--- a/operator/internal/operatormetrics/scrape_wiring.go
+++ b/operator/internal/operatormetrics/scrape_wiring.go
@@ -54,9 +54,10 @@ func desiredOperatorServiceMonitor(namespace string) *unstructured.Unstructured 
 					"key":  kubernetes.ScrapeTokenSecretKey,
 					"name": kubernetes.ScrapeTokenSecretName,
 				},
-				"path":   "/metrics",
-				"port":   "https",
-				"scheme": "https",
+				"honorLabels": true,
+				"path":        "/metrics",
+				"port":        "https",
+				"scheme":      "https",
 				"tlsConfig": map[string]interface{}{
 					"insecureSkipVerify": false,
 					"serverName":         fmt.Sprintf("%s.%s.svc", OperatorMetricsServiceName, namespace),

--- a/operator/internal/operatormetrics/scrape_wiring_test.go
+++ b/operator/internal/operatormetrics/scrape_wiring_test.go
@@ -119,6 +119,9 @@ func TestDesiredOperatorServiceMonitorSpec(t *testing.T) {
 	if endpoint["scheme"] != "https" {
 		t.Fatalf("unexpected scheme: %#v", endpoint["scheme"])
 	}
+	if endpoint["honorLabels"] != true {
+		t.Fatalf("expected honorLabels true, got %#v", endpoint["honorLabels"])
+	}
 	tlsConfig, ok := endpoint["tlsConfig"].(map[string]interface{})
 	if !ok {
 		t.Fatal("expected tlsConfig map")


### PR DESCRIPTION
Add `service="konflux-operator"` and `check="konflux-ready"` constant labels to the existing `konflux_up` gauge so it conforms with the `konflux_up` ecosystem in o11y.

All Konflux availability alerts and the KonfluxAlert meta-alert join on `service` and `check`; without these labels the metric would be invisible to the shared alerting and dashboard infrastructure. The labels are required for metric forwarding to RHOBS and for writing targeted PrometheusRule alert expressions.

Assisted-by: Cursor + Opus 4.6