### PR TITLE
feat(KONFLUX-9075): generalize metrics scrape TLS secret selection

### DIFF
--- a/operator/internal/common/scrape_token.go
+++ b/operator/internal/common/scrape_token.go
@@ -59,6 +59,9 @@ type ScrapeTokenReconcilerConfig struct {
 	// updates (and SM presence) are visible without waiting on the informer cache.
 	// When nil, Client is used.
 	SecretReader client.Reader
+	// MetricsTLSSecretName is the operand TLS Secret verified before deferred ServiceMonitor
+	// apply. When empty, defaults to metrics-server-cert (controller operands).
+	MetricsTLSSecretName string
 }
 
 // DeferredSMApplyResult captures operand ServiceMonitor state from deferred apply without
@@ -115,16 +118,17 @@ func ReconcilePrometheusScrapeToken(ctx context.Context, cfg ScrapeTokenReconcil
 		return reconcile.Result{}, err
 	}
 	if wait != nil {
-		// Retain an existing SM for orphan cleanup unless the metrics-server-cert Secret
+		// Retain an existing SM for orphan cleanup unless the configured metrics TLS Secret
 		// is absent. When it is missing, skip retain so orphan cleanup drops the stale SM
 		// (whose tlsConfig.ca references the absent Secret); deferred apply recreates the
 		// SM once the Secret verifies again. For other not-ready reasons (empty, mismatch)
 		// the Secret object still exists and CA refs resolve, so retain is safe.
 		if tlsResult.Reason == kubernetes.MetricsTLSReasonCertMissing {
 			logf.FromContext(ctx).Info(
-				"skipping ServiceMonitor retain while metrics-server-cert is absent",
+				"skipping ServiceMonitor retain while metrics TLS secret is absent",
 				"namespace", cfg.OperandNamespace,
 				"servicemonitor", cfg.ServiceMonitorName,
+				"secret", kubernetes.ResolveMetricsTLSSecretName(cfg.MetricsTLSSecretName),
 			)
 		} else {
 			if retainErr := retainOperandServiceMonitorIfPresent(ctx, cfg); retainErr != nil {
@@ -181,9 +185,10 @@ func ensureMetricsTLSReadyForServiceMonitor(
 	cfg ScrapeTokenReconcilerConfig,
 ) (kubernetes.MetricsScrapeTLSResult, *reconcile.Result, error) {
 	tlsResult, err := kubernetes.ReconcileMetricsScrapeTLS(ctx, kubernetes.MetricsScrapeTLSInput{
-		Client:    cfg.Client,
-		Reader:    cfg.SecretReader,
-		Namespace: cfg.OperandNamespace,
+		Client:     cfg.Client,
+		Reader:     cfg.SecretReader,
+		Namespace:  cfg.OperandNamespace,
+		SecretName: cfg.MetricsTLSSecretName,
 	})
 	if err != nil {
 		return kubernetes.MetricsScrapeTLSResult{}, nil, fmt.Errorf("reconcile metrics scrape TLS: %w", err)

--- a/operator/internal/common/scrape_token_test.go
+++ b/operator/internal/common/scrape_token_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/konflux-ci/konflux-ci/operator/internal/constant"
 	"github.com/konflux-ci/konflux-ci/operator/pkg/kubernetes"
@@ -61,6 +63,37 @@ func (f *fakeTokenCreator) CreateScraperToken(
 	}
 	f.scraper = scraper
 	return f.token, f.expiresAt, nil
+}
+
+type logCapture struct {
+	infos []logRecord
+}
+
+type logRecord struct {
+	msg string
+	kv  []any
+}
+
+func (l *logCapture) Init(logr.RuntimeInfo) {}
+func (l *logCapture) Enabled(int) bool      { return true }
+func (l *logCapture) Info(_ int, msg string, kv ...any) {
+	l.infos = append(l.infos, logRecord{msg: msg, kv: kv})
+}
+func (l *logCapture) Error(_ error, msg string, kv ...any) {
+	l.infos = append(l.infos, logRecord{msg: msg, kv: kv})
+}
+func (l *logCapture) WithName(string) logr.LogSink   { return l }
+func (l *logCapture) WithValues(...any) logr.LogSink { return l }
+
+func logValue(kv []any, key string) string {
+	for i := 0; i+1 < len(kv); i += 2 {
+		if k, ok := kv[i].(string); ok && k == key {
+			if v, ok := kv[i+1].(string); ok {
+				return v
+			}
+		}
+	}
+	return ""
 }
 
 func metricsTLSObjects(t *testing.T) []client.Object {
@@ -1288,6 +1321,169 @@ func TestReconcilePrometheusScrapeToken_SkipsRetainWhenCertMissing(t *testing.T)
 	}
 	if result.RequeueAfter != kubernetes.DefaultMetricsTLSRequeue {
 		t.Fatalf("requeue: got %v want %v", result.RequeueAfter, kubernetes.DefaultMetricsTLSRequeue)
+	}
+}
+
+func TestReconcilePrometheusScrapeToken_UsesCustomMetricsTLSSecretName(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	const customSecret = "operand-tls"
+
+	caPEM, leafPEM, err := kubernetes.NewSelfSignedMetricsTLSMaterial()
+	if err != nil {
+		t.Fatalf("tls material: %v", err)
+	}
+	custom := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      customSecret,
+			Namespace: testBuildServiceNamespace,
+		},
+		Data: map[string][]byte{
+			kubernetes.MetricsCACertKey:            caPEM,
+			kubernetes.MetricsServerCertTLSCertKey: leafPEM,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithObjects(custom).Build()
+	smApplyCalls := 0
+	_, err = ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:               c,
+		Clock:                testclock.NewFakeClock(now),
+		TokenCreator:         &fakeTokenCreator{token: "tok", expiresAt: now.Add(time.Hour)},
+		Scraper:              kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace:     testBuildServiceNamespace,
+		ServiceMonitorName:   testBuildServiceNamespace,
+		MetricsTLSSecretName: customSecret,
+		Apply: func(applyCtx context.Context, secret *corev1.Secret) error {
+			return c.Create(applyCtx, secret)
+		},
+		ApplyServiceMonitor: func(context.Context) error {
+			smApplyCalls++
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if smApplyCalls != 1 {
+		t.Fatalf("ApplyServiceMonitor calls: got %d want 1 when custom TLS secret is ready", smApplyCalls)
+	}
+
+	// Default metrics-server-cert name must not satisfy TLS when only the operand Secret exists.
+	c = fake.NewClientBuilder().WithObjects(custom).Build()
+	_, err = ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:             c,
+		Clock:              testclock.NewFakeClock(now),
+		TokenCreator:       &fakeTokenCreator{token: "tok", expiresAt: now.Add(time.Hour)},
+		Scraper:            kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace:   testBuildServiceNamespace,
+		ServiceMonitorName: testBuildServiceNamespace,
+		Apply: func(applyCtx context.Context, secret *corev1.Secret) error {
+			return c.Create(applyCtx, secret)
+		},
+		ApplyServiceMonitor: func(context.Context) error {
+			t.Fatal("ServiceMonitor apply must not run while default metrics TLS secret is missing")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("reconcile without custom secret name: %v", err)
+	}
+}
+
+func TestReconcilePrometheusScrapeToken_DoesNotFallBackToDefaultCertWhenCustomNameSet(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	const customSecret = "operand-tls"
+
+	sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	sm.SetGroupVersionKind(operandServiceMonitorGVK)
+	sm.SetNamespace(testBuildServiceNamespace)
+	sm.SetName(testBuildServiceNamespace)
+
+	// metrics-server-cert is present but the configured operand TLS Secret is missing.
+	c := clientWithMetricsTLS(t, sm)
+	smApplyCalls := 0
+	result, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:               c,
+		Clock:                testclock.NewFakeClock(now),
+		TokenCreator:         &fakeTokenCreator{token: "tok", expiresAt: now.Add(time.Hour)},
+		Scraper:              kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace:     testBuildServiceNamespace,
+		ServiceMonitorName:   testBuildServiceNamespace,
+		MetricsTLSSecretName: customSecret,
+		Apply: func(applyCtx context.Context, secret *corev1.Secret) error {
+			return c.Create(applyCtx, secret)
+		},
+		ApplyServiceMonitor: func(context.Context) error {
+			smApplyCalls++
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if smApplyCalls != 0 {
+		t.Fatalf(
+			"ApplyServiceMonitor calls: got %d want 0 when custom TLS secret is missing despite default cert",
+			smApplyCalls,
+		)
+	}
+	if result.RequeueAfter != kubernetes.DefaultMetricsTLSRequeue {
+		t.Fatalf("requeue: got %v want %v", result.RequeueAfter, kubernetes.DefaultMetricsTLSRequeue)
+	}
+}
+
+func TestReconcilePrometheusScrapeToken_SkipRetainLogUsesConfiguredSecretName(t *testing.T) {
+	const customSecret = "operand-tls"
+	capture := &logCapture{}
+	ctx := logf.IntoContext(context.Background(), logr.New(capture))
+	now := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+
+	sm := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	sm.SetGroupVersionKind(operandServiceMonitorGVK)
+	sm.SetNamespace(testBuildServiceNamespace)
+	sm.SetName(testBuildServiceNamespace)
+
+	c := fake.NewClientBuilder().WithObjects(sm).Build()
+	_, err := ReconcilePrometheusScrapeToken(ctx, ScrapeTokenReconcilerConfig{
+		Client:               c,
+		Clock:                testclock.NewFakeClock(now),
+		TokenCreator:         &fakeTokenCreator{token: "tok", expiresAt: now.Add(time.Hour)},
+		Scraper:              kubernetes.OperandMetricsScraperSA(testBuildServiceNamespace),
+		OperandNamespace:     testBuildServiceNamespace,
+		ServiceMonitorName:   testBuildServiceNamespace,
+		MetricsTLSSecretName: customSecret,
+		Apply: func(applyCtx context.Context, secret *corev1.Secret) error {
+			return c.Create(applyCtx, secret)
+		},
+		ApplyServiceMonitor: func(context.Context) error {
+			t.Fatal("retain must be skipped when custom TLS secret is absent")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	var skipLog *logRecord
+	for i := range capture.infos {
+		if strings.Contains(capture.infos[i].msg, "skipping ServiceMonitor retain") {
+			skipLog = &capture.infos[i]
+			break
+		}
+	}
+	if skipLog == nil {
+		t.Fatal("expected skip-retain log message")
+	}
+	if strings.Contains(skipLog.msg, kubernetes.MetricsServerCertSecretName) {
+		t.Fatalf("log message must not hardcode %q: %q", kubernetes.MetricsServerCertSecretName, skipLog.msg)
+	}
+	if !strings.Contains(skipLog.msg, "metrics TLS secret is absent") {
+		t.Fatalf("unexpected log message: %q", skipLog.msg)
+	}
+	if got := logValue(skipLog.kv, "secret"); got != customSecret {
+		t.Fatalf("log secret field: got %q want %q", got, customSecret)
 	}
 }
 

--- a/operator/internal/predicate/predicate.go
+++ b/operator/internal/predicate/predicate.go
@@ -37,6 +37,13 @@ var PrometheusScrapeTokenSecretPredicate = predicate.NewPredicateFuncs(kubernete
 // (cert-manager issued; watched by name because it is not a CR ownerRef).
 var MetricsTLSSecretPredicate = predicate.NewPredicateFuncs(kubernetes.IsMetricsTLSSecret)
 
+// MetricsTLSSecretNamedPredicate limits Secret watches to a named operand TLS Secret.
+func MetricsTLSSecretNamedPredicate(secretName string) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return kubernetes.IsMetricsTLSSecretNamed(obj, secretName)
+	})
+}
+
 // generationOrMetadataChanged returns true if the update is NOT a status-only change.
 // It detects spec changes (generation bump), ownerReference changes, and
 // label/annotation changes -- none of which are reflected in the generation

--- a/operator/internal/predicate/predicate_test.go
+++ b/operator/internal/predicate/predicate_test.go
@@ -488,3 +488,42 @@ func TestMetricsTLSSecretPredicate(t *testing.T) {
 		}},
 	})).To(gomega.BeTrue())
 }
+
+func TestMetricsTLSSecretNamedPredicate(t *testing.T) {
+	g := gomega.NewWithT(t)
+	const custom = "operand-tls"
+	pred := MetricsTLSSecretNamedPredicate(custom)
+
+	g.Expect(pred.Create(event.CreateEvent{
+		Object: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name:      kubernetes.MetricsServerCertSecretName,
+			Namespace: "operand-ns",
+		}},
+	})).To(gomega.BeFalse())
+	g.Expect(pred.Create(event.CreateEvent{
+		Object: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name:      custom,
+			Namespace: "operand-ns",
+		}},
+	})).To(gomega.BeTrue())
+	g.Expect(pred.Update(event.UpdateEvent{
+		ObjectNew: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name:      custom,
+			Namespace: "operand-ns",
+		}},
+	})).To(gomega.BeTrue())
+
+	defaultPred := MetricsTLSSecretNamedPredicate("")
+	g.Expect(defaultPred.Create(event.CreateEvent{
+		Object: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name:      kubernetes.MetricsServerCertSecretName,
+			Namespace: "operand-ns",
+		}},
+	})).To(gomega.BeTrue())
+	g.Expect(defaultPred.Create(event.CreateEvent{
+		Object: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name:      custom,
+			Namespace: "operand-ns",
+		}},
+	})).To(gomega.BeFalse(), "empty config name must not watch custom secrets")
+}

--- a/operator/pkg/kubernetes/metrics_tls.go
+++ b/operator/pkg/kubernetes/metrics_tls.go
@@ -82,6 +82,22 @@ type MetricsScrapeTLSInput struct {
 	// updates are not missed due to informer lag. When nil, Client is used.
 	Reader    client.Reader
 	Namespace string
+	// SecretName is the TLS Secret to verify (tls.crt + ca.crt). When empty, defaults to
+	// MetricsServerCertSecretName (controller operands).
+	SecretName string
+}
+
+// ResolveMetricsTLSSecretName returns the effective metrics TLS Secret name.
+// When secretName is empty, defaults to MetricsServerCertSecretName (controller operands).
+func ResolveMetricsTLSSecretName(secretName string) string {
+	if secretName != "" {
+		return secretName
+	}
+	return MetricsServerCertSecretName
+}
+
+func metricsTLSSecretName(in MetricsScrapeTLSInput) string {
+	return ResolveMetricsTLSSecretName(in.SecretName)
 }
 
 func metricsTLSReader(in MetricsScrapeTLSInput) client.Reader {
@@ -105,7 +121,7 @@ func EvaluateMetricsScrapeTLS(ctx context.Context, in MetricsScrapeTLSInput) (Me
 	secret := &corev1.Secret{}
 	if err := reader.Get(ctx, types.NamespacedName{
 		Namespace: in.Namespace,
-		Name:      MetricsServerCertSecretName,
+		Name:      metricsTLSSecretName(in),
 	}, secret); err != nil {
 		if apierrors.IsNotFound(err) {
 			return MetricsScrapeTLSResult{Reason: MetricsTLSReasonCertMissing}, nil

--- a/operator/pkg/kubernetes/metrics_tls_test.go
+++ b/operator/pkg/kubernetes/metrics_tls_test.go
@@ -72,6 +72,54 @@ func metricsTLSSecret(ns, rv string, caPEM, leafPEM []byte) *corev1.Secret {
 	}
 }
 
+func operandTLSSecret(name, ns, rv string, caPEM, leafPEM []byte) *corev1.Secret {
+	secret := metricsTLSSecret(ns, rv, caPEM, leafPEM)
+	secret.Name = name
+	return secret
+}
+
+func TestMetricsTLSSecretName(t *testing.T) {
+	if got := metricsTLSSecretName(MetricsScrapeTLSInput{}); got != MetricsServerCertSecretName {
+		t.Fatalf("default secret name: got %q want %q", got, MetricsServerCertSecretName)
+	}
+	if got := metricsTLSSecretName(MetricsScrapeTLSInput{SecretName: "operand-tls"}); got != "operand-tls" {
+		t.Fatalf("custom secret name: got %q", got)
+	}
+}
+
+func TestEvaluateMetricsScrapeTLS_CustomSecretName(t *testing.T) {
+	ctx := context.Background()
+	caPEM, leafPEM := mustMetricsTLSMaterial(t)
+	const customSecret = "operand-tls"
+	c := fake.NewClientBuilder().WithScheme(testMetricsTLSScheme(t)).WithObjects(
+		operandTLSSecret(customSecret, testMetricsTLSNamespace, "rv-custom", caPEM, leafPEM),
+	).Build()
+
+	result, err := EvaluateMetricsScrapeTLS(ctx, MetricsScrapeTLSInput{
+		Client:     c,
+		Namespace:  testMetricsTLSNamespace,
+		SecretName: customSecret,
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if !result.Ready {
+		t.Fatalf("expected ready with custom secret, reason=%q", result.Reason)
+	}
+
+	missingDefault, err := EvaluateMetricsScrapeTLS(ctx, MetricsScrapeTLSInput{
+		Client:    c,
+		Namespace: testMetricsTLSNamespace,
+	})
+	if err != nil {
+		t.Fatalf("evaluate default name: %v", err)
+	}
+	if missingDefault.Ready || missingDefault.Reason != MetricsTLSReasonCertMissing {
+		t.Fatalf("default name should miss metrics-server-cert: ready=%v reason=%q",
+			missingDefault.Ready, missingDefault.Reason)
+	}
+}
+
 func TestEvaluateMetricsScrapeTLS_Ready(t *testing.T) {
 	ctx := context.Background()
 	caPEM, leafPEM := mustMetricsTLSMaterial(t)
@@ -226,6 +274,20 @@ func TestVerifyCertPEMSignedByCA(t *testing.T) {
 func TestParseFirstCertPEM_NoBlock(t *testing.T) {
 	if _, err := parseFirstCertPEM(nil); err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestResolveMetricsTLSSecretName(t *testing.T) {
+	t.Parallel()
+	if got := ResolveMetricsTLSSecretName(""); got != MetricsServerCertSecretName {
+		t.Fatalf("empty name: got %q want %q", got, MetricsServerCertSecretName)
+	}
+	const custom = "operand-tls"
+	if got := ResolveMetricsTLSSecretName(custom); got != custom {
+		t.Fatalf("custom name: got %q want %q", got, custom)
+	}
+	if got := ResolveMetricsTLSSecretName(MetricsServerCertSecretName); got != MetricsServerCertSecretName {
+		t.Fatalf("explicit default: got %q want %q", got, MetricsServerCertSecretName)
 	}
 }
 

--- a/operator/pkg/kubernetes/scrape_token.go
+++ b/operator/pkg/kubernetes/scrape_token.go
@@ -336,13 +336,19 @@ func IsPrometheusScrapeTokenSecret(obj client.Object) bool {
 		obj.GetNamespace() != ""
 }
 
-// IsMetricsTLSSecret reports whether obj is the metrics TLS Secret used for verified
-// Prometheus scrape wiring (konflux-issuer leaf Secret with tls.crt + ca.crt).
-func IsMetricsTLSSecret(obj client.Object) bool {
+// IsMetricsTLSSecretNamed reports whether obj is the named metrics TLS Secret used for
+// verified Prometheus scrape wiring.
+func IsMetricsTLSSecretNamed(obj client.Object, secretName string) bool {
 	if obj == nil || obj.GetNamespace() == "" {
 		return false
 	}
-	return obj.GetName() == MetricsServerCertSecretName
+	return obj.GetName() == ResolveMetricsTLSSecretName(secretName)
+}
+
+// IsMetricsTLSSecret reports whether obj is the metrics TLS Secret used for verified
+// Prometheus scrape wiring (konflux-issuer leaf Secret with tls.crt + ca.crt).
+func IsMetricsTLSSecret(obj client.Object) bool {
+	return IsMetricsTLSSecretNamed(obj, MetricsServerCertSecretName)
 }
 
 // IsMetricsScrapeWiringSecret reports whether obj is a Secret that should wake scrape

--- a/operator/pkg/kubernetes/scrape_token_test.go
+++ b/operator/pkg/kubernetes/scrape_token_test.go
@@ -320,6 +320,32 @@ func TestIsMetricsTLSSecret(t *testing.T) {
 	}
 }
 
+func TestIsMetricsTLSSecretNamed(t *testing.T) {
+	t.Parallel()
+	const custom = "operand-tls"
+	if IsMetricsTLSSecretNamed(nil, custom) {
+		t.Fatal("nil object should not match")
+	}
+	if IsMetricsTLSSecretNamed(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: custom}}, custom) {
+		t.Fatal("empty namespace should not match")
+	}
+	if !IsMetricsTLSSecretNamed(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: MetricsServerCertSecretName, Namespace: "ns"},
+	}, "") {
+		t.Fatal("empty secret name should default to metrics-server-cert")
+	}
+	if !IsMetricsTLSSecretNamed(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: custom, Namespace: "ns"},
+	}, custom) {
+		t.Fatal("expected custom secret name to match")
+	}
+	if IsMetricsTLSSecretNamed(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: MetricsServerCertSecretName, Namespace: "ns"},
+	}, custom) {
+		t.Fatal("wrong secret name should not match")
+	}
+}
+
 func TestIgnoreScrapeTokenNotFound(t *testing.T) {
 	t.Parallel()
 	if err := IgnoreScrapeTokenNotFound(nil); err != nil {


### PR DESCRIPTION
Today deferred ServiceMonitor apply always waits on metrics-server-cert. Some operands expose HTTPS metrics using their own TLS Secret instead of the controller-runtime metrics-server-cert pattern.

Add optional secret naming through the existing scrape-token path:
- MetricsScrapeTLSInput.SecretName (default: metrics-server-cert)
- ScrapeTokenReconcilerConfig.MetricsTLSSecretName
- IsMetricsTLSSecretNamed and MetricsTLSSecretNamedPredicate for watches

Behavior is unchanged for existing controller operands when the new fields are unset. Unit tests cover custom and default secret selection.

Next steps (follow-up PRs on KONFLUX-9075):
- componentMetrics API on KonfluxNamespaceLister + Konflux forwarding
- namespace-lister workload metrics endpoint (HTTPS :9100, no SM yet)
- monitoring bundle (ServiceMonitor, scrape token, NetworkPolicy)
- OpenShift UWM CI + component-monitoring docs

Assisted-by: Cursor