### PR TITLE
fix: clear BearerTokenFile to prevent in-cluster token override

### DIFF
--- a/test/go-tests/pkg/clients/kube/client.go
+++ b/test/go-tests/pkg/clients/kube/client.go
@@ -100,6 +100,14 @@ func NewAdminKubernetesClient() (*CustomClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	// When running inside a pod with a projected SA token, the transport
+	// may re-read the token file and override the static BearerToken from
+	// the kubeconfig. Clear BearerTokenFile so the static token is always
+	// used, preventing "failed to get server groups" errors when the
+	// projected token's audience doesn't match.
+	if adminKubeconfig.BearerToken != "" {
+		adminKubeconfig.BearerTokenFile = ""
+	}
 	clientSets, err := createClientSetsFromConfig(adminKubeconfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When running inside a pod with a projected SA token, the Go HTTP transport re-reads the token file and overrides the static BearerToken from the KUBECONFIG. This causes 'failed to get server groups: Unauthorized' errors during API discovery when the projected token's OIDC audience doesn't match what the API server expects for certain operations.

Clear BearerTokenFile when a static BearerToken is already set from the kubeconfig, ensuring the static token is used consistently for all API calls including server group discovery.