### PR TITLE
fix(KONFLUX-15486): require commit SHA in /allow to prevent fork secret abuse

### DIFF
--- a/.github/workflows/operator-test-e2e.yaml
+++ b/.github/workflows/operator-test-e2e.yaml
@@ -20,12 +20,12 @@ jobs:
           github.event.pull_request.head.repo.full_name != github.repository
         run: |
           set -euo pipefail
-          echo "❌ Fork PR: heavy jobs do not run on push (no secrets). Comment /allow to trigger tests." >&2
+          echo "❌ Fork PR: heavy jobs do not run on push (no secrets). Comment /allow <commit-sha> to trigger tests." >&2
           {
             echo "### Fork PR"
             echo ""
             echo "Tests are not run automatically from forks."
-            echo "**Action Required:** A maintainer must comment \`/allow\` on this PR to trigger tests."
+            echo "**Action Required:** A maintainer must comment \`/allow <commit-sha>\` on this PR to trigger tests."
           } >>"${GITHUB_STEP_SUMMARY}"
           exit 1
 

--- a/.github/workflows/pr-comment-commands.yaml
+++ b/.github/workflows/pr-comment-commands.yaml
@@ -1,8 +1,11 @@
-# For fork PRs only: org members trigger E2E runs by commenting /allow on the PR.
+# For fork PRs only: org members trigger E2E runs by commenting /allow <commit-sha> on the PR.
 # (Same-repo PRs from collaborators run CI automatically via pull_request_target.)
 #
-# Flow: Maintainer comments /allow → we verify the head SHA was seen by GitHub before
-# the comment (TOCTOU using check suite created_at; server-side, not spoofable), then dispatch "e2e".
+# Flow: Maintainer comments "/allow <commit-sha>" → we verify the provided SHA matches
+# the current PR HEAD (prevents approving stale code), verify the SHA was seen by GitHub
+# before the comment (TOCTOU using check suite created_at; server-side, not spoofable),
+# then dispatch "e2e".  Requiring the SHA forces the maintainer to identify the exact
+# revision they reviewed before granting secret access to fork code.
 
 name: PR Comment Commands
 
@@ -29,17 +32,79 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
-            // 1. Fetch PR to get the current HEAD SHA
+            // 1. Parse the commit SHA from the comment body ("/allow <commit-sha>").
+            const parts = context.payload.comment.body.trim().split(/\s+/);
+            const providedSha = parts.length >= 2 ? parts[1] : '';
+
+            // 2. Fetch PR to get the current HEAD SHA.
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number
             });
-
             const headSha = pr.data.head.sha;
-            console.log(`Checking SHA: ${headSha}`);
 
-            // 2. When did GitHub first see this SHA? Use check suite created_at (server-side, not spoofable).
+            // 3. Validate: must be present, hex-only, 7–40 chars (rejects branch names/tags).
+            if (!providedSha) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  "⚠️ **Missing commit SHA.** Usage: `/allow <commit-sha>`",
+                  "",
+                  "Copy the full commit SHA from the PR's **Commits** tab and include it:",
+                  "```",
+                  `/allow ${headSha}`,
+                  "```",
+                  "This ensures you are approving a specific, reviewed revision."
+                ].join("\n")
+              });
+              core.setFailed("No commit SHA provided.");
+              return;
+            }
+
+            // Full 40-char hex SHA required: rejects branches, tags, and abbreviated SHAs
+            // (short prefixes are collision-feasible and could match a different commit).
+            if (!/^[0-9a-f]{40}$/i.test(providedSha)) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  `⚠️ **Invalid commit SHA.** \`${providedSha}\` is not a full 40-character commit SHA.`,
+                  "",
+                  "Copy the **full** commit SHA from the PR's **Commits** tab.",
+                  "Abbreviated SHAs, branch names, and tags are not accepted."
+                ].join("\n")
+              });
+              core.setFailed("Invalid ref format — must be a full 40-character hex commit SHA.");
+              return;
+            }
+
+            // 4. Provided SHA must exactly match the current PR HEAD.
+            if (headSha.toLowerCase() !== providedSha.toLowerCase()) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  "⚠️ **SHA mismatch.** The commit you approved is not the current PR head.",
+                  "",
+                  `You provided: \`${providedSha}\``,
+                  `Current HEAD: \`${headSha}\``,
+                  "",
+                  "The PR may have been updated since you last reviewed it.",
+                  "Please review the latest changes and comment `/allow` again with the new SHA."
+                ].join("\n")
+              });
+              core.setFailed("Provided SHA does not match current PR HEAD.");
+              return;
+            }
+
+            console.log(`SHA verified: provided=${providedSha}, HEAD=${headSha}`);
+
+            // 5. TOCTOU: ensure the SHA was seen by GitHub before the /allow comment.
             const { data: suitesData } = await github.rest.checks.listSuitesForRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -58,19 +123,17 @@ jobs:
             const commentTime = new Date(context.payload.comment.created_at);
             console.log(`Comment: ${commentTime.toISOString()}, SHA first seen: ${shaFirstSeenAt.toISOString()}`);
 
-            // 3. If SHA appeared after the comment, abort. Small buffer for server clock skew only.
             if (shaFirstSeenAt > new Date(commentTime.getTime() + 2000)) {
-              const message = [
-                "⚠️ **Security Halt:** The code revision is newer than your `/allow` command.",
-                "",
-                "To prevent testing unreviewed code, this run has been aborted.",
-                "Please review the new changes and comment `/allow` again."
-              ].join("\n");
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: message
+                body: [
+                  "⚠️ **Security Halt:** The code revision is newer than your `/allow` command.",
+                  "",
+                  "To prevent testing unreviewed code, this run has been aborted.",
+                  "Please review the new changes and comment `/allow <commit-sha>` again with the updated SHA."
+                ].join("\n")
               });
               core.setFailed("Aborting: TOCTOU (SHA is newer than comment).");
               return;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ PRs trigger the following workflows:
 - **`operator-test`** — `go mod tidy -diff` + `make test`, uploads coverage
 - **`operator-lint`** — golangci-lint
 - **`operator-verify-generated-files`** — ensures CRDs/RBAC/deepcopy are up to date
-- **`operator-test-e2e`** — full operator e2e (fork PRs require `/allow`)
+- **`operator-test-e2e`** — full operator e2e (fork PRs require `/allow <commit-sha>`)
 - **`kube-linter`** — lints rendered kustomize manifests
 - **`check-toc`** — validates markdown TOC (excludes `operator/docs/`, `.cursor/*`, `skills/*`)
 - **`differential-shellcheck`** — ShellCheck on changed shell scripts
@@ -113,7 +113,7 @@ PRs trigger the following workflows:
 - **`.tekton` task/pipeline edits:** `pipeline.yaml` tasks `deploy-konflux-its` and `konflux-e2e-tests-its` hardcode `taskRef.revision: main`. To verify changes, temporarily point both at the PR’s git ref, run operator E2E, then restore `main` before merge (see `.tekton/pipelines/operator-e2e/README.md`).
 - **`integrations/` changes:** Scripts in `integrations/` manage platform integrations (sigstore signing stack, quay integration for image-controller). E2E tests do not exercise these scripts, so CI coverage does not validate changes here. When reviewing version bumps or script changes, recommend manual verification on a local cluster before merge.
 - **Same-repo branches preferred**: E2E tests run automatically
-- **Fork PRs**: Require maintainer `/allow` comment to trigger tests
+- **Fork PRs**: Require maintainer `/allow <commit-sha>` comment to trigger tests
 - Run kube-linter before submitting
 - Update TOC if markdown structure changed
 - Run `make manifests generate` if API or RBAC annotations changed
@@ -156,7 +156,7 @@ Detailed guides live in `skills/` — each subdirectory contains a `SKILL.md` wi
 | [ginkgo-testing](skills/ginkgo-testing/SKILL.md) | Writing or reviewing Ginkgo tests — cleanup patterns, soft assertions |
 | [go-toolchain-upgrade](skills/go-toolchain-upgrade/SKILL.md) | `go.mod`/`go.sum`, Go pins, or `go.mod requires go` CI failures |
 | [pr-review](skills/pr-review/SKILL.md) | Reviewing human-authored PRs — upstream/downstream hygiene and related checks |
-| [create-pr](skills/create-pr/SKILL.md) | Opening PRs, fork `/allow` behavior |
+| [create-pr](skills/create-pr/SKILL.md) | Opening PRs, fork `/allow <commit-sha>` behavior |
 | [debug-e2e-tests](skills/debug-e2e-tests/SKILL.md) | Triaging or investigating failed e2e / OpenShift CI runs |
 | [update-upstream-deps](skills/update-upstream-deps/SKILL.md) | Bumping upstream SHAs or editing `upstream-kustomizations/` (triggers manifest rebuild) |
 | [companion-pr-review](skills/companion-pr-review/SKILL.md) | MintMaker/Renovate parent or companion PRs — what to skip vs review lightly |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,7 +181,7 @@ Maintainers can add the `skip-image-verify` label and re-run the manifest
 companion workflow to bypass image verification.
 
 **Operator E2E Tests** does not run when labels alone change (only on new
-commits, reopen, merge queue, or maintainer `/allow` on fork PRs). After you add
+commits, reopen, merge queue, or maintainer `/allow <commit-sha>` on fork PRs). After you add
 `force-run-e2e`, start CI manually—for example re-run **Operator E2E Tests** from
 the PR Checks or Actions UI, or push a new commit to the PR branch.
 

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -10,11 +10,13 @@ description: Create pull requests for konflux-ci repository. Explains CI behavio
 | PR Source | E2E Tests | Trigger |
 |-----------|-----------|---------|
 | Same-repo branch | Automatic | Push |
-| Fork | Manual | Org member comments `/allow` |
+| Fork | Manual | Org member comments `/allow <commit-sha>` |
 
-Fork PRs cannot access secrets. The `/allow` command:
-1. Verifies code hasn't changed since comment (TOCTOU check)
-2. Triggers E2E via `repository_dispatch`
+Fork PRs cannot access secrets. The `/allow <commit-sha>` command:
+1. Verifies the provided SHA is a valid commit hash (not a branch/tag)
+2. Verifies the SHA matches the current PR HEAD (prevents approving stale code)
+3. Verifies code hasn't changed since comment (TOCTOU check)
+4. Triggers E2E via `repository_dispatch`
 
 See `.github/workflows/operator-test-e2e.yaml` (check-prerequisites job) and `.github/workflows/pr-comment-commands.yaml`.
 
@@ -29,7 +31,7 @@ gh repo view konflux-ci/konflux-ci --json viewerPermission --jq '.viewerPermissi
 ```
 
 If user has write access → push to `upstream` (CI runs automatically)
-If user does NOT have write access → push to fork (needs `/allow`)
+If user does NOT have write access → push to fork (needs `/allow <commit-sha>`)
 
 ## Workflow
 
@@ -43,7 +45,7 @@ gh pr create --repo konflux-ci/konflux-ci
 **Without write access (fork):**
 1. Fork and clone
 2. Push to fork, open PR against `konflux-ci/konflux-ci`
-3. Wait for maintainer `/allow`
+3. Wait for maintainer `/allow <commit-sha>`
 
 ## Pre-PR Checklist
 
@@ -64,6 +66,6 @@ From `CONTRIBUTING.md`:
 
 ## Troubleshooting
 
-**CI not running on fork PR:** Normal - wait for `/allow` from maintainer.
+**CI not running on fork PR:** Normal - wait for `/allow <commit-sha>` from maintainer.
 
-**E2E failed after /allow:** Code changed after `/allow`. Maintainer must re-review and `/allow` again.
+**E2E failed after /allow:** Code changed after `/allow`. Maintainer must re-review and `/allow <commit-sha>` again.


### PR DESCRIPTION
When a maintainer comments /allow on a fork PR, pr-comment-commands.yaml dispatches a repository_dispatch event that checks out the fork tree and runs E2E scripts with GITHUB_PRIVATE_KEY, QUAY_TOKEN, GH_TOKEN, and other secrets. A fork author could modify scripts or build files to exfiltrate these credentials, and the maintainer might /allow without noticing the change.

Fix: require `/allow <commit-sha>` instead of bare `/allow`. The maintainer must now provide the exact commit SHA they reviewed. The workflow validates that:
1. The argument is a hex commit SHA (not a branch name or tag)
2. It matches the current PR HEAD (rejects stale approvals)
3. The SHA existed before the comment was posted (existing TOCTOU check)

If any check fails, the workflow posts a clear error comment explaining what went wrong and how to retry.

Addresses: CWE-829 (Inclusion of Functionality from Untrusted Control Sphere), CWE-522 (Insufficiently Protected Credentials)

Assisted-by: Cursor + Opus 4.6