### PR TITLE
test(KFLUXVNGD-1179): add e2e test for konflux_up ecosystem label wiring

### DIFF
--- a/test/go-tests/metricsopenshift/konflux_up_labels_test.go
+++ b/test/go-tests/metricsopenshift/konflux_up_labels_test.go
@@ -1,0 +1,68 @@
+package metricsopenshift
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/metricsopenshift"
+)
+
+func init() {
+	loadMetricsCatalog()
+}
+
+var _ = Describe("konflux_up ecosystem labels", Label("openshift", "metrics-uwm"), func() {
+	It("exposes konflux_up with service=konflux-operator after metricRelabelings",
+		Label("operator"),
+		func(ctx SpecContext) {
+			GinkgoHelper()
+			promql := metricsopenshift.KonfluxUpPromQL()
+
+			dumpOnFailure := true
+			defer func() {
+				if !dumpOnFailure {
+					return
+				}
+
+				fmt.Fprintln(GinkgoWriter, "\n=== DEBUG: broad konflux_up (no label filter) ===")
+				broadResult, err := metricsopenshift.QueryPrometheus(ctx, kubeREST, metricsopenshift.BroadKonfluxUpPromQL())
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "error querying broad konflux_up: %v\n", err)
+				} else {
+					for _, sample := range broadResult.Data.Result {
+						fmt.Fprintf(GinkgoWriter, "  labels: %v\n", sample.Metric)
+					}
+					if len(broadResult.Data.Result) == 0 {
+						fmt.Fprintln(GinkgoWriter, "  (no series)")
+					}
+				}
+
+				fmt.Fprintln(GinkgoWriter, "\n=== DEBUG: all time series from konflux-operator namespace ===")
+				allResult, err := metricsopenshift.QueryPrometheus(ctx, kubeREST, metricsopenshift.AllOperatorSeriesPromQL())
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "error querying operator series: %v\n", err)
+				} else {
+					for _, sample := range allResult.Data.Result {
+						fmt.Fprintf(GinkgoWriter, "  %s %v\n", sample.Metric["__name__"], sample.Metric)
+					}
+					if len(allResult.Data.Result) == 0 {
+						fmt.Fprintln(GinkgoWriter, "  (no series)")
+					}
+				}
+			}()
+
+			Eventually(func(g Gomega) {
+				result, err := metricsopenshift.QueryPrometheus(ctx, kubeREST, promql)
+				g.Expect(err).NotTo(HaveOccurred())
+				if len(result.Data.Result) > 0 {
+					dumpOnFailure = false
+				}
+				g.Expect(result.Data.Result).NotTo(BeEmpty(),
+					"expected konflux_up{service=\"konflux-operator\"} to return at least one series; "+
+						"metricRelabelings may not be restoring the service label after honorLabels override")
+			}).WithTimeout(uwmTargetTimeout).WithPolling(uwmTargetInterval).Should(Succeed())
+		},
+	)
+})

--- a/test/go-tests/pkg/metricsopenshift/names.go
+++ b/test/go-tests/pkg/metricsopenshift/names.go
@@ -38,6 +38,24 @@ func UpPromQL(target metricsauth.Target) string {
 	)
 }
 
+// KonfluxUpPromQL returns a PromQL expression that matches the konflux_up gauge with
+// the ecosystem service label. This catches metricRelabelings failures where the
+// service ConstLabel is renamed to exported_service by Prometheus.
+func KonfluxUpPromQL() string {
+	return `konflux_up{service="konflux-operator"}`
+}
+
+// BroadKonfluxUpPromQL returns a relaxed konflux_up query without label filters,
+// for debugging label mismatches.
+func BroadKonfluxUpPromQL() string {
+	return `konflux_up`
+}
+
+// AllOperatorSeriesPromQL returns all time series scraped from the operator namespace.
+func AllOperatorSeriesPromQL() string {
+	return `{namespace="konflux-operator"}`
+}
+
 // BroadUpPromQL returns a relaxed up query for debugging label mismatches in UWM.
 func BroadUpPromQL(target metricsauth.Target) string {
 	return fmt.Sprintf(`up{namespace=%q}`, target.Namespace)


### PR DESCRIPTION
Add an e2e test that queries UWM Prometheus for
`konflux_up{service="konflux-operator"}` to verify the service ConstLabel survives Prometheus target-label collision resolution.

On failure, the test dumps all `konflux_up` labels and every time series from the konflux-operator namespace for diagnosis.

This test is expected to fail until the operator ServiceMonitor adds a metricRelabelings rule to restore the service label.

Assisted-by: Cursor + Opus 4.6