### PR TITLE
chore(deps): tidy replace-linked modules on operator go.mod bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,6 +51,12 @@
       "matchDatasources": ["helm"],
       "matchPackageNames": ["scaffold"],
       "additionalBranchPrefix": "integrations/"
+    },
+    {
+      "description": "Propagate operator go.mod updates to test/go-tests via local replace",
+      "matchManagers": ["gomod"],
+      "matchPaths": ["operator/**"],
+      "postUpdateOptions": ["gomodTidyAll"]
     }
   ],
   "gomod": {


### PR DESCRIPTION
Enable Renovate gomodTidyAll for operator/** so MintMaker also updates test/go-tests when shared dependencies change via the local operator replace.

Assisted-by: Cursor