### PR TITLE
fix(KONFLUX-15487): scope webhook patch/delete to operator-managed names

### DIFF
--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -62,16 +62,53 @@ rules:
   - create
 - apiGroups:
   - admissionregistration.k8s.io
+  resourceNames:
+  - integration-service-mutating-webhook-configuration
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - delete
+  - get
+  - patch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - release-service-mutating-webhook-configuration
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - delete
+  - get
+  - patch
+- apiGroups:
+  - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
   - create
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - integration-service-validating-webhook-configuration
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
   - delete
   - get
-  - list
   - patch
-  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - release-service-validating-webhook-configuration
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - delete
+  - get
+  - patch
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
+++ b/operator/internal/controller/integrationservice/konfluxintegrationservice_controller.go
@@ -138,7 +138,9 @@ type KonfluxIntegrationServiceReconciler struct {
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates;issuers,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;patch
-// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;patch;delete
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,resourceNames=integration-service-mutating-webhook-configuration,verbs=get;patch;delete
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,resourceNames=integration-service-validating-webhook-configuration,verbs=get;patch;delete
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=create;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/operator/internal/controller/releaseservice/konfluxreleaseservice_controller.go
+++ b/operator/internal/controller/releaseservice/konfluxreleaseservice_controller.go
@@ -125,7 +125,9 @@ type KonfluxReleaseServiceReconciler struct {
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates;issuers,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=appstudio.redhat.com,resources=releaseserviceconfigs,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;patch
-// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;patch;delete
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,resourceNames=release-service-mutating-webhook-configuration,verbs=get;patch;delete
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,resourceNames=release-service-validating-webhook-configuration,verbs=get;patch;delete
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=create;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Split kubebuilder markers per controller: get/patch/delete with resourceNames for the four embedded webhook configs; create/list/watch unscoped for informer and initial install (Kubernetes RBAC limit).

Assisted-by: Cursor