### PR TITLE
add new registry proxy fields to KonfluxInfo

### DIFF
--- a/operator/api/v1alpha1/konfluxinfo_types.go
+++ b/operator/api/v1alpha1/konfluxinfo_types.go
@@ -335,20 +335,36 @@ type ClusterConfigData struct {
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="!self.contains('@')",message="URL must not contain credentials (userinfo). Use a Secret for proxy authentication."
 	PackageRegistryProxyPnpmURL string `json:"packageRegistryProxyPnpmUrl,omitempty"`
+
+	// PackageRegistryProxyBundlerURL is the URL of the RubyGems (Bundler) package registry proxy.
+	// Written as "package-registry-proxy-bundler-url" in the cluster-config ConfigMap.
+	// Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
+	// +optional
+	// +kubebuilder:validation:XValidation:rule="!self.contains('@')",message="URL must not contain credentials (userinfo). Use a Secret for proxy authentication."
+	PackageRegistryProxyBundlerURL string `json:"packageRegistryProxyBundlerUrl,omitempty"`
+
+	// PackageRegistryProxyCargoURL is the URL of the Cargo (Rust crates) package registry proxy.
+	// Written as "package-registry-proxy-cargo-url" in the cluster-config ConfigMap.
+	// Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
+	// +optional
+	// +kubebuilder:validation:XValidation:rule="!self.contains('@')",message="URL must not contain credentials (userinfo). Use a Secret for proxy authentication."
+	PackageRegistryProxyCargoURL string `json:"packageRegistryProxyCargoUrl,omitempty"`
 }
 
 // ConfigMap key constants for cluster-config proxy fields.
 // These are the kebab-case keys written to the ConfigMap, mapped from camelCase CRD fields.
 const (
-	ClusterConfigKeyAllowCacheProxy              = "allow-cache-proxy"
-	ClusterConfigKeyHTTPProxy                    = "http-proxy"
-	ClusterConfigKeyNoProxy                      = "no-proxy"
-	ClusterConfigKeyAllowPackageRegistryProxy    = "allow-package-registry-proxy"
-	ClusterConfigKeyPackageRegistryProxyNpmURL   = "package-registry-proxy-npm-url"
-	ClusterConfigKeyPackageRegistryProxyYarnURL  = "package-registry-proxy-yarn-url"
-	ClusterConfigKeyPackageRegistryProxyGomodURL = "package-registry-proxy-gomod-url"
-	ClusterConfigKeyPackageRegistryProxyPipURL   = "package-registry-proxy-pip-url"
-	ClusterConfigKeyPackageRegistryProxyPnpmURL  = "package-registry-proxy-pnpm-url"
+	ClusterConfigKeyAllowCacheProxy                = "allow-cache-proxy"
+	ClusterConfigKeyHTTPProxy                      = "http-proxy"
+	ClusterConfigKeyNoProxy                        = "no-proxy"
+	ClusterConfigKeyAllowPackageRegistryProxy      = "allow-package-registry-proxy"
+	ClusterConfigKeyPackageRegistryProxyNpmURL     = "package-registry-proxy-npm-url"
+	ClusterConfigKeyPackageRegistryProxyYarnURL    = "package-registry-proxy-yarn-url"
+	ClusterConfigKeyPackageRegistryProxyGomodURL   = "package-registry-proxy-gomod-url"
+	ClusterConfigKeyPackageRegistryProxyPipURL     = "package-registry-proxy-pip-url"
+	ClusterConfigKeyPackageRegistryProxyPnpmURL    = "package-registry-proxy-pnpm-url"
+	ClusterConfigKeyPackageRegistryProxyBundlerURL = "package-registry-proxy-bundler-url"
+	ClusterConfigKeyPackageRegistryProxyCargoURL   = "package-registry-proxy-cargo-url"
 )
 
 // All is an iterator that yields all non-empty key-value pairs from ClusterConfigData.
@@ -466,6 +482,16 @@ func (d ClusterConfigData) All(yield func(key, value string) bool) {
 	}
 	if d.PackageRegistryProxyPnpmURL != "" {
 		if !yield(ClusterConfigKeyPackageRegistryProxyPnpmURL, d.PackageRegistryProxyPnpmURL) {
+			return
+		}
+	}
+	if d.PackageRegistryProxyBundlerURL != "" {
+		if !yield(ClusterConfigKeyPackageRegistryProxyBundlerURL, d.PackageRegistryProxyBundlerURL) {
+			return
+		}
+	}
+	if d.PackageRegistryProxyCargoURL != "" {
+		if !yield(ClusterConfigKeyPackageRegistryProxyCargoURL, d.PackageRegistryProxyCargoURL) {
 			return
 		}
 	}

--- a/operator/api/v1alpha1/konfluxinfo_types_test.go
+++ b/operator/api/v1alpha1/konfluxinfo_types_test.go
@@ -30,33 +30,35 @@ func TestClusterConfigData_All(t *testing.T) {
 
 		noProxy := ".cluster.local,169.254.169.254"
 		data := ClusterConfigData{
-			DefaultOIDCIssuer:            "https://oidc.example.com",
-			EnableKeylessSigning:         ptr.To(true),
-			FulcioInternalUrl:            "https://fulcio-internal.example.com",
-			FulcioExternalUrl:            "https://fulcio-external.example.com",
-			RekorInternalUrl:             "https://rekor-internal.example.com",
-			RekorExternalUrl:             "https://rekor-external.example.com",
-			TufInternalUrl:               "https://tuf-internal.example.com",
-			TufExternalUrl:               "https://tuf-external.example.com",
-			TrustifyServerInternalUrl:    "https://trustify-internal.example.com",
-			TrustifyServerExternalUrl:    "https://trustify-external.example.com",
-			BuildIdentityRegexp:          "^https://konflux\\.dev/build/.*$",
-			TrustifyOIDCIssuerUrl:        "https://keycloak-external/realm/foobar",
-			TektonChainsIdentity:         "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller",
-			AllowCacheProxy:              ptr.To(true),
-			HTTPProxy:                    "squid.caching.svc.cluster.local:3128",
-			NoProxy:                      &noProxy,
-			AllowPackageRegistryProxy:    ptr.To(true),
-			PackageRegistryProxyNpmURL:   "https://npm-proxy.example.com",
-			PackageRegistryProxyYarnURL:  "https://yarn-proxy.example.com",
-			PackageRegistryProxyGomodURL: "https://gomod-proxy.example.com",
-			PackageRegistryProxyPipURL:   "https://pip-proxy.example.com",
-			PackageRegistryProxyPnpmURL:  "https://pnpm-proxy.example.com",
+			DefaultOIDCIssuer:              "https://oidc.example.com",
+			EnableKeylessSigning:           ptr.To(true),
+			FulcioInternalUrl:              "https://fulcio-internal.example.com",
+			FulcioExternalUrl:              "https://fulcio-external.example.com",
+			RekorInternalUrl:               "https://rekor-internal.example.com",
+			RekorExternalUrl:               "https://rekor-external.example.com",
+			TufInternalUrl:                 "https://tuf-internal.example.com",
+			TufExternalUrl:                 "https://tuf-external.example.com",
+			TrustifyServerInternalUrl:      "https://trustify-internal.example.com",
+			TrustifyServerExternalUrl:      "https://trustify-external.example.com",
+			BuildIdentityRegexp:            "^https://konflux\\.dev/build/.*$",
+			TrustifyOIDCIssuerUrl:          "https://keycloak-external/realm/foobar",
+			TektonChainsIdentity:           "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller",
+			AllowCacheProxy:                ptr.To(true),
+			HTTPProxy:                      "squid.caching.svc.cluster.local:3128",
+			NoProxy:                        &noProxy,
+			AllowPackageRegistryProxy:      ptr.To(true),
+			PackageRegistryProxyNpmURL:     "https://npm-proxy.example.com",
+			PackageRegistryProxyYarnURL:    "https://yarn-proxy.example.com",
+			PackageRegistryProxyGomodURL:   "https://gomod-proxy.example.com",
+			PackageRegistryProxyPipURL:     "https://pip-proxy.example.com",
+			PackageRegistryProxyPnpmURL:    "https://pnpm-proxy.example.com",
+			PackageRegistryProxyBundlerURL: "https://bundler-proxy.example.com",
+			PackageRegistryProxyCargoURL:   "https://cargo-proxy.example.com",
 		}
 
 		collected := maps.Collect(data.All)
 
-		g.Expect(collected).To(gomega.HaveLen(22))
+		g.Expect(collected).To(gomega.HaveLen(24))
 		g.Expect(collected["defaultOIDCIssuer"]).To(gomega.Equal("https://oidc.example.com"))
 		g.Expect(collected["enableKeylessSigning"]).To(gomega.Equal("true"))
 		g.Expect(collected["fulcioInternalUrl"]).To(gomega.Equal("https://fulcio-internal.example.com"))
@@ -79,6 +81,8 @@ func TestClusterConfigData_All(t *testing.T) {
 		g.Expect(collected[ClusterConfigKeyPackageRegistryProxyGomodURL]).To(gomega.Equal("https://gomod-proxy.example.com"))
 		g.Expect(collected[ClusterConfigKeyPackageRegistryProxyPipURL]).To(gomega.Equal("https://pip-proxy.example.com"))
 		g.Expect(collected[ClusterConfigKeyPackageRegistryProxyPnpmURL]).To(gomega.Equal("https://pnpm-proxy.example.com"))
+		g.Expect(collected[ClusterConfigKeyPackageRegistryProxyBundlerURL]).To(gomega.Equal("https://bundler-proxy.example.com"))
+		g.Expect(collected[ClusterConfigKeyPackageRegistryProxyCargoURL]).To(gomega.Equal("https://cargo-proxy.example.com"))
 	})
 
 	t.Run("should not yield empty fields", func(t *testing.T) {
@@ -122,28 +126,30 @@ func TestClusterConfigData_All(t *testing.T) {
 
 		noProxy := ""
 		data := ClusterConfigData{
-			DefaultOIDCIssuer:            "https://oidc.example.com",
-			EnableKeylessSigning:         ptr.To(true),
-			FulcioInternalUrl:            "https://fulcio-internal.example.com",
-			FulcioExternalUrl:            "https://fulcio-external.example.com",
-			RekorInternalUrl:             "https://rekor-internal.example.com",
-			RekorExternalUrl:             "https://rekor-external.example.com",
-			TufInternalUrl:               "https://tuf-internal.example.com",
-			TufExternalUrl:               "https://tuf-external.example.com",
-			TrustifyServerInternalUrl:    "https://trustify-internal.example.com",
-			TrustifyServerExternalUrl:    "https://trustify-external.example.com",
-			BuildIdentityRegexp:          "^https://konflux\\.dev/build/.*$",
-			TrustifyOIDCIssuerUrl:        "https://keycloak-external/realm/foobar",
-			TektonChainsIdentity:         "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller",
-			AllowCacheProxy:              ptr.To(true),
-			HTTPProxy:                    "squid:3128",
-			NoProxy:                      &noProxy,
-			AllowPackageRegistryProxy:    ptr.To(true),
-			PackageRegistryProxyNpmURL:   "https://npm-proxy.example.com",
-			PackageRegistryProxyYarnURL:  "https://yarn-proxy.example.com",
-			PackageRegistryProxyGomodURL: "https://gomod-proxy.example.com",
-			PackageRegistryProxyPipURL:   "https://pip-proxy.example.com",
-			PackageRegistryProxyPnpmURL:  "https://pnpm-proxy.example.com",
+			DefaultOIDCIssuer:              "https://oidc.example.com",
+			EnableKeylessSigning:           ptr.To(true),
+			FulcioInternalUrl:              "https://fulcio-internal.example.com",
+			FulcioExternalUrl:              "https://fulcio-external.example.com",
+			RekorInternalUrl:               "https://rekor-internal.example.com",
+			RekorExternalUrl:               "https://rekor-external.example.com",
+			TufInternalUrl:                 "https://tuf-internal.example.com",
+			TufExternalUrl:                 "https://tuf-external.example.com",
+			TrustifyServerInternalUrl:      "https://trustify-internal.example.com",
+			TrustifyServerExternalUrl:      "https://trustify-external.example.com",
+			BuildIdentityRegexp:            "^https://konflux\\.dev/build/.*$",
+			TrustifyOIDCIssuerUrl:          "https://keycloak-external/realm/foobar",
+			TektonChainsIdentity:           "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller",
+			AllowCacheProxy:                ptr.To(true),
+			HTTPProxy:                      "squid:3128",
+			NoProxy:                        &noProxy,
+			AllowPackageRegistryProxy:      ptr.To(true),
+			PackageRegistryProxyNpmURL:     "https://npm-proxy.example.com",
+			PackageRegistryProxyYarnURL:    "https://yarn-proxy.example.com",
+			PackageRegistryProxyGomodURL:   "https://gomod-proxy.example.com",
+			PackageRegistryProxyPipURL:     "https://pip-proxy.example.com",
+			PackageRegistryProxyPnpmURL:    "https://pnpm-proxy.example.com",
+			PackageRegistryProxyBundlerURL: "https://bundler-proxy.example.com",
+			PackageRegistryProxyCargoURL:   "https://cargo-proxy.example.com",
 		}
 
 		var yielded []string
@@ -162,28 +168,30 @@ func TestClusterConfigData_All(t *testing.T) {
 
 		noProxy := ""
 		data := ClusterConfigData{
-			DefaultOIDCIssuer:            "oidc",
-			EnableKeylessSigning:         ptr.To(true),
-			FulcioInternalUrl:            "fulcio-int",
-			FulcioExternalUrl:            "fulcio-ext",
-			RekorInternalUrl:             "rekor-int",
-			RekorExternalUrl:             "rekor-ext",
-			TufInternalUrl:               "tuf-int",
-			TufExternalUrl:               "tuf-ext",
-			TrustifyServerInternalUrl:    "trustify-int",
-			TrustifyServerExternalUrl:    "trustify-ext",
-			BuildIdentityRegexp:          "regexp",
-			TrustifyOIDCIssuerUrl:        "trustify-oidc",
-			TektonChainsIdentity:         "chains-identity",
-			AllowCacheProxy:              ptr.To(true),
-			HTTPProxy:                    "proxy:3128",
-			NoProxy:                      &noProxy,
-			AllowPackageRegistryProxy:    ptr.To(true),
-			PackageRegistryProxyNpmURL:   "npm",
-			PackageRegistryProxyYarnURL:  "yarn",
-			PackageRegistryProxyGomodURL: "gomod",
-			PackageRegistryProxyPipURL:   "pip",
-			PackageRegistryProxyPnpmURL:  "pnpm",
+			DefaultOIDCIssuer:              "oidc",
+			EnableKeylessSigning:           ptr.To(true),
+			FulcioInternalUrl:              "fulcio-int",
+			FulcioExternalUrl:              "fulcio-ext",
+			RekorInternalUrl:               "rekor-int",
+			RekorExternalUrl:               "rekor-ext",
+			TufInternalUrl:                 "tuf-int",
+			TufExternalUrl:                 "tuf-ext",
+			TrustifyServerInternalUrl:      "trustify-int",
+			TrustifyServerExternalUrl:      "trustify-ext",
+			BuildIdentityRegexp:            "regexp",
+			TrustifyOIDCIssuerUrl:          "trustify-oidc",
+			TektonChainsIdentity:           "chains-identity",
+			AllowCacheProxy:                ptr.To(true),
+			HTTPProxy:                      "proxy:3128",
+			NoProxy:                        &noProxy,
+			AllowPackageRegistryProxy:      ptr.To(true),
+			PackageRegistryProxyNpmURL:     "npm",
+			PackageRegistryProxyYarnURL:    "yarn",
+			PackageRegistryProxyGomodURL:   "gomod",
+			PackageRegistryProxyPipURL:     "pip",
+			PackageRegistryProxyPnpmURL:    "pnpm",
+			PackageRegistryProxyBundlerURL: "bundler",
+			PackageRegistryProxyCargoURL:   "cargo",
 		}
 
 		// Count total fields
@@ -192,7 +200,7 @@ func TestClusterConfigData_All(t *testing.T) {
 			totalFields++
 			return true
 		})
-		g.Expect(totalFields).To(gomega.Equal(22))
+		g.Expect(totalFields).To(gomega.Equal(24))
 
 		// Verify early termination works at every position
 		for stopAt := 1; stopAt <= totalFields; stopAt++ {
@@ -210,28 +218,30 @@ func TestClusterConfigData_All(t *testing.T) {
 
 		noProxy := ""
 		data := ClusterConfigData{
-			DefaultOIDCIssuer:            "oidc",
-			EnableKeylessSigning:         ptr.To(false),
-			FulcioInternalUrl:            "fulcio-internal",
-			FulcioExternalUrl:            "fulcio-external",
-			RekorInternalUrl:             "rekor-internal",
-			RekorExternalUrl:             "rekor-external",
-			TufInternalUrl:               "tuf-internal",
-			TufExternalUrl:               "tuf-external",
-			TrustifyServerInternalUrl:    "trustify-internal",
-			TrustifyServerExternalUrl:    "trustify-external",
-			BuildIdentityRegexp:          "^https://konflux\\.dev/build/.*$",
-			TrustifyOIDCIssuerUrl:        "https://keycloak-external/realm/foobar",
-			TektonChainsIdentity:         "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller",
-			AllowCacheProxy:              ptr.To(true),
-			HTTPProxy:                    "proxy:3128",
-			NoProxy:                      &noProxy,
-			AllowPackageRegistryProxy:    ptr.To(false),
-			PackageRegistryProxyNpmURL:   "https://npm-proxy.example.com",
-			PackageRegistryProxyYarnURL:  "https://yarn-proxy.example.com",
-			PackageRegistryProxyGomodURL: "https://gomod-proxy.example.com",
-			PackageRegistryProxyPipURL:   "https://pip-proxy.example.com",
-			PackageRegistryProxyPnpmURL:  "https://pnpm-proxy.example.com",
+			DefaultOIDCIssuer:              "oidc",
+			EnableKeylessSigning:           ptr.To(false),
+			FulcioInternalUrl:              "fulcio-internal",
+			FulcioExternalUrl:              "fulcio-external",
+			RekorInternalUrl:               "rekor-internal",
+			RekorExternalUrl:               "rekor-external",
+			TufInternalUrl:                 "tuf-internal",
+			TufExternalUrl:                 "tuf-external",
+			TrustifyServerInternalUrl:      "trustify-internal",
+			TrustifyServerExternalUrl:      "trustify-external",
+			BuildIdentityRegexp:            "^https://konflux\\.dev/build/.*$",
+			TrustifyOIDCIssuerUrl:          "https://keycloak-external/realm/foobar",
+			TektonChainsIdentity:           "https://kubernetes.io/namespaces/tekton-pipelines/serviceaccounts/tekton-chains-controller",
+			AllowCacheProxy:                ptr.To(true),
+			HTTPProxy:                      "proxy:3128",
+			NoProxy:                        &noProxy,
+			AllowPackageRegistryProxy:      ptr.To(false),
+			PackageRegistryProxyNpmURL:     "https://npm-proxy.example.com",
+			PackageRegistryProxyYarnURL:    "https://yarn-proxy.example.com",
+			PackageRegistryProxyGomodURL:   "https://gomod-proxy.example.com",
+			PackageRegistryProxyPipURL:     "https://pip-proxy.example.com",
+			PackageRegistryProxyPnpmURL:    "https://pnpm-proxy.example.com",
+			PackageRegistryProxyBundlerURL: "https://bundler-proxy.example.com",
+			PackageRegistryProxyCargoURL:   "https://cargo-proxy.example.com",
 		}
 
 		var keys []string
@@ -263,6 +273,8 @@ func TestClusterConfigData_All(t *testing.T) {
 			ClusterConfigKeyPackageRegistryProxyGomodURL,
 			ClusterConfigKeyPackageRegistryProxyPipURL,
 			ClusterConfigKeyPackageRegistryProxyPnpmURL,
+			ClusterConfigKeyPackageRegistryProxyBundlerURL,
+			ClusterConfigKeyPackageRegistryProxyCargoURL,
 		}
 
 		g.Expect(keys).To(gomega.Equal(expectedOrder))

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxes.yaml
@@ -1357,6 +1357,26 @@ spec:
                                   An empty string is a valid value meaning no hosts are excluded from proxying.
                                   When nil (omitted), the key is absent from the ConfigMap.
                                 type: string
+                              packageRegistryProxyBundlerUrl:
+                                description: |-
+                                  PackageRegistryProxyBundlerURL is the URL of the RubyGems (Bundler) package registry proxy.
+                                  Written as "package-registry-proxy-bundler-url" in the cluster-config ConfigMap.
+                                  Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: URL must not contain credentials (userinfo).
+                                    Use a Secret for proxy authentication.
+                                  rule: '!self.contains(''@'')'
+                              packageRegistryProxyCargoUrl:
+                                description: |-
+                                  PackageRegistryProxyCargoURL is the URL of the Cargo (Rust crates) package registry proxy.
+                                  Written as "package-registry-proxy-cargo-url" in the cluster-config ConfigMap.
+                                  Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: URL must not contain credentials (userinfo).
+                                    Use a Secret for proxy authentication.
+                                  rule: '!self.contains(''@'')'
                               packageRegistryProxyGomodUrl:
                                 description: |-
                                   PackageRegistryProxyGomodURL is the URL of the Go module proxy.

--- a/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxinfoes.yaml
+++ b/operator/config/crd/bases/konflux.konflux-ci.dev_konfluxinfoes.yaml
@@ -163,6 +163,26 @@ spec:
                           An empty string is a valid value meaning no hosts are excluded from proxying.
                           When nil (omitted), the key is absent from the ConfigMap.
                         type: string
+                      packageRegistryProxyBundlerUrl:
+                        description: |-
+                          PackageRegistryProxyBundlerURL is the URL of the RubyGems (Bundler) package registry proxy.
+                          Written as "package-registry-proxy-bundler-url" in the cluster-config ConfigMap.
+                          Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: URL must not contain credentials (userinfo). Use
+                            a Secret for proxy authentication.
+                          rule: '!self.contains(''@'')'
+                      packageRegistryProxyCargoUrl:
+                        description: |-
+                          PackageRegistryProxyCargoURL is the URL of the Cargo (Rust crates) package registry proxy.
+                          Written as "package-registry-proxy-cargo-url" in the cluster-config ConfigMap.
+                          Do not embed credentials in this URL — the ConfigMap is readable by all authenticated users.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: URL must not contain credentials (userinfo). Use
+                            a Secret for proxy authentication.
+                          rule: '!self.contains(''@'')'
                       packageRegistryProxyGomodUrl:
                         description: |-
                           PackageRegistryProxyGomodURL is the URL of the Go module proxy.

--- a/operator/config/samples/konflux-e2e.yaml
+++ b/operator/config/samples/konflux-e2e.yaml
@@ -148,6 +148,8 @@ spec:
       #     # packageRegistryProxyGomodUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy"
       #     # packageRegistryProxyPipUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple"
       #     # packageRegistryProxyPnpmUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"
+      #     # packageRegistryProxyBundlerUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy"
+      #     # packageRegistryProxyCargoUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy"
   # enterpriseContract:
   #   # skipPolicies disables deployment of EnterpriseContractPolicy resources.
   #   # When true, only CRDs, namespace, RBAC, and ConfigMap are deployed;

--- a/operator/config/samples/konflux_v1alpha1_konflux.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konflux.yaml
@@ -159,6 +159,8 @@ spec:
       #     # packageRegistryProxyGomodUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy"
       #     # packageRegistryProxyPipUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple"
       #     # packageRegistryProxyPnpmUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"
+      #     # packageRegistryProxyBundlerUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy"
+      #     # packageRegistryProxyCargoUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy"
   # enterpriseContract:
   #   # skipPolicies disables deployment of EnterpriseContractPolicy resources.
   #   # When true, only CRDs, namespace, RBAC, and ConfigMap are deployed;

--- a/operator/config/samples/konflux_v1alpha1_konfluxinfo.yaml
+++ b/operator/config/samples/konflux_v1alpha1_konfluxinfo.yaml
@@ -143,3 +143,5 @@ spec:
       packageRegistryProxyGomodUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy"
       packageRegistryProxyPipUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple"
       packageRegistryProxyPnpmUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"
+      packageRegistryProxyBundlerUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy"
+      packageRegistryProxyCargoUrl: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy"

--- a/operator/internal/controller/info/konfluxinfo_controller_test.go
+++ b/operator/internal/controller/info/konfluxinfo_controller_test.go
@@ -183,18 +183,52 @@ var _ = Describe("KonfluxInfo Controller", func() {
 			Expect(err.Error()).To(ContainSubstring("must not contain credentials"))
 		})
 
+		It("should reject packageRegistryProxyBundlerUrl containing credentials", func(ctx context.Context) {
+			cr := &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				Spec: konfluxv1alpha1.KonfluxInfoSpec{
+					ClusterConfig: &konfluxv1alpha1.ClusterConfig{
+						Data: &konfluxv1alpha1.ClusterConfigData{
+							PackageRegistryProxyBundlerURL: "https://user:pass@rubygems.example.com",
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, cr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must not contain credentials"))
+		})
+
+		It("should reject packageRegistryProxyCargoUrl containing credentials", func(ctx context.Context) {
+			cr := &konfluxv1alpha1.KonfluxInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+				Spec: konfluxv1alpha1.KonfluxInfoSpec{
+					ClusterConfig: &konfluxv1alpha1.ClusterConfig{
+						Data: &konfluxv1alpha1.ClusterConfigData{
+							PackageRegistryProxyCargoURL: "https://user:pass@crates.example.com",
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, cr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must not contain credentials"))
+		})
+
 		It("should allow proxy URLs without credentials", func(ctx context.Context) {
 			cr := &konfluxv1alpha1.KonfluxInfo{
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 				Spec: konfluxv1alpha1.KonfluxInfoSpec{
 					ClusterConfig: &konfluxv1alpha1.ClusterConfig{
 						Data: &konfluxv1alpha1.ClusterConfigData{
-							HTTPProxy:                    "squid.caching.svc.cluster.local:3128",
-							PackageRegistryProxyNpmURL:   "https://npm-proxy.internal.svc:8080",
-							PackageRegistryProxyYarnURL:  "https://yarn-proxy.internal.svc:8080",
-							PackageRegistryProxyGomodURL: "https://go-proxy.internal.svc:8080",
-							PackageRegistryProxyPipURL:   "https://pypi-proxy.internal.svc:8080",
-							PackageRegistryProxyPnpmURL:  "https://pnpm-proxy.internal.svc:8080",
+							HTTPProxy:                      "squid.caching.svc.cluster.local:3128",
+							PackageRegistryProxyNpmURL:     "https://npm-proxy.internal.svc:8080",
+							PackageRegistryProxyYarnURL:    "https://yarn-proxy.internal.svc:8080",
+							PackageRegistryProxyGomodURL:   "https://go-proxy.internal.svc:8080",
+							PackageRegistryProxyPipURL:     "https://pypi-proxy.internal.svc:8080",
+							PackageRegistryProxyPnpmURL:    "https://pnpm-proxy.internal.svc:8080",
+							PackageRegistryProxyBundlerURL: "https://rubygems-proxy.internal.svc:8080",
+							PackageRegistryProxyCargoURL:   "https://cargo-proxy.internal.svc:8080",
 						},
 					},
 				},

--- a/operator/internal/controller/info/konfluxinfo_customization_test.go
+++ b/operator/internal/controller/info/konfluxinfo_customization_test.go
@@ -1296,15 +1296,17 @@ func TestKonfluxInfoClusterConfig(t *testing.T) {
 			Spec: konfluxv1alpha1.KonfluxInfoSpec{
 				ClusterConfig: &konfluxv1alpha1.ClusterConfig{
 					Data: &konfluxv1alpha1.ClusterConfigData{
-						AllowCacheProxy:              &allowCache,
-						HTTPProxy:                    "squid.caching.svc.cluster.local:3128",
-						NoProxy:                      &noProxy,
-						AllowPackageRegistryProxy:    &allowPkgRegistry,
-						PackageRegistryProxyNpmURL:   "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy",
-						PackageRegistryProxyYarnURL:  "https://artifact-registry-proxy.caching.svc.cluster.local/repository/yarn-proxy",
-						PackageRegistryProxyGomodURL: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy",
-						PackageRegistryProxyPipURL:   "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple",
-						PackageRegistryProxyPnpmURL:  "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pnpm-proxy",
+						AllowCacheProxy:                &allowCache,
+						HTTPProxy:                      "squid.caching.svc.cluster.local:3128",
+						NoProxy:                        &noProxy,
+						AllowPackageRegistryProxy:      &allowPkgRegistry,
+						PackageRegistryProxyNpmURL:     "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy",
+						PackageRegistryProxyYarnURL:    "https://artifact-registry-proxy.caching.svc.cluster.local/repository/yarn-proxy",
+						PackageRegistryProxyGomodURL:   "https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy",
+						PackageRegistryProxyPipURL:     "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple",
+						PackageRegistryProxyPnpmURL:    "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pnpm-proxy",
+						PackageRegistryProxyBundlerURL: "https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy",
+						PackageRegistryProxyCargoURL:   "https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy",
 					},
 				},
 			},
@@ -1341,6 +1343,8 @@ func TestKonfluxInfoClusterConfig(t *testing.T) {
 		g.Expect(clusterConfigMap.Data).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyGomodURL, "https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy"))
 		g.Expect(clusterConfigMap.Data).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPipURL, "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple"))
 		g.Expect(clusterConfigMap.Data).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPnpmURL, "https://artifact-registry-proxy.caching.svc.cluster.local/repository/pnpm-proxy"))
+		g.Expect(clusterConfigMap.Data).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyBundlerURL, "https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy"))
+		g.Expect(clusterConfigMap.Data).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyCargoURL, "https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy"))
 	})
 
 	t.Run("should omit proxy keys from cluster-config ConfigMap when fields are nil/empty", func(t *testing.T) {
@@ -1391,6 +1395,8 @@ func TestKonfluxInfoClusterConfig(t *testing.T) {
 		g.Expect(clusterConfigMap.Data).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyGomodURL))
 		g.Expect(clusterConfigMap.Data).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPipURL))
 		g.Expect(clusterConfigMap.Data).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPnpmURL))
+		g.Expect(clusterConfigMap.Data).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyBundlerURL))
+		g.Expect(clusterConfigMap.Data).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyCargoURL))
 	})
 
 	t.Run("should write allow-cache-proxy as false when explicitly set to false", func(t *testing.T) {
@@ -1446,15 +1452,17 @@ func TestClusterConfigDataProxyFieldsIterator(t *testing.T) {
 		noProxy := ""
 
 		data := konfluxv1alpha1.ClusterConfigData{
-			AllowCacheProxy:              &allowCache,
-			HTTPProxy:                    "squid.caching.svc.cluster.local:3128",
-			NoProxy:                      &noProxy,
-			AllowPackageRegistryProxy:    &allowPkgRegistry,
-			PackageRegistryProxyNpmURL:   "https://npm-proxy.example.com",
-			PackageRegistryProxyYarnURL:  "https://yarn-proxy.example.com",
-			PackageRegistryProxyGomodURL: "https://gomod-proxy.example.com",
-			PackageRegistryProxyPipURL:   "https://pip-proxy.example.com",
-			PackageRegistryProxyPnpmURL:  "https://pnpm-proxy.example.com",
+			AllowCacheProxy:                &allowCache,
+			HTTPProxy:                      "squid.caching.svc.cluster.local:3128",
+			NoProxy:                        &noProxy,
+			AllowPackageRegistryProxy:      &allowPkgRegistry,
+			PackageRegistryProxyNpmURL:     "https://npm-proxy.example.com",
+			PackageRegistryProxyYarnURL:    "https://yarn-proxy.example.com",
+			PackageRegistryProxyGomodURL:   "https://gomod-proxy.example.com",
+			PackageRegistryProxyPipURL:     "https://pip-proxy.example.com",
+			PackageRegistryProxyPnpmURL:    "https://pnpm-proxy.example.com",
+			PackageRegistryProxyBundlerURL: "https://bundler-proxy.example.com",
+			PackageRegistryProxyCargoURL:   "https://cargo-proxy.example.com",
 		}
 
 		collected := make(map[string]string)
@@ -1471,6 +1479,8 @@ func TestClusterConfigDataProxyFieldsIterator(t *testing.T) {
 		g.Expect(collected).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyGomodURL, "https://gomod-proxy.example.com"))
 		g.Expect(collected).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPipURL, "https://pip-proxy.example.com"))
 		g.Expect(collected).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPnpmURL, "https://pnpm-proxy.example.com"))
+		g.Expect(collected).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyBundlerURL, "https://bundler-proxy.example.com"))
+		g.Expect(collected).To(gomega.HaveKeyWithValue(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyCargoURL, "https://cargo-proxy.example.com"))
 	})
 
 	t.Run("should not yield proxy keys when fields are nil/empty", func(t *testing.T) {
@@ -1495,6 +1505,8 @@ func TestClusterConfigDataProxyFieldsIterator(t *testing.T) {
 		g.Expect(collected).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyGomodURL))
 		g.Expect(collected).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPipURL))
 		g.Expect(collected).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyPnpmURL))
+		g.Expect(collected).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyBundlerURL))
+		g.Expect(collected).NotTo(gomega.HaveKey(konfluxv1alpha1.ClusterConfigKeyPackageRegistryProxyCargoURL))
 	})
 
 	t.Run("should yield false for *bool set to false", func(t *testing.T) {


### PR DESCRIPTION
Add the following package registry proxy URL fields to the KonfluxInfo ClusterConfig API:

- package-registry-proxy-bundler-url
- package-registry-proxy-cargo-url

These follow the precedent for similar fields for the npm, pip, gomod, and other Hermeto backends.