### PR TITLE
Fixed #8240 -- Consolidate transient PipelineRun failure detection into a shared helper 

### DIFF
--- a/test/go-tests/pkg/clients/has/components.go
+++ b/test/go-tests/pkg/clients/has/components.go
@@ -13,6 +13,7 @@ import (
 	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/constants"
 	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/logs"
 	"github.com/konflux-ci/konflux-ci/test/go-tests/pkg/utils"
+	tektonUtils "github.com/konflux-ci/konflux-ci/test/go-tests/pkg/utils/tekton"
 	imagecontroller "github.com/konflux-ci/image-controller/api/v1alpha1"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -677,16 +678,8 @@ func (h *Controller) UpdateComponent(component *appservice.Component) error {
 }
 
 // buildPipelineRunIsTransient checks whether a build PipelineRun failure
-// reason indicates a transient error worth retrying. Transient failures:
-//   - CouldntGetTask — task-level resolver timeout (SRVKP-2749)
-//   - CouldntGetPipeline — pipeline-level resolver timeout (e.g. git
-//     resolver exceeding Tekton's global resolution timeout)
-//   - TaskRunImagePullFailed — image-pull flakes (RHTAPBUGS-985)
-//   - "resolution took longer than global timeout" in the condition
-//     message — fallback when Tekton uses a generic reason
+// reason indicates a transient error worth retrying by delegating to the shared
+// tektonUtils.IsTransientPipelineRunFailure helper.
 func buildPipelineRunIsTransient(reason, message string) bool {
-	return reason == "CouldntGetTask" ||
-		reason == "CouldntGetPipeline" ||
-		reason == "TaskRunImagePullFailed" ||
-		strings.Contains(message, "resolution took longer than global timeout")
+	return tektonUtils.IsTransientPipelineRunFailure(reason, message)
 }

--- a/test/go-tests/pkg/clients/has/components_test.go
+++ b/test/go-tests/pkg/clients/has/components_test.go
@@ -32,6 +32,18 @@ func TestBuildPipelineRunIsTransient(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "unexpected EOF in message is transient",
+			reason:   "Failed",
+			message:  "connection error: unexpected EOF",
+			expected: true,
+		},
+		{
+			name:     "TaskRunImagePullFailed in message is transient",
+			reason:   "Failed",
+			message:  "task failed: TaskRunImagePullFailed",
+			expected: true,
+		},
+		{
 			name:     "generic Failed reason is not transient",
 			reason:   "Failed",
 			message:  "task X failed with exit code 1",

--- a/test/go-tests/pkg/clients/release/releases.go
+++ b/test/go-tests/pkg/clients/release/releases.go
@@ -277,13 +277,7 @@ func pipelineRunHasTransientFailure(pr *pipeline.PipelineRun, c client.Client) b
 	if cond == nil {
 		return false
 	}
-	reason := cond.Reason
-	return reason == "TaskRunImagePullFailed" ||
-		reason == "CouldntGetPipeline" ||
-		reason == "CouldntGetTask" ||
-		strings.Contains(cond.Message, "TaskRunImagePullFailed") ||
-		strings.Contains(cond.Message, "unexpected EOF") ||
-		strings.Contains(cond.Message, "resolution took longer than global timeout")
+	return tekton.IsTransientPipelineRunFailure(cond.Reason, cond.Message)
 }
 
 // WaitForReleasePipelineToBeFinishedWithRetry waits for the managed release

--- a/test/go-tests/pkg/utils/tekton/pipelineruns.go
+++ b/test/go-tests/pkg/utils/tekton/pipelineruns.go
@@ -300,6 +300,22 @@ func HasPipelineRunFailed(pr *pipeline.PipelineRun) bool {
 	return pr.IsDone() && pr.GetStatusCondition().GetCondition(apis.ConditionSucceeded).IsFalse()
 }
 
+// IsTransientPipelineRunFailure checks whether a PipelineRun failure reason or message
+// indicates a transient error worth retrying. Transient failures include:
+//   - CouldntGetTask — task-level resolver timeout (SRVKP-2749)
+//   - CouldntGetPipeline — pipeline-level resolver timeout (e.g. git resolver
+//     exceeding Tekton's global resolution timeout)
+//   - TaskRunImagePullFailed — image-pull flakes (RHTAPBUGS-985, tektoncd/pipeline#7184)
+//   - "unexpected EOF" or "resolution took longer than global timeout" in the condition message
+func IsTransientPipelineRunFailure(reason, message string) bool {
+	return reason == "CouldntGetTask" ||
+		reason == "CouldntGetPipeline" ||
+		reason == "TaskRunImagePullFailed" ||
+		strings.Contains(message, "TaskRunImagePullFailed") ||
+		strings.Contains(message, "unexpected EOF") ||
+		strings.Contains(message, "resolution took longer than global timeout")
+}
+
 func GetFailedPipelineRunDetails(c crclient.Client, pipelineRun *pipeline.PipelineRun) (*FailedPipelineRunDetails, error) {
 	d := &FailedPipelineRunDetails{}
 	var condText string

--- a/test/go-tests/pkg/utils/tekton/pipelineruns_test.go
+++ b/test/go-tests/pkg/utils/tekton/pipelineruns_test.go
@@ -123,3 +123,70 @@ func TestGetFailedPipelineRunDetails(t *testing.T) {
 		})
 	}
 }
+
+func TestIsTransientPipelineRunFailure(t *testing.T) {
+	tests := []struct {
+		name     string
+		reason   string
+		message  string
+		expected bool
+	}{
+		{
+			name:     "CouldntGetTask reason",
+			reason:   "CouldntGetTask",
+			expected: true,
+		},
+		{
+			name:     "CouldntGetPipeline reason",
+			reason:   "CouldntGetPipeline",
+			message:  "Error retrieving pipeline for pipelinerun: resolver failed",
+			expected: true,
+		},
+		{
+			name:     "TaskRunImagePullFailed reason",
+			reason:   "TaskRunImagePullFailed",
+			expected: true,
+		},
+		{
+			name:     "TaskRunImagePullFailed in message",
+			reason:   "Failed",
+			message:  "task failed: TaskRunImagePullFailed",
+			expected: true,
+		},
+		{
+			name:     "unexpected EOF in message",
+			reason:   "Failed",
+			message:  "connection error: unexpected EOF",
+			expected: true,
+		},
+		{
+			name:     "resolution timeout in message",
+			reason:   "Failed",
+			message:  "resolution took longer than global timeout of 1m0s",
+			expected: true,
+		},
+		{
+			name:     "generic Failed reason is not transient",
+			reason:   "Failed",
+			message:  "task X failed with exit code 1",
+			expected: false,
+		},
+		{
+			name:     "empty reason is not transient",
+			reason:   "",
+			expected: false,
+		},
+		{
+			name:     "Succeeded is not transient",
+			reason:   "Succeeded",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsTransientPipelineRunFailure(tc.reason, tc.message)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
# Description

Consolidates transient Tekton `PipelineRun` failure detection into a single shared helper `IsTransientPipelineRunFailure` in `test/go-tests/pkg/utils/tekton`.

Previously, `test/go-tests/pkg/clients/has/components.go` and `test/go-tests/pkg/clients/release/releases.go` maintained separate pattern checks for transient failures. This resulted in coverage drift (such as `unexpected EOF` being checked in release retries but omitted from build retries) and duplicate maintenance across two test packages.

Fixes #8240

## Changes

- **Extracted Shared Helper**: Defined `IsTransientPipelineRunFailure(reason, message string) bool` in `test/go-tests/pkg/utils/tekton/pipelineruns.go` containing all combined transient failure patterns:
  - `CouldntGetTask` (reason)
  - `CouldntGetPipeline` (reason)
  - `TaskRunImagePullFailed` (reason or message)
  - `"unexpected EOF"` (message)
  - `"resolution took longer than global timeout"` (message)
- **Updated Build Path**: Refactored `buildPipelineRunIsTransient` in `test/go-tests/pkg/clients/has/components.go` to delegate to `tektonUtils.IsTransientPipelineRunFailure`. The build retry logic now automatically inherits `"unexpected EOF"` handling.
- **Updated Release Path**: Refactored `pipelineRunHasTransientFailure` in `test/go-tests/pkg/clients/release/releases.go` to delegate the `PipelineRun`-level condition check to `tekton.IsTransientPipelineRunFailure`, while preserving child-TaskRun inspection logic.
- **Consolidated Unit Tests**:
  - Added `TestIsTransientPipelineRunFailure` table test in `pipelineruns_test.go`.
  - Expanded `TestBuildPipelineRunIsTransient` in `components_test.go` to verify inherited transient cases.

## How Has This Been Tested?

Ran unit tests across all affected test packages:

```bash
cd test/go-tests
go test -v ./pkg/utils/tekton ./pkg/clients/has ./pkg/clients/release
