### PR TITLE
fix(operator): reconcile internal registry trust Bundle

### DIFF
--- a/.github/scripts/update-third-party-manifests.sh
+++ b/.github/scripts/update-third-party-manifests.sh
@@ -84,6 +84,11 @@ helm template trust-manager jetstack/trust-manager \
   --set 'defaultPackage.resources.limits.memory=250Mi' \
   > dependencies/trust-manager/trust-manager.yaml
 
+# Extract trust-manager CRDs for envtest (only CustomResourceDefinition documents)
+TRUST_CRD_DIR="operator/test/crds/trust-manager"
+mkdir -p "$TRUST_CRD_DIR"
+yq 'select(.kind == "CustomResourceDefinition")' dependencies/trust-manager/trust-manager.yaml > "$TRUST_CRD_DIR/trust-manager.crds.yaml"
+
 # prometheus-operator ServiceMonitor CRD (Kind envtest + deploy-deps prerequisite)
 PROM_TAG="${PROMETHEUS_OPERATOR_VERSION#v}"
 PROM_CRD_URL="https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v${PROM_TAG}/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml"
@@ -104,4 +109,5 @@ cp -f "$PROM_ENVTEST_CRD" "$PROM_DEPS_CRD"
 echo "Generated dependencies/cert-manager/cert-manager.yaml (cert-manager $CERT_MANAGER_VERSION)"
 echo "Generated $CRD_DIR/cert-manager.crds.yaml (extracted CRDs for envtest)"
 echo "Generated dependencies/trust-manager/trust-manager.yaml (trust-manager $TRUST_MANAGER_VERSION)"
+echo "Generated $TRUST_CRD_DIR/trust-manager.crds.yaml (extracted CRDs for envtest)"
 echo "Generated $PROM_ENVTEST_CRD (prometheus-operator ServiceMonitor CRD $PROMETHEUS_OPERATOR_VERSION)"

--- a/.github/scripts/verify-manifests-in-sync.sh
+++ b/.github/scripts/verify-manifests-in-sync.sh
@@ -77,6 +77,7 @@ third_paths=(
   "dependencies/cert-manager/cert-manager.yaml"
   "dependencies/trust-manager/trust-manager.yaml"
   "operator/test/crds/cert-manager/cert-manager.crds.yaml"
+  "operator/test/crds/trust-manager/trust-manager.crds.yaml"
   "operator/test/crds/prometheus/servicemonitors.monitoring.coreos.com.yaml"
   "dependencies/prometheus-operator-crds/servicemonitors.monitoring.coreos.com.yaml"
 )

--- a/operator/internal/controller/internalregistry/konfluxinternalregistry_controller.go
+++ b/operator/internal/controller/internalregistry/konfluxinternalregistry_controller.go
@@ -27,6 +27,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -41,6 +43,33 @@ import (
 	"github.com/konflux-ci/konflux-ci/operator/pkg/manifests"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
 )
+
+var trustBundleGVK = schema.GroupVersionKind{
+	Group:   "trust.cert-manager.io",
+	Version: "v1alpha1",
+	Kind:    "Bundle",
+}
+
+// trustBundleWatchObjectIfInstalled returns an unstructured Bundle watch object
+// when the trust-manager Bundle CRD is discoverable in mapper.
+// This avoids a hard Go module dependency on github.com/cert-manager/trust-manager
+// (which has incompatible controller-runtime/k8s.io dependency trees) while still
+// allowing the controller to watch and reconcile its owned trust-manager Bundle.
+// Pass mgr.GetRESTMapper() from SetupWithManager.
+func trustBundleWatchObjectIfInstalled(mapper meta.RESTMapper) (*unstructured.Unstructured, bool) {
+	if mapper == nil {
+		return nil, false
+	}
+	if _, err := mapper.RESTMapping(trustBundleGVK.GroupKind(), trustBundleGVK.Version); err != nil {
+		if !meta.IsNoMatchError(err) {
+			logf.Log.Error(err, "failed to resolve trust-manager Bundle REST mapping; skipping watch registration")
+		}
+		return nil, false
+	}
+	bundle := &unstructured.Unstructured{}
+	bundle.SetGroupVersionKind(trustBundleGVK)
+	return bundle, true
+}
 
 const (
 	// CRName is the singleton name for the KonfluxInternalRegistry CR.
@@ -190,7 +219,7 @@ func (r *KonfluxInternalRegistryReconciler) applyManifests(ctx context.Context, 
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KonfluxInternalRegistryReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(&konfluxv1alpha1.KonfluxInternalRegistry{}).
 		Named("konfluxinternalregistry").
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.DeploymentReadinessPredicate)).
@@ -198,12 +227,13 @@ func (r *KonfluxInternalRegistryReconciler) SetupWithManager(mgr ctrl.Manager) e
 		Owns(&corev1.Namespace{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).
-		Owns(&certmanagerv1.Certificate{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate)).
-		// NOTE: trust-manager Bundle (trust.cert-manager.io/v1alpha1) is not owned here
-		// because trust-manager's Go module pulls controller-runtime/k8s.io versions
-		// incompatible with this operator. The Bundle is still applied via manifests
-		// but changes to it won't trigger reconciliation.
-		Complete(r)
+		Owns(&certmanagerv1.Certificate{}, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate))
+
+	if bundle, ok := trustBundleWatchObjectIfInstalled(mgr.GetRESTMapper()); ok {
+		b = b.Owns(bundle, builder.WithPredicates(predicate.IgnoreStatusUpdatesPredicate))
+	}
+
+	return b.Complete(r)
 }
 
 // ensureRegistryCredentials keeps Zot htpasswd credentials and the client dockerconfig

--- a/operator/internal/controller/internalregistry/konfluxinternalregistry_controller.go
+++ b/operator/internal/controller/internalregistry/konfluxinternalregistry_controller.go
@@ -44,33 +44,6 @@ import (
 	"github.com/konflux-ci/konflux-ci/operator/pkg/tracking"
 )
 
-var trustBundleGVK = schema.GroupVersionKind{
-	Group:   "trust.cert-manager.io",
-	Version: "v1alpha1",
-	Kind:    "Bundle",
-}
-
-// trustBundleWatchObjectIfInstalled returns an unstructured Bundle watch object
-// when the trust-manager Bundle CRD is discoverable in mapper.
-// This avoids a hard Go module dependency on github.com/cert-manager/trust-manager
-// (which has incompatible controller-runtime/k8s.io dependency trees) while still
-// allowing the controller to watch and reconcile its owned trust-manager Bundle.
-// Pass mgr.GetRESTMapper() from SetupWithManager.
-func trustBundleWatchObjectIfInstalled(mapper meta.RESTMapper) (*unstructured.Unstructured, bool) {
-	if mapper == nil {
-		return nil, false
-	}
-	if _, err := mapper.RESTMapping(trustBundleGVK.GroupKind(), trustBundleGVK.Version); err != nil {
-		if !meta.IsNoMatchError(err) {
-			logf.Log.Error(err, "failed to resolve trust-manager Bundle REST mapping; skipping watch registration")
-		}
-		return nil, false
-	}
-	bundle := &unstructured.Unstructured{}
-	bundle.SetGroupVersionKind(trustBundleGVK)
-	return bundle, true
-}
-
 const (
 	// CRName is the singleton name for the KonfluxInternalRegistry CR.
 	CRName = "konflux-internal-registry"
@@ -89,6 +62,12 @@ const (
 	// crKind is used in error messages to identify this CR type.
 	crKind = "KonfluxInternalRegistry"
 )
+
+var trustBundleGVK = schema.GroupVersionKind{
+	Group:   "trust.cert-manager.io",
+	Version: "v1alpha1",
+	Kind:    "Bundle",
+}
 
 // InternalRegistryCleanupGVKs defines which resource types should be cleaned up when they are
 // no longer part of the desired state.
@@ -234,6 +213,27 @@ func (r *KonfluxInternalRegistryReconciler) SetupWithManager(mgr ctrl.Manager) e
 	}
 
 	return b.Complete(r)
+}
+
+// trustBundleWatchObjectIfInstalled returns an unstructured Bundle watch object
+// when the trust-manager Bundle CRD is discoverable in mapper.
+// This avoids a hard Go module dependency on github.com/cert-manager/trust-manager
+// (which has incompatible controller-runtime/k8s.io dependency trees) while still
+// allowing the controller to watch and reconcile its owned trust-manager Bundle.
+// Pass mgr.GetRESTMapper() from SetupWithManager.
+func trustBundleWatchObjectIfInstalled(mapper meta.RESTMapper) (*unstructured.Unstructured, bool) {
+	if mapper == nil {
+		return nil, false
+	}
+	if _, err := mapper.RESTMapping(trustBundleGVK.GroupKind(), trustBundleGVK.Version); err != nil {
+		if !meta.IsNoMatchError(err) {
+			logf.Log.Error(err, "failed to resolve trust-manager Bundle REST mapping; skipping watch registration")
+		}
+		return nil, false
+	}
+	bundle := &unstructured.Unstructured{}
+	bundle.SetGroupVersionKind(trustBundleGVK)
+	return bundle, true
 }
 
 // ensureRegistryCredentials keeps Zot htpasswd credentials and the client dockerconfig

--- a/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
+++ b/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
@@ -678,9 +678,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, unrelated)).To(Succeed())
-			DeferCleanup(func(cleanupCtx context.Context) {
-				_ = k8sClient.Delete(cleanupCtx, unrelated)
-			})
+			DeferCleanup(testutil.DeleteAndWait, k8sClient, unrelated)
 
 			By("modifying the unrelated Bundle")
 			Eventually(func(g Gomega) {
@@ -741,7 +739,19 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 	})
 
 	Context("Controller Setup without trust-manager CRD", func() {
-		It("successfully configures controller without panic or error", func() {
+		It("successfully configures controller without Bundle watch when CRD is absent", func() {
+			// Use a REST mapper that has no registered GVKs.
+			// This simulates a cluster where the trust-manager CRD is not installed,
+			// so trustBundleWatchObjectIfInstalled must return (nil, false) and
+			// SetupWithManager must succeed without registering the Bundle Owns() watch.
+			emptyMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{})
+			bundle, ok := trustBundleWatchObjectIfInstalled(emptyMapper)
+			Expect(ok).To(BeFalse(), "emptyMapper should not find the Bundle GVK")
+			Expect(bundle).To(BeNil())
+
+			// Verify the manager wiring path via testutil.NewTestManager (connected to
+			// the shared testEnv, which does have the CRD), but drive the CRD-absent
+			// discovery through the empty mapper directly to confirm no panic/error.
 			mgr := testutil.NewTestManager(testEnv)
 			reconciler := &KonfluxInternalRegistryReconciler{
 				Client:      mgr.GetClient(),

--- a/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
+++ b/operator/internal/controller/internalregistry/konfluxinternalregistry_controller_test.go
@@ -25,10 +25,13 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	konfluxv1alpha1 "github.com/konflux-ci/konflux-ci/operator/api/v1alpha1"
 	"github.com/konflux-ci/konflux-ci/operator/internal/condition"
@@ -38,6 +41,13 @@ import (
 )
 
 const internalRegistryNamespace = "kind-registry"
+
+func internalRegistryClusterScopedChildren() []client.Object {
+	bundle := &unstructured.Unstructured{}
+	bundle.SetGroupVersionKind(trustBundleGVK)
+	bundle.SetName("trusted-ca")
+	return []client.Object{bundle}
+}
 
 var _ = Describe("KonfluxInternalRegistry Controller", func() {
 	Context("When reconciling a resource", Ordered, func() {
@@ -59,6 +69,9 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 
 		AfterAll(func() {
 			testutil.DeleteAndWait(ctx, k8sClient, &konfluxv1alpha1.KonfluxInternalRegistry{ObjectMeta: metav1.ObjectMeta{Name: CRName}})
+			for _, child := range internalRegistryClusterScopedChildren() {
+				testutil.DeleteAndWait(ctx, k8sClient, child)
+			}
 		})
 
 		It("should successfully reconcile the resource", func() {
@@ -93,6 +106,35 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 			}
 			Expect(found).To(BeTrue(), "Owner reference should be set")
 		})
+
+		It("should create trust-manager Bundle with ownership and labels", func() {
+			bundle := &unstructured.Unstructured{}
+			bundle.SetGroupVersionKind(trustBundleGVK)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "trusted-ca"}, bundle)).To(Succeed())
+
+			labels := bundle.GetLabels()
+			Expect(labels).NotTo(BeNil())
+			Expect(labels[constant.KonfluxOwnerLabel]).To(Equal(CRName))
+			Expect(labels[constant.KonfluxComponentLabel]).To(Equal("registry"))
+
+			ownerRefs := bundle.GetOwnerReferences()
+			Expect(ownerRefs).NotTo(BeEmpty())
+			found := false
+			for _, ref := range ownerRefs {
+				if ref.Name == CRName && ref.Kind == "KonfluxInternalRegistry" {
+					found = true
+					Expect(ref.Controller).NotTo(BeNil())
+					Expect(*ref.Controller).To(BeTrue())
+					break
+				}
+			}
+			Expect(found).To(BeTrue(), "Owner reference should be set on Bundle")
+
+			targetKey, found, err := unstructured.NestedString(bundle.Object, "spec", "target", "configMap", "key")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(targetKey).To(Equal("ca-bundle.crt"))
+		})
 	})
 
 	Context("Self-healing", func() {
@@ -101,7 +143,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry, internalRegistryClusterScopedChildren()...)
 
 			deploymentNN := types.NamespacedName{
 				Name:      "registry",
@@ -134,7 +176,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry, internalRegistryClusterScopedChildren()...)
 
 			cmNN := types.NamespacedName{
 				Name:      "zot-config",
@@ -164,7 +206,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry, internalRegistryClusterScopedChildren()...)
 
 			svcNN := types.NamespacedName{
 				Name:      "registry-service",
@@ -194,7 +236,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry, internalRegistryClusterScopedChildren()...)
 
 			secretNN := types.NamespacedName{
 				Name:      HtpasswdSecretName,
@@ -224,7 +266,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry, internalRegistryClusterScopedChildren()...)
 
 			certNN := types.NamespacedName{
 				Name:      "registry-cert",
@@ -257,7 +299,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry, internalRegistryClusterScopedChildren()...)
 
 			deploymentNN := types.NamespacedName{
 				Name:      "registry",
@@ -300,7 +342,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry, internalRegistryClusterScopedChildren()...)
 
 			cmNN := types.NamespacedName{
 				Name:      "zot-config",
@@ -337,7 +379,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry, internalRegistryClusterScopedChildren()...)
 
 			svcNN := types.NamespacedName{
 				Name:      "registry-service",
@@ -376,7 +418,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry, internalRegistryClusterScopedChildren()...)
 
 			certNN := types.NamespacedName{
 				Name:      "registry-cert",
@@ -413,7 +455,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry, internalRegistryClusterScopedChildren()...)
 
 			secretNN := types.NamespacedName{
 				Name:      HtpasswdSecretName,
@@ -452,7 +494,7 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: CRName},
 			}
 			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
-			DeferCleanup(testutil.DeleteAndWait, k8sClient, registry)
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry, internalRegistryClusterScopedChildren()...)
 
 			nsNN := types.NamespacedName{
 				Name: internalRegistryNamespace,
@@ -482,6 +524,232 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 				g.Expect(ns.Labels).To(HaveKey(constant.KonfluxComponentLabel))
 			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
 		})
+
+		It("recreates trust-manager Bundle when deleted", func(ctx context.Context) {
+			registry := &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry, internalRegistryClusterScopedChildren()...)
+
+			bundleNN := types.NamespacedName{Name: "trusted-ca"}
+
+			By("waiting for initial Bundle creation")
+			Eventually(func(g Gomega) {
+				bundle := &unstructured.Unstructured{}
+				bundle.SetGroupVersionKind(trustBundleGVK)
+				g.Expect(k8sClient.Get(ctx, bundleNN, bundle)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the Bundle")
+			bundleToDelete := &unstructured.Unstructured{}
+			bundleToDelete.SetGroupVersionKind(trustBundleGVK)
+			bundleToDelete.SetName(bundleNN.Name)
+			Expect(k8sClient.Delete(ctx, bundleToDelete)).To(Succeed())
+
+			By("verifying the Bundle is recreated with correct spec and ownership")
+			Eventually(func(g Gomega) {
+				bundle := &unstructured.Unstructured{}
+				bundle.SetGroupVersionKind(trustBundleGVK)
+				g.Expect(k8sClient.Get(ctx, bundleNN, bundle)).To(Succeed())
+				g.Expect(bundle.GetLabels()).To(HaveKeyWithValue(constant.KonfluxOwnerLabel, CRName))
+				g.Expect(bundle.GetLabels()).To(HaveKeyWithValue(constant.KonfluxComponentLabel, "registry"))
+				targetKey, found, err := unstructured.NestedString(bundle.Object, "spec", "target", "configMap", "key")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(targetKey).To(Equal("ca-bundle.crt"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores trust-manager Bundle spec when modified", func(ctx context.Context) {
+			registry := &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry, internalRegistryClusterScopedChildren()...)
+
+			bundleNN := types.NamespacedName{Name: "trusted-ca"}
+
+			By("waiting for initial Bundle creation")
+			Eventually(func(g Gomega) {
+				bundle := &unstructured.Unstructured{}
+				bundle.SetGroupVersionKind(trustBundleGVK)
+				g.Expect(k8sClient.Get(ctx, bundleNN, bundle)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("modifying the Bundle spec")
+			Eventually(func(g Gomega) {
+				bundle := &unstructured.Unstructured{}
+				bundle.SetGroupVersionKind(trustBundleGVK)
+				g.Expect(k8sClient.Get(ctx, bundleNN, bundle)).To(Succeed())
+				err := unstructured.SetNestedField(bundle.Object, "tampered-ca-bundle.crt", "spec", "target", "configMap", "key")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(k8sClient.Update(ctx, bundle)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Bundle spec is restored to ca-bundle.crt")
+			Eventually(func(g Gomega) {
+				bundle := &unstructured.Unstructured{}
+				bundle.SetGroupVersionKind(trustBundleGVK)
+				g.Expect(k8sClient.Get(ctx, bundleNN, bundle)).To(Succeed())
+				targetKey, found, err := unstructured.NestedString(bundle.Object, "spec", "target", "configMap", "key")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(targetKey).To(Equal("ca-bundle.crt"))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+
+		It("restores trust-manager Bundle labels when stripped", func(ctx context.Context) {
+			registry := &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry, internalRegistryClusterScopedChildren()...)
+
+			bundleNN := types.NamespacedName{Name: "trusted-ca"}
+
+			By("waiting for initial Bundle creation with ownership labels")
+			Eventually(func(g Gomega) {
+				bundle := &unstructured.Unstructured{}
+				bundle.SetGroupVersionKind(trustBundleGVK)
+				g.Expect(k8sClient.Get(ctx, bundleNN, bundle)).To(Succeed())
+				g.Expect(bundle.GetLabels()).To(HaveKey(constant.KonfluxOwnerLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("stripping ownership labels from the Bundle")
+			Eventually(func(g Gomega) {
+				bundle := &unstructured.Unstructured{}
+				bundle.SetGroupVersionKind(trustBundleGVK)
+				g.Expect(k8sClient.Get(ctx, bundleNN, bundle)).To(Succeed())
+				delete(bundle.GetLabels(), constant.KonfluxOwnerLabel)
+				delete(bundle.GetLabels(), constant.KonfluxComponentLabel)
+				g.Expect(k8sClient.Update(ctx, bundle)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("verifying the Bundle labels are restored")
+			Eventually(func(g Gomega) {
+				bundle := &unstructured.Unstructured{}
+				bundle.SetGroupVersionKind(trustBundleGVK)
+				g.Expect(k8sClient.Get(ctx, bundleNN, bundle)).To(Succeed())
+				g.Expect(bundle.GetLabels()).To(HaveKey(constant.KonfluxOwnerLabel))
+				g.Expect(bundle.GetLabels()).To(HaveKey(constant.KonfluxComponentLabel))
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+		})
+	})
+
+	Context("Watch Association Filtering", func() {
+		It("does not affect KonfluxInternalRegistry when an unrelated Bundle is mutated or deleted", func(ctx context.Context) {
+			registry := &konfluxv1alpha1.KonfluxInternalRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: CRName},
+			}
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			testutil.DeferCleanupParentAndChildren(k8sClient, registry, internalRegistryClusterScopedChildren()...)
+
+			By("waiting for initial reconciliation to finish")
+			var initialRV string
+			Eventually(func(g Gomega) {
+				reg := &konfluxv1alpha1.KonfluxInternalRegistry{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, reg)).To(Succeed())
+				readyCond := meta.FindStatusCondition(reg.Status.Conditions, condition.TypeReady)
+				g.Expect(readyCond).NotTo(BeNil())
+				initialRV = reg.ResourceVersion
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("creating an unrelated Bundle without Konflux ownership")
+			unrelated := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "trust.cert-manager.io/v1alpha1",
+					"kind":       "Bundle",
+					"metadata": map[string]interface{}{
+						"name": "unrelated-custom-bundle",
+					},
+					"spec": map[string]interface{}{
+						"sources": []interface{}{
+							map[string]interface{}{
+								"useDefaultCAs": true,
+							},
+						},
+						"target": map[string]interface{}{
+							"configMap": map[string]interface{}{
+								"key": "custom.crt",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, unrelated)).To(Succeed())
+			DeferCleanup(func(cleanupCtx context.Context) {
+				_ = k8sClient.Delete(cleanupCtx, unrelated)
+			})
+
+			By("modifying the unrelated Bundle")
+			Eventually(func(g Gomega) {
+				u := &unstructured.Unstructured{}
+				u.SetGroupVersionKind(trustBundleGVK)
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "unrelated-custom-bundle"}, u)).To(Succeed())
+				err := unstructured.SetNestedField(u.Object, "modified.crt", "spec", "target", "configMap", "key")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(k8sClient.Update(ctx, u)).To(Succeed())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			By("deleting the unrelated Bundle")
+			Expect(k8sClient.Delete(ctx, unrelated)).To(Succeed())
+
+			By("confirming the unrelated Bundle was deleted and KonfluxInternalRegistry was not reconciled")
+			Eventually(func(g Gomega) {
+				u := &unstructured.Unstructured{}
+				u.SetGroupVersionKind(trustBundleGVK)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "unrelated-custom-bundle"}, u)
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).WithTimeout(testutil.EventuallyTimeout).WithPolling(testutil.EventuallyPolling).Should(Succeed())
+
+			Consistently(func(g Gomega) {
+				reg := &konfluxv1alpha1.KonfluxInternalRegistry{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: CRName}, reg)).To(Succeed())
+				g.Expect(reg.ResourceVersion).To(Equal(initialRV), "unrelated Bundle lifecycle events must not trigger KonfluxInternalRegistry reconciliation")
+			}, "2s", "250ms").Should(Succeed())
+		})
+	})
+
+	Context("trustBundleWatchObjectIfInstalled helper function", func() {
+		It("should return unstructured Bundle object when CRD is available in RESTMapper", func() {
+			bundle, ok := trustBundleWatchObjectIfInstalled(k8sClient.RESTMapper())
+			Expect(ok).To(BeTrue())
+			Expect(bundle).NotTo(BeNil())
+			Expect(bundle.GroupVersionKind()).To(Equal(trustBundleGVK))
+		})
+
+		It("should return false when RESTMapper is nil", func() {
+			bundle, ok := trustBundleWatchObjectIfInstalled(nil)
+			Expect(ok).To(BeFalse())
+			Expect(bundle).To(BeNil())
+		})
+
+		It("should return false when GVK is not in RESTMapper", func() {
+			emptyMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{})
+			bundle, ok := trustBundleWatchObjectIfInstalled(emptyMapper)
+			Expect(ok).To(BeFalse())
+			Expect(bundle).To(BeNil())
+		})
+
+		It("should return false when RESTMapper returns a non-NoMatch error", func() {
+			errMapper := errRESTMapper{err: fmt.Errorf("discovery client connection refused")}
+			bundle, ok := trustBundleWatchObjectIfInstalled(errMapper)
+			Expect(ok).To(BeFalse())
+			Expect(bundle).To(BeNil())
+		})
+	})
+
+	Context("Controller Setup without trust-manager CRD", func() {
+		It("successfully configures controller without panic or error", func() {
+			mgr := testutil.NewTestManager(testEnv)
+			reconciler := &KonfluxInternalRegistryReconciler{
+				Client:      mgr.GetClient(),
+				Scheme:      mgr.GetScheme(),
+				ObjectStore: objectStore,
+			}
+			Expect(reconciler.SetupWithManager(mgr)).To(Succeed())
+		})
 	})
 
 	Context("tracking.IsNoKindMatchError helper function", func() {
@@ -509,3 +777,30 @@ var _ = Describe("KonfluxInternalRegistry Controller", func() {
 		})
 	})
 })
+
+// errRESTMapper returns a fixed RESTMapping error for trustBundleWatchObjectIfInstalled testing.
+type errRESTMapper struct {
+	err error
+}
+
+func (m errRESTMapper) KindFor(_ schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, m.err
+}
+func (m errRESTMapper) KindsFor(_ schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, m.err
+}
+func (m errRESTMapper) ResourceFor(_ schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, m.err
+}
+func (m errRESTMapper) ResourcesFor(_ schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, m.err
+}
+func (m errRESTMapper) RESTMapping(_ schema.GroupKind, _ ...string) (*meta.RESTMapping, error) {
+	return nil, m.err
+}
+func (m errRESTMapper) RESTMappings(_ schema.GroupKind, _ ...string) ([]*meta.RESTMapping, error) {
+	return nil, m.err
+}
+func (m errRESTMapper) ResourceSingularizer(_ string) (string, error) {
+	return "", m.err
+}

--- a/operator/internal/controller/testutil/testutil.go
+++ b/operator/internal/controller/testutil/testutil.go
@@ -83,7 +83,7 @@ var (
 // (e.g., "..", "..", ".." for internal/controller/buildservice/).
 //
 // Vendored envtest CRDs:
-//   - cert-manager, prometheus: .github/scripts/update-third-party-manifests.sh
+//   - cert-manager, trust-manager, prometheus: .github/scripts/update-third-party-manifests.sh
 //   - enterprise-contract, release: rebuild-upstream-manifests.sh / verify-manifests-in-sync.sh
 //   - openshift: .github/scripts/update-openshift-test-crds.sh (pinned github.com/openshift/api)
 func SetupTestEnv(basePath string) *TestEnv {
@@ -118,6 +118,7 @@ func SetupTestEnv(basePath string) *TestEnv {
 		CRDDirectoryPaths: []string{
 			filepath.Join(basePath, "config", "crd", "bases"),
 			filepath.Join(basePath, "test", "crds", "cert-manager"),
+			filepath.Join(basePath, "test", "crds", "trust-manager"),
 			filepath.Join(basePath, "test", "crds", "prometheus"),
 			filepath.Join(basePath, "test", "crds", "enterprise-contract"),
 			filepath.Join(basePath, "test", "crds", "release"),

--- a/operator/test/crds/trust-manager/trust-manager.crds.yaml
+++ b/operator/test/crds/trust-manager/trust-manager.crds.yaml
@@ -1,0 +1,515 @@
+# Source: trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: "bundles.trust.cert-manager.io"
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.24.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.24.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  group: trust.cert-manager.io
+  names:
+    kind: Bundle
+    listKind: BundleList
+    plural: bundles
+    singular: bundle
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Bundle ConfigMap Target Key
+          jsonPath: .spec.target.configMap.key
+          name: ConfigMap Target
+          type: string
+        - description: Bundle Secret Target Key
+          jsonPath: .spec.target.secret.key
+          name: Secret Target
+          type: string
+        - description: Bundle has been synced
+          jsonPath: .status.conditions[?(@.type == "Synced")].status
+          name: Synced
+          type: string
+        - description: Reason Bundle has Synced status
+          jsonPath: .status.conditions[?(@.type == "Synced")].reason
+          name: Reason
+          type: string
+        - description: Timestamp Bundle was created
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec represents the desired state of the Bundle resource.
+              properties:
+                sources:
+                  description: sources is a set of references to data whose data will sync to the target.
+                  items:
+                    description: |-
+                      BundleSource is the set of sources whose data will be appended and synced to
+                      the BundleTarget in all Namespaces.
+                    properties:
+                      configMap:
+                        description: |-
+                          configMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
+                          list of ConfigMap's `data` key(s) using label selector, in the trust namespace.
+                        properties:
+                          includeAllKeys:
+                            description: |-
+                              includeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                              This field must not be true when `key` is set.
+                            type: boolean
+                          key:
+                            description: key of the entry in the object's `data` field to be used.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              name is the name of the source object in the trust namespace.
+                              This field must be left empty when `selector` is set
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          selector:
+                            description: |-
+                              selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `name` is set.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                        x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                          - message: exactly one of the fields in [name selector] must be set
+                            rule: '[has(self.name),has(self.selector)].filter(x,x==true).size() == 1'
+                      inLine:
+                        description: inLine is a simple string to append as the source data.
+                        maxLength: 1048576
+                        minLength: 1
+                        type: string
+                      secret:
+                        description: |-
+                          secret is a reference (by name) to a Secret's `data` key(s), or to a
+                          list of Secret's `data` key(s) using label selector, in the trust namespace.
+                        properties:
+                          includeAllKeys:
+                            description: |-
+                              includeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                              This field must not be true when `key` is set.
+                            type: boolean
+                          key:
+                            description: key of the entry in the object's `data` field to be used.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              name is the name of the source object in the trust namespace.
+                              This field must be left empty when `selector` is set
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          selector:
+                            description: |-
+                              selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `name` is set.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                        x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                          - message: exactly one of the fields in [name selector] must be set
+                            rule: '[has(self.name),has(self.selector)].filter(x,x==true).size() == 1'
+                      useDefaultCAs:
+                        description: |-
+                          useDefaultCAs indicates whether the default CA bundle should be used as a source.
+                          The default CA bundle is available only if trust-manager was installed with
+                          default CA support enabled, either via the Helm chart or by starting the
+                          trust-manager controller with the "--default-package-location" flag.
+                          If default CA support was not enabled at startup, setting this field to true
+                          will result in reconciliation failure.
+                          The version of the default CA package used for this Bundle is reported in
+                          status.defaultCAVersion.
+                        type: boolean
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                      - message: exactly one of the fields in [configMap secret inLine useDefaultCAs] must be set
+                        rule: '[has(self.configMap),has(self.secret),has(self.inLine),has(self.useDefaultCAs)].filter(x,x==true).size() == 1'
+                  maxItems: 100
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: atomic
+                target:
+                  description: target is the target location in all namespaces to sync source data to.
+                  properties:
+                    additionalFormats:
+                      description: additionalFormats specifies any additional formats to write to the target
+                      properties:
+                        jks:
+                          description: |-
+                            jks requests a JKS-formatted binary trust bundle to be written to the target.
+                            The bundle has "changeit" as the default password.
+                            For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+                            Format is deprecated: Writing JKS is subject for removal. Please migrate to PKCS12.
+                            PKCS#12 trust stores created by trust-manager are compatible with Java.
+                          minProperties: 1
+                          properties:
+                            key:
+                              description: key is the key of the entry in the object's `data` field to be used.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            password:
+                              default: changeit
+                              description: password for JKS trust store
+                              maxLength: 128
+                              minLength: 1
+                              type: string
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        pkcs12:
+                          description: |-
+                            pkcs12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+
+                            The bundle is by default created without a password.
+                            For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+                          minProperties: 1
+                          properties:
+                            key:
+                              description: key is the key of the entry in the object's `data` field to be used.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            password:
+                              default: ""
+                              description: password for PKCS12 trust store
+                              maxLength: 128
+                              minLength: 0
+                              type: string
+                            profile:
+                              description: |-
+                                profile specifies the certificate encryption algorithms and the HMAC algorithm
+                                used to create the PKCS12 trust store.
+
+                                If provided, allowed values are:
+                                `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+                                `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+                                `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms (e.g. because of company policy).
+
+                                Default value is `LegacyRC2` for backward compatibility.
+                              enum:
+                                - LegacyRC2
+                                - LegacyDES
+                                - Modern2023
+                              type: string
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                      x-kubernetes-validations:
+                        - message: at least one of the fields in [jks pkcs12] must be set
+                          rule: '[has(self.jks),has(self.pkcs12)].filter(x,x==true).size() >= 1'
+                    configMap:
+                      description: |-
+                        configMap is the target ConfigMap in Namespaces that all Bundle source
+                        data will be synced to.
+                      properties:
+                        key:
+                          description: key is the key of the entry in the object's `data` field to be used.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        metadata:
+                          description: metadata is an optional set of labels and annotations to be copied to the target.
+                          minProperties: 1
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: annotations is a key value map to be copied to the target.
+                              minProperties: 1
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: labels is a key value map to be copied to the target.
+                              minProperties: 1
+                              type: object
+                          type: object
+                      required:
+                        - key
+                      type: object
+                    namespaceSelector:
+                      description: |-
+                        namespaceSelector will, if set, only sync the target resource in
+                        Namespaces which match the selector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    secret:
+                      description: |-
+                        secret is the target Secret that all Bundle source data will be synced to.
+                        Using Secrets as targets is only supported if enabled at trust-manager startup.
+                        By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+                      properties:
+                        key:
+                          description: key is the key of the entry in the object's `data` field to be used.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        metadata:
+                          description: metadata is an optional set of labels and annotations to be copied to the target.
+                          minProperties: 1
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: annotations is a key value map to be copied to the target.
+                              minProperties: 1
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: labels is a key value map to be copied to the target.
+                              minProperties: 1
+                              type: object
+                          type: object
+                      required:
+                        - key
+                      type: object
+                  type: object
+                  x-kubernetes-validations:
+                    - message: at least one of the fields in [configMap secret] must be set
+                      rule: '[has(self.configMap),has(self.secret)].filter(x,x==true).size() >= 1'
+              required:
+                - sources
+              type: object
+            status:
+              description: status of the Bundle. This is set and managed automatically.
+              minProperties: 1
+              properties:
+                conditions:
+                  description: conditions represent the latest available observations of the Bundle's current state.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 10
+                  minItems: 0
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                defaultCAVersion:
+                  description: |-
+                    defaultCAVersion is the version of the default CA package used when resolving
+                    the default CA source(s) for this Bundle (for example, when any source has
+                    useDefaultCAs set to true), if applicable.
+                    Bundles resolved from identical sets of default CA certificates will report
+                    the same defaultCAVersion value.
+                  maxLength: 253
+                  minLength: 1
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}


### PR DESCRIPTION
## What does this PR do?

Adds reconciliation for the trust-manager `Bundle` managed by the `KonfluxInternalRegistry` controller.

The controller already applies the `trusted-ca` Bundle as part of the internal registry resources, but changes or deletion of the Bundle did not trigger reconciliation because the controller could not directly import the trust-manager Go API due to dependency/version compatibility constraints.

This change adds a dynamic `unstructured.Unstructured` watch for the `trust.cert-manager.io/v1alpha1` `Bundle` resource without introducing a new Go dependency.

## Why is this needed?

Without a Bundle watch, out-of-band changes such as:

* deletion of the managed Bundle;
* modification of its specification; or
* removal of its Konflux ownership labels

could leave the resource in a drifted or missing state until another event caused the `KonfluxInternalRegistry` to reconcile.

The controller now observes changes to the managed Bundle and restores the desired state.

## What changed?

* Added dynamic discovery and watch registration for the trust-manager `Bundle` GVK.
* Register the watch only when the Bundle resource is available in the cluster.
* Ignore status-only Bundle updates.
* Use controller ownership to ensure unrelated Bundles do not trigger reconciliation.
* Added envtest support for the trust-manager Bundle CRD.
* Updated third-party manifest extraction and verification scripts to keep the CRD synchronized.
* Added regression coverage for Bundle creation, deletion/recreation, spec drift, label drift, ownership filtering, and missing-CRD behavior.

## Testing

The following checks were run:

* `go test -v -count=1 ./operator/internal/controller/internalregistry/...`
* `go vet ./...`
* `git diff main...HEAD --check`

The internal registry controller test suite passes, including the new Bundle reconciliation tests.

## Notes

No new Go dependencies were introduced.

The implementation uses the existing dynamic CRD watch approach used elsewhere in the operator to avoid the trust-manager dependency compatibility issue.
