### PR TITLE
feat: conformance tests can use pre-provisioned clusters

### DIFF
--- a/test/e2e/e2e.env.template
+++ b/test/e2e/e2e.env.template
@@ -42,6 +42,22 @@ export MY_GITHUB_ORG="${GH_ORG}"
 export E2E_APPLICATIONS_NAMESPACE=default-tenant
 export TEST_ENVIRONMENT=upstream
 
+# Pre-provisioned cluster support (optional — for staging/shared clusters).
+# Both the tenant and managed namespaces must be provisioned externally (e.g. via
+# GitOps in konflux-release-data). Set both variables:
+#   E2E_APPLICATIONS_NAMESPACE — the tenant namespace (overrides default-tenant above)
+#   E2E_MANAGED_NAMESPACE      — the managed namespace for release pipelines
+#
+# When E2E_MANAGED_NAMESPACE is set, the suite:
+#   - adapts setup-release.sh to skip namespace creation and tolerate RBAC errors
+#   - makes patchECPForE2E and grantIntegrationRunnerJobRBAC non-fatal
+#   - validates critical release prerequisites after setup
+#   - cleans up resources individually instead of deleting the namespace
+#
+# Example for staging:
+# export E2E_APPLICATIONS_NAMESPACE=conformance-tenant
+# export E2E_MANAGED_NAMESPACE=conformance-managed-tenant
+
 # Optional: Override build pipeline bundle for docker-build-oci-ta-min (default: derived from operator manifest below).
 # Set CUSTOM_DOCKER_BUILD_OCI_TA_MIN_PIPELINE_BUNDLE before sourcing to use a different bundle.
 # Must be sourced from repo root so operator/... is found.

--- a/test/go-tests/pkg/constants/constants.go
+++ b/test/go-tests/pkg/constants/constants.go
@@ -7,8 +7,15 @@ type BuildPipelineType string
 const (
 	GITHUB_TOKEN_ENV            string = "GITHUB_TOKEN"            // #nosec
 	GITHUB_E2E_ORGANIZATION_ENV string = "MY_GITHUB_ORG"           // #nosec
+	GITHUB_E2E_REPO_ENV         string = "E2E_REPO"               // #nosec
+	GITHUB_E2E_ITS_REPO_ENV     string = "E2E_ITS_REPO"           // #nosec
 	DefaultGitHubE2EOrganization string = "konflux-ci"
 	QUAY_E2E_ORGANIZATION_ENV   string = "QUAY_E2E_ORGANIZATION"   // #nosec
+
+	// DefaultIntegrationSRepo is the public repo used by the IntegrationTestScenario git resolver.
+	// If changed to a private repo, a secret must be created in the namespace and token/tokenKey
+	// params added to the resolver — see Konflux docs on accessing private repos in ITS.
+	DefaultIntegrationSRepo string = "testrepo"
 
 	TEKTON_CHAINS_NS string = "openshift-pipelines" // #nosec
 

--- a/test/go-tests/pkg/utils/build/task_results.go
+++ b/test/go-tests/pkg/utils/build/task_results.go
@@ -112,12 +112,6 @@ func ValidateBuildPipelineTestResults(pipelineRun *pipeline.PipelineRun, c crcli
 
 		resultsToValidate := []string{constants.TektonTaskTestOutputName}
 
-		switch taskName {
-		case "tpa-scan":
-			resultsToValidate = append(resultsToValidate, "SCAN_OUTPUT")
-			resultsToValidate = append(resultsToValidate, "REPORTS")
-		}
-
 		if err := validateTaskRunResult(imageURL, results, resultsToValidate, taskName); err != nil {
 			return err
 		}

--- a/test/go-tests/tests/conformance/README.md
+++ b/test/go-tests/tests/conformance/README.md
@@ -51,3 +51,21 @@ They run against an upstream Konflux instance deployed via scripts in the [konfl
 ### Configuration
 
 The test scenarios are defined in [scenarios.go](./config/scenarios.go). Update `UpstreamAppSpecs` to test your own component/repository.
+
+#### Pre-provisioned (staging) mode
+
+By default the conformance tests create and tear down their own namespaces on a
+local Kind cluster. To run against a pre-provisioned cluster (e.g. staging) where
+namespaces are managed externally:
+
+| Environment Variable | Purpose |
+|---|---|
+| `E2E_APPLICATIONS_NAMESPACE` | Tenant namespace (e.g. `conformance-tenant`) |
+| `E2E_MANAGED_NAMESPACE` | Managed namespace for release resources (e.g. `conformance-managed-tenant`). **Setting this enables pre-provisioned mode.** |
+
+When `E2E_MANAGED_NAMESPACE` is set:
+- Setup adapts `setup-release.sh` to tolerate pre-existing namespaces and RBAC
+- Cleanup deletes only test-created resources (filtered by application label) instead of deleting the namespace
+- `verifyECPPatched`, `verifyPreProvisionedRBAC`, and `verifyReleasePrerequisites` assert that the environment is correctly configured before tests run
+
+See `test/e2e/e2e.env.template` for full environment variable documentation.

--- a/test/go-tests/tests/conformance/config/scenarios.go
+++ b/test/go-tests/tests/conformance/config/scenarios.go
@@ -14,12 +14,12 @@ var UpstreamAppSpecs = []ApplicationSpec{
 		Skip:            false,
 		ComponentSpec: ComponentSpec{
 			Name:              "konflux-ci-upstream",
-			GitSourceUrl:      fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, constants.DefaultGitHubE2EOrganization), "testrepo"),
+			GitSourceUrl:      fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, constants.DefaultGitHubE2EOrganization), utils.GetEnv(constants.GITHUB_E2E_REPO_ENV, constants.DefaultIntegrationSRepo)),
 			GitSourceRevision: "878eb2976b97946f577a8dbb0cc391d5370efbbb",
 			DockerFilePath:    "Dockerfile",
 			BuildPipelineType: constants.DockerBuildOciTAMin,
 			IntegrationTestScenario: IntegrationTestScenarioSpec{
-				GitURL:      fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, constants.DefaultGitHubE2EOrganization), "testrepo"),
+				GitURL:      fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, constants.DefaultGitHubE2EOrganization), utils.GetEnv(constants.GITHUB_E2E_ITS_REPO_ENV, constants.DefaultIntegrationSRepo)),
 				GitRevision: "7ab8dd0157209308324be243d98301d8be3ae295",
 				TestPath:    "integration-tests/testrepo-integration.yaml",
 			},

--- a/test/go-tests/tests/conformance/conformance.go
+++ b/test/go-tests/tests/conformance/conformance.go
@@ -29,6 +29,7 @@ import (
 	e2eConfig "github.com/konflux-ci/konflux-ci/test/go-tests/tests/conformance/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // conformanceCleanupBudget returns the max wall time to wait for AfterAll cleanup.
@@ -61,7 +62,9 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 
 	fw := &framework.Framework{}
 	var buildPipelineAnnotation map[string]string
-	var componentNewBaseBranch, gitRevision, componentRepositoryName, componentName string
+	var appName string
+	var componentNewBaseBranch, gitRevision, componentRepositoryName, componentName, releaseName string
+	var releaseRes setupReleaseResult
 
 	for _, appSpec := range e2eConfig.UpstreamAppSpecs {
 		appSpec := appSpec
@@ -79,22 +82,65 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				userNamespace = fw.UserNamespace
-				managedNamespace = "default-managed-tenant"
-				klog.Info("conformance: namespaces ready", "user", userNamespace, "managed", managedNamespace)
+				managedNamespace = os.Getenv("E2E_MANAGED_NAMESPACE")
+				if managedNamespace == "" {
+					managedNamespace = "default-managed-tenant"
+				}
+				klog.Infof("conformance: namespaces ready user=%s managed=%s", userNamespace, managedNamespace)
 
-				componentName = fmt.Sprintf("%s-%s", appSpec.ComponentSpec.Name, util.GenerateRandomString(4))
+				suffix := util.GenerateRandomString(4)
+				componentName = fmt.Sprintf("%s-%s", appSpec.ComponentSpec.Name, suffix)
+				appName = fmt.Sprintf("%s-%s", appSpec.ApplicationName, suffix)
 				pacBranchName = constants.PaCPullRequestBranchPrefix + componentName
 				componentRepositoryName = utils.ExtractGitRepositoryNameFromURL(appSpec.ComponentSpec.GitSourceUrl)
 
-				gomega.Expect(runSetupRelease(appSpec.ApplicationName, componentName, userNamespace, managedNamespace)).To(gomega.Succeed())
-				gomega.Expect(patchECPForE2E(fw.AsKubeAdmin, "default", managedNamespace)).To(gomega.Succeed())
-				gomega.Expect(grantIntegrationRunnerJobRBAC(userNamespace)).To(gomega.Succeed())
+				if isPreProvisioned() {
+					client := fw.AsKubeAdmin.CommonController.KubeRest()
+					pruneDanglingSASecrets(context.Background(), client, managedNamespace)
+					gomega.Expect(ensureReleasePipelineSA(context.Background(), client, managedNamespace)).To(gomega.Succeed())
+				}
+
+				releaseName = fmt.Sprintf("release-%s", suffix)
+				var setupErr error
+				releaseRes, setupErr = runSetupRelease(appName, componentName, userNamespace, managedNamespace, releaseName)
+				gomega.Expect(setupErr).NotTo(gomega.HaveOccurred())
+				preProvisioned := isPreProvisioned()
+				if preProvisioned {
+					// Pre-provisioned setup uses intentionally mixed error handling:
+					// mutations (ensureSASecret, patchECP, grantRBAC) are non-fatal
+					// warnings because the cluster may already be partially configured,
+					// while verifications (verifyECPPatched, verifyReleasePrerequisites)
+					// are fatal Expects because tests cannot succeed without them.
+					client := fw.AsKubeAdmin.CommonController.KubeRest()
+					runIRNames := []string{componentName, releaseRes.TrustedArtifactsIR}
+					if err := ensureSASecret(context.Background(), client, managedNamespace, runIRNames); err != nil {
+						klog.Warningf("conformance: ensureSASecret failed (non-fatal): %v", err)
+					}
+					if err := patchECPForE2E(fw.AsKubeAdmin, releaseRes.ECPName, managedNamespace); err != nil {
+						klog.Warningf("conformance: patchECPForE2E failed (non-fatal in pre-provisioned env): %v", err)
+					}
+					if err := grantIntegrationRunnerJobRBAC(fw.AsKubeAdmin, userNamespace); err != nil {
+						klog.Warningf("conformance: grantIntegrationRunnerJobRBAC failed (non-fatal in pre-provisioned env): %v", err)
+					}
+					gomega.Expect(verifyECPPatched(fw.AsKubeAdmin, releaseRes.ECPName, managedNamespace)).To(gomega.Succeed())
+					if err := verifyPreProvisionedRBAC(fw.AsKubeAdmin, userNamespace); err != nil {
+						klog.Warningf("conformance: pre-provisioned RBAC check failed (non-fatal, tests may still pass): %v", err)
+					}
+					gomega.Expect(verifyReleasePrerequisites(fw.AsKubeAdmin, managedNamespace)).To(gomega.Succeed())
+				} else {
+					gomega.Expect(patchECPForE2E(fw.AsKubeAdmin, releaseRes.ECPName, managedNamespace)).To(gomega.Succeed())
+					gomega.Expect(grantIntegrationRunnerJobRBAC(fw.AsKubeAdmin, userNamespace)).To(gomega.Succeed())
+				}
 
 				buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(appSpec.ComponentSpec.BuildPipelineType)
 			})
 
 			ginkgo.AfterAll(func() {
-				if strings.EqualFold(os.Getenv("E2E_SKIP_CLEANUP"), "true") || ginkgo.CurrentSpecReport().Failed() || strings.Contains(ginkgo.GinkgoLabelFilter(), upstreamKonfluxTestLabel) {
+				skipCleanup := strings.EqualFold(os.Getenv("E2E_SKIP_CLEANUP"), "true")
+				if !isPreProvisioned() {
+					skipCleanup = skipCleanup || ginkgo.CurrentSpecReport().Failed() || strings.Contains(ginkgo.GinkgoLabelFilter(), upstreamKonfluxTestLabel)
+				}
+				if skipCleanup {
 					return
 				}
 				klog.Info("conformance: cleaning up")
@@ -102,7 +148,14 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 				ctx, cancel := context.WithTimeout(context.Background(), budget)
 				defer cancel()
 
-				_ = fw.AsKubeAdmin.CommonController.KubeInterface().CoreV1().Namespaces().Delete(ctx, managedNamespace, metav1.DeleteOptions{})
+				if isPreProvisioned() {
+					cleanupTenantResources(ctx, fw, userNamespace, appName, componentName, releaseName)
+				} else {
+					if err := fw.AsKubeAdmin.CommonController.KubeInterface().CoreV1().Namespaces().Delete(ctx, managedNamespace, metav1.DeleteOptions{}); err != nil {
+						klog.Warningf("conformance cleanup: delete managed namespace %s: %v", managedNamespace, err)
+					}
+				}
+
 				cleanupWithRetry(ctx, "delete PaC branch", func() error {
 					return fw.AsKubeAdmin.CommonController.GitHub.DeleteRef(ctx, componentRepositoryName, pacBranchName)
 				})
@@ -112,14 +165,37 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 				cleanupWithRetry(ctx, "cleanup webhooks", func() error {
 					return build.CleanupWebhooks(ctx, fw, componentRepositoryName)
 				})
+
+				if isPreProvisioned() {
+					// The release PipelineRun is created asynchronously by the
+					// release-service and may not exist until ~50s after the
+					// last spec finishes. Poll until it appears, then sweep.
+					// This is non-fatal: if the test failed before reaching the
+					// release stage, no PipelineRun will ever appear and that's fine.
+					client := fw.AsKubeAdmin.CommonController.KubeRest()
+					appLabel := crclient.MatchingLabels{"appstudio.openshift.io/application": appName}
+					pollDeadline := time.Now().Add(60 * time.Second)
+					for time.Now().Before(pollDeadline) {
+						if ctx.Err() != nil {
+							klog.Warningf("conformance cleanup: context cancelled while waiting for release PipelineRun")
+							break
+						}
+						prList := &tektonapi.PipelineRunList{}
+						if err := client.List(ctx, prList, crclient.InNamespace(managedNamespace), appLabel); err == nil && len(prList.Items) > 0 {
+							break
+						}
+						time.Sleep(5 * time.Second)
+					}
+					cleanupManagedResources(ctx, fw, managedNamespace, appName, componentName, releaseName, releaseRes)
+				}
 			})
 
 			// --- Application & Component Setup ---
 
 			ginkgo.It("creates an application", ginkgo.Label(devEnvTestLabel, upstreamKonfluxTestLabel), func() {
-				createdApplication, createErr := fw.AsKubeAdmin.HasController.CreateApplication(appSpec.ApplicationName, userNamespace)
+				createdApplication, createErr := fw.AsKubeAdmin.HasController.CreateApplication(appName, userNamespace)
 				gomega.Expect(createErr).NotTo(gomega.HaveOccurred())
-				gomega.Expect(createdApplication.Spec.DisplayName).To(gomega.Equal(appSpec.ApplicationName))
+				gomega.Expect(createdApplication.Spec.DisplayName).To(gomega.Equal(appName))
 				gomega.Expect(createdApplication.Namespace).To(gomega.Equal(userNamespace))
 			})
 
@@ -127,7 +203,7 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 				its := appSpec.ComponentSpec.IntegrationTestScenario
 				gomega.Eventually(func() error {
 					var createErr error
-					integrationTestScenario, createErr = fw.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", appSpec.ApplicationName, userNamespace, its.GitURL, its.GitRevision, its.TestPath, "", []string{})
+					integrationTestScenario, createErr = fw.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", appName, userNamespace, its.GitURL, its.GitRevision, its.TestPath, "", []string{})
 					return createErr
 				}, time.Minute*2, time.Second*5).Should(gomega.Succeed(), "timed out creating IntegrationTestScenario")
 			})
@@ -142,7 +218,7 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 			ginkgo.It(fmt.Sprintf("creates component %s (private: %t) from git source %s", appSpec.ComponentSpec.Name, appSpec.ComponentSpec.Private, appSpec.ComponentSpec.GitSourceUrl), ginkgo.Label(devEnvTestLabel, upstreamKonfluxTestLabel), func() {
 				componentObj := appservice.ComponentSpec{
 					ComponentName: componentName,
-					Application:   appSpec.ApplicationName,
+					Application:   appName,
 					Source: appservice.ComponentSource{
 						ComponentSourceUnion: appservice.ComponentSourceUnion{
 							GitSource: &appservice.GitSource{
@@ -154,7 +230,7 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 						},
 					},
 				}
-				component, err = fw.AsKubeAdmin.HasController.CreateComponentCheckImageRepository(componentObj, userNamespace, "", "", appSpec.ApplicationName, false, utils.MergeMaps(constants.ComponentPaCRequestAnnotation, buildPipelineAnnotation))
+				component, err = fw.AsKubeAdmin.HasController.CreateComponentCheckImageRepository(componentObj, userNamespace, "", "", appName, false, utils.MergeMaps(constants.ComponentPaCRequestAnnotation, buildPipelineAnnotation))
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
@@ -175,14 +251,14 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 								return nil
 							}
 						}
-						dumpDiagnostics(fw.AsKubeAdmin, component.GetName(), appSpec.ApplicationName, userNamespace)
+						dumpDiagnostics(fw.AsKubeAdmin, component.GetName(), appName, userNamespace)
 						return fmt.Errorf("PaC branch %s not found among %d PRs", pacBranchName, len(prs))
 					}, pullRequestCreationTimeout, defaultPollingInterval).Should(gomega.Succeed(), "timed out waiting for PaC PR")
 
 					gomega.Eventually(func() error {
-						pipelineRun, err = fw.AsKubeAdmin.HasController.GetComponentPipelineRun(component.GetName(), appSpec.ApplicationName, userNamespace, prSHA)
+						pipelineRun, err = fw.AsKubeAdmin.HasController.GetComponentPipelineRun(component.GetName(), appName, userNamespace, prSHA)
 						if err != nil {
-							dumpDiagnostics(fw.AsKubeAdmin, component.GetName(), appSpec.ApplicationName, userNamespace)
+							dumpDiagnostics(fw.AsKubeAdmin, component.GetName(), appName, userNamespace)
 							return err
 						}
 						return fw.AsKubeAdmin.TektonController.DeletePipelineRun(pipelineRun.Name, pipelineRun.Namespace)
@@ -217,9 +293,9 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 					headSHA = mergeResult.GetSHA()
 
 					gomega.Eventually(func() error {
-						pipelineRun, err = fw.AsKubeAdmin.HasController.GetComponentPipelineRun(component.GetName(), appSpec.ApplicationName, userNamespace, headSHA)
+						pipelineRun, err = fw.AsKubeAdmin.HasController.GetComponentPipelineRun(component.GetName(), appName, userNamespace, headSHA)
 						if err != nil {
-							dumpDiagnostics(fw.AsKubeAdmin, component.GetName(), appSpec.ApplicationName, userNamespace)
+							dumpDiagnostics(fw.AsKubeAdmin, component.GetName(), appName, userNamespace)
 							return err
 						}
 						if !pipelineRun.HasStarted() {
@@ -247,7 +323,7 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 
 			ginkgo.When("Build PipelineRun completes successfully", func() {
 				ginkgo.It("should validate Tekton TaskRun test results successfully", func() {
-					pipelineRun, err = fw.AsKubeAdmin.HasController.GetComponentPipelineRun(component.GetName(), appSpec.ApplicationName, userNamespace, headSHA)
+					pipelineRun, err = fw.AsKubeAdmin.HasController.GetComponentPipelineRun(component.GetName(), appName, userNamespace, headSHA)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 					err = build.ValidateBuildPipelineTestResults(pipelineRun, fw.AsKubeAdmin.CommonController.KubeRest(), false)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -255,7 +331,7 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 
 				ginkgo.It("should validate that the build pipelineRun is signed", ginkgo.Label(upstreamKonfluxTestLabel), func() {
 					gomega.Eventually(func() error {
-						pipelineRun, err = fw.AsKubeAdmin.HasController.GetComponentPipelineRun(component.GetName(), appSpec.ApplicationName, userNamespace, headSHA)
+						pipelineRun, err = fw.AsKubeAdmin.HasController.GetComponentPipelineRun(component.GetName(), appName, userNamespace, headSHA)
 						if err != nil {
 							return err
 						}
@@ -276,7 +352,7 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 				ginkgo.It("should validate that the build pipelineRun is annotated with the name of the Snapshot", ginkgo.Label(upstreamKonfluxTestLabel), func() {
 					gomega.Eventually(func() error {
 						var getErr error
-						pipelineRun, getErr = fw.AsKubeAdmin.HasController.GetComponentPipelineRun(component.GetName(), appSpec.ApplicationName, userNamespace, headSHA)
+						pipelineRun, getErr = fw.AsKubeAdmin.HasController.GetComponentPipelineRun(component.GetName(), appName, userNamespace, headSHA)
 						if getErr != nil {
 							return getErr
 						}
@@ -293,7 +369,7 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 					gomega.Eventually(func() error {
 						testPipelinerun, err = fw.AsKubeAdmin.IntegrationController.GetIntegrationPipelineRun(integrationTestScenario.Name, snapshot.Name, userNamespace)
 						if err != nil {
-							dumpDiagnostics(fw.AsKubeAdmin, component.GetName(), appSpec.ApplicationName, userNamespace)
+							dumpDiagnostics(fw.AsKubeAdmin, component.GetName(), appName, userNamespace)
 							return err
 						}
 						if !testPipelinerun.HasStarted() {
@@ -413,9 +489,9 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					gomega.Eventually(func() error {
-						testPipelinerun, err = fw.AsKubeAdmin.HasController.GetComponentPipelineRunWithType(component.GetName(), appSpec.ApplicationName, userNamespace, "build", "", "incoming")
+						testPipelinerun, err = fw.AsKubeAdmin.HasController.GetComponentPipelineRunWithType(component.GetName(), appName, userNamespace, "build", "", "incoming")
 						if err != nil {
-							dumpDiagnostics(fw.AsKubeAdmin, component.GetName(), appSpec.ApplicationName, userNamespace)
+							dumpDiagnostics(fw.AsKubeAdmin, component.GetName(), appName, userNamespace)
 							return err
 						}
 						if !testPipelinerun.HasStarted() {
@@ -431,7 +507,7 @@ var _ = ginkgo.Describe("[conformance]", ginkgo.Label(devEnvTestLabel, upstreamK
 					gomega.Expect(testPipelinerun.Labels["pipelinesascode.tekton.dev/event-type"]).To(gomega.Equal("incoming"))
 					gomega.Expect(testPipelinerun.Labels["pipelines.appstudio.openshift.io/type"]).To(gomega.Equal("build"))
 					gomega.Expect(testPipelinerun.Labels["appstudio.openshift.io/component"]).To(gomega.Equal(component.GetName()))
-					gomega.Expect(testPipelinerun.Labels["appstudio.openshift.io/application"]).To(gomega.Equal(appSpec.ApplicationName))
+					gomega.Expect(testPipelinerun.Labels["appstudio.openshift.io/application"]).To(gomega.Equal(appName))
 				})
 
 				ginkgo.It("should have a source commit SHA label", func() {

--- a/test/go-tests/tests/conformance/setup.go
+++ b/test/go-tests/tests/conformance/setup.go
@@ -6,36 +6,182 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
 	ecp "github.com/conforma/crds/api/v1alpha1"
+	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
 	buildcontrollers "github.com/konflux-ci/build-service/controllers"
+	imagecontroller "github.com/konflux-ci/image-controller/api/v1alpha1"
+	integrationv1beta2 "github.com/konflux-ci/integration-service/api/v1beta2"
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 
 	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/framework"
 	ginkgo "github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// isPreProvisioned returns true when the suite is targeting a pre-provisioned
+// (e.g. staging) cluster where the managed namespace is externally managed.
+// The single source of truth is the E2E_MANAGED_NAMESPACE env var.
+func isPreProvisioned() bool {
+	return os.Getenv("E2E_MANAGED_NAMESPACE") != ""
+}
+
+// pruneDanglingSASecrets removes references to non-existent Secrets from
+// the release-pipeline ServiceAccount. This is always safe to call, even
+// during concurrent runs, because it only removes references that point
+// to Secrets that have already been deleted.
+func pruneDanglingSASecrets(ctx context.Context, client crclient.Client, managedNS string) {
+	sa := &corev1.ServiceAccount{}
+	saKey := crclient.ObjectKey{Namespace: managedNS, Name: "release-pipeline"}
+	if err := client.Get(ctx, saKey, sa); err != nil {
+		if !k8sErrors.IsNotFound(err) {
+			klog.Warningf("conformance pre-run: get SA: %v", err)
+		}
+		return
+	}
+	pruned := make([]corev1.ObjectReference, 0, len(sa.Secrets))
+	for _, ref := range sa.Secrets {
+		secret := &corev1.Secret{}
+		sKey := crclient.ObjectKey{Namespace: managedNS, Name: ref.Name}
+		if err := client.Get(ctx, sKey, secret); err != nil {
+			if k8sErrors.IsNotFound(err) {
+				klog.Infof("conformance pre-run: pruning dangling secret ref %q from SA", ref.Name)
+				continue
+			}
+			klog.Warningf("conformance pre-run: check secret %q existence: %v", ref.Name, err)
+		}
+		pruned = append(pruned, ref)
+	}
+	if len(pruned) != len(sa.Secrets) {
+		sa.Secrets = pruned
+		if err := client.Update(ctx, sa); err != nil {
+			klog.Warningf("conformance pre-run: update SA after pruning: %v", err)
+		}
+	}
+}
+
+// setupReleaseResult holds the actual resource names created by runSetupRelease.
+// Callers should use these instead of reconstructing names from suffix conventions.
+type setupReleaseResult struct {
+	ECPName            string
+	TrustedArtifactsIR string
+}
 
 // runSetupRelease downloads setup-release.sh from the ConfigMap shipped by the
 // operator (konflux-cli/setup-release) and executes it to create the managed
 // namespace, ImageRepositories, EnterpriseContractPolicy, ReleasePlanAdmission,
-// and ReleasePlan needed by the release flow.
-func runSetupRelease(appName, componentName, tenantNS, managedNS string) error {
+// and ReleasePlan needed by the release flow. releaseName controls the name of the
+// ReleasePlan and ReleasePlanAdmission resources (randomized per run to avoid collisions).
+func runSetupRelease(appName, componentName, tenantNS, managedNS, releaseName string) (setupReleaseResult, error) {
+	var result setupReleaseResult
+	result.ECPName = "default"
+	result.TrustedArtifactsIR = "trusted-artifacts"
+
 	scriptContent, err := downloadScriptFromConfigMap("konflux-cli", "setup-release", "setup-release.sh")
 	if err != nil {
-		return fmt.Errorf("download setup-release.sh from ConfigMap: %w", err)
+		return result, fmt.Errorf("download setup-release.sh from ConfigMap: %w", err)
 	}
 
 	tmpDir, err := os.MkdirTemp("", "setup-release-*")
 	if err != nil {
-		return fmt.Errorf("create temp dir: %w", err)
+		return result, fmt.Errorf("create temp dir: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
 
+	preProvisioned := isPreProvisioned()
+	if preProvisioned {
+		klog.Infof("conformance: managed namespace %s is pre-provisioned (E2E_MANAGED_NAMESPACE set), adapting setup-release.sh", managedNS)
+
+		// Give per-run names to shared resources so concurrent test runs
+		// don't clobber each other. Each run owns its own resources and
+		// cleans them up independently.
+		taSuffix := strings.TrimPrefix(releaseName, "release-")
+
+		taName := "trusted-artifacts-" + taSuffix
+		result.TrustedArtifactsIR = taName
+		s := string(scriptContent)
+		// Replace only the resource-defining contexts, not comments or log lines.
+		s = strings.ReplaceAll(s, `name: trusted-artifacts`, `name: `+taName)
+		s = strings.ReplaceAll(s, `/trusted-artifacts`, `/`+taName)
+		s = strings.ReplaceAll(s, `("trusted-artifacts"`, `("`+taName+`"`)
+		s = strings.ReplaceAll(s, `imagerepository trusted-artifacts`, `imagerepository `+taName)
+		scriptContent = []byte(s)
+		klog.Infof("conformance: renamed trusted-artifacts -> %s for run isolation", taName)
+
+		ecpName := "ecp-" + taSuffix
+		result.ECPName = ecpName
+		oldJQ := `.metadata.namespace = "'"${MANAGED_NS}"'"'`
+		newJQ := `.metadata.namespace = "'"${MANAGED_NS}"'" | .metadata.name = "` + ecpName + `"'`
+		scriptContent = []byte(strings.Replace(string(scriptContent), oldJQ, newJQ, 1))
+		// Point the ReleasePlanAdmission at the per-run ECP.
+		scriptContent = []byte(strings.Replace(string(scriptContent), "policy: ${CONFORMA_POLICY}", "policy: "+ecpName, 1))
+		klog.Infof("conformance: renamed ECP -> %s for run isolation", ecpName)
+
+		type scriptPatch struct {
+			name          string
+			re            *regexp.Regexp
+			repl          []byte
+			expectedCount int // 0 means "any number > 0"
+		}
+		patches := []scriptPatch{
+			{
+				name:          "namespace-creation",
+				re:            regexp.MustCompile(`(?s)kubectl apply -f - <<EOF\napiVersion: v1\nkind: Namespace\n.*?\nEOF`),
+				repl:          []byte(`echo "Namespace ${MANAGED_NS} already exists, skipping creation"`),
+				expectedCount: 1,
+			},
+			{
+				// The || true must go on the kubectl line (after <<EOF), NOT after the
+				// closing EOF marker -- placing it after EOF breaks the heredoc terminator.
+				name:          "rolebinding-non-fatal",
+				re:            regexp.MustCompile(`(?m)(kubectl apply -f - <<EOF\napiVersion: rbac\.authorization\.k8s\.io/v1\nkind: RoleBinding)`),
+				repl:          []byte("kubectl apply -f - <<EOF || true\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding"),
+				expectedCount: 2,
+			},
+			{
+				// SSO secret fetch may return Forbidden; the script already handles
+				// empty SSO_TOKEN but set -e kills it on the kubectl error.
+				name:          "sso-secret-non-fatal",
+				re:            regexp.MustCompile("(\\{.data.\\$SSO_ACCOUNT\\}\")" + `\)`),
+				repl:          []byte("${1} 2>/dev/null || true)"),
+				expectedCount: 1,
+			},
+			{
+				// Skip SA creation -- in pre-provisioned mode the SA is
+				// ensured by ensureReleasePipelineSA in Go before the script
+				// runs. The script's kubectl apply would overwrite .secrets
+				// added by a concurrent run's ensureSASecret.
+				name:          "skip-sa-creation",
+				re:            regexp.MustCompile(`(?s)kubectl apply -f - <<EOF\napiVersion: v1\nkind: ServiceAccount\n.*?\nEOF`),
+				repl:          []byte(`echo "ServiceAccount release-pipeline is pre-provisioned, skipping creation"`),
+				expectedCount: 1,
+			},
+		}
+		for _, p := range patches {
+			matches := p.re.FindAllIndex(scriptContent, -1)
+			if len(matches) == 0 {
+				klog.Warningf("conformance: regex patch %q did not match setup-release.sh; upstream script format may have changed", p.name)
+				continue
+			}
+			if p.expectedCount > 0 && len(matches) != p.expectedCount {
+				klog.Warningf("conformance: regex patch %q matched %d times (expected %d); upstream script may have changed", p.name, len(matches), p.expectedCount)
+			}
+			scriptContent = p.re.ReplaceAll(scriptContent, p.repl)
+		}
+	}
+
 	scriptPath := filepath.Join(tmpDir, "setup-release.sh")
 	if err := os.WriteFile(scriptPath, scriptContent, 0o755); err != nil {
-		return fmt.Errorf("write setup-release.sh: %w", err)
+		return result, fmt.Errorf("write setup-release.sh: %w", err)
 	}
 
 	args := []string{
@@ -43,12 +189,174 @@ func runSetupRelease(appName, componentName, tenantNS, managedNS string) error {
 		"-m", managedNS,
 		"-a", appName,
 		"-c", componentName,
+		"-r", releaseName,
 	}
 	klog.Infof("conformance: running setup-release.sh %v (from ConfigMap konflux-cli/setup-release)", args)
 	cmd := exec.Command(scriptPath, args...)
 	cmd.Stdout = ginkgo.GinkgoWriter
 	cmd.Stderr = ginkgo.GinkgoWriter
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		if preProvisioned {
+			klog.Warningf("conformance: setup-release.sh exited with error (non-fatal in pre-provisioned env): %v", err)
+		} else {
+			return result, fmt.Errorf("setup-release.sh: %w", err)
+		}
+	}
+	return result, nil
+}
+
+// ensureReleasePipelineSA creates the release-pipeline ServiceAccount in the
+// managed namespace if it does not already exist. In pre-provisioned mode the
+// script's kubectl-apply is skipped to avoid overwriting secrets from
+// concurrent runs, so the SA must exist before the script runs.
+func ensureReleasePipelineSA(ctx context.Context, client crclient.Client, managedNS string) error {
+	sa := &corev1.ServiceAccount{}
+	key := crclient.ObjectKey{Namespace: managedNS, Name: "release-pipeline"}
+	if err := client.Get(ctx, key, sa); err == nil {
+		klog.Infof("conformance: release-pipeline SA already exists in %s", managedNS)
+		return nil
+	} else if !k8sErrors.IsNotFound(err) {
+		return fmt.Errorf("check release-pipeline SA in %s: %w", managedNS, err)
+	}
+
+	sa = &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "release-pipeline",
+			Namespace: managedNS,
+		},
+	}
+	if err := client.Create(ctx, sa); err != nil {
+		if k8sErrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("create release-pipeline SA in %s: %w", managedNS, err)
+	}
+	klog.Infof("conformance: created release-pipeline SA in %s", managedNS)
+	return nil
+}
+
+// ensureSASecret reads the push-secret names from this run's ImageRepositories
+// and appends them to the release-pipeline ServiceAccount's secrets list.
+// This is safe for concurrent test runs because it appends (never replaces) secrets,
+// preventing one run from overwriting another run's credentials.
+func ensureSASecret(ctx context.Context, client crclient.Client, managedNS string, irNames []string) error {
+	secretNames := make([]string, 0, len(irNames))
+
+	for _, irName := range irNames {
+		ir := &imagecontroller.ImageRepository{}
+		key := crclient.ObjectKey{Namespace: managedNS, Name: irName}
+		if err := client.Get(ctx, key, ir); err != nil {
+			klog.Warningf("conformance: get ImageRepository %s/%s: %v", managedNS, irName, err)
+			continue
+		}
+		if name := ir.Status.Credentials.PushSecretName; name != "" {
+			secretNames = append(secretNames, name)
+		}
+	}
+
+	if len(secretNames) == 0 {
+		return fmt.Errorf("no push-secret names found in ImageRepository status for %v", irNames)
+	}
+
+	const maxRetries = 3
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		sa := &corev1.ServiceAccount{}
+		saKey := crclient.ObjectKey{Namespace: managedNS, Name: "release-pipeline"}
+		if err := client.Get(ctx, saKey, sa); err != nil {
+			return fmt.Errorf("get release-pipeline SA in %s: %w", managedNS, err)
+		}
+
+		// Prune dangling references -- secrets that no longer exist in the
+		// namespace (left over from runs whose cleanup predated this fix).
+		pruned := make([]corev1.ObjectReference, 0, len(sa.Secrets))
+		for _, ref := range sa.Secrets {
+			secret := &corev1.Secret{}
+			sKey := crclient.ObjectKey{Namespace: managedNS, Name: ref.Name}
+			if err := client.Get(ctx, sKey, secret); err != nil {
+				if k8sErrors.IsNotFound(err) {
+					klog.Infof("conformance: pruning dangling secret ref %q from release-pipeline SA", ref.Name)
+					continue
+				}
+				klog.Warningf("conformance: check secret %q existence: %v", ref.Name, err)
+			}
+			pruned = append(pruned, ref)
+		}
+		sa.Secrets = pruned
+
+		existing := make(map[string]bool, len(sa.Secrets))
+		for _, ref := range sa.Secrets {
+			existing[ref.Name] = true
+		}
+
+		for _, name := range secretNames {
+			if !existing[name] {
+				sa.Secrets = append(sa.Secrets, corev1.ObjectReference{Name: name})
+				klog.Infof("conformance: appending secret %q to release-pipeline SA in %s", name, managedNS)
+			}
+		}
+
+		if err := client.Update(ctx, sa); err != nil {
+			if k8sErrors.IsConflict(err) && attempt < maxRetries-1 {
+				klog.Warningf("conformance: SA update conflict (attempt %d/%d), retrying", attempt+1, maxRetries)
+				continue
+			}
+			return fmt.Errorf("update release-pipeline SA in %s: %w", managedNS, err)
+		}
+		return nil
+	}
+	return nil
+}
+
+// removeSASecrets reads the push-secret names from this run's ImageRepositories
+// and removes only those references from the release-pipeline SA, leaving
+// secrets belonging to other concurrent runs intact.
+func removeSASecrets(ctx context.Context, client crclient.Client, managedNS string, irNames []string) {
+	toRemove := make(map[string]bool)
+
+	for _, irName := range irNames {
+		ir := &imagecontroller.ImageRepository{}
+		key := crclient.ObjectKey{Namespace: managedNS, Name: irName}
+		if err := client.Get(ctx, key, ir); err != nil {
+			if !k8sErrors.IsNotFound(err) {
+				klog.Warningf("conformance cleanup: get ImageRepository %s/%s for SA secret removal: %v", managedNS, irName, err)
+			}
+			continue
+		}
+		if name := ir.Status.Credentials.PushSecretName; name != "" {
+			toRemove[name] = true
+		}
+	}
+
+	if len(toRemove) == 0 {
+		return
+	}
+
+	sa := &corev1.ServiceAccount{}
+	saKey := crclient.ObjectKey{Namespace: managedNS, Name: "release-pipeline"}
+	if err := client.Get(ctx, saKey, sa); err != nil {
+		klog.Warningf("conformance cleanup: get release-pipeline SA for secret removal: %v", err)
+		return
+	}
+
+	filtered := make([]corev1.ObjectReference, 0, len(sa.Secrets))
+	for _, ref := range sa.Secrets {
+		if !toRemove[ref.Name] {
+			filtered = append(filtered, ref)
+		} else {
+			klog.Infof("conformance cleanup: removing secret %q from release-pipeline SA in %s", ref.Name, managedNS)
+		}
+	}
+
+	if len(filtered) != len(sa.Secrets) {
+		sa.Secrets = filtered
+		if err := client.Update(ctx, sa); err != nil {
+			if k8sErrors.IsConflict(err) {
+				klog.Warningf("conformance cleanup: SA update conflict during secret removal, will be cleaned up by next run's pruneDanglingSASecrets")
+			} else {
+				klog.Warningf("conformance cleanup: update release-pipeline SA after secret removal: %v", err)
+			}
+		}
+	}
 }
 
 // e2eECPExclusions lists policy rules to exclude during E2E tests. Conformance runs
@@ -130,46 +438,100 @@ func downloadScriptFromConfigMap(namespace, configMapName, key string) ([]byte, 
 
 // grantIntegrationRunnerJobRBAC creates a Role + RoleBinding so that the
 // konflux-integration-runner SA can manage Jobs and Pods in the tenant namespace.
-// TODO: remove once the integration test pipeline no longer creates/deletes Jobs
-// directly and instead runs the image via a Tekton task.
-func grantIntegrationRunnerJobRBAC(namespace string) error {
-	manifest := fmt.Sprintf(`
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: integration-runner-jobs
-  namespace: %[1]s
-rules:
-- apiGroups: [""]
-  resources: [pods]
-  verbs: [get, list, watch, delete]
-- apiGroups: [""]
-  resources: [pods/log]
-  verbs: [get, list]
-- apiGroups: [batch]
-  resources: [jobs]
-  verbs: [create, delete, get, list, watch]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: integration-runner-jobs
-  namespace: %[1]s
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: integration-runner-jobs
-subjects:
-- kind: ServiceAccount
-  name: konflux-integration-runner
-  namespace: %[1]s
-`, namespace)
+func grantIntegrationRunnerJobRBAC(hub *framework.ControllerHub, namespace string) error {
+	ctx := context.Background()
+	client := hub.CommonController.KubeRest()
 
-	cmd := exec.Command(resolveKubectl(), "apply", "-f", "-")
-	cmd.Stdin = strings.NewReader(manifest)
-	cmd.Stdout = ginkgo.GinkgoWriter
-	cmd.Stderr = ginkgo.GinkgoWriter
-	return cmd.Run()
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "integration-runner-jobs",
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "list", "watch", "delete"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods/log"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"batch"},
+				Resources: []string{"jobs"},
+				Verbs:     []string{"create", "delete", "get", "list", "watch"},
+			},
+		},
+	}
+
+	existing := &rbacv1.Role{}
+	err := client.Get(ctx, crclient.ObjectKeyFromObject(role), existing)
+	if err != nil {
+		if !k8sErrors.IsNotFound(err) {
+			return fmt.Errorf("get Role %s/%s: %w", namespace, role.Name, err)
+		}
+		if err := client.Create(ctx, role); err != nil {
+			return fmt.Errorf("create Role %s/%s: %w", namespace, role.Name, err)
+		}
+	} else {
+		existing.Rules = role.Rules
+		if err := client.Update(ctx, existing); err != nil {
+			return fmt.Errorf("update Role %s/%s: %w", namespace, role.Name, err)
+		}
+	}
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "integration-runner-jobs",
+			Namespace: namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "integration-runner-jobs",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "konflux-integration-runner",
+				Namespace: namespace,
+			},
+		},
+	}
+
+	existingRB := &rbacv1.RoleBinding{}
+	err = client.Get(ctx, crclient.ObjectKeyFromObject(rb), existingRB)
+	if err != nil {
+		if !k8sErrors.IsNotFound(err) {
+			return fmt.Errorf("get RoleBinding %s/%s: %w", namespace, rb.Name, err)
+		}
+		if err := client.Create(ctx, rb); err != nil {
+			return fmt.Errorf("create RoleBinding %s/%s: %w", namespace, rb.Name, err)
+		}
+	} else if !subjectsMatch(existingRB.Subjects, rb.Subjects) {
+		// roleRef is immutable, but Subjects can be updated.
+		existingRB.Subjects = rb.Subjects
+		if err := client.Update(ctx, existingRB); err != nil {
+			return fmt.Errorf("update RoleBinding %s/%s subjects: %w", namespace, rb.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// subjectsMatch returns true if two Subject slices have the same entries (order-sensitive).
+func subjectsMatch(a, b []rbacv1.Subject) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Kind != b[i].Kind || a[i].Name != b[i].Name || a[i].Namespace != b[i].Namespace {
+			return false
+		}
+	}
+	return true
 }
 
 // dumpDiagnostics logs component build status, application status, PaC repository state,
@@ -207,6 +569,273 @@ func dumpDiagnostics(hub *framework.ControllerHub, componentName, appName, names
 				status)
 		}
 	}
+}
+
+// cleanupManagedResources deletes test-created resources from the managed namespace
+// on pre-provisioned clusters where we cannot delete the namespace itself.
+// appName scopes the cleanup to resources belonging to this test run's application,
+// avoiding interference with concurrent test executions in the same namespace.
+// componentName identifies this run's ImageRepositories so that only their push
+// secrets are removed from the release-pipeline SA.
+func cleanupManagedResources(ctx context.Context, fw *framework.Framework, ns, appName, componentName, releaseName string, releaseRes setupReleaseResult) {
+	client := fw.AsKubeAdmin.CommonController.KubeRest()
+
+	appLabel := crclient.MatchingLabels{"appstudio.openshift.io/application": appName}
+
+	prList := &pipelinev1.PipelineRunList{}
+	if err := client.List(ctx, prList, crclient.InNamespace(ns), appLabel); err != nil {
+		klog.Warningf("conformance cleanup: list PipelineRuns in %s: %v", ns, err)
+	} else {
+		for i := range prList.Items {
+			pr := &prList.Items[i]
+			completed := pr.Status.CompletionTime != nil
+			if len(pr.Finalizers) > 0 && completed {
+				pr.Finalizers = nil
+				if err := client.Update(ctx, pr); err != nil {
+					klog.Warningf("conformance cleanup: strip finalizers from PipelineRun %s/%s: %v", ns, pr.Name, err)
+				}
+			} else if len(pr.Finalizers) > 0 {
+				klog.Warningf("conformance cleanup: PipelineRun %s/%s still running, skipping finalizer strip", ns, pr.Name)
+			}
+			if err := client.Delete(ctx, pr); err != nil {
+				klog.Warningf("conformance cleanup: delete PipelineRun %s/%s: %v", ns, pr.Name, err)
+			}
+		}
+	}
+	irNames := []string{componentName, releaseRes.TrustedArtifactsIR}
+
+	// Remove this run's push secrets from the SA before deleting ImageRepositories,
+	// since we need to read the secret names from ImageRepository status.
+	removeSASecrets(ctx, client, ns, irNames)
+	// Delete only this run's ImageRepositories, not other runs'.
+	for _, irName := range irNames {
+		ir := &imagecontroller.ImageRepository{}
+		irKey := crclient.ObjectKey{Namespace: ns, Name: irName}
+		if err := client.Get(ctx, irKey, ir); err != nil {
+			if !k8sErrors.IsNotFound(err) {
+				klog.Warningf("conformance cleanup: get ImageRepository %s/%s: %v", ns, irName, err)
+			}
+		} else {
+			if err := client.Delete(ctx, ir); err != nil {
+				klog.Warningf("conformance cleanup: delete ImageRepository %s/%s: %v", ns, irName, err)
+			}
+		}
+	}
+	if err := fw.AsKubeAdmin.TektonController.DeleteEnterpriseContractPolicy(releaseRes.ECPName, ns, false); err != nil {
+		klog.Warningf("conformance cleanup: delete ECP %s in %s: %v", releaseRes.ECPName, ns, err)
+	}
+	rpa := &releaseApi.ReleasePlanAdmission{}
+	rpaKey := crclient.ObjectKey{Namespace: ns, Name: releaseName}
+	if err := client.Get(ctx, rpaKey, rpa); err != nil {
+		if !k8sErrors.IsNotFound(err) {
+			klog.Warningf("conformance cleanup: get ReleasePlanAdmission %s/%s: %v", ns, releaseName, err)
+		}
+	} else {
+		if err := client.Delete(ctx, rpa); err != nil {
+			klog.Warningf("conformance cleanup: delete ReleasePlanAdmission %s/%s: %v", ns, releaseName, err)
+		}
+	}
+}
+
+// cleanupTenantResources deletes test-created resources from the tenant namespace.
+// appName scopes the cleanup to resources belonging to this test run's application,
+// avoiding interference with concurrent test executions in the same namespace.
+// componentName is used to delete the per-component ImageRepository.
+// releaseName is used to delete the ReleasePlan by name as a fallback, since
+// setup-release.sh does not add the appstudio.openshift.io/application label.
+func cleanupTenantResources(ctx context.Context, fw *framework.Framework, ns, appName, componentName, releaseName string) {
+	client := fw.AsKubeAdmin.CommonController.KubeRest()
+
+	appLabel := crclient.MatchingLabels{"appstudio.openshift.io/application": appName}
+
+	app := &appstudioApi.Application{}
+	appKey := crclient.ObjectKey{Namespace: ns, Name: appName}
+	if err := client.Get(ctx, appKey, app); err != nil {
+		if !k8sErrors.IsNotFound(err) {
+			klog.Warningf("conformance cleanup: get Application %s/%s: %v", ns, appName, err)
+		}
+	} else {
+		if err := client.Delete(ctx, app); err != nil {
+			klog.Warningf("conformance cleanup: delete Application %s/%s: %v", ns, appName, err)
+		}
+	}
+	itsList := &integrationv1beta2.IntegrationTestScenarioList{}
+	if err := client.List(ctx, itsList, crclient.InNamespace(ns), appLabel); err != nil {
+		klog.Warningf("conformance cleanup: list IntegrationTestScenarios in %s: %v", ns, err)
+	} else {
+		for i := range itsList.Items {
+			if err := client.Delete(ctx, &itsList.Items[i]); err != nil {
+				klog.Warningf("conformance cleanup: delete IntegrationTestScenario %s/%s: %v", ns, itsList.Items[i].Name, err)
+			}
+		}
+	}
+	snapList := &appstudioApi.SnapshotList{}
+	if err := client.List(ctx, snapList, crclient.InNamespace(ns), appLabel); err != nil {
+		klog.Warningf("conformance cleanup: list Snapshots in %s: %v", ns, err)
+	} else {
+		for i := range snapList.Items {
+			if err := client.Delete(ctx, &snapList.Items[i]); err != nil {
+				klog.Warningf("conformance cleanup: delete Snapshot %s/%s: %v", ns, snapList.Items[i].Name, err)
+			}
+		}
+	}
+	prList := &pipelinev1.PipelineRunList{}
+	if err := client.List(ctx, prList, crclient.InNamespace(ns), appLabel); err != nil {
+		klog.Warningf("conformance cleanup: list PipelineRuns in %s: %v", ns, err)
+	} else {
+		for i := range prList.Items {
+			if err := client.Delete(ctx, &prList.Items[i]); err != nil {
+				klog.Warningf("conformance cleanup: delete PipelineRun %s/%s: %v", ns, prList.Items[i].Name, err)
+			}
+		}
+	}
+	rpList := &releaseApi.ReleasePlanList{}
+	if err := client.List(ctx, rpList, crclient.InNamespace(ns), appLabel); err != nil {
+		klog.Warningf("conformance cleanup: list ReleasePlans in %s: %v", ns, err)
+	} else {
+		for i := range rpList.Items {
+			if err := client.Delete(ctx, &rpList.Items[i]); err != nil {
+				klog.Warningf("conformance cleanup: delete ReleasePlan %s/%s: %v", ns, rpList.Items[i].Name, err)
+			}
+		}
+	}
+	// Fallback: delete ReleasePlan by name since setup-release.sh does not add
+	// the appstudio.openshift.io/application label.
+	rp := &releaseApi.ReleasePlan{}
+	rpKey := crclient.ObjectKey{Namespace: ns, Name: releaseName}
+	if err := client.Get(ctx, rpKey, rp); err != nil {
+		if !k8sErrors.IsNotFound(err) {
+			klog.Warningf("conformance cleanup: get ReleasePlan %s/%s: %v", ns, releaseName, err)
+		}
+	} else {
+		if err := client.Delete(ctx, rp); err != nil {
+			klog.Warningf("conformance cleanup: delete ReleasePlan %s/%s: %v", ns, releaseName, err)
+		}
+	}
+	relList := &releaseApi.ReleaseList{}
+	if err := client.List(ctx, relList, crclient.InNamespace(ns), appLabel); err != nil {
+		klog.Warningf("conformance cleanup: list Releases in %s: %v", ns, err)
+	} else {
+		for i := range relList.Items {
+			if err := client.Delete(ctx, &relList.Items[i]); err != nil {
+				klog.Warningf("conformance cleanup: delete Release %s/%s: %v", ns, relList.Items[i].Name, err)
+			}
+		}
+	}
+	// Delete the Component (Application deletion does not cascade).
+	comp := &appstudioApi.Component{}
+	compKey := crclient.ObjectKey{Namespace: ns, Name: componentName}
+	if err := client.Get(ctx, compKey, comp); err != nil {
+		if !k8sErrors.IsNotFound(err) {
+			klog.Warningf("conformance cleanup: get Component %s/%s: %v", ns, componentName, err)
+		}
+	} else {
+		if err := client.Delete(ctx, comp); err != nil {
+			klog.Warningf("conformance cleanup: delete Component %s/%s: %v", ns, componentName, err)
+		}
+	}
+	// Delete this run's ImageRepository from the tenant namespace (auto-created
+	// by image-controller when the Component was created).
+	ir := &imagecontroller.ImageRepository{}
+	irKey := crclient.ObjectKey{Namespace: ns, Name: componentName}
+	if err := client.Get(ctx, irKey, ir); err != nil {
+		if !k8sErrors.IsNotFound(err) {
+			klog.Warningf("conformance cleanup: get ImageRepository %s/%s: %v", ns, componentName, err)
+		}
+	} else {
+		if err := client.Delete(ctx, ir); err != nil {
+			klog.Warningf("conformance cleanup: delete ImageRepository %s/%s: %v", ns, componentName, err)
+		}
+	}
+}
+
+// verifyReleasePrerequisites checks that the critical resources created by
+// setup-release.sh actually exist. This catches silent failures in
+// pre-provisioned mode where some script commands may fail non-fatally.
+func verifyReleasePrerequisites(hub *framework.ControllerHub, managedNS string) error {
+	ctx := context.Background()
+	client := hub.CommonController.KubeRest()
+
+	// Verify ECP exists in managed namespace.
+	ecpList := &ecp.EnterpriseContractPolicyList{}
+	if err := client.List(ctx, ecpList, crclient.InNamespace(managedNS)); err != nil {
+		return fmt.Errorf("list ECPs in %s: %w", managedNS, err)
+	}
+	if len(ecpList.Items) == 0 {
+		return fmt.Errorf("no EnterpriseContractPolicy found in %s; setup-release.sh may have failed", managedNS)
+	}
+
+	// Verify at least one ReleasePlanAdmission exists.
+	rpaList := &releaseApi.ReleasePlanAdmissionList{}
+	if err := client.List(ctx, rpaList, crclient.InNamespace(managedNS)); err != nil {
+		return fmt.Errorf("list ReleasePlanAdmissions in %s: %w", managedNS, err)
+	}
+	if len(rpaList.Items) == 0 {
+		return fmt.Errorf("no ReleasePlanAdmission found in %s; setup-release.sh may have failed", managedNS)
+	}
+
+	// Verify the release-pipeline ServiceAccount exists. Without it the release
+	// PipelineRun will fail with a confusing "serviceaccount not found" error.
+	sa := &corev1.ServiceAccount{}
+	saKey := crclient.ObjectKey{Namespace: managedNS, Name: "release-pipeline"}
+	if err := client.Get(ctx, saKey, sa); err != nil {
+		return fmt.Errorf("release-pipeline ServiceAccount not found in %s: %w", managedNS, err)
+	}
+
+	return nil
+}
+
+// verifyPreProvisionedRBAC checks that the integration-runner Role and RoleBinding
+// exist in the tenant namespace. In pre-provisioned environments, these are
+// managed by GitOps and grantIntegrationRunnerJobRBAC may fail to create them.
+func verifyPreProvisionedRBAC(hub *framework.ControllerHub, tenantNS string) error {
+	ctx := context.Background()
+	client := hub.CommonController.KubeRest()
+
+	role := &rbacv1.Role{}
+	if err := client.Get(ctx, crclient.ObjectKey{Namespace: tenantNS, Name: "integration-runner-jobs"}, role); err != nil {
+		return fmt.Errorf("integration-runner-jobs Role not found in %s; integration tests will fail: %w", tenantNS, err)
+	}
+
+	rb := &rbacv1.RoleBinding{}
+	if err := client.Get(ctx, crclient.ObjectKey{Namespace: tenantNS, Name: "integration-runner-jobs"}, rb); err != nil {
+		return fmt.Errorf("integration-runner-jobs RoleBinding not found in %s; integration tests will fail: %w", tenantNS, err)
+	}
+	return nil
+}
+
+// verifyECPPatched checks that the ECP in the managed namespace has the expected
+// E2E exclusions applied. Returns an error if any exclusion is missing, which
+// gives a clear setup failure instead of an opaque downstream policy violation.
+func verifyECPPatched(hub *framework.ControllerHub, policyName, managedNS string) error {
+	policy, err := hub.TektonController.GetEnterpriseContractPolicy(policyName, managedNS)
+	if err != nil {
+		return fmt.Errorf("could not verify ECP patch in %s/%s: %w", managedNS, policyName, err)
+	}
+	verified := false
+	for _, src := range policy.Spec.Sources {
+		if src.Config == nil {
+			continue
+		}
+		verified = true
+		seen := make(map[string]bool, len(src.Config.Exclude))
+		for _, e := range src.Config.Exclude {
+			seen[e] = true
+		}
+		var missing []string
+		for _, e := range e2eECPExclusions {
+			if !seen[e] {
+				missing = append(missing, e)
+			}
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("ECP %s/%s is missing required exclusions %v; EC validation will fail", managedNS, policyName, missing)
+		}
+	}
+	if !verified {
+		return fmt.Errorf("ECP %s/%s has no sources with Config; patchECPForE2E may have failed", managedNS, policyName)
+	}
+	return nil
 }
 
 // cleanupWithRetry runs fn until it returns nil, ctx is done, or a 30s per-step retry budget elapses.


### PR DESCRIPTION
Adds support for running conformance tests against pre-provisioned clusters where namespaces are externally managed via GitOps. When `E2E_MANAGED_NAMESPACE` is set, the suite adapts setup and cleanup behavior to work within limited RBAC permissions and support parallel test execution.

## Pre-provisioned mode (`E2E_MANAGED_NAMESPACE` set)

- Detects pre-provisioned mode and adapts `setup-release.sh` at runtime via regex patches
- `patchECPForE2E` and `grantIntegrationRunnerJobRBAC` are non-fatal only in pre-provisioned mode
- Uses `|| true` for roleBinding commands and namespace creation instead of blanket `set -e` removal
- Verifies release testing prerequisites before starting release testing

## Parallel run isolation

- All resources (application, component, ECP, trusted-artifacts, release) are suffixed with a random per-run identifier to prevent collisions
- `release-pipeline` ServiceAccount secrets are managed via Go client (append/remove) instead of `kubectl apply` to avoid overwriting concurrent runs
- ECP is renamed per run (`ecp-<suffix>`) so cleanup of one run doesn't break another's release validation
- `trusted-artifacts` ImageRepository is renamed per run for full isolation

## ServiceAccount management

- `ensureReleasePipelineSA` creates the SA if it doesn't exist (first run in fresh namespaces)
- `ensureSASecret` appends push secrets with retry logic for ResourceVersion conflicts
- `pruneDanglingSASecrets` removes dangling secret references before each run
- `removeSASecrets` cleans up only the current run's secrets on teardown

## Cleanup

- Calls kube client API for individual resource cleanup instead of namespace deletion
- Non-fatal polling loop in `AfterAll` waits for release PipelineRun without aborting cleanup if it never appears
- Context cancellation check in cleanup polling to ensure graceful exit

## Environment variables

| Variable | Purpose | Default |
|----------|---------|---------|
| `E2E_REPO` | Override the component source repo | `testrepo` |
| `E2E_ITS_REPO` | Override the IntegrationTestScenario repo (should be public unless secrets are configured) | `testrepo` |
| `E2E_MANAGED_NAMESPACE` | Triggers pre-provisioned mode | — |
| `E2E_APPLICATIONS_NAMESPACE` | Sets the tenant namespace | — |

