### PR TITLE
fix(KFLUXVNGD-1179): restore service label on konflux_up via metricRelabelings

### DIFF
--- a/operator/docs/component-monitoring.md
+++ b/operator/docs/component-monitoring.md
@@ -483,13 +483,18 @@ and dashboards across the fleet.
 
 The operator emits `konflux_up` with `ConstLabels` in `internal/operatormetrics/health.go`.
 Because `ConstLabels` produce a metric-side `service` label that collides with the
-Prometheus target label of the same name, the operator's ServiceMonitor sets
-`honorLabels: true` (in `scrape_wiring.go`) to preserve the metric's labels.
+Prometheus target label of the same name, Prometheus renames the metric label to
+`exported_service`. The operator's ServiceMonitor uses a `metricRelabelings` rule
+(in `scrape_wiring.go`) to copy `exported_service` back into `service` after
+scrape-time collision resolution. `honorLabels: true` is **not** used because
+in some environments the monitoring stack overrides it, and combining it with
+`metricRelabelings` would reverse the intended behavior on clusters that respect it.
 
 **Adding new `konflux_up` signals:**
 
 When adding a new availability metric to the operator or any component:
 
 1. Use the metric name `konflux_up` with unique `service` + `check` label values
-2. If using `ConstLabels` that collide with target labels, set `honorLabels: true`
-   on the ServiceMonitor endpoint
+2. If using `ConstLabels` that collide with target labels, add a `metricRelabelings`
+   rule to copy the `exported_<label>` back into `<label>` — do not rely on
+   `honorLabels: true` as it may be overridden by external policies

--- a/operator/internal/operatormetrics/scrape_wiring.go
+++ b/operator/internal/operatormetrics/scrape_wiring.go
@@ -54,10 +54,18 @@ func desiredOperatorServiceMonitor(namespace string) *unstructured.Unstructured 
 					"key":  kubernetes.ScrapeTokenSecretKey,
 					"name": kubernetes.ScrapeTokenSecretName,
 				},
-				"honorLabels": true,
-				"path":        "/metrics",
-				"port":        "https",
-				"scheme":      "https",
+				"metricRelabelings": []interface{}{
+					map[string]interface{}{
+						"sourceLabels": []interface{}{"exported_service"},
+						"targetLabel":  "service",
+						"regex":        "(.+)",
+						"replacement":  "$1",
+						"action":       "replace",
+					},
+				},
+				"path":   "/metrics",
+				"port":   "https",
+				"scheme": "https",
 				"tlsConfig": map[string]interface{}{
 					"insecureSkipVerify": false,
 					"serverName":         fmt.Sprintf("%s.%s.svc", OperatorMetricsServiceName, namespace),

--- a/operator/internal/operatormetrics/scrape_wiring_test.go
+++ b/operator/internal/operatormetrics/scrape_wiring_test.go
@@ -119,8 +119,32 @@ func TestDesiredOperatorServiceMonitorSpec(t *testing.T) {
 	if endpoint["scheme"] != "https" {
 		t.Fatalf("unexpected scheme: %#v", endpoint["scheme"])
 	}
-	if endpoint["honorLabels"] != true {
-		t.Fatalf("expected honorLabels true, got %#v", endpoint["honorLabels"])
+	if _, hasHonorLabels := endpoint["honorLabels"]; hasHonorLabels {
+		t.Fatal("honorLabels should not be set (conflicts with metricRelabelings)")
+	}
+	relabelings, ok := endpoint["metricRelabelings"].([]interface{})
+	if !ok || len(relabelings) < 1 {
+		t.Fatal("expected metricRelabelings with at least one rule")
+	}
+	rule, ok := relabelings[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected relabeling rule map")
+	}
+	srcLabels, ok := rule["sourceLabels"].([]interface{})
+	if !ok || len(srcLabels) != 1 || srcLabels[0] != "exported_service" {
+		t.Fatalf("unexpected sourceLabels: %#v", rule["sourceLabels"])
+	}
+	if rule["targetLabel"] != "service" {
+		t.Fatalf("unexpected targetLabel: %#v", rule["targetLabel"])
+	}
+	if rule["regex"] != "(.+)" {
+		t.Fatalf("regex must use a capture group for $1 replacement, got %#v", rule["regex"])
+	}
+	if rule["replacement"] != "$1" {
+		t.Fatalf("unexpected replacement: %#v", rule["replacement"])
+	}
+	if rule["action"] != "replace" {
+		t.Fatalf("unexpected action: %#v", rule["action"])
 	}
 	tlsConfig, ok := endpoint["tlsConfig"].(map[string]interface{})
 	if !ok {

--- a/test/go-tests/metricsopenshift/konflux_up_labels_test.go
+++ b/test/go-tests/metricsopenshift/konflux_up_labels_test.go
@@ -1,0 +1,68 @@
+package metricsopenshift
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/metricsopenshift"
+)
+
+func init() {
+	loadMetricsCatalog()
+}
+
+var _ = Describe("konflux_up ecosystem labels", Label("openshift", "metrics-uwm"), func() {
+	It("exposes konflux_up with service=konflux-operator after metricRelabelings",
+		Label("operator"),
+		func(ctx SpecContext) {
+			GinkgoHelper()
+			promql := metricsopenshift.KonfluxUpPromQL()
+
+			dumpOnFailure := true
+			defer func() {
+				if !dumpOnFailure {
+					return
+				}
+
+				fmt.Fprintln(GinkgoWriter, "\n=== DEBUG: broad konflux_up (no label filter) ===")
+				broadResult, err := metricsopenshift.QueryPrometheus(ctx, kubeREST, metricsopenshift.BroadKonfluxUpPromQL())
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "error querying broad konflux_up: %v\n", err)
+				} else {
+					for _, sample := range broadResult.Data.Result {
+						fmt.Fprintf(GinkgoWriter, "  labels: %v\n", sample.Metric)
+					}
+					if len(broadResult.Data.Result) == 0 {
+						fmt.Fprintln(GinkgoWriter, "  (no series)")
+					}
+				}
+
+				fmt.Fprintln(GinkgoWriter, "\n=== DEBUG: all time series from konflux-operator namespace ===")
+				allResult, err := metricsopenshift.QueryPrometheus(ctx, kubeREST, metricsopenshift.AllOperatorSeriesPromQL())
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "error querying operator series: %v\n", err)
+				} else {
+					for _, sample := range allResult.Data.Result {
+						fmt.Fprintf(GinkgoWriter, "  %s %v\n", sample.Metric["__name__"], sample.Metric)
+					}
+					if len(allResult.Data.Result) == 0 {
+						fmt.Fprintln(GinkgoWriter, "  (no series)")
+					}
+				}
+			}()
+
+			Eventually(func(g Gomega) {
+				result, err := metricsopenshift.QueryPrometheus(ctx, kubeREST, promql)
+				g.Expect(err).NotTo(HaveOccurred())
+				if len(result.Data.Result) > 0 {
+					dumpOnFailure = false
+				}
+				g.Expect(result.Data.Result).NotTo(BeEmpty(),
+					"expected konflux_up{service=\"konflux-operator\"} to return at least one series; "+
+						"metricRelabelings may not be restoring the service label after honorLabels override")
+			}).WithTimeout(uwmTargetTimeout).WithPolling(uwmTargetInterval).Should(Succeed())
+		},
+	)
+})

--- a/test/go-tests/pkg/metricsopenshift/names.go
+++ b/test/go-tests/pkg/metricsopenshift/names.go
@@ -38,6 +38,24 @@ func UpPromQL(target metricsauth.Target) string {
 	)
 }
 
+// KonfluxUpPromQL returns a PromQL expression that matches the konflux_up gauge with
+// the ecosystem service label. This catches metricRelabelings failures where the
+// service ConstLabel is renamed to exported_service by Prometheus.
+func KonfluxUpPromQL() string {
+	return `konflux_up{service="konflux-operator"}`
+}
+
+// BroadKonfluxUpPromQL returns a relaxed konflux_up query without label filters,
+// for debugging label mismatches.
+func BroadKonfluxUpPromQL() string {
+	return `konflux_up`
+}
+
+// AllOperatorSeriesPromQL returns all time series scraped from the operator namespace.
+func AllOperatorSeriesPromQL() string {
+	return `{namespace="konflux-operator"}`
+}
+
 // BroadUpPromQL returns a relaxed up query for debugging label mismatches in UWM.
 func BroadUpPromQL(target metricsauth.Target) string {
 	return fmt.Sprintf(`up{namespace=%q}`, target.Namespace)


### PR DESCRIPTION
OpenShift's user-workload-monitoring overrides `honorLabels: true` on ServiceMonitor endpoints, causing Prometheus to rename the `konflux_up` gauge's `service="konflux-operator"` ConstLabel to `exported_service` and replace it with the Kubernetes Service target label.

This makes `konflux_up{service="konflux-operator"}` return no results, rendering the metric invisible to ecosystem alerting and dashboards that join on `service` and `check`.

Add a `metricRelabelings` rule to the operator's ServiceMonitor endpoint that copies `exported_service` back into `service` after scrape-time collision resolution. Remove the now-counterproductive `honorLabels: true` which would reverse the relabeling on clusters that respect it.

Add an e2e test that queries UWM Prometheus for
`konflux_up{service="konflux-operator"}` to catch label collision regressions.

Assisted-by: Cursor + Opus 4.6