### PR TITLE
fix(KFLUXSE-462): strip scheme from Segment apiHost served to the browser SDK

### DIFF
--- a/operator/internal/controller/ui/konfluxui_controller.go
+++ b/operator/internal/controller/ui/konfluxui_controller.go
@@ -791,7 +791,12 @@ func (r *KonfluxUIReconciler) reconcileSegmentSecret(ctx context.Context, tc *tr
 		return "", nil
 	}
 
-	apiURL := segmentBridge.Spec.GetSegmentAPIURL()
+	// The browser Segment SDK (analytics-next) expects a bare "apiHost" with
+	// no scheme -- it builds the request URL itself as `${protocol}://${apiHost}`.
+	// GetSegmentAPIURL() always returns a full "https://..." URL (required by
+	// the CronJob's SEGMENT_BATCH_API), so strip the scheme here for this
+	// browser-facing consumer only. See segment.StripURLScheme for details.
+	apiURL := segment.StripURLScheme(segmentBridge.Spec.GetSegmentAPIURL())
 
 	// Create the content-hashed Secret and apply it via the tracking client
 	secret := hashedsecret.Build(

--- a/operator/internal/controller/ui/konfluxui_controller.go
+++ b/operator/internal/controller/ui/konfluxui_controller.go
@@ -791,7 +791,12 @@ func (r *KonfluxUIReconciler) reconcileSegmentSecret(ctx context.Context, tc *tr
 		return "", nil
 	}
 
-	apiURL := segmentBridge.Spec.GetSegmentAPIURL()
+	// The browser Segment SDK (analytics-next) expects a bare "apiHost" with
+	// no scheme -- it builds the request URL itself as `${protocol}://${apiHost}`.
+	// GetSegmentAPIURL() always returns a full "https://..." URL (required by
+	// the CronJob's SEGMENT_BATCH_API), so strip the scheme here for this
+	// browser-facing consumer only. See segment.ExtractURLHostAndPath for details.
+	apiURL := segment.ExtractURLHostAndPath(segmentBridge.Spec.GetSegmentAPIURL())
 
 	// Create the content-hashed Secret and apply it via the tracking client
 	secret := hashedsecret.Build(

--- a/operator/internal/controller/ui/konfluxui_controller_test.go
+++ b/operator/internal/controller/ui/konfluxui_controller_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/konflux-ci/konflux-ci/operator/pkg/hashedsecret"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/ingress"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/segment"
 )
 
 const (
@@ -2006,10 +2007,13 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 	Context("Segment Secret reconciliation via Reconcile", Serial, func() {
 		// expectedSecretName computes the hashed secret name for a given write key and API URL.
+		// apiURL is the full CR-style URL (with scheme); it is stripped down to a bare
+		// host+path here to match what the controller actually stores for the
+		// browser-facing Secret (see segment.StripURLScheme).
 		expectedSecretName := func(writeKey, apiURL string) string {
 			return hashedsecret.Build(segmentSecretBaseName, uiNamespace, map[string]string{
 				segmentKeyWriteKey: writeKey,
-				segmentKeyAPIURL:   apiURL,
+				segmentKeyAPIURL:   segment.StripURLScheme(apiURL),
 			}).Name
 		}
 
@@ -2122,7 +2126,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 					Name: name, Namespace: uiNamespace,
 				}, secret)).To(Succeed())
 				g.Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("test-write-key"))
-				g.Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal(konfluxv1alpha1.DefaultSegmentAPIURL))
+				g.Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal(segment.StripURLScheme(konfluxv1alpha1.DefaultSegmentAPIURL)))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
@@ -2143,7 +2147,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 					Name: name, Namespace: uiNamespace,
 				}, secret)).To(Succeed())
 				g.Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("test-write-key"))
-				g.Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal("https://console.redhat.com/connections/api/v1"))
+				g.Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal("console.redhat.com/connections/api/v1"))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 

--- a/operator/internal/controller/ui/konfluxui_controller_test.go
+++ b/operator/internal/controller/ui/konfluxui_controller_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/konflux-ci/konflux-ci/operator/pkg/hashedsecret"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/ingress"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
+	"github.com/konflux-ci/konflux-ci/operator/pkg/segment"
 )
 
 const (
@@ -2006,10 +2007,13 @@ var _ = Describe("KonfluxUI Controller", func() {
 
 	Context("Segment Secret reconciliation via Reconcile", Serial, func() {
 		// expectedSecretName computes the hashed secret name for a given write key and API URL.
+		// apiURL is the full CR-style URL (with scheme); it is stripped down to a bare
+		// host+path here to match what the controller actually stores for the
+		// browser-facing Secret (see segment.ExtractURLHostAndPath).
 		expectedSecretName := func(writeKey, apiURL string) string {
 			return hashedsecret.Build(segmentSecretBaseName, uiNamespace, map[string]string{
 				segmentKeyWriteKey: writeKey,
-				segmentKeyAPIURL:   apiURL,
+				segmentKeyAPIURL:   segment.ExtractURLHostAndPath(apiURL),
 			}).Name
 		}
 
@@ -2122,7 +2126,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 					Name: name, Namespace: uiNamespace,
 				}, secret)).To(Succeed())
 				g.Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("test-write-key"))
-				g.Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal(konfluxv1alpha1.DefaultSegmentAPIURL))
+				g.Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal(segment.ExtractURLHostAndPath(konfluxv1alpha1.DefaultSegmentAPIURL)))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 
@@ -2143,7 +2147,7 @@ var _ = Describe("KonfluxUI Controller", func() {
 					Name: name, Namespace: uiNamespace,
 				}, secret)).To(Succeed())
 				g.Expect(string(secret.Data[segmentKeyWriteKey])).To(Equal("test-write-key"))
-				g.Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal("https://console.redhat.com/connections/api/v1"))
+				g.Expect(string(secret.Data[segmentKeyAPIURL])).To(Equal("console.redhat.com/connections/api/v1"))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
 

--- a/operator/pkg/segment/segment.go
+++ b/operator/pkg/segment/segment.go
@@ -19,6 +19,7 @@ package segment
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -88,6 +89,34 @@ func ResolveWriteKeySecretRef(
 		)
 	}
 	return string(value), nil
+}
+
+// StripURLScheme removes the scheme (e.g. "https://") from rawURL, returning
+// only the host and path (e.g. "api.segment.io/v1").
+//
+// KonfluxSegmentBridgeSpec.GetSegmentAPIURL() always returns a full URL with
+// an "https://" scheme (enforced by CRD validation), because the CronJob's
+// Go HTTP client needs the full URL to build SEGMENT_BATCH_API. The browser
+// Segment SDK (analytics-next) is a different consumer of the same
+// configured host: it takes a bare "apiHost" (no scheme) and a separate
+// "protocol" setting, then concatenates them itself
+// (`${protocol}://${apiHost}`). Passing the full URL as apiHost therefore
+// produces a malformed "https://https://..." address that fails silently
+// in the browser before any network request is attempted.
+//
+// This helper must only be applied where the value is destined for the
+// browser SDK (the segment-bridge-config Secret's "url" key, served at
+// /segment/url). It must NOT be applied to the CronJob's SEGMENT_BATCH_API
+// construction, which correctly needs the scheme intact.
+//
+// If rawURL fails to parse, it is returned unchanged so callers fail loudly
+// downstream rather than silently losing data.
+func StripURLScheme(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return rawURL
+	}
+	return u.Host + u.Path
 }
 
 // LogWriteKeyResolution logs how the Segment write key was resolved.

--- a/operator/pkg/segment/segment.go
+++ b/operator/pkg/segment/segment.go
@@ -19,6 +19,7 @@ package segment
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -88,6 +89,35 @@ func ResolveWriteKeySecretRef(
 		)
 	}
 	return string(value), nil
+}
+
+// ExtractURLHostAndPath reduces rawURL to just its host and path (e.g.
+// "api.segment.io/v1"), dropping the scheme (e.g. "https://") as well as
+// any query string or fragment.
+//
+// KonfluxSegmentBridgeSpec.GetSegmentAPIURL() always returns a full URL with
+// an "https://" scheme (enforced by CRD validation), because the CronJob's
+// Go HTTP client needs the full URL to build SEGMENT_BATCH_API. The browser
+// Segment SDK (analytics-next) is a different consumer of the same
+// configured host: it takes a bare "apiHost" (no scheme) and a separate
+// "protocol" setting, then concatenates them itself
+// (`${protocol}://${apiHost}`). Passing the full URL as apiHost therefore
+// produces a malformed "https://https://..." address that fails silently
+// in the browser before any network request is attempted.
+//
+// This helper must only be applied where the value is destined for the
+// browser SDK (the segment-bridge-config Secret's "url" key, served at
+// /segment/url). It must NOT be applied to the CronJob's SEGMENT_BATCH_API
+// construction, which correctly needs the scheme intact.
+//
+// If rawURL fails to parse, it is returned unchanged so callers fail loudly
+// downstream rather than silently losing data.
+func ExtractURLHostAndPath(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return rawURL
+	}
+	return u.Host + u.EscapedPath()
 }
 
 // LogWriteKeyResolution logs how the Segment write key was resolved.

--- a/operator/pkg/segment/segment_test.go
+++ b/operator/pkg/segment/segment_test.go
@@ -82,6 +82,29 @@ func TestLogWriteKeyResolution(t *testing.T) {
 	})
 }
 
+func TestStripURLScheme(t *testing.T) {
+	t.Run("strips https scheme from the default Segment API URL", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(StripURLScheme("https://api.segment.io/v1")).To(gomega.Equal("api.segment.io/v1"))
+	})
+
+	t.Run("strips https scheme from a custom proxy URL, preserving host and path", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(StripURLScheme("https://console.redhat.com/connections/api/v1")).
+			To(gomega.Equal("console.redhat.com/connections/api/v1"))
+	})
+
+	t.Run("returns input unchanged when it cannot be parsed", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(StripURLScheme("://not a url")).To(gomega.Equal("://not a url"))
+	})
+
+	t.Run("returns input unchanged when there is no host", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(StripURLScheme("api.segment.io/v1")).To(gomega.Equal("api.segment.io/v1"))
+	})
+}
+
 func TestResolveWriteKeySecretRef(t *testing.T) {
 	ctx := context.Background()
 	namespace := "segment-bridge"

--- a/operator/pkg/segment/segment_test.go
+++ b/operator/pkg/segment/segment_test.go
@@ -82,6 +82,36 @@ func TestLogWriteKeyResolution(t *testing.T) {
 	})
 }
 
+func TestExtractURLHostAndPath(t *testing.T) {
+	t.Run("strips https scheme from the default Segment API URL", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(ExtractURLHostAndPath("https://api.segment.io/v1")).To(gomega.Equal("api.segment.io/v1"))
+	})
+
+	t.Run("strips https scheme from a custom proxy URL, preserving host and path", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(ExtractURLHostAndPath("https://console.redhat.com/connections/api/v1")).
+			To(gomega.Equal("console.redhat.com/connections/api/v1"))
+	})
+
+	t.Run("returns input unchanged when it cannot be parsed", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(ExtractURLHostAndPath("://not a url")).To(gomega.Equal("://not a url"))
+	})
+
+	t.Run("returns input unchanged when there is no host", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(ExtractURLHostAndPath("api.segment.io/v1")).To(gomega.Equal("api.segment.io/v1"))
+	})
+
+	t.Run("preserves percent-escaped reserved characters in the path", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		result := ExtractURLHostAndPath("https://example.com/a%2Fb")
+		g.Expect(result).To(gomega.Equal("example.com/a%2Fb"))
+		g.Expect(result).NotTo(gomega.Equal("example.com/a/b"))
+	})
+}
+
 func TestResolveWriteKeySecretRef(t *testing.T) {
 	ctx := context.Background()
 	namespace := "segment-bridge"


### PR DESCRIPTION
The Segment analytics-next SDK builds request URLs as
`${protocol}://${apiHost}`. The UI controller wrote the full
GetSegmentAPIURL() value (always https://...) into the browser-facing
segment-bridge-config Secret, producing malformed https://https://...
URLs and silently breaking user_login, user_logout, and
feedback_submitted events.

This change strip away the scheme only when populating the Secret served
at /segment/url. CronJob SEGMENT_BATCH_API construction is unchanged and still
uses the full URL with scheme

Assisted-by: Cursor