### PR TITLE
fix(ci): allow test/go-tests go.mod in manifest companion allowlist

### DIFF
--- a/.github/workflows/renovate-manifest-companion.yaml
+++ b/.github/workflows/renovate-manifest-companion.yaml
@@ -76,11 +76,14 @@ jobs:
               .github/scripts/export-third-party-chart-env.sh) ;;
               operator/go.mod) ;;
               operator/go.sum) ;;
+              # MintMaker/Renovate often bumps shared deps in test/go-tests/go.mod too.
+              test/go-tests/go.mod) ;;
+              test/go-tests/go.sum) ;;
               *) disallowed+=("$file") ;;
             esac
           done
           if ((${#disallowed[@]})); then
-            echo "::error::Refusing to run: PR changes files outside the manifest companion allowlist (operator/upstream-kustomizations/*, dependencies/registry/*, .github/scripts/export-third-party-chart-env.sh, operator/go.mod, operator/go.sum)."
+            echo "::error::Refusing to run: PR changes files outside the manifest companion allowlist (operator/upstream-kustomizations/*, dependencies/registry/kustomization.yml, .github/scripts/export-third-party-chart-env.sh, operator/go.mod, operator/go.sum, test/go-tests/go.mod, test/go-tests/go.sum)."
             printf '%s\n' "${disallowed[@]}" | sed 's/^/  - /' >&2
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,12 +158,17 @@ pinned `github.com/openshift/api` module by
 `.github/scripts/update-openshift-test-crds.sh`; CI verifies these stay in
 sync when `operator/go.mod` changes.
 
-When **MintMaker** or **Renovate** opens a PR that only bumps digests or chart
-versions, a **companion PR** may be opened automatically
+When **MintMaker** or **Renovate** opens a PR that only bumps pins in the
+companion allowlist, a **companion PR** may be opened automatically
 (`.github/workflows/renovate-manifest-companion.yaml`) that includes the matching
-rendered output. **Prefer merging the companion PR** (or a single PR that
-includes both pins and regenerated files) so `main` never carries mismatched
-pins and manifests.
+rendered output. Triggers include upstream kustomization digests,
+`.github/scripts/export-third-party-chart-env.sh`, and `operator/go.mod` /
+`operator/go.sum` (for OpenShift envtest CRDs derived from
+`github.com/openshift/api`). The workflow also permits `test/go-tests/go.mod` and
+`test/go-tests/go.sum` in the same PR when Renovate bumps a shared dependency in
+both Go modules; those files do not affect manifest regeneration. **Prefer merging
+the companion PR** (or a single PR that includes both pins and regenerated files)
+so `main` never carries mismatched pins and manifests.
 
 When verify fails on a **pull request**, CI cancels in-progress or queued
 **Operator E2E Tests** runs for the same commit (with retries, so runs queued

--- a/skills/companion-pr-review/SKILL.md
+++ b/skills/companion-pr-review/SKILL.md
@@ -10,9 +10,10 @@ description: >-
 
 ## Overview
 
-When MintMaker/Renovate bumps pins under `operator/upstream-kustomizations/`
-or `.github/scripts/export-third-party-chart-env.sh`, a **parent PR** opens
-with pin-only changes. A separate workflow
+When MintMaker/Renovate bumps pins under `operator/upstream-kustomizations/`,
+`.github/scripts/export-third-party-chart-env.sh`, or shared dependencies in
+`operator/go.mod` / `operator/go.sum`, a **parent PR** opens with pin-only
+changes. A separate workflow
 (`.github/workflows/renovate-manifest-companion.yaml`) asynchronously opens a
 **companion PR** that adds regenerated manifests.
 
@@ -43,6 +44,10 @@ Skip review and retro when **both**:
    - `operator/upstream-kustomizations/**`
    - `.github/scripts/export-third-party-chart-env.sh`
    - `dependencies/registry/kustomization.yml` (registry digest bumps only)
+   - `operator/go.mod` / `operator/go.sum` (OpenShift envtest CRDs from
+     `github.com/openshift/api`)
+   - `test/go-tests/go.mod` / `test/go-tests/go.sum` (sidecar when Renovate
+     bumps a shared dependency in both Go modules)
 
 Apply this **even before** `deps-only` / `superseded-by-companion` labels land.
 Do not run full review, do not approve, do not add `ready-for-merge`.
@@ -54,8 +59,7 @@ the table above instead.
 
 **Not companion-eligible** (review normally):
 
-- Changes to `test/go-tests/go.mod`, `operator/docs/go.mod`, `operator/go.mod`
-- Non-allowlist paths
+- Changes to `operator/docs/go.mod` or other non-allowlist paths
 - Human-authored PRs touching upstream kustomizations
 
 ## Check companion workflow state before commenting


### PR DESCRIPTION
## Summary

- Expand the manifest companion PR diff allowlist to include `test/go-tests/go.mod` and `test/go-tests/go.sum`, which Renovate often updates alongside `operator/go.mod` for shared dependencies
- Document the full companion trigger paths and allowlist in `CONTRIBUTING.md` and `skills/companion-pr-review/SKILL.md`

Fixes false failures on dependency bot PRs (e.g. controller-runtime, golang.org/x/crypto) where the companion workflow triggered on `operator/go.mod` changes but refused to run because the test module was also bumped.

## Test plan

- [ ] Re-run the **Renovate manifest companion PR** workflow on a failing MintMaker PR (e.g. #9072) and confirm the allowlist step passes
- [ ] Confirm companion run completes (noop or opens companion PR as appropriate)

---
Yftach's Cursor

Made with [Cursor](https://cursor.com)