### PR TITLE
fix(KONFLUX-15487): remove dead impersonate and LSAR from manager-role

### DIFF
--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -27,13 +27,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - groups
-  - users
-  verbs:
-  - impersonate
-- apiGroups:
-  - ""
-  resources:
   - namespaces
   - serviceaccounts
   - services
@@ -116,12 +109,6 @@ rules:
   - list
   - patch
   - watch
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - localsubjectaccessreviews
-  verbs:
-  - create
 - apiGroups:
   - batch
   resources:

--- a/operator/internal/controller/ui/konfluxui_controller.go
+++ b/operator/internal/controller/ui/konfluxui_controller.go
@@ -170,8 +170,6 @@ type KonfluxUIReconciler struct {
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates;issuers,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=ingresses,verbs=get
 // +kubebuilder:rbac:groups=dex.coreos.com,resources=*,verbs=*
-// +kubebuilder:rbac:groups=core,resources=users;groups,verbs=impersonate
-// +kubebuilder:rbac:groups=authorization.k8s.io,resources=localsubjectaccessreviews,verbs=create
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Proxy SA keeps impersonate/LSAR via konflux-proxy; manager only needs escalate on that ClusterRole to apply it. Operator Tests exercise UI reconcile; Operator E2E and Tekton e2e proxy tests catch deploy or runtime proxy/auth regressions.

Assisted-by: Cursor